### PR TITLE
MM-24557 - Support fuzzy-searching incident name via REST API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.4.0 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/lithammer/fuzzysearch v1.1.0
 	github.com/mattermost/ldap v3.0.4+incompatible // indirect
 	github.com/mattermost/mattermost-plugin-api v0.0.11-0.20200423151631-d6f334d539a1
 	github.com/mattermost/mattermost-server/v5 v5.21.0

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6Fm
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lithammer/fuzzysearch v1.1.0 h1:go9v8tLCrNTTlH42OAaq4eHFe81TDHEnlrMEb6R4f+A=
+github.com/lithammer/fuzzysearch v1.1.0/go.mod h1:Bqx4wo8lTOFcJr3ckpY6HA9lEIOO0H5HrkJ5CsN56HQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -213,6 +213,7 @@ func (h *IncidentHandler) getHeaders(w http.ResponseWriter, r *http.Request) {
 	}
 	active, _ := strconv.ParseBool(r.URL.Query().Get("active"))
 	commanderID := r.URL.Query().Get("commander_user_id")
+	search := r.URL.Query().Get("search")
 
 	filterOptions := incident.HeaderFilterOptions{
 		TeamID:      teamID,
@@ -222,6 +223,7 @@ func (h *IncidentHandler) getHeaders(w http.ResponseWriter, r *http.Request) {
 		OrderBy:     orderBy,
 		Active:      active,
 		CommanderID: commanderID,
+		Search:      search,
 	}
 
 	incidentHeaders, err := h.incidentService.GetHeaders(filterOptions)

--- a/server/incident/header_filter.go
+++ b/server/incident/header_filter.go
@@ -33,6 +33,11 @@ type HeaderFilterOptions struct {
 
 	// CommanderID filters by commander's Mattermost user ID. Defaults to blank (no filter).
 	CommanderID string
+
+	// Search returns results of the search term, ordered by relevance, and respecting the other
+	// header filter options (except Sort & OrderBy which are mutually exclusive of relevance
+	// ordering).
+	Search string
 }
 
 // HeaderFilter header filter type.

--- a/server/pluginkvstore/incident_store_test.go
+++ b/server/pluginkvstore/incident_store_test.go
@@ -9,52 +9,62 @@ import (
 	mock_pluginkvstore "github.com/mattermost/mattermost-plugin-incident-response/server/pluginkvstore/mocks"
 )
 
+var id1 = incident.Header{
+	ID:              "id1",
+	Name:            "incident 1 - wheel cat aliens wheelbarrow",
+	IsActive:        true,
+	CommanderUserID: "commander1",
+	TeamID:          "team1",
+	CreatedAt:       123,
+	EndedAt:         440,
+}
+
+var id2 = incident.Header{
+	ID:              "id2",
+	Name:            "incident 2 - horse stapler battery shotgun mouse shotputmouse",
+	IsActive:        true,
+	CommanderUserID: "commander2",
+	TeamID:          "team1",
+	CreatedAt:       145,
+	EndedAt:         555,
+}
+
+var id3 = incident.Header{
+	ID:              "id3",
+	Name:            "incident 3 - stapler horse battery shotgun mouse shotputmouse",
+	IsActive:        false,
+	CommanderUserID: "commander1",
+	TeamID:          "team1",
+	CreatedAt:       222,
+	EndedAt:         666,
+}
+
+var id4 = incident.Header{
+	ID:              "id4",
+	Name:            "incident 4 - titanic terminator aliens",
+	IsActive:        false,
+	CommanderUserID: "commander3",
+	TeamID:          "team2",
+	CreatedAt:       333,
+	EndedAt:         444,
+}
+
+var id5 = incident.Header{
+	ID:              "id5",
+	Name:            "incident 5 - ubik high castle electric sheep",
+	IsActive:        true,
+	CommanderUserID: "commander3",
+	TeamID:          "team2",
+	CreatedAt:       223,
+	EndedAt:         550,
+}
+
 var dbHeaderMap = idHeaderMap{
-	"id1": incident.Header{
-		ID:              "id1",
-		Name:            "incident 1",
-		IsActive:        true,
-		CommanderUserID: "commander1",
-		TeamID:          "team1",
-		CreatedAt:       123,
-		EndedAt:         440,
-	},
-	"id2": incident.Header{
-		ID:              "id2",
-		Name:            "incident 2",
-		IsActive:        true,
-		CommanderUserID: "commander2",
-		TeamID:          "team1",
-		CreatedAt:       145,
-		EndedAt:         555,
-	},
-	"id3": incident.Header{
-		ID:              "id3",
-		Name:            "incident 3",
-		IsActive:        false,
-		CommanderUserID: "commander1",
-		TeamID:          "team1",
-		CreatedAt:       222,
-		EndedAt:         666,
-	},
-	"id4": incident.Header{
-		ID:              "id4",
-		Name:            "incident 4",
-		IsActive:        false,
-		CommanderUserID: "commander3",
-		TeamID:          "team2",
-		CreatedAt:       333,
-		EndedAt:         444,
-	},
-	"id5": incident.Header{
-		ID:              "id5",
-		Name:            "incident 5",
-		IsActive:        true,
-		CommanderUserID: "commander3",
-		TeamID:          "team2",
-		CreatedAt:       223,
-		EndedAt:         550,
-	},
+	"id1": id1,
+	"id2": id2,
+	"id3": id3,
+	"id4": id4,
+	"id5": id5,
 }
 
 func Test_incidentStore_GetHeaders(t *testing.T) {
@@ -67,53 +77,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 		{
 			name:    "simple getHeaders, no options",
 			options: incident.HeaderFilterOptions{},
-			want: []incident.Header{
-				{
-					ID:              "id4",
-					Name:            "incident 4",
-					IsActive:        false,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       333,
-					EndedAt:         444,
-				},
-				{
-					ID:              "id5",
-					Name:            "incident 5",
-					IsActive:        true,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       223,
-					EndedAt:         550,
-				},
-				{
-					ID:              "id3",
-					Name:            "incident 3",
-					IsActive:        false,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       222,
-					EndedAt:         666,
-				},
-				{
-					ID:              "id2",
-					Name:            "incident 2",
-					IsActive:        true,
-					CommanderUserID: "commander2",
-					TeamID:          "team1",
-					CreatedAt:       145,
-					EndedAt:         555,
-				},
-				{
-					ID:              "id1",
-					Name:            "incident 1",
-					IsActive:        true,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       123,
-					EndedAt:         440,
-				},
-			},
+			want:    []incident.Header{id4, id5, id3, id2, id1},
 		},
 		{
 			name: "team1 only, ascending",
@@ -121,88 +85,14 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				TeamID:  "team1",
 				OrderBy: incident.Asc,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id1",
-					Name:            "incident 1",
-					IsActive:        true,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       123,
-					EndedAt:         440,
-				},
-				{
-					ID:              "id2",
-					Name:            "incident 2",
-					IsActive:        true,
-					CommanderUserID: "commander2",
-					TeamID:          "team1",
-					CreatedAt:       145,
-					EndedAt:         555,
-				},
-				{
-					ID:              "id3",
-					Name:            "incident 3",
-					IsActive:        false,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       222,
-					EndedAt:         666,
-				},
-			},
+			want: []incident.Header{id1, id2, id3},
 		},
 		{
 			name: "sort by ended_at",
 			options: incident.HeaderFilterOptions{
 				Sort: "ended_at",
 			},
-			want: []incident.Header{
-				{
-					ID:              "id3",
-					Name:            "incident 3",
-					IsActive:        false,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       222,
-					EndedAt:         666,
-				},
-				{
-					ID:              "id2",
-					Name:            "incident 2",
-					IsActive:        true,
-					CommanderUserID: "commander2",
-					TeamID:          "team1",
-					CreatedAt:       145,
-					EndedAt:         555,
-				},
-				{
-					ID:              "id5",
-					Name:            "incident 5",
-					IsActive:        true,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       223,
-					EndedAt:         550,
-				},
-				{
-					ID:              "id4",
-					Name:            "incident 4",
-					IsActive:        false,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       333,
-					EndedAt:         444,
-				},
-				{
-					ID:              "id1",
-					Name:            "incident 1",
-					IsActive:        true,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       123,
-					EndedAt:         440,
-				},
-			},
+			want: []incident.Header{id3, id2, id5, id4, id1},
 		},
 		{
 			name: "no options, paged by 1",
@@ -210,17 +100,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				Page:    0,
 				PerPage: 1,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id4",
-					Name:            "incident 4",
-					IsActive:        false,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       333,
-					EndedAt:         444,
-				},
-			},
+			want: []incident.Header{id4},
 		},
 		{
 			name: "no options, paged by 3",
@@ -228,35 +108,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				Page:    0,
 				PerPage: 3,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id4",
-					Name:            "incident 4",
-					IsActive:        false,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       333,
-					EndedAt:         444,
-				},
-				{
-					ID:              "id5",
-					Name:            "incident 5",
-					IsActive:        true,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       223,
-					EndedAt:         550,
-				},
-				{
-					ID:              "id3",
-					Name:            "incident 3",
-					IsActive:        false,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       222,
-					EndedAt:         666,
-				},
-			},
+			want: []incident.Header{id4, id5, id3},
 		},
 		{
 			name: "no options, page 1 by 2",
@@ -264,26 +116,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				Page:    1,
 				PerPage: 2,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id3",
-					Name:            "incident 3",
-					IsActive:        false,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       222,
-					EndedAt:         666,
-				},
-				{
-					ID:              "id2",
-					Name:            "incident 2",
-					IsActive:        true,
-					CommanderUserID: "commander2",
-					TeamID:          "team1",
-					CreatedAt:       145,
-					EndedAt:         555,
-				},
-			},
+			want: []incident.Header{id3, id2},
 		},
 		{
 			name: "no options, page 1 by 3",
@@ -291,26 +124,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				Page:    1,
 				PerPage: 3,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id2",
-					Name:            "incident 2",
-					IsActive:        true,
-					CommanderUserID: "commander2",
-					TeamID:          "team1",
-					CreatedAt:       145,
-					EndedAt:         555,
-				},
-				{
-					ID:              "id1",
-					Name:            "incident 1",
-					IsActive:        true,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       123,
-					EndedAt:         440,
-				},
-			},
+			want: []incident.Header{id2, id1},
 		},
 		{
 			name: "no options, page 1 by 5",
@@ -328,26 +142,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				Page:    1,
 				PerPage: 2,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id5",
-					Name:            "incident 5",
-					IsActive:        true,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       223,
-					EndedAt:         550,
-				},
-				{
-					ID:              "id2",
-					Name:            "incident 2",
-					IsActive:        true,
-					CommanderUserID: "commander2",
-					TeamID:          "team1",
-					CreatedAt:       145,
-					EndedAt:         555,
-				},
-			},
+			want: []incident.Header{id5, id2},
 		},
 		{
 			name: "only active, page 1 of 2",
@@ -356,17 +151,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				PerPage: 2,
 				Active:  true,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id1",
-					Name:            "incident 1",
-					IsActive:        true,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       123,
-					EndedAt:         440,
-				},
-			},
+			want: []incident.Header{id1},
 		},
 		{
 			name: "active, commander3, asc",
@@ -375,17 +160,7 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				CommanderID: "commander3",
 				OrderBy:     incident.Asc,
 			},
