### PR TITLE
MM-24480 Check for id on post endpoints.

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -70,12 +70,16 @@ func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}) {
 // HandleErrorWithCode writes code, errTitle and err as json into the response.
 func HandleErrorWithCode(w http.ResponseWriter, code int, errTitle string, err error) {
 	w.WriteHeader(code)
+	details := ""
+	if err != nil {
+		details = err.Error()
+	}
 	b, _ := json.Marshal(struct {
 		Error   string `json:"error"`
 		Details string `json:"details"`
 	}{
 		Error:   errTitle,
-		Details: err.Error(),
+		Details: details,
 	})
 	logrus.Warn(string(b))
 	_, _ = w.Write(b)

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -36,7 +36,6 @@ func NewIncidentHandler(router *mux.Router, incidentService incident.Service, pl
 	}
 
 	incidentsRouter := router.PathPrefix("/incidents").Subrouter()
-	incidentsRouter.HandleFunc("", handler.createIncident).Methods(http.MethodPost)
 	incidentsRouter.HandleFunc("", handler.getIncidents).Methods(http.MethodGet)
 	incidentsRouter.HandleFunc("/create-dialog", handler.createIncidentFromDialog).Methods(http.MethodPost)
 	incidentsRouter.HandleFunc("/end-dialog", handler.endIncidentFromDialog).Methods(http.MethodPost)
@@ -82,16 +81,6 @@ func (h *IncidentHandler) permissionsToIncidentChannelRequired(next http.Handler
 
 		next.ServeHTTP(w, r)
 	})
-}
-
-func (h *IncidentHandler) createIncident(w http.ResponseWriter, r *http.Request) {
-	_, err := h.incidentService.CreateIncident(nil)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
 }
 
 // createIncidentFromDialog handles the interactive dialog submission when a user presses confirm on

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -46,6 +46,11 @@ func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if playbook.ID != "" {
+		HandleErrorWithCode(w, http.StatusBadRequest, "Playbook given already has ID", nil)
+		return
+	}
+
 	if !h.pluginAPI.User.HasPermissionToTeam(userID, playbook.TeamID, model.PERMISSION_VIEW_TEAM) {
 		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", fmt.Errorf("userID %s does not have permission to create playbook on teamID %s", userID, playbook.TeamID))
 		return


### PR DESCRIPTION
#### Summary
- Makes sure a playbook does not already have an ID when being created
- Removes unused create incident route. (to be restored later when we flesh out a full API or need it)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24480
