### PR TITLE
MM-25176 - Creating an incident with invalid channel name still creates incident

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -130,8 +130,8 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 	if err != nil {
 		var msg string
 
-		if errors.Is(err, incident.ErrChannelDisplayNameLong) {
-			msg = "The channel name is too long. Please use a name with fewer than 64 characters."
+		if errors.Is(err, incident.ErrChannelDisplayNameInvalid) {
+			msg = "The channel name is invalid or too long. Please use a valid name with fewer than 64 characters."
 		}
 
 		if msg != "" {

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -41,8 +41,8 @@ type DialogState struct {
 // ErrNotFound used to indicate entity not found.
 var ErrNotFound = errors.New("not found")
 
-// ErrChannelDisplayNameLong is used to indicate a channel name is too long.
-var ErrChannelDisplayNameLong = errors.New("channel name is too long")
+// ErrChannelDisplayNameInvalid is used to indicate a channel name is too long.
+var ErrChannelDisplayNameInvalid = errors.New("channel name is invalid or too long")
 
 // ErrIncidentNotActive is used to indicate trying to run a command on an incident that has ended.
 var ErrIncidentNotActive = errors.New("incident not active")

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -58,12 +58,7 @@ func (s *ServiceImpl) GetIncidents(options HeaderFilterOptions) ([]Incident, err
 
 // CreateIncident creates a new incident.
 func (s *ServiceImpl) CreateIncident(incdnt *Incident) (*Incident, error) {
-	// Create incident
-	incdnt, err := s.store.CreateIncident(incdnt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create incident: %w", err)
-	}
-
+	// Try to create the channel first
 	channel, err := s.createIncidentChannel(incdnt)
 	if err != nil {
 		return nil, err
@@ -87,8 +82,9 @@ func (s *ServiceImpl) CreateIncident(incdnt *Incident) (*Incident, error) {
 		}
 	}
 
-	if err = s.store.UpdateIncident(incdnt); err != nil {
-		return nil, fmt.Errorf("failed to update incident: %w", err)
+	incdnt, err = s.store.CreateIncident(incdnt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create incident: %w", err)
 	}
 
 	s.poster.PublishWebsocketEventToTeam(incidentUpdatedWSEvent, incdnt, incdnt.TeamID)
@@ -510,7 +506,7 @@ func (s *ServiceImpl) createIncidentChannel(incdnt *Incident) (*model.Channel, e
 			// Let the user correct display name errors:
 			if appErr.Id == "model.channel.is_valid.display_name.app_error" ||
 				appErr.Id == "model.channel.is_valid.2_or_more.app_error" {
-				return nil, ErrChannelDisplayNameLong
+				return nil, ErrChannelDisplayNameInvalid
 			}
 
 			// We can fix channel Name errors:

--- a/server/incident/service_test.go
+++ b/server/incident/service_test.go
@@ -41,7 +41,7 @@ func TestCreateIncident(t *testing.T) {
 		s := incident.NewService(client, store, poster, configService, telemetry)
 
 		_, err := s.CreateIncident(incdnt)
-		require.Equal(t, err, incident.ErrChannelDisplayNameLong)
+		require.Equal(t, err, incident.ErrChannelDisplayNameInvalid)
 	})
 
 	t.Run("invalid channel name has only invalid characters", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestCreateIncident(t *testing.T) {
 		s := incident.NewService(client, store, poster, configService, telemetry)
 
 		_, err := s.CreateIncident(incdnt)
-		require.Equal(t, err, incident.ErrChannelDisplayNameLong)
+		require.Equal(t, err, incident.ErrChannelDisplayNameInvalid)
 	})
 
 	t.Run("channel name already exists, fixed on second try", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
- We were creating an incident and then trying to create the channel, so when channel creation failed we had an orphaned incident. 
- This is a bug-fix; I chose to create the incident after the channel is successfully created.
- It is possible (but unlikely) that the incident creation will fail. Should we be handling that? If so, how? What would we do with the new channel? Maybe we need a new ticket if that would require a non-trivial redesign?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25176
