### PR TITLE
MM-25402 - Playbook can be created with very long names

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useState, useCallback} from 'react';
+import React, {useEffect, useState} from 'react';
 import moment from 'moment';
 import {debounce} from 'debounce';
 import {components, ControlProps} from 'react-select';
-import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
+import TextWithTooltip from 'src/components/widgets/text_with_tooltip';
 import {StatusFilter} from 'src/components/backstage/incidents/incident_list/status_filter';
 import SearchInput from 'src/components/backstage/incidents/incident_list/search_input';
 import ProfileSelector from 'src/components/profile/profile_selector/profile_selector';
@@ -25,7 +25,6 @@ import BackstageIncidentDetails from '../incident_details';
 import StatusBadge from '../status_badge';
 
 import './incident_list.scss';
-import {OVERLAY_DELAY} from 'src/utils/constants';
 
 const debounceDelay = 300; // in milliseconds
 const PER_PAGE = 15;
@@ -250,32 +249,3 @@ const endedAt = (isActive: boolean, time: number) => {
     return '--';
 };
 
-const TextWithTooltip = (props: {id: string; text: string; className: string}) => {
-    const [ref, setRefState] = useState<HTMLAnchorElement|null>(null);
-    const setRef = useCallback((node) => {
-        setRefState(node);
-    }, []);
-
-    const text = (
-        <a
-            ref={setRef}
-            className={props.className}
-        >
-            {props.text}
-        </a>
-    );
-
-    if (ref && ref.offsetWidth < ref.scrollWidth) {
-        return (
-            <OverlayTrigger
-                placement='top'
-                delayShow={OVERLAY_DELAY}
-                overlay={<Tooltip id={`${props.id}_name`}>{props.text}</Tooltip>}
-            >
-                {text}
-            </OverlayTrigger>
-        );
-    }
-
-    return text;
-};

--- a/webapp/src/components/backstage/playbook/playbook.scss
+++ b/webapp/src/components/backstage/playbook/playbook.scss
@@ -35,12 +35,22 @@ $announcement-bar-height: 32px;
         padding: 2rem 6rem;
 
         .playbook-item {
+            display: flex;
+            padding-top: 15px;
+            padding-bottom: 15px;
+            align-items: center;
             margin: 0;
-            line-height: 4.8rem;
             border-bottom: 1px solid var(--center-channel-color-16);
 
             &:hover {
                 background: var(--center-channel-color-04);
+            }
+
+            .title {
+                font-weight: 600;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                overflow: hidden;
             }
         }
     }

--- a/webapp/src/components/backstage/playbook/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook/playbook_edit.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 
 import {Playbook, Checklist, ChecklistItem} from 'src/types/playbook';
 import {savePlaybook} from 'src/client';
-
 import {ChecklistDetails} from 'src/components/checklist/checklist';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
+import {MAX_NAME_LENGTH} from 'src/utils/constants';
 
 import BackIcon from '../../assets/icons/back_icon';
 
@@ -174,6 +174,7 @@ export default class PlaybookEdit extends React.PureComponent<Props, State> {
                         type='text'
                         placeholder='Playbook Name'
                         value={this.state.title}
+                        maxLength={MAX_NAME_LENGTH}
                         onChange={this.handleTitleChange}
                     />
                     <div className='checklist-container'>

--- a/webapp/src/components/backstage/playbook/playbook_list/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook/playbook_list/playbook_list.tsx
@@ -8,6 +8,7 @@ import {newPlaybook, Playbook} from 'src/types/playbook';
 import {deletePlaybook} from 'src/client';
 
 import PlaybookEdit from '../playbook_edit';
+import TextWithTooltip from 'src/components/widgets/text_with_tooltip';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import '../playbook.scss';
@@ -136,7 +137,11 @@ export default class PlaybookList extends React.PureComponent<Props, State> {
                                             className='row playbook-item'
                                             key={p.id}
                                         >
-                                            <div className='col-sm-10'> {p.title} </div>
+                                            <TextWithTooltip
+                                                id={p.title}
+                                                text={p.title}
+                                                className={'col-sm-10 title'}
+                                            />
                                             <div className='col-sm-2'>
                                                 <a onClick={() => this.editPlaybook(p)} >
                                                     {'Edit'}

--- a/webapp/src/components/widgets/text_with_tooltip.tsx
+++ b/webapp/src/components/widgets/text_with_tooltip.tsx
@@ -1,0 +1,67 @@
+import React, {useState, useCallback, useRef, useEffect} from 'react';
+import {Tooltip, OverlayTrigger} from 'react-bootstrap';
+import {debounce} from 'debounce';
+
+import {OVERLAY_DELAY} from 'src/utils/constants';
+
+interface Props {
+    id: string;
+    text: string;
+    className?: string;
+}
+
+const TextWithTooltip = (props: Props) => {
+    const ref = useRef<HTMLAnchorElement|null>(null);
+    const [showTooltip, setShowTooltip] = useState(false);
+
+    const resizeListener = useCallback(debounce(() => {
+        if (ref?.current && ref?.current?.offsetWidth < ref?.current?.scrollWidth) {
+            setShowTooltip(true);
+        } else {
+            setShowTooltip(false);
+        }
+    }, 300), []);
+
+    useEffect(() => {
+        window.addEventListener('resize', resizeListener);
+
+        // clean up function
+        return () => {
+            window.removeEventListener('resize', resizeListener);
+        };
+    }, []);
+
+    useEffect(() => {
+        resizeListener();
+    });
+
+    const setRef = useCallback((node) => {
+        ref.current = node;
+        resizeListener();
+    }, []);
+
+    const text = (
+        <a
+            ref={setRef}
+            className={props.className}
+        >
+            {props.text}
+        </a>
+    );
+
+    if (showTooltip) {
+        return (
+            <OverlayTrigger
+                placement='top'
+                delayShow={OVERLAY_DELAY}
+                overlay={<Tooltip id={`${props.id}_name`}>{props.text}</Tooltip>}
+            >
+                {text}
+            </OverlayTrigger>
+        );
+    }
+
+    return text;
+};
+
+export default TextWithTooltip;

--- a/webapp/src/utils/constants.ts
+++ b/webapp/src/utils/constants.ts
@@ -2,3 +2,5 @@
 // See LICENSE.txt for license information.
 
 export const OVERLAY_DELAY = 400;
+
+export const MAX_NAME_LENGTH = 64;


### PR DESCRIPTION
#### Summary
* Added `MAX_NAME_LENGTH=64` const
* Restricting playbook names to be max 64 characters (consistent with incidents names)
* Ellipsized playbook titles will show tooltip
* Fixed `TextWithTooltip` to monitor size changes internally rather than relying on external updates.
* Fixed playbook title styling (made it consistent with incident title)

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-25402

#### Screenshots
![2020-06-03 at 3 20 PM](https://user-images.githubusercontent.com/25732808/83679723-ddf57e00-a5ad-11ea-9365-5ae2697bd943.gif)