-			want: []incident.Header{
-				{
-					ID:              "id5",
-					Name:            "incident 5",
-					IsActive:        true,
-					CommanderUserID: "commander3",
-					TeamID:          "team2",
-					CreatedAt:       223,
-					EndedAt:         550,
-				},
-			},
+			want: []incident.Header{id5},
 		},
 		{
 			name: "commander1, asc, by ended_at",
@@ -394,26 +169,37 @@ func Test_incidentStore_GetHeaders(t *testing.T) {
 				OrderBy:     incident.Asc,
 				Sort:        "ended_at",
 			},
-			want: []incident.Header{
-				{
-					ID:              "id1",
-					Name:            "incident 1",
-					IsActive:        true,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       123,
-					EndedAt:         440,
-				},
-				{
-					ID:              "id3",
-					Name:            "incident 3",
-					IsActive:        false,
-					CommanderUserID: "commander1",
-					TeamID:          "team1",
-					CreatedAt:       222,
-					EndedAt:         666,
-				},
+			want: []incident.Header{id1, id3},
+		},
+		{
+			name: "search for horse",
+			options: incident.HeaderFilterOptions{
+				Search: "horse",
 			},
+			want: []incident.Header{id2, id3},
+		},
+		{
+			name: "search for aliens & commander3",
+			options: incident.HeaderFilterOptions{
+				CommanderID: "commander3",
+				Search:      "aliens",
+			},
+			want: []incident.Header{id4},
+		},
+		{
+			name: "fuzzy search using starting characters",
+			options: incident.HeaderFilterOptions{
+				Search: "sbsm",
+			},
+			want: []incident.Header{id2, id3},
+		},
+		{
+			name: "fuzzy search using starting characters, active",
+			options: incident.HeaderFilterOptions{
+				Search: "sbsm",
+				Active: true,
+			},
+			want: []incident.Header{id2},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### Summary
- Based on #80 
- Fuzzy search works as you would expect (can search by initials of words, stuff like that) -- pretty slick.
- Other options are respected, up until Sort and OrderBy -- those can't work with the search results, since the search results are ordered by relevance. 
- Simplified the testing a bit, much easier to write new cases now.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24557