### PR TITLE
MM-26586 Fix backstage sidebar colours

### DIFF
--- a/webapp/src/components/backstage/backstage.scss
+++ b/webapp/src/components/backstage/backstage.scss
@@ -27,6 +27,7 @@
                 padding-left: 1.6rem;
                 line-height: 48px;
                 opacity: 0.56;
+                color: var(--sidebar-text);
 
                 &:hover {
                     opacity: 1;


### PR DESCRIPTION
#### Summary
Looks fine on dark and light themes now.

#### Ticket Link
![image](https://user-images.githubusercontent.com/3191642/86959954-a8473600-c113-11ea-96f2-4d710a8551c6.png)
![image](https://user-images.githubusercontent.com/3191642/86960006-bb5a0600-c113-11ea-94f6-589982143152.png)
![image](https://user-images.githubusercontent.com/3191642/86960038-c876f500-c113-11ea-8e80-9a31159d7444.png)


