### PR TITLE
MM-25391, MM-25392 - Change incident name to link

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -148,9 +148,9 @@ export function BackstageIncidentList(props: Props) {
                                     key={incident.id}
                                     onClick={() => openIncidentDetails(incident)}
                                 >
-                                    <div className='col-sm-3 incident-item__title'>
+                                    <a className='col-sm-3 incident-item__title'>
                                         {incident.name}
-                                    </div>
+                                    </a>
                                     <div className='col-sm-2'> {
                                         <StatusBadge isActive={incident.is_active}/>
                                     }


### PR DESCRIPTION
#### Summary
- This fixes a couple bugs at once: 
  - the incident name looks like a link (MM-25391)
  - long incident names with no spaces will wrap (MM-25392)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25391
- https://mattermost.atlassian.net/browse/MM-25392