### PR TITLE
MM-24743: fix RHS rendering on Safari

### DIFF
--- a/webapp/src/components/rhs/incident_details/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details/incident_details.tsx
@@ -84,6 +84,7 @@ export default class IncidentDetails extends React.PureComponent<Props> {
                     renderThumbHorizontal={renderThumbHorizontal}
                     renderThumbVertical={renderThumbVertical}
                     renderView={renderView}
+                    style={{position: 'absolute'}}
                 >
                     <div className='IncidentDetails'>
                         <div className='inner-container'>

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -88,6 +88,7 @@ export default class RightHandSidebar extends React.PureComponent<Props> {
                                 renderThumbHorizontal={renderThumbHorizontal}
                                 renderThumbVertical={renderThumbVertical}
                                 renderView={renderView}
+                                style={{position: 'absolute'}}
                             >
                                 <IncidentList
                                     incidents={this.props.incidents}


### PR DESCRIPTION
#### Summary
Copy the webapp's inline style declaration of `position: absolute` to make the RHS's use of the `Scrollbar` component compatible with Safari.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-24743