### PR TITLE
Fixing flaky and failing tests

### DIFF
--- a/tests-e2e/cypress/integration/backstage_spec.js
+++ b/tests-e2e/cypress/integration/backstage_spec.js
@@ -13,16 +13,15 @@
 import users from '../fixtures/users.json';
 
 describe('Backstage', () => {
-	before(() => {
+	beforeEach(() => {
 		// # Login as non-admin user
 		cy.apiLogin('user-1');
 		cy.visit('/');
+		cy.openIncidentBackstage();
 	});
 
 	it('Opens incident backstage by default with "Incidents & Playbooks" button in main menu', () => {
-		cy.openIncidentBackstage();
-
-		// * Verify that the heading is visible and contains "Incident"
+		// * Verify that when backstage loads, the heading is visible and contains "Incident"
 		cy.findByTestId('titleIncident').should('be.visible').contains('Incidents');
 	});
 

--- a/tests-e2e/cypress/integration/incident_dialog_spec.js
+++ b/tests-e2e/cypress/integration/incident_dialog_spec.js
@@ -14,7 +14,8 @@ import * as TIMEOUTS from '../fixtures/timeouts';
 
 function openIncidentDialog() {
 	const incidentStartCommand = '/incident start';
-	cy.findByTestId('post_textbox').clear().type(incidentStartCommand + '{enter}');
+	cy.findByTestId('post_textbox').clear().type(incidentStartCommand).type('{enter}');
+	cy.wait(TIMEOUTS.MEDIUM);
 }
 
 function closeIncidentDialog() {
@@ -42,7 +43,7 @@ describe('Incident Creation Modal', () => {
 		cy.get('#interactiveDialogModalIntroductionText').contains('Commander');
 	});
 
-	it ('Contains channel name', () => {
+	it('Contains channel name', () => {
 		// * Verify channel name is there
 		cy.findByTestId('incidentName').should('be.visible');
 		cy.findByText("Channel Name");

--- a/tests-e2e/cypress/integration/incident_icon_spec.js
+++ b/tests-e2e/cypress/integration/incident_icon_spec.js
@@ -11,7 +11,6 @@
  */
  
 import users from '../fixtures/users.json';
-import * as TIMEOUTS from '../fixtures/timeouts';
 
 describe('Incident Icon', () => {
 	beforeEach(() => {
@@ -26,7 +25,7 @@ describe('Incident Icon', () => {
 			cy.get('#incidentIcon').should('be.visible').click();
 		});
 		cy.get('#rhsContainer').should('be.visible').within(() => {
-			cy.findByText('Incident List').should('be.visible');
+			cy.findByText('Incident').should('be.visible');
 		});
 		/**
 		* TODO:

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import * as TIMEOUTS from '../fixtures/timeouts';
+
 const incidentStartCommand = "/incident start";
 
 // function startIncident(incidentID) {
@@ -15,7 +17,8 @@ Cypress.Commands.add('startIncident', (incidentID) => {
 // Starts incident with the `/incident start` slash command
 // function startIncidentWithSlashCommand(incidentID) {
 Cypress.Commands.add('startIncidentWithSlashCommand', (incidentID) => {
-	cy.findByTestId('post_textbox').clear().type(incidentStartCommand + '{enter}');
+	cy.findByTestId('post_textbox').clear().type(incidentStartCommand).type('{enter}');
+	cy.wait(TIMEOUTS.MEDIUM);
 	cy.startIncident(incidentID);
 });
 
@@ -29,8 +32,9 @@ Cypress.Commands.add('startIncidentFromRHS', (incidentID) => {
 		cy.get('#incidentIcon').click();
 	});
 	cy.get('#rhsContainer').should('be.visible').within(() => {
-		cy.findByText('Incident List').should('be.visible');
-		cy.get('#incidentRHSIconPlus').click();
+		// cy.findByText('Incident List').should('be.visible');
+		// cy.get('#incidentRHSIconPlus').click();
+		cy.findByText('+ Create new incident').click();
 	});
 	cy.startIncident(incidentID);
 });


### PR DESCRIPTION
There were some tests failing with the latest plugin version because of the unavailability of incident list on the RHS. Some tests were failing because the `/incident start` command was failing to get issued. The changes in this PR includes:
- Fixing the first issue by replacing the check for incident list on the RHS with check for the `Incident` text on the RHS header.
- Fixing the flaky tests in backstage by using `beforeEach` instead of `before` so that the failure due to logout/login between tests is eliminated.
- Fixing the flaky tests while issuing the `/incident start` command by explicitly adding the enter press.
- Fixing the failure to launch the incident creation modal by adding a tiny wait between issuing of the command and modal pop-up.
- Replacing the check for incident creation + icon in the RHS with the check for `+ Create new incident` button.

Including the screenshots of the failing tests earlier and passing tests with changes below.

Before:
![Screen Shot 2020-06-30 at 5 50 35 PM](https://user-images.githubusercontent.com/691331/86196333-e2a74680-bb07-11ea-9ecb-fbe62d87e5b2.png)

After:
![Screen Shot 2020-06-30 at 7 13 29 PM](https://user-images.githubusercontent.com/691331/86196345-e89d2780-bb07-11ea-8cb4-270433379e44.png)


