### PR TITLE
MM-25306 - Commander dropdown is greyed out in RHS

### DIFF
--- a/webapp/src/components/profile/profile_selector/profile_button/profile_button.scss
+++ b/webapp/src/components/profile/profile_selector/profile_button/profile_button.scss
@@ -16,13 +16,16 @@
         color: var(--center-channel-color-72);
     }
 
-    &:active {
-        background: var(--button-bg-08);
-        color: var(--button-bg);
-    }
+    .IncidentProfile {
+        &:active {
+            background: var(--button-bg-08);
+            color: var(--button-bg);
+        }
 
-    &.active {
-        cursor: pointer;
+        &.active {
+            cursor: pointer;
+            color: var(--center-channel-color);
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
- Commander dropdown is center-channel color when it is available to be used.

- when not in the incident channel:
![image](https://user-images.githubusercontent.com/1490756/82571487-06628e80-9b51-11ea-98e3-ee196b140c00.png)
- when in the channel:
![image](https://user-images.githubusercontent.com/1490756/82571606-2f831f00-9b51-11ea-83f2-00d61233e4fe.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25306