### PR TITLE
MM-23854 - Non-admin user cannot start an incident from RHS (or post) in GM and DM channels

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -98,8 +98,12 @@ export function getIncidents(teamId?: string) {
 export function startIncident(postId?: string) {
     return async (dispatch: Dispatch<AnyAction>, getState: GetStateFunc) => {
         const currentChanel = getCurrentChannel(getState());
+        const currentTeamId = getCurrentTeamId(getState());
 
-        const args = {channel_id: currentChanel?.id};
+        const args = {
+            channel_id: currentChanel?.id,
+            team_id: currentTeamId,
+        };
 
         // Add unique id
         const clientId = generateId();


### PR DESCRIPTION
#### Summary
- Need to add the team_id in the execute args in case we're in a DM or GM

#### Ticket Link
- Fixes https://mattermost.atlassian.net/browse/MM-23854
- Fixes https://mattermost.atlassian.net/browse/MM-23855
