### PR TITLE
MM-24900 - Removing the X from RHS header

### DIFF
--- a/webapp/src/components/rhs/incident_details/index.ts
+++ b/webapp/src/components/rhs/incident_details/index.ts
@@ -14,7 +14,6 @@ import {getTeam, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 
-import {toggleRHS} from 'src/selectors';
 import {Incident} from 'src/types/incident';
 import {
     endIncident,
@@ -23,6 +22,7 @@ import {
     removeChecklistItem,
     renameChecklistItem,
     reorderChecklist,
+    toggleRHS,
 } from 'src/actions';
 
 import IncidentDetails from './incident_details';

--- a/webapp/src/components/rhs_header/index.ts
+++ b/webapp/src/components/rhs_header/index.ts
@@ -10,7 +10,6 @@ import {
     startIncident,
     setRHSState,
     setRHSOpen,
-    toggleRHS,
     openBackstageModal,
 } from 'src/actions';
 
@@ -32,7 +31,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
             startIncident,
             setRHSState,
             setRHSOpen,
-            toggleRHS,
             openBackstageModal,
         }, dispatch),
     };

--- a/webapp/src/components/rhs_header/rhs_header.tsx
+++ b/webapp/src/components/rhs_header/rhs_header.tsx
@@ -18,7 +18,6 @@ interface Props {
         startIncident: () => void;
         setRHSState: (state: RHSState) => void;
         setRHSOpen: (open: boolean) => void;
-        toggleRHS: () => void;
         openBackstageModal: (selectedArea: BackstageArea) => void;
     };
 }
@@ -28,10 +27,6 @@ const OVERLAY_DELAY = 400;
 export default function RHSHeader(props: Props) {
     const goBack = () => {
         props.actions.setRHSState(RHSState.List);
-    };
-
-    const closeRHS = () => {
-        props.actions.toggleRHS();
     };
 
     const headerButtons = (
@@ -62,14 +57,6 @@ export default function RHSHeader(props: Props) {
                     />
                 </button>
             </OverlayTrigger>
-            <button
-                className='navigation-bar__button ml-1'
-                onClick={closeRHS}
-            >
-                <i
-                    className='icon icon-close'
-                />
-            </button>
         </div>
     );
 


### PR DESCRIPTION
#### Summary
- Remove the `X` in the RHS header given that we deviated of the approach of replacing the webapp RHS header for now.
- Fixed `toggleRHS` reference issue that was causing an error when redirecting to DM the commander in mobile view.

#### Ticket Link
[MM-24900](https://mattermost.atlassian.net/browse/MM-24900)
