### PR TITLE
MM-25400 - Long incident name pushes components

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_details/incident_details.scss
+++ b/webapp/src/components/backstage/incidents/incident_details/incident_details.scss
@@ -43,6 +43,13 @@ $font-family: Open Sans;
             align-items: center;
             flex: 1 1 auto;
 
+            .title-text {
+                max-width: 17em;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
             .light {
                 padding-left: 1rem;
             }

--- a/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
+++ b/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
@@ -148,7 +148,7 @@ export default class BackstageIncidentDetails extends React.PureComponent<Props,
                         className='Backstage__header__back'
                         onClick={this.props.onClose}
                     />
-                    <span className='mr-1'>{`Incident ${this.props.incident.name}`}</span>
+                    <span className='title-text mr-1'>{`Incident ${this.props.incident.name}`}</span>
 
                     { this.props.involvedInIncident &&
                     <OverlayTrigger


### PR DESCRIPTION
#### Summary
- This solutions maintains Maria and Asaad's original design, and caps the width of the title to 16em. 
- 16em is arbitrary, @asaadmahmood need design input on if this is the desired width -- please play around with the wrapping and see if it's what you want. 
- Here's what a long title looks like:
![image](https://user-images.githubusercontent.com/1490756/82842472-a3059300-9ea7-11ea-93e3-cca3ddb22263.png)
- Here's the same viewport width with a short title:
![image](https://user-images.githubusercontent.com/1490756/82842485-b7499000-9ea7-11ea-8a52-0beec63d5042.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25400