### PR TITLE
MM-24735 - Backstage sidebar themeing

### DIFF
--- a/webapp/src/components/backstage/backstage.scss
+++ b/webapp/src/components/backstage/backstage.scss
@@ -27,7 +27,7 @@
                 height: 48px;
                 padding-left: 32px;
                 line-height: 48px;
-                opacity: 0.6;
+                opacity: 0.56;
 
                 &:hover {
                     opacity: 1;


### PR DESCRIPTION
#### Summary
- @marianunez I searched all uses of `background` and I think the backstage is only set in this one file, but I wanted to check with you just in case I missed one.
- Looping in @asaadmahmood for visibility -- if you want to review, please do.

Looks like:
![image](https://user-images.githubusercontent.com/1490756/81418622-f2fc0000-911a-11ea-93f4-4eea8abd9755.png)

![image](https://user-images.githubusercontent.com/1490756/81418643-fabba480-911a-11ea-89a3-9610c964e7ce.png)

Hovering on Incidents menu item:
![image](https://user-images.githubusercontent.com/1490756/81418662-05763980-911b-11ea-816a-4869f61d04f1.png)


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24735