### PR TITLE
MM-25565 - State lost from incident details view to incident list

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -111,6 +111,7 @@ export function BackstageIncidentList(props: Props) {
                     <div className='list'>
                         <div className='IncidentList__filters'>
                             <SearchInput
+                                default={fetchParams.search_term}
                                 onSearch={debounce(setSearchTerm, debounceDelay)}
                             />
                             <ProfileSelector
@@ -122,7 +123,10 @@ export function BackstageIncidentList(props: Props) {
                                 getUsers={fetchCommanders}
                                 onSelectedChange={setCommanderId}
                             />
-                            <StatusFilter onChange={setStatus}/>
+                            <StatusFilter
+                                default={fetchParams.status}
+                                onChange={setStatus}
+                            />
                         </div>
                         <div className='Backstage-list-header'>
                             <div className='row'>

--- a/webapp/src/components/backstage/incidents/incident_list/search_input.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/search_input.tsx
@@ -1,18 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useState} from 'react';
 
 import './seach_input.scss';
 
 interface Props {
+    default: string | undefined;
     onSearch: (term: string) => void;
 }
 
 export default function SearchInput(props: Props) {
     const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setTerm(event.target.value);
         props.onSearch(event.target.value);
     };
+
+    const [term, setTerm] = useState(props.default ? props.default : '');
 
     return (
         <div className='IncidentList-search'>
@@ -20,6 +24,7 @@ export default function SearchInput(props: Props) {
                 type='text'
                 placeholder='Search by Incident name'
                 onChange={onChange}
+                value={term}
             />
         </div>
     );

--- a/webapp/src/components/backstage/incidents/incident_list/status_filter.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/status_filter.tsx
@@ -8,6 +8,7 @@ import ReactSelect from 'react-select';
 import './status_filter.scss';
 
 interface Props {
+    default: string | undefined;
     onChange: (newStatus: string) => void;
 }
 
@@ -28,7 +29,15 @@ export function StatusFilter(props: Props) {
         setOpen(!isOpen);
     };
 
-    const [selected, setSelected] = useState<Option>(fixedOptions[2]);
+    const getDefault = () => {
+        const defaultOption = fixedOptions.find((val) => val.value === props.default);
+        if (defaultOption) {
+            return defaultOption;
+        }
+        return fixedOptions[2];
+    };
+
+    const [selected, setSelected] = useState(getDefault());
 
     const onSelectedChange = async (val: Option) => {
         toggleOpen();
@@ -101,8 +110,15 @@ const Dropdown = ({children, isOpen, target, onClose}: DropdownProps) => (
         css={{position: 'relative'}}
     >
         {target}
-        {isOpen ? <Menu className='IncidentFilter-select status-filter-select__container'>{children}</Menu> : null}
-        {isOpen ? <Blanket onClick={onClose}/> : null}
+        {
+            isOpen &&
+            <>
+                <Menu className='IncidentFilter-select status-filter-select__container'>
+                    {children}
+                </Menu>
+                <Blanket onClick={onClose}/>
+            </>
+        }
     </div>
 );
 

--- a/webapp/src/components/profile/profile_selector/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector/profile_selector.tsx
@@ -42,8 +42,8 @@ export default function ProfileSelector(props: Props) {
         setOpen(!isOpen);
     };
 
-    // Allow the parent component to control the open state.
-    const [oldOpenToggle, setOldOpenToggle] = useState(false);
+    // Allow the parent component to control the open state -- only after mounting.
+    const [oldOpenToggle, setOldOpenToggle] = useState(props.controlledOpenToggle);
     useEffect(() => {
         // eslint-disable-next-line no-undefined
         if (props.controlledOpenToggle !== undefined && props.controlledOpenToggle !== oldOpenToggle) {


### PR DESCRIPTION
#### Summary
- I noticed a couple of bugs when going from list to details and back to list:
  - The search term would disappear, but the search term was still set
  - The status selection would disappear, but the status was still set
  - After clicking reset `Reset to all commanders` in the commander profile selector, and going to the incident details and returning, the commander profile selector would begin open and focused.
- These changes fix those issues.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25565
