### PR TITLE
MM-24722 - Fixes Can create checklist item with empty name

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -353,6 +354,13 @@ func (h *IncidentHandler) addChecklistItem(w http.ResponseWriter, r *http.Reques
 	var checklistItem playbook.ChecklistItem
 	if err := json.NewDecoder(r.Body).Decode(&checklistItem); err != nil {
 		HandleError(w, err)
+		return
+	}
+
+	checklistItem.Title = strings.TrimSpace(checklistItem.Title)
+	if checklistItem.Title == "" {
+		HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter: checklist item title",
+			errors.New("checklist item title must not be blank"))
 		return
 	}
 

--- a/webapp/src/components/checklist/checklist.tsx
+++ b/webapp/src/components/checklist/checklist.tsx
@@ -168,14 +168,13 @@ export const ChecklistDetails = ({checklist, enableEdit, onChange, addItem, remo
                 <form
                     onSubmit={(e) => {
                         e.preventDefault();
-                        if (newValue === '') {
+                        if (newValue.trim() === '') {
                             setInputExpanded(false);
                             return;
                         }
                         addItem({
                             title: newValue,
                             checked: false,
-                            checked_modified: '',
                         });
                         setNewValue('');
                         setInputExpanded(false);

--- a/webapp/src/components/checklist/checklist_item.tsx
+++ b/webapp/src/components/checklist/checklist_item.tsx
@@ -55,8 +55,13 @@ export const ChecklistItemDetailsEdit = ({checklistItem, onEdit, onRemove}: Chec
     const [title, setTitle] = useState(checklistItem.title);
 
     const submit = () => {
-        if (title !== checklistItem.title && title !== '') {
-            onEdit(title);
+        const trimmedTitle = title.trim();
+        if (trimmedTitle === '') {
+            setTitle(checklistItem.title);
+            return;
+        }
+        if (trimmedTitle !== checklistItem.title) {
+            onEdit(trimmedTitle);
         }
     };
 
@@ -70,7 +75,7 @@ export const ChecklistItemDetailsEdit = ({checklistItem, onEdit, onRemove}: Chec
             <input
                 className='form-control'
                 type='text'
-                defaultValue={title}
+                value={title}
                 onBlur={submit}
                 onKeyPress={(e) => {
                     if (e.key === 'Enter') {


### PR DESCRIPTION
#### Summary
Need some feedback on this. There are two states we're adjusting here:
1. For new checklist items: if you press enter with no text, don't save the new item (same as cancel)
2. For existing checklist items: if the input box blurs with no text, don't save the blank text.

The UX might be a little weird for 2, because you can blur with new text, then remove all text and click done, and the title will revert to the last blur (not the original when you clicked `edit`). It's because we make a server call to rename the checklist item immediately everytime the input box blurs.

But I'm not sure if the UX is bad enough to warrant a rearchitect to fix it. The rearchitect would be: wait until the user clicks `done` to make the server call to update the entire list. That might break things, @crspeller?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24722