### PR TITLE
MM-25024: pass team id when querying incidents

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -15,14 +15,20 @@ import './backstage.scss';
 interface Props {
     onBack: () => void;
     selectedArea: BackstageArea;
+    currentTeamId: string;
     currentTeamName: string;
     setSelectedArea: (area: BackstageArea) => void;
 }
 
-const Backstage = ({onBack, selectedArea, setSelectedArea, currentTeamName}: Props): React.ReactElement => {
+const Backstage = ({onBack, selectedArea, setSelectedArea, currentTeamId, currentTeamName}: Props): React.ReactElement => {
     let activeArea = <PlaybookList/>;
     if (selectedArea === BackstageArea.Incidents) {
-        activeArea = <IncidentList currentTeamName={currentTeamName}/>;
+        activeArea = (
+            <IncidentList
+                currentTeamId={currentTeamId}
+                currentTeamName={currentTeamName}
+            />
+        );
     }
 
     return (

--- a/webapp/src/components/backstage/backstage_modal/backstage_modal.tsx
+++ b/webapp/src/components/backstage/backstage_modal/backstage_modal.tsx
@@ -14,12 +14,13 @@ const ANIMATION_DURATION = 100;
 interface Props {
     show: boolean;
     selectedArea: BackstageArea;
+    currentTeamId: string;
     currentTeamName: string;
     close: () => void;
     setSelectedArea: (selectedArea: BackstageArea) => void;
 }
 
-const BackstageModal = ({show, selectedArea, currentTeamName, close, setSelectedArea}: Props) => {
+const BackstageModal = ({show, selectedArea, currentTeamId, currentTeamName, close, setSelectedArea}: Props) => {
     return (
         <CSSTransition
             in={show}
@@ -33,6 +34,7 @@ const BackstageModal = ({show, selectedArea, currentTeamName, close, setSelected
                 <Backstage
                     onBack={close}
                     selectedArea={selectedArea}
+                    currentTeamId={currentTeamId}
                     currentTeamName={currentTeamName}
                     setSelectedArea={setSelectedArea}
                 />

--- a/webapp/src/components/backstage/backstage_modal/index.tsx
+++ b/webapp/src/components/backstage/backstage_modal/index.tsx
@@ -16,6 +16,7 @@ const mapStateToProps = (state: object): object => {
     return {
         show: backstageModal(state).open,
         selectedArea: backstageModal(state).selectedArea,
+        currentTeamId: currentTeam.id,
         currentTeamName: currentTeam.display_name,
     };
 };

--- a/webapp/src/components/backstage/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incident_list/incident_list.tsx
@@ -14,6 +14,7 @@ import Profile from 'src/components/profile';
 import './incident_list.scss';
 
 interface Props {
+    currentTeamId: string;
     currentTeamName: string;
 }
 
@@ -22,7 +23,7 @@ export default function IncidentList(props: Props) {
 
     useEffect(() => {
         async function fetchAllIncidents() {
-            const data = await fetchIncidents();
+            const data = await fetchIncidents(props.currentTeamId);
             setIncidents(data);
         }
 


### PR DESCRIPTION
#### Summary
The incidents list in the backstage was missing a `teamId` parameter when querying the server, resulting in the admin seeing incidents across all teams, but non-admins seeing nothing.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-25024