### PR TITLE
[MM-23822] Panic creating an incident with the same name as an existing channel

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -71,6 +71,8 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 
 	if errors.Is(err, incident.ErrChannelExists) {
 		h.poster.Ephemeral(request.UserId, request.ChannelId, "Error: A channel with the name `%v` already exists. Please choose a different name.", name)
+		w.WriteHeader(http.StatusOK)
+		return
 	} else if err != nil {
 		HandleError(w, err)
 		return


### PR DESCRIPTION
#### Summary
- don't continue if the channel name exists, but don't return an error (it's not an internal server error)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-23822