### PR TITLE
MM-25326 - Leaving channel crashes webapp

### DIFF
--- a/webapp/src/components/rhs/incident_details/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details/incident_details.tsx
@@ -74,6 +74,7 @@ export default class RHSIncidentDetails extends React.PureComponent<Props> {
 
     public render(): JSX.Element {
         const incidentChannel = this.props.channelDetails?.length > 0 ? this.props.channelDetails[0] : null;
+        const mainChannelLink = incidentChannel ? `/${incidentChannel.team_name}/channels/${incidentChannel.name}` : '';
 
         const fetchUsers = async () => {
             return incidentChannel ? fetchUsersInChannel(this.props.channelDetails[0].id) : [];
@@ -168,7 +169,7 @@ export default class RHSIncidentDetails extends React.PureComponent<Props> {
                                 <div className='help-text'>
                                     {'Go to '}
                                     <Link
-                                        to={`/${this.props.channelDetails[0].team_name}/channels/${this.props.channelDetails[0].name}`}
+                                        to={mainChannelLink}
                                         text={'the incident channel'}
                                     />
                                     {' to make changes.'}


### PR DESCRIPTION
#### Summary
- @lieut-data can you check if this solves the crashes you were seeing? I couldn't reproduce the exact error you saw, but I did reproduce the crash, and this solves it.
  - Incidentally, for me it only crashes for the admin -- not for a regular user leaving an incident channel with the channel details open in the RHS. So maybe I'm seeing a different bug than you?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25326