### PR TITLE
MM-24748 - Guard for null checklists

### DIFF
--- a/webapp/src/components/rhs/incident_details/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details/incident_details.tsx
@@ -96,7 +96,7 @@ export default class IncidentDetails extends React.PureComponent<Props> {
                             />
                         </div>
 
-                        {this.props.incident.playbook.checklists.map((checklist: Checklist, index: number) => (
+                        {this.props.incident.playbook.checklists?.map((checklist: Checklist, index: number) => (
                             <ChecklistDetails
                                 checklist={checklist}
                                 enableEdit={this.props.involvedInIncident && this.props.viewingIncidentChannel}


### PR DESCRIPTION
#### Summary
Guarded for null checklists to avoid crashing the webapp in the case an incident has no checklits. This is a rare scenario moving forward but may have been caused by an upgrade with old data.

#### Ticket Link
[MM-24748](https://mattermost.atlassian.net/browse/MM-24748)