### PR TITLE
Fix conditional for adding postId

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -99,7 +99,7 @@ export function startIncident(postId? : string) {
         const args = {channel_id: currentChanel?.id};
 
         let command = '/incident start';
-        if (!postId) {
+        if (postId) {
             command = `${command} ${postId}`;
         }
 


### PR DESCRIPTION
#### Summary

Fixed inverted conditional when adding the `postId` starting an incident. Last minute feedback PR change that was causing the post link to not show on the incident channel. 🤦‍♀️