### PR TITLE
MM-24653 Confirmation modal for leaving playbook creation / edit screen.

### DIFF
--- a/webapp/src/components/playbook/playbook_edit.tsx
+++ b/webapp/src/components/playbook/playbook_edit.tsx
@@ -7,6 +7,7 @@ import {Playbook, Checklist, ChecklistItem} from 'src/types/playbook';
 import {savePlaybook} from 'src/client';
 
 import {ChecklistDetails} from 'src/components/checklist/checklist';
+import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import BackIcon from './back_icon';
 
@@ -22,6 +23,7 @@ interface State{
     checklists: Checklist[];
     newPlaybook: boolean;
     changesMade: boolean;
+    confirmOpen: boolean;
 }
 
 export default class PlaybookEdit extends React.PureComponent<Props, State> {
@@ -33,6 +35,7 @@ export default class PlaybookEdit extends React.PureComponent<Props, State> {
             checklists: this.props.playbook.checklists,
             newPlaybook: !this.props.playbook.id,
             changesMade: false,
+            confirmOpen: false,
         };
     }
 
@@ -116,6 +119,22 @@ export default class PlaybookEdit extends React.PureComponent<Props, State> {
         });
     }
 
+    public confirmOrClose = () => {
+        if (this.state.changesMade) {
+            this.setState({
+                confirmOpen: true,
+            });
+        } else {
+            this.props.onClose();
+        }
+    }
+
+    public confirmCancel = () => {
+        this.setState({
+            confirmOpen: false,
+        });
+    }
+
     public render(): JSX.Element {
         const title = this.state.newPlaybook ? 'New Playbook' : 'Edit Playbook';
 
@@ -125,14 +144,14 @@ export default class PlaybookEdit extends React.PureComponent<Props, State> {
                     <div className='title'>
                         <BackIcon
                             className='back-icon mr-4'
-                            onClick={this.props.onClose}
+                            onClick={this.confirmOrClose}
                         />
                         {title}
                     </div>
                     <div className='header-button-div'>
                         <button
                             className='btn btn-link mr-2'
-                            onClick={this.props.onClose}
+                            onClick={this.confirmOrClose}
                         >
                             {'Cancel'}
                         </button>
@@ -180,6 +199,14 @@ export default class PlaybookEdit extends React.PureComponent<Props, State> {
                         </div>
                     </div>
                 </div>
+                <ConfirmModal
+                    show={this.state.confirmOpen}
+                    title={'Confirm discard'}
+                    message={'Are you sure you want to discard your changes?'}
+                    confirmButtonText={'Discard Changes'}
+                    onConfirm={this.props.onClose}
+                    onCancel={this.confirmCancel}
+                />
             </div>
         );
     }


### PR DESCRIPTION
#### Summary
Adds a confirmation modal for navigating away from playbook creation.
You can still navigate away with the back button without confirmation. This was left out of this PR because the move to using routes will make implementing this different if we feel it necessary. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24653
