### PR TITLE
Easier developer flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ export GO111MODULE=on
 
 # You can include assets this directory into the bundle. This can be e.g. used to include profile pictures.
 ASSETS_DIR ?= assets
+PWD := $(shell pwd)
+OS := $(shell uname 2> /dev/null)
 
 # Verify environment, and define PLUGIN_ID, PLUGIN_VERSION, HAS_SERVER and HAS_WEBAPP as needed.
 include build/setup.mk
@@ -122,13 +124,6 @@ ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run build;
 endif
 
-## Builds the webapp in debug mode, if it exists.
-webapp-debug: webapp/.npminstall
-ifneq ($(HAS_WEBAPP),)
-	cd webapp && \
-	$(NPM) run debug;
-endif
-
 ## Generates a tar bundle of the plugin for install.
 .PHONY: bundle
 bundle:
@@ -163,12 +158,6 @@ dist:	apply server webapp bundle
 .PHONY: deploy
 deploy: dist
 	./build/bin/deploy $(PLUGIN_ID) dist/$(BUNDLE_NAME)
-
-.PHONY: debug-deploy
-debug-deploy: debug-dist deploy
-
-.PHONY: debug-dist
-debug-dist: apply server webapp-debug bundle
 
 ## Runs any lints and unit tests defined for the server and webapp, if they exist.
 .PHONY: test
