### PR TITLE
MM-25396: look for channel export in redux

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_details/index.tsx
+++ b/webapp/src/components/backstage/incidents/incident_details/index.tsx
@@ -12,8 +12,6 @@ import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 
-import {isExportPluginLoaded} from 'src/utils/utils';
-
 import {Incident} from 'src/types/incident';
 
 import {navigateToUrl} from 'src/actions';
@@ -49,12 +47,14 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
 
     const channelStats = getAllChannelStats(state)[mainChannelId];
 
+    const isExportPluginLoaded = Boolean(state.plugins?.plugins?.['com.mattermost.plugin-channel-export']);
+
     return {
         involvedInIncident,
         totalMessages,
         membersCount: channelStats?.member_count || 1,
         mainChannelDetails,
-        exportAvailable: isExportPluginLoaded(),
+        exportAvailable: isExportPluginLoaded,
         exportLicensed: isExportLicensed(state),
     };
 }

--- a/webapp/src/utils/utils.ts
+++ b/webapp/src/utils/utils.ts
@@ -32,13 +32,6 @@ export const isMobile = () => {
     return window.innerWidth <= MOBILE_SCREEN_WIDTH;
 };
 
-export const isExportPluginLoaded = () => {
-    const exportPluginId = 'com.mattermost.plugin-channel-export';
-
-    // @ts-ignore
-    return Boolean(window.plugins[exportPluginId]);
-};
-
 export const registerCssVars = (theme: any) => {
     cssVars({
         variables: {


### PR DESCRIPTION
#### Summary
Instead of checking `window.plugins`, look for the channel export in the Redux store instead. My original idea of using `window.plugins` was flawed because the webapp doesn't actually /remove/ plugins from that array on disable.

Using Redux wasn't as straightforward as I hoped. As part of https://mattermost.atlassian.net/browse/MM-17087, the `RECEIVED_WEBAPP_PLUGIN` action is no longer emitted when a plugin is enabled, meaning the Redux store wasn't kept up-to-date for /enabling/ a plugin after load. For now, I've fixed this in a linked channel export plugin PR to emit the event manually, but I'll circle back and fix this in the webapp proper.

The net result of this change is that I can install/enable or disable the channel export plugin, and incident details updates in realtime! :tada:

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-25396

See also https://github.com/mattermost/mattermost-plugin-channel-export/pull/9