### PR TITLE
MM-23851 - Fix issue with invalid post links

### DIFF
--- a/webapp/src/components/rhs/incident_list/incident_list.tsx
+++ b/webapp/src/components/rhs/incident_list/incident_list.tsx
@@ -35,7 +35,7 @@ export default class IncidentList extends React.PureComponent<Props> {
                     </div>
                     <a
                         className='link'
-                        onClick={this.props.actions.startIncident}
+                        onClick={() => this.props.actions.startIncident()}
                     >
                         {'+ Create new incident'}
                     </a>

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -96,7 +96,7 @@ export default class RightHandSidebar extends React.PureComponent<Props> {
                             </div>
                             <i
                                 className='fa fa-plus'
-                                onClick={this.props.actions.startIncident}
+                                onClick={() => this.props.actions.startIncident()}
                             />
                         </div>
                     }


### PR DESCRIPTION
#### Summary

Changed to use arrow function `onClick` when starting an incident from the RHS given that the action was incorrectly receiving the `eventArgs` as the `postId`. 

#### Ticket Link
[MM-23851](https://mattermost.atlassian.net/browse/MM-23851)
