### PR TITLE
MM-24533: fix channel name generation

### DIFF
--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -483,27 +483,27 @@ func (s *ServiceImpl) createIncidentChannel(incdnt *Incident) (*model.Channel, e
 		Header:      channelHeader,
 	}
 
-	// Loop in case we accidentally chose an existing channel name
-	// Prefer the channel name the user chose. But if it already exists, add some random bits.
-	for succeeded := false; !succeeded; {
-		if err := s.pluginAPI.Channel.Create(channel); err != nil {
-			if appErr, ok := err.(*model.AppError); ok {
-
-				// Let the user correct display name errors:
-				if appErr.Id == "model.channel.is_valid.display_name.app_error" {
-					return nil, ErrChannelDisplayNameLong
-				}
-
-				// We can fix channel Name errors:
-				if appErr.Id == "store.sql_channel.save_channel.exists.app_error" ||
-					appErr.Id == "model.channel.is_valid.2_or_more.app_error" {
-					channel.Name = addRandomBits(channel.Name)
-					continue
-				}
+	// Prefer the channel name the user chose. But if it already exists, add some random bits
+	// and try exactly once more.
+	err := s.pluginAPI.Channel.Create(channel)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			// Let the user correct display name errors:
+			if appErr.Id == "model.channel.is_valid.display_name.app_error" ||
+				appErr.Id == "model.channel.is_valid.2_or_more.app_error" {
+				return nil, ErrChannelDisplayNameLong
 			}
+
+			// We can fix channel Name errors:
+			if appErr.Id == "store.sql_channel.save_channel.exists.app_error" {
+				channel.Name = addRandomBits(channel.Name)
+				err = s.pluginAPI.Channel.Create(channel)
+			}
+		}
+
+		if err != nil {
 			return nil, fmt.Errorf("failed to create incident channel: %w", err)
 		}
-		succeeded = true
 	}
 
 	if _, err := s.pluginAPI.Channel.AddUser(channel.Id, incdnt.CommanderUserID, s.configService.GetConfiguration().BotUserID); err != nil {
@@ -580,7 +580,7 @@ func cleanChannelName(channelName string) string {
 	channelName = strings.ToLower(channelName)
 	// Trim spaces
 	channelName = strings.TrimSpace(channelName)
-	// Change all dashes to whitespace, remove evrything that's not a word or whitespace, all space becomes dashes
+	// Change all dashes to whitespace, remove everything that's not a word or whitespace, all space becomes dashes
 	channelName = strings.ReplaceAll(channelName, "-", " ")
 	channelName = allNonSpaceNonWordRegex.ReplaceAllString(channelName, "")
 	channelName = strings.ReplaceAll(channelName, " ", "-")

--- a/server/incident/service_test.go
+++ b/server/incident/service_test.go
@@ -1,0 +1,136 @@
+package incident_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+	mock_poster "github.com/mattermost/mattermost-plugin-incident-response/server/bot/mocks"
+	"github.com/mattermost/mattermost-plugin-incident-response/server/config"
+	mock_config "github.com/mattermost/mattermost-plugin-incident-response/server/config/mocks"
+	"github.com/mattermost/mattermost-plugin-incident-response/server/incident"
+	mock_incident "github.com/mattermost/mattermost-plugin-incident-response/server/incident/mocks"
+	"github.com/mattermost/mattermost-plugin-incident-response/server/telemetry"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateIncident(t *testing.T) {
+	t.Run("invalid channel name has only invalid characters", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		pluginAPI := &plugintest.API{}
+		client := pluginapi.NewClient(pluginAPI)
+		store := mock_incident.NewMockStore(controller)
+		poster := mock_poster.NewMockPoster(controller)
+		configService := mock_config.NewMockService(controller)
+		telemetry := &telemetry.NoopTelemetry{}
+
+		teamId := model.NewId()
+		incdnt := &incident.Incident{
+			Header: incident.Header{
+				Name:   "###",
+				TeamID: teamId,
+			},
+		}
+
+		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
+		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.display_name.app_error"})
+
+		s := incident.NewService(client, store, poster, configService, telemetry)
+
+		_, err := s.CreateIncident(incdnt)
+		require.Equal(t, err, incident.ErrChannelDisplayNameLong)
+	})
+
+	t.Run("invalid channel name has only invalid characters", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		pluginAPI := &plugintest.API{}
+		client := pluginapi.NewClient(pluginAPI)
+		store := mock_incident.NewMockStore(controller)
+		poster := mock_poster.NewMockPoster(controller)
+		configService := mock_config.NewMockService(controller)
+		telemetry := &telemetry.NoopTelemetry{}
+
+		teamId := model.NewId()
+		incdnt := &incident.Incident{
+			Header: incident.Header{
+				Name:   "###",
+				TeamID: teamId,
+			},
+		}
+
+		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
+		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.2_or_more.app_error"})
+
+		s := incident.NewService(client, store, poster, configService, telemetry)
+
+		_, err := s.CreateIncident(incdnt)
+		require.Equal(t, err, incident.ErrChannelDisplayNameLong)
+	})
+
+	t.Run("channel name already exists, fixed on second try", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		pluginAPI := &plugintest.API{}
+		client := pluginapi.NewClient(pluginAPI)
+		store := mock_incident.NewMockStore(controller)
+		poster := mock_poster.NewMockPoster(controller)
+		configService := mock_config.NewMockService(controller)
+		telemetry := &telemetry.NoopTelemetry{}
+
+		teamId := model.NewId()
+		incdnt := &incident.Incident{
+			Header: incident.Header{
+				Name:            "###",
+				TeamID:          teamId,
+				CommanderUserID: "user_id",
+			},
+		}
+
+		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
+		pluginAPI.On("CreateChannel", &model.Channel{TeamId: teamId, Type: model.CHANNEL_PRIVATE, DisplayName: "###", Name: "", Header: "The channel was created by the Incident Response plugin."}).Return(nil, &model.AppError{Id: "store.sql_channel.save_channel.exists.app_error"})
+		mattermostConfig := &model.Config{}
+		mattermostConfig.SetDefaults()
+		pluginAPI.On("GetConfig").Return(mattermostConfig)
+		pluginAPI.On("CreateChannel", mock.Anything).Return(&model.Channel{Id: "channel_id"}, nil)
+		pluginAPI.On("AddUserToChannel", "channel_id", "user_id", "bot_user_id").Return(nil, nil)
+		configService.EXPECT().GetConfiguration().Return(&config.Configuration{BotUserID: "bot_user_id"})
+		store.EXPECT().UpdateIncident(gomock.Any()).Return(nil)
+		poster.EXPECT().PublishWebsocketEventToTeam("incident_update", gomock.Any(), teamId)
+		pluginAPI.On("GetUser", "user_id").Return(&model.User{Id: "user_id", Username: "username"}, nil)
+		poster.EXPECT().PostMessage("channel_id", "This incident has been started by @%s", "username")
+
+		s := incident.NewService(client, store, poster, configService, telemetry)
+
+		_, err := s.CreateIncident(incdnt)
+		require.NoError(t, err)
+	})
+
+	t.Run("channel name already exists, failed second try", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		pluginAPI := &plugintest.API{}
+		client := pluginapi.NewClient(pluginAPI)
+		store := mock_incident.NewMockStore(controller)
+		poster := mock_poster.NewMockPoster(controller)
+		configService := mock_config.NewMockService(controller)
+		telemetry := &telemetry.NoopTelemetry{}
+
+		teamId := model.NewId()
+		incdnt := &incident.Incident{
+			Header: incident.Header{
+				Name:            "###",
+				TeamID:          teamId,
+				CommanderUserID: "user_id",
+			},
+		}
+
+		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
+		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "store.sql_channel.save_channel.exists.app_error"})
+
+		s := incident.NewService(client, store, poster, configService, telemetry)
+
+		_, err := s.CreateIncident(incdnt)
+		require.EqualError(t, err, "failed to create incident channel: : , ")
+	})
+}


### PR DESCRIPTION
#### Summary
If the channel name consisted of solely invalid characters, they were all stripped out, the server would reject the too short name, and then we'd add a `-<random string>`. This, itself, would then be invalid, and the process would be completely indefinitely, leaving the plugin in an infinite loop.

![image](https://user-images.githubusercontent.com/1023171/80253480-bbd41c00-864f-11ea-8792-8803f515d58b.png)

Fix this by eliminating the loop and instead trying at most once. Also reject channel names that are too short up front for simplicity.


#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-24533