### PR TITLE
Fix crash for users not in incident channel.

### DIFF
--- a/webapp/src/components/rhs/incident_details/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details/incident_details.tsx
@@ -74,7 +74,7 @@ export default class IncidentDetails extends React.PureComponent<Props> {
                             {'End Incident'}
                         </button>
                         {
-                            !this.props.allowEndIncident && this.props.channelDetails && this.props.channelDetails.length > 0 &&
+                            !this.props.allowEndIncident && this.props.channelDetails?.length > 0 &&
                             <div className='help-text'>
                                 {'Go to '}
                                 <Link


### PR DESCRIPTION
#### Summary
Users not in incident channel don't get it in their `this.props.channelDetails` list. So it would crash.
