### PR TITLE
Use logrus to log errors in HandleError

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.2.1+incompatible
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
-	github.com/sirupsen/logrus v1.5.0 // indirect
+	github.com/sirupsen/logrus v1.5.0
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.14.1 // indirect
 	golang.org/x/crypto v0.0.0-20200414173820-0848c9571904 // indirect

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 )
 
 type contextKey string
@@ -50,6 +51,7 @@ func HandleError(w http.ResponseWriter, err error) {
 		Error:   "An internal error has occurred. Check app server logs for details.",
 		Details: err.Error(),
 	})
+	logrus.Warn(string(b))
 	_, _ = w.Write(b)
 }
 
@@ -75,6 +77,7 @@ func HandleErrorWithCode(w http.ResponseWriter, code int, errTitle string, err e
 		Error:   errTitle,
 		Details: err.Error(),
 	})
+	logrus.Warn(string(b))
 	_, _ = w.Write(b)
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-incident-response/server/telemetry"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/sirupsen/logrus"
 )
 
 // These credentials for Rudder need to be populated at build-time,
@@ -46,6 +47,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 func (p *Plugin) OnActivate() error {
 	pluginAPIClient := pluginapi.NewClient(p.API)
 	p.config = config.NewConfigService(pluginAPIClient)
+	pluginapi.ConfigureLogrus(logrus.New(), pluginAPIClient)
 
 	botID, err := pluginAPIClient.Bot.EnsureBot(&model.Bot{
 		Username:    "incident",


### PR DESCRIPTION
#### Summary
Using logrus to log instead of sending error details down to the webapp.