@@ -216,3 +205,114 @@ endif
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@cat Makefile | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z0-9_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort
+
+
+##
+## The following are commands that can make a developer's life easier
+##
+
+# sd is an easier-to-type alias for server-debug
+.PHONY: sd
+sd: server-debug
+
+# server-debug builds and deploys a debug version of the plugin for your architecture.
+# Then resets the plugin to pick up the changes.
+.PHONY: server-debug
+server-debug: apply server-debug-build reset
+
+.PHONY: server-debug-build
+server-debug-build:
+	mkdir -p server/dist
+
+ifeq ($(OS),Darwin)
+	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-darwin-amd64;
+else ifeq ($(OS),Linux)
+	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-linux-amd64;
+else ifeq ($(OS),Windows_NT)
+	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-windows-amd64.exe;
+else
+	$(error make debug depends on uname to return your OS. If it does not return 'Darwin' (meaning OSX), 'Linux', or 'Windows_NT' (all recent versions of Windows), you will need to edit the Makefile for your own OS.)
+endif
+
+	rm -rf dist/
+	mkdir -p dist/$(PLUGIN_ID)/server/dist
+	cp $(MANIFEST_FILE) dist/$(PLUGIN_ID)/
+	cp -r server/dist/* dist/$(PLUGIN_ID)/server/dist/
+	mkdir -p ../mattermost-server/plugins
+	cp -r dist/* ../mattermost-server/plugins/
+
+# wd is an easier-to-type alias for webapp-debug
+.PHONY: wd
+wd: webapp-debug
+
+# webapp-debug builds and deploys the plugin's webapp in watch mode with source-maps.
+# Webpack will run make-reset after detecting and compiling changes.
+.PHONY: webapp-debug
+webapp-debug:
+ifneq ($(HAS_WEBAPP),)
+# link the webapp directory
+	rm -rf ../mattermost-server/plugins/$(PLUGIN_ID)/webapp
+	mkdir -p ../mattermost-server/plugins/$(PLUGIN_ID)/webapp
+	ln -nfs $(PWD)/webapp/dist ../mattermost-server/plugins/$(PLUGIN_ID)/webapp/dist
+# start an npm watch
+	cd webapp && $(NPM) run debug:watch
+endif
+
+# Reset the plugin
+.PHONY: reset
+reset:
+ifeq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSWORD),$(CURL)),)
+	$(error In order to use make reset, the following environment variables need to be defined: MM_SERVICESETTINGS_SITEURL, MM_ADMIN_USERNAME, MM_ADMIN_PASSWORD, and you need to have curl installed.)
+endif
+
+# If we were debugging, we have to unattach the delve process or else we can't disable the plugin.
+# NOTE: we are assuming the dlv was listening on port 2346, as in the debug-plugin.sh script.
+	@DELVE_PID=$(shell ps aux | grep "dlv attach.*2346" | grep -v "grep" | awk -F " " '{print $$2}') && \
+	if [ "$$DELVE_PID" -gt 0 ] > /dev/null 2>&1 ; then \
+		echo "Located existing delve process running with PID: $$DELVE_PID. Killing." ; \
+		kill -9 $$DELVE_PID ; \
+	fi
+
+	@echo "\nRestarting plugin via API"
+	$(eval TOKEN := $(shell curl -i -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep -o "Token: [0-9a-z]*" | cut -f2 -d' ' 2> /dev/null))
+	@curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/disable > /dev/null && \
+		curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable > /dev/null && \
+		echo "OK." || echo "Sorry, something went wrong. Check that MM_ADMIN_USERNAME and MM_ADMIN_PASSWORD env variables are set correctly."
+
+
+.PHONY: debug-plugin
+debug-plugin:
+	$(eval PLUGIN_PID := $(shell ps aux | grep "plugins/${PLUGIN_ID}" | grep -v "grep" | awk -F " " '{print $$2}'))
+	$(eval NUM_PID := $(shell echo -n ${PLUGIN_PID} | wc -w))
+
+	@if [ ${NUM_PID} -gt 2 ]; then \
+		echo "** There is more than 1 plugin process running. Run 'make kill-plugin' to get rid of them."; \
+		echo "   Then run 'make reset' to start the plugin process again, and 'make debug-plugin' attach the dlv process."; \
+		exit 1; \
+	fi
+
+	@if [ -z ${PLUGIN_PID} ]; then \
+		echo "Could not find plugin PID; the plugin is not running. Exiting."; \
+		exit 1; \
+	fi
+
+	@echo "Located Plugin running with PID: ${PLUGIN_PID}"
+	dlv attach ${PLUGIN_PID} --listen :2346 --headless=true --api-version=2 --accept-multiclient &
+
+.PHONY: kill-plugin
+kill-plugin:
+# If we were debugging, we have to unattach the delve process or else we can't disable the plugin.
+# NOTE: we are assuming the dlv was listening on port 2346, as in the debug-plugin.sh script.
+	$(eval DELVE_PID := $(shell ps aux | grep "dlv attach.*2346" | grep -v "grep" | awk -F " " '{print $$2}'))
+
+	@if [ -n "${DELVE_PID}" ]; then \
+		echo "Located existing delve process running with PID: ${DELVE_PID}. Killing."; \
+		kill -9 ${DELVE_PID}; \
+	fi
+
+	$(eval PLUGIN_PID := $(shell ps aux | grep "plugins/${PLUGIN_ID}" | grep -v "grep" | awk -F " " '{print $$2}'))
+
+	@for PID in ${PLUGIN_PID}; do \
+		echo "Killing plugin pid $$PID"; \
+		kill -9 $$PID; \
+	done; \

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "build": "webpack --mode=production",
-    "debug": "webpack --mode=none",
+    "debug:watch": "webpack --mode=development --watch",
     "lint": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet",
     "fix": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix",
     "test": "jest --forceExit --detectOpenHandles --verbose",

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -1,4 +1,14 @@
-var path = require('path');
+const exec = require('child_process').exec;
+
+const path = require('path');
+
+const NPM_TARGET = process.env.npm_lifecycle_event; //eslint-disable-line no-process-env
+let mode = 'production';
+let devtool = '';
+if (NPM_TARGET === 'development') {
+    mode = 'development';
+    devtool = 'source-map';
+}
 
 module.exports = {
     entry: [
@@ -57,4 +67,22 @@ module.exports = {
         publicPath: '/',
         filename: 'main.js',
     },
+    devtool,
+    mode,
+    plugins: [
+        {
+            apply: (compiler) => {
+                compiler.hooks.afterEmit.tap('AfterEmitPlugin', () => {
+                    exec('cd .. && make reset', (err, stdout, stderr) => {
+                        if (stdout) {
+                            process.stdout.write(stdout);
+                        }
+                        if (stderr) {
+                            process.stderr.write(stderr);
+                        }
+                    });
+                });
+            },
+        },
+    ],
 };


### PR DESCRIPTION
#### Summary
- These are makefile and webpack changes that I thought had made their way into plugin template, but I guess didn't. Will make that PR after this one goes through review.

Hah, found it: https://github.com/mattermost/mattermost-plugin-starter-template/pull/39
- Wanted to use it in Jira for awhile before committing. This current PR includes some improvements made during Workflows dev.

Quick Instructions:
Server-only change:
- Instead of running `make deploy`, run `make sd`

Webapp-only changes:
- Instead of `make deploy`, run `make wd`
- This will watch for webapp changes and push them and restart the plugin. Usually the plugin will show the updated webapp components the next time you get to that state. Sometimes it crashes the webapp, so you need to refresh.

To debug the server part of a plugin through your IDE:
- run `make debug-plugin`, which will attach a delve headless process to the plugin. Attach your debugger of choice to localhost:2346

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-23614