### PR TITLE
MM-24904 - Playbook with empty name is created

### DIFF
--- a/webapp/src/components/playbook/playbook_edit.tsx
+++ b/webapp/src/components/playbook/playbook_edit.tsx
@@ -139,7 +139,7 @@ export default class PlaybookEdit extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element {
         const title = this.state.newPlaybook ? 'New Playbook' : 'Edit Playbook';
-        const saveDisabled = this.state.title === '' || !this.state.changesMade;
+        const saveDisabled = this.state.title.trim() === '' || !this.state.changesMade;
 
         return (
             <div className='Playbook'>


### PR DESCRIPTION
#### Summary
- on new playbook, disable save when title is empty

#### Ticket Link
- fixes: https://mattermost.atlassian.net/browse/MM-24904
- fixes: https://mattermost.atlassian.net/browse/MM-24907