### PR TITLE
MM-24491 - `GET /incidents/{id}` should check permissions

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -164,7 +164,7 @@ func (h *IncidentHandler) getIncidents(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// getIncident handles the /incidents/{id} endpoint
+// getIncident handles the /incidents/{id} endpoint.
 func (h *IncidentHandler) getIncident(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	incidentID := vars["id"]

--- a/server/permissions/permissions.go
+++ b/server/permissions/permissions.go
@@ -20,7 +20,7 @@ func CheckHasPermissionsToIncidentChannel(userID, incidentID string, pluginAPI *
 
 	incidentToCheck, err := incidentService.GetIncident(incidentID)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not get incident id `%s`: %w", incidentID, err)
 	}
 
 	isChannelMember := pluginAPI.User.HasPermissionToChannel(userID, incidentToCheck.ChannelIDs[0], model.PERMISSION_READ_CHANNEL)
@@ -40,7 +40,7 @@ func CheckHasPermissionsToIncidentTeam(userID, incidentID string, pluginAPI *plu
 
 	incidentToCheck, err := incidentService.GetIncident(incidentID)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not get incident id `%s`: %w", incidentID, err)
 	}
 
 	channel, err := pluginAPI.Channel.Get(incidentToCheck.ChannelIDs[0])


### PR DESCRIPTION
#### Summary
- User should not be able to view an incident unless part of the team

#### Ticket Link
- Fixes https://mattermost.atlassian.net/browse/MM-24491

```release-note
Add permissions check (can read team) to the `GET /incidents/{id}` endpoint
```