### PR TITLE
MM-25398 - Pass channel id param to export from incident directly

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
+++ b/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
@@ -126,10 +126,12 @@ export default class BackstageIncidentDetails extends React.PureComponent<Props,
             );
         }
 
+        const mainChannelId = this.props.incident.channel_ids[0];
+
         return (
             <a
                 className={'export-link'}
-                href={exportChannelUrl(this.props.mainChannelDetails?.id)}
+                href={exportChannelUrl(mainChannelId)}
                 target={'_new'}
                 onClick={this.onExportClick}
             >


### PR DESCRIPTION
#### Summary
Fixed the channel id parameter to use the one directly from the incident instead of the channel details one that was relying on redux state. 

This PR fixes the associated ticket especifically for channel export. However, this same issue causes that the message count is not accurate in this case and the link to the incident channel not functional. 

We need to complete [MM-25108](https://mattermost.atlassian.net/browse/MM-25108) to not rely on the local state for the extra channel data.

#### Ticket Link
[MM-25398](https://mattermost.atlassian.net/browse/MM-25398)
