### PR TITLE
MM-24456 - CreateChannel followed by AddChannelMember is racy when a replica exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/mattermost/ldap v3.0.4+incompatible // indirect
-	github.com/mattermost/mattermost-plugin-api v0.0.10
+	github.com/mattermost/mattermost-plugin-api v0.0.11-0.20200423151631-d6f334d539a1
 	github.com/mattermost/mattermost-server/v5 v5.21.0
 	github.com/mholt/archiver/v3 v3.3.0
 	github.com/mitchellh/go-testing-interface v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/mattermost/gosaml2 v0.3.2/go.mod h1:Z429EIOiEi9kbq6yHoApfzlcXpa6dzRDc
 github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN2BZP/PdX23VDU=
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
-github.com/mattermost/mattermost-plugin-api v0.0.10 h1:sVogAFMUNnKlrD7a5Kyc2JAvJtuyrgEGhgEDM1NSWKg=
-github.com/mattermost/mattermost-plugin-api v0.0.10/go.mod h1:hAJhL1GSGZO8EEIUo2t14m+cS/PSRCFEK3d8NUUTaGg=
+github.com/mattermost/mattermost-plugin-api v0.0.11-0.20200423151631-d6f334d539a1 h1:nhEPnvuk3ZKshW4tuGKXM0/pJQhtNvlMNXh4aseKr5w=
+github.com/mattermost/mattermost-plugin-api v0.0.11-0.20200423151631-d6f334d539a1/go.mod h1:hAJhL1GSGZO8EEIUo2t14m+cS/PSRCFEK3d8NUUTaGg=
 github.com/mattermost/mattermost-server/v5 v5.21.0 h1:cu5XP+AQF7D+hmo00Tm2l/eH658mLpMv3SgX/pwyigE=
 github.com/mattermost/mattermost-server/v5 v5.21.0/go.mod h1:wklWzfPTiBHGwdSjJAAVXX1WOba2huw3Ov4Qa4hkBno=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=


### PR DESCRIPTION
#### Summary
Bumping mattermost-plugin-api version to use the fixed version.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-24456

```release-note
Fixed incident creation when a replica exists
```