### PR TITLE
github/pr-template: add Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thank you for contributing a pull request! Here are a few tips to help you:
+
+1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
+2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
+3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
+-->
+
+#### Summary
+<!--
+A description of what this pull request does.
+-->
+
+#### Ticket Link
+<!--
+If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.
+
+  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX
+
+Otherwise, link the JIRA ticket.
+-->
+
+#### Release Note
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
#### Summary
This Pull request add a template for contributors follow when opening a PR. Also adds a release note section to be filled


#### Ticket Link
N/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
