### PR TITLE
MM-26491: Use a squirrel builder for SQL queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/mattermost-plugin-incident-response
 go 1.13
 
 require (
+	github.com/Masterminds/squirrel v1.1.0
 	github.com/golang/mock v1.4.3
 	github.com/gorilla/mux v1.7.4
 	github.com/mattermost/mattermost-plugin-api v0.0.11-0.20200626173704-d13af3838960

--- a/server/pluginkvstore/incident_store.go
+++ b/server/pluginkvstore/incident_store.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-plugin-incident-response/server/bot"
 	"github.com/mattermost/mattermost-plugin-incident-response/server/incident"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -36,15 +37,22 @@ var _ incident.Store = (*incidentStore)(nil)
 
 // incidentStore holds the information needed to fulfill the methods in the store interface.
 type incidentStore struct {
-	pluginAPI PluginAPIClient
-	log       bot.Logger
+	pluginAPI    PluginAPIClient
+	log          bot.Logger
+	queryBuilder sq.StatementBuilderType
 }
 
 // NewIncidentStore creates a new store for incident ServiceImpl.
 func NewIncidentStore(pluginAPI PluginAPIClient, log bot.Logger) incident.Store {
+	builder := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+	if pluginAPI.Store.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+		builder = builder.PlaceholderFormat(sq.Dollar)
+	}
+
 	newStore := &incidentStore{
-		pluginAPI: pluginAPI,
-		log:       log,
+		pluginAPI:    pluginAPI,
+		log:          log,
+		queryBuilder: builder,
 	}
 	return newStore
 }
@@ -187,16 +195,19 @@ func (s *incidentStore) GetAllIncidentMembersCount(incidentID string) (int64, er
 		return 0, errors.Wrap(err, "failed to get a database connection")
 	}
 
+	query := s.queryBuilder.
+		Select("COUNT(DISTINCT UserId)").
+		From("ChannelMemberHistory AS u").
+		Where(sq.Eq{"ChannelId": incidentID}).
+		Where(sq.Expr("u.UserId NOT IN (SELECT UserId FROM Bots)"))
+
+	queryStr, queryArgs, err := query.ToSql()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to build the query to retrieve all members in an incident")
+	}
+
 	var numMembers int64
-	err = db.QueryRow(`
-		SELECT
-		    COUNT(DISTINCT UserId)
-		FROM
-		    ChannelMemberHistory AS u
-		WHERE
-		    ChannelId = ?
-		AND u.UserId NOT IN (SELECT UserId FROM Bots)
-	`, incidentID).Scan(&numMembers)
+	err = db.QueryRow(queryStr, queryArgs...).Scan(&numMembers)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to query database")
 	}

--- a/server/pluginkvstore/pluginapi_client.go
+++ b/server/pluginkvstore/pluginapi_client.go
@@ -21,6 +21,7 @@ type KVAPI interface {
 // It is implemented by mattermost-plugin-api/Client.Store, or by the mock StoreAPI.
 type StoreAPI interface {
 	GetMasterDB() (*sql.DB, error)
+	DriverName() string
 }
 
 // PluginAPIClient is the struct combining the interfaces defined above, which is everything


### PR DESCRIPTION
#### Summary
This PR fixes a bug that reproduced only when using PostgreSQL, as the syntax of the query to retrieve all the members involved in an incident used MySQL-specific format; namely, the question mark as placeholder, instead of the dollar that PostgreSQL uses.

To solve this, we add a dependency on [squirrel](https://github.com/Masterminds/squirrel), which is now used to create the SQL queries we have (just that one, for now).

The interesting part is in the builder, created for now inside the `incidentStore` structure (we can always move it outside as an external service if we add more features, but for now it's dumb simple, so we can safely keep it there). This builder (stolen from the server code) changes the placeholder format from a question to a dollar if we're using PostgreSQL instead of MySQL.

Considerations on the review:
- I'm not sure how to write a test that checks that the bug disappears, as it depends on changing the backend store from MySQL to PostgreSQL.
- Also, please take a look at the SQL query itself, I'm not sure if I'm missing some cool squirrel's features that could make the query easier.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26491
