### PR TITLE
MM-26773 - Support re-ordering stages in playbooks backstage

### DIFF
--- a/webapp/src/components/backstage/playbook/playbook.scss
+++ b/webapp/src/components/backstage/playbook/playbook.scss
@@ -14,17 +14,9 @@ $announcement-bar-height: 32px;
         width: 400px;
     }
 
-    .checklists-container {
-        padding-bottom: 22px;
-
-        .new-stage {
-            padding-top: 25px;
-        }
-    }
-
-    .checklist-container {
-        margin: 10px;
+    .multi-checklist-editor-container {
         padding-top: 22px;
+        padding-bottom: 50px;
         font-size: 14px;
         width: 400px;
     }

--- a/webapp/src/components/checklist.scss
+++ b/webapp/src/components/checklist.scss
@@ -132,7 +132,7 @@ $font-family: Open Sans;
     }
 }
 
-// Used by Checklist and Checkbox components
+// Used by ChecklistEditor and Checkbox components
 .checkbox-container__close {
     cursor: pointer;
     opacity: 0;
@@ -154,4 +154,3 @@ $font-family: Open Sans;
         margin-top: 5px;
     }
 }
-

--- a/webapp/src/components/checklist.tsx
+++ b/webapp/src/components/checklist.tsx
@@ -19,12 +19,6 @@ import './checklist.scss';
 
 interface Props {
     checklist: Checklist;
-    startEditMode?: boolean;
-    showEditModeButton?: boolean;
-    enableEditTitle?: boolean;
-    enableEditChecklistItems: boolean;
-    titleChange?: (newTitle: string) => void;
-    removeList?: () => void;
     onChange?: (itemNum: number, checked: boolean) => void;
     onRedirect?: (itemNum: number) => void;
     addItem: (checklistItem: ChecklistItem) => void;
@@ -33,11 +27,10 @@ interface Props {
     reorderItems: (itemNum: number, newPosition: number) => void;
 }
 
-export const ChecklistDetails = ({checklist, startEditMode: propEditMode = false, enableEditTitle = false, showEditModeButton = true, enableEditChecklistItems, titleChange, removeList, onChange, onRedirect, addItem, removeItem, editItem, reorderItems}: Props): React.ReactElement => {
+export const ChecklistDetails = ({checklist, onChange, onRedirect, addItem, removeItem, editItem, reorderItems}: Props): React.ReactElement => {
     const [newValue, setNewValue] = useState('');
-    const [checklistTitle, setChecklistTitle] = useState(checklist.title);
     const [inputExpanded, setInputExpanded] = useState(false);
-    const [editMode, setEditMode] = useState(propEditMode);
+    const [editMode, setEditMode] = useState(false);
 
     const [checklistItems, setChecklistItems] = useState(checklist.items);
 
@@ -73,67 +66,21 @@ export const ChecklistDetails = ({checklist, startEditMode: propEditMode = false
         reorderItems(result.source.index, result.destination.index);
     };
 
-    const onTitleChange = () => {
-        const trimmedTitle = checklistTitle.trim();
-        if (trimmedTitle === '') {
-            setChecklistTitle(checklist.title);
-            return;
-        }
-        if (trimmedTitle !== checklist.title) {
-            if (titleChange) {
-                titleChange(checklistTitle);
-            }
-        }
-    };
-
     return (
         <div
             className='checklist-inner-container'
         >
             <div className='title'>
-                {(!editMode || !enableEditTitle) && checklistTitle}
-                {
-                    editMode && enableEditTitle &&
-                    <input
-                        id={'checklist-name'}
-                        className='form-control input-name'
-                        type='text'
-                        placeholder='Default Stage'
-                        value={checklistTitle}
-                        maxLength={MAX_NAME_LENGTH}
-                        onBlur={onTitleChange}
-                        onKeyPress={(e) => {
-                            if (e.key === 'Enter') {
-                                onTitleChange();
-                            }
-                        }}
-                        onChange={(e) => {
-                            setChecklistTitle(e.target.value);
-                        }}
-                    />
-                }
+                {checklist.title}
                 {' '}
-                {
-                    showEditModeButton &&
-                    <a
-                        className='checkbox-title__edit'
-                        onClick={() => {
-                            setEditMode(!editMode);
-                        }}
-                    >
-                        <span className='font-weight--normal'>{editMode ? '(done)' : '(edit)'}</span>
-                    </a>
-                }
-                {' '}
-                {
-                    editMode && enableEditTitle &&
-                    <span
-                        onClick={removeList}
-                        className='checkbox-container__close'
-                    >
-                        <i className='icon icon-close'/>
-                    </span>
-                }
+                <a
+                    className='checkbox-title__edit'
+                    onClick={() => {
+                        setEditMode(!editMode);
+                    }}
+                >
+                    <span className='font-weight--normal'>{editMode ? '(done)' : '(edit)'}</span>
+                </a>
             </div>
             <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable
@@ -181,6 +128,12 @@ export const ChecklistDetails = ({checklist, startEditMode: propEditMode = false
                                                         {...draggableProvided.draggableProps}
                                                         {...draggableProvided.dragHandleProps}
                                                         style={draggableProvided.draggableProps.style}
+                                                        onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+                                                            if (event.defaultPrevented) {
+                                                                return;
+                                                            }
+                                                            event.currentTarget.focus();
+                                                        }}
                                                     >
                                                         <ChecklistItemDetailsEdit
                                                             checklistItem={checklistItem}
@@ -202,7 +155,7 @@ export const ChecklistDetails = ({checklist, startEditMode: propEditMode = false
                                     <ChecklistItemDetails
                                         key={checklistItem.title + index}
                                         checklistItem={checklistItem}
-                                        disabled={!enableEditChecklistItems}
+                                        disabled={false}
                                         onChange={(checked: boolean) => {
                                             if (onChange) {
                                                 onChange(index, checked);
@@ -221,7 +174,7 @@ export const ChecklistDetails = ({checklist, startEditMode: propEditMode = false
                     )}
                 </Droppable>
             </DragDropContext>
-            {enableEditChecklistItems && inputExpanded &&
+            {inputExpanded &&
                 <form
                     onSubmit={(e) => {
                         e.preventDefault();
@@ -251,7 +204,7 @@ export const ChecklistDetails = ({checklist, startEditMode: propEditMode = false
                     <small className='light mt-1 d-block'>{'Press Enter to Add Item or Escape to Cancel'}</small>
                 </form>
             }
-            {enableEditChecklistItems && !inputExpanded &&
+            {!inputExpanded &&
                 <div className='IncidentDetails__add-item'>
                     <a
                         href='#'

--- a/webapp/src/components/checklist_editor.scss
+++ b/webapp/src/components/checklist_editor.scss
@@ -1,0 +1,38 @@
+// MultiChecklistEditor
+.multi-checklist-editor {
+    .new-stage {
+        padding-top: 10px;
+    }
+
+    // ChecklistEditor component
+    .checklist-editor-inner-container {
+        display: flex;
+        flex-direction: column;
+        padding-bottom: 25px;
+
+        .title {
+            display: flex;
+            align-items: center;
+            font-weight: 600;
+            padding: 0 0 8px;
+
+            .checkbox-title__edit {
+                width: 70px;
+                padding: 0 5px 0 5px;
+            }
+
+            &:hover {
+                .checkbox-container__close {
+                    opacity: 1;
+                }
+            }
+        }
+
+        .checklist-item-container {
+            padding-left: 25px;
+        }
+        .checklist-new-item {
+            padding-top: 8px;
+        }
+    }
+}

--- a/webapp/src/components/checklist_editor.tsx
+++ b/webapp/src/components/checklist_editor.tsx
@@ -1,0 +1,242 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState} from 'react';
+import {
+    Draggable,
+    Droppable,
+    DroppableProvided,
+    DraggableProvided,
+} from 'react-beautiful-dnd';
+
+import {Checklist, ChecklistItem} from 'src/types/playbook';
+import {MAX_NAME_LENGTH} from 'src/constants';
+
+import {ChecklistItemDetailsEdit} from './checklist_item';
+import './checklist.scss';
+
+interface Props {
+    checklist: Checklist;
+    checklistIndex: number;
+    onChange: (checklist: Checklist) => void;
+    onRemove: () => void;
+}
+
+export const ChecklistEditor = ({
+    checklist,
+    checklistIndex,
+    onChange,
+    onRemove,
+}: Props): React.ReactElement => {
+    const [newValue, setNewValue] = useState('');
+    const [checklistTitle, setChecklistTitle] = useState(checklist.title);
+    const [inputExpanded, setInputExpanded] = useState(false);
+
+    const onEscapeKey = (e: {key: string}) => {
+        if (e.key === 'Escape') {
+            setNewValue('');
+            setInputExpanded(false);
+        }
+    };
+
+    const onTitleChange = () => {
+        const trimmedTitle = checklistTitle.trim();
+        if (trimmedTitle === '') {
+            setChecklistTitle(checklist.title);
+            return;
+        }
+        if (trimmedTitle !== checklist.title) {
+            const newChecklist = {
+                ...checklist,
+                title: trimmedTitle,
+            } as Checklist;
+            onChange(newChecklist);
+        }
+    };
+
+    const onAddChecklistItem = (item: ChecklistItem) => {
+        const newChecklist = {
+            ...checklist,
+            items: [...checklist.items, item],
+        } as Checklist;
+        onChange(newChecklist);
+    };
+
+    const onChangeChecklistItem = (checklistItemIndex: number, item: ChecklistItem) => {
+        const newChecklist = {
+            ...checklist,
+            items: [...checklist.items],
+        } as Checklist;
+        newChecklist.items[checklistItemIndex] = item;
+        onChange(newChecklist);
+    };
+
+    const onRemoveChecklistItem = (checklistItemIndex: number) => {
+        const newChecklist = {
+            ...checklist,
+            items: [...checklist.items],
+        } as Checklist;
+        newChecklist.items.splice(checklistItemIndex, 1);
+        onChange(newChecklist);
+    };
+
+    return (
+        <Draggable
+            draggableId={checklist.title + checklistIndex}
+            index={checklistIndex}
+        >
+            {(rootDraggableProvided: DraggableProvided) => (
+                <div
+                    ref={rootDraggableProvided.innerRef}
+                    {...rootDraggableProvided.draggableProps}
+                    style={rootDraggableProvided.draggableProps.style}
+                    className={'checklist-editor-inner-container'}
+                >
+                    <div
+                        {...rootDraggableProvided.dragHandleProps}
+                        className='title'
+                        onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+                            if (event.defaultPrevented) {
+                                return;
+                            }
+                            event.currentTarget.focus();
+                        }}
+                    >
+                        {
+                            <i
+                                className='icon icon-menu pr-2'
+                            />
+                        }
+                        <input
+                            className='form-control input-name'
+                            type='text'
+                            placeholder='Default Stage'
+                            value={checklistTitle}
+                            maxLength={MAX_NAME_LENGTH}
+                            onClick={(e) => e.stopPropagation()}
+                            onBlur={onTitleChange}
+                            onKeyPress={(e) => {
+                                if (e.key === 'Enter') {
+                                    onTitleChange();
+                                }
+                            }}
+                            onChange={(e) => {
+                                setChecklistTitle(e.target.value);
+                            }}
+                        />
+                        {' '}
+                        <span
+                            onClick={onRemove}
+                            className='checkbox-container__close'
+                        >
+                            <i className='icon icon-close'/>
+                        </span>
+                    </div>
+
+                    <Droppable
+                        droppableId={String(checklistIndex)}
+                        type='checklist_item'
+                    >
+                        {(droppableProvided: DroppableProvided) => (
+                            <div
+                                ref={droppableProvided.innerRef}
+                                {...droppableProvided.droppableProps}
+                                className='checklist-item-container'
+                            >
+                                {
+                                    !checklist.items.length &&
+                                    <div className='light mt-1 mb-2'>{'You don\'t have any checklist items to edit yet.'}</div>
+                                }
+                                {checklist.items.map((checklistItem: ChecklistItem, idx: number) => (
+                                    <Draggable
+                                        index={idx}
+                                        key={checklistIndex + checklistItem.title + idx}
+                                        draggableId={checklistIndex + checklistItem.title + idx}
+                                    >
+                                        {(draggableProvided: DraggableProvided) => {
+                                            return (
+                                                <div className='checklist-item-containerz'>
+                                                    <div
+                                                        ref={draggableProvided.innerRef}
+                                                        {...draggableProvided.draggableProps}
+                                                        {...draggableProvided.dragHandleProps}
+                                                        style={draggableProvided.draggableProps.style}
+                                                        onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+                                                            if (event.defaultPrevented) {
+                                                                return;
+                                                            }
+                                                            event.currentTarget.focus();
+                                                        }}
+                                                    >
+                                                        <ChecklistItemDetailsEdit
+                                                            checklistItem={checklistItem}
+                                                            onEdit={(item: ChecklistItem) => {
+                                                                onChangeChecklistItem(idx, item);
+                                                            }}
+                                                            onRemove={() => {
+                                                                onRemoveChecklistItem(idx);
+                                                            }}
+                                                        />
+
+                                                    </div>
+                                                </div>
+                                            );
+                                        }}
+                                    </Draggable>
+                                ))}
+                                {droppableProvided.placeholder}
+                            </div>
+                        )}
+                    </Droppable>
+                    {inputExpanded &&
+                    <div
+                        className='checklist-item-container'
+                    >
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                if (newValue.trim() === '') {
+                                    setInputExpanded(false);
+                                    return;
+                                }
+                                onAddChecklistItem({
+                                    title: newValue,
+                                    checked: false,
+                                    command: '',
+                                });
+                                setNewValue('');
+                                setInputExpanded(false);
+                            }}
+                        >
+                            <input
+                                autoFocus={true}
+                                type='text'
+                                value={newValue}
+                                maxLength={MAX_NAME_LENGTH}
+                                className='form-control mt-2'
+                                placeholder={'Enter a new item'}
+                                onKeyDown={(e) => onEscapeKey(e)}
+                                onChange={(e) => setNewValue(e.target.value)}
+                            />
+                            <small className='light mt-1 d-block'>{'Press Enter to Add Item or Escape to Cancel'}</small>
+                        </form>
+                    </div>
+                    }
+                    {!inputExpanded &&
+                    <div className='checklist-item-container checklist-new-item'>
+                        <a
+                            href='#'
+                            onClick={() => {
+                                setInputExpanded(true);
+                            }}
+                        >
+                            <i className='icon icon-plus'/>
+                            {'Add new checklist item'}
+                        </a>
+                    </div>
+                    }
+                </div>
+            )}
+        </Draggable>
+    );
+};

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -142,6 +142,7 @@ export const ChecklistItemDetailsEdit = ({checklistItem, onEdit, onRemove}: Chec
                     type='text'
                     value={title}
                     maxLength={MAX_NAME_LENGTH}
+                    onClick={(e) => e.stopPropagation()}
                     onBlur={submit}
                     placeholder={'Title'}
                     onKeyPress={(e) => {
@@ -159,6 +160,7 @@ export const ChecklistItemDetailsEdit = ({checklistItem, onEdit, onRemove}: Chec
                     value={command}
                     onBlur={submit}
                     placeholder={'/Slash Command'}
+                    onClick={(e) => e.stopPropagation()}
                     onKeyPress={(e) => {
                         if (e.key === 'Enter') {
                             submit();

--- a/webapp/src/components/multi_checklist_editor.tsx
+++ b/webapp/src/components/multi_checklist_editor.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {
+    DragDropContext,
+    Droppable,
+    DropResult,
+    DroppableProvided,
+} from 'react-beautiful-dnd';
+
+import {Checklist, emptyChecklist} from 'src/types/playbook';
+
+import {ChecklistEditor} from './checklist_editor';
+import './checklist_editor.scss';
+
+interface Props {
+    checklist: Checklist[];
+    onChange: (checklist: Checklist[]) => void;
+}
+
+export const MultiChecklistEditor = ({
+    checklist: propChecklist = [],
+    onChange,
+}: Props): React.ReactElement => {
+    const onDragEnd = (result: DropResult) => {
+        if (!result.destination) {
+            return;
+        }
+
+        if (result.destination.droppableId === result.source.droppableId &&
+                result.destination.index === result.source.index) {
+            return;
+        }
+
+        if (result.type === 'checklist') {
+            onReorderChecklist(result.source.index, result.destination.index);
+            return;
+        }
+
+        if (result.type === 'checklist_item') {
+            const sourceChecklistIndex = result.source.droppableId;
+            const destinationChecklistIndex = result.destination.droppableId;
+            onReorderChecklistItem(Number(sourceChecklistIndex), Number(destinationChecklistIndex), result.source.index, result.destination.index);
+        }
+    };
+
+    const onReorderChecklist = (sourceIndex: number, destinationIndex: number) => {
+        const newChecklist = [...propChecklist];
+        const [removed] = newChecklist.splice(sourceIndex, 1);
+        newChecklist.splice(destinationIndex, 0, removed);
+
+        onChange(newChecklist);
+    };
+
+    const onReorderChecklistItem = (checklistIndex: number, newChecklistIndex: number, checklistItemIndex: number, newChecklistItemIndex: number): void => {
+        const newChecklist = [...propChecklist];
+
+        if (checklistIndex === newChecklistIndex) {
+            // items moved within stage
+            const changedChecklist = {...newChecklist[checklistIndex]} as Checklist;
+            const changedChecklistItems = [...changedChecklist.items];
+            const [removed] = changedChecklistItems.splice(checklistItemIndex, 1);
+            changedChecklistItems.splice(newChecklistItemIndex, 0, removed);
+            changedChecklist.items = changedChecklistItems;
+
+            newChecklist[checklistIndex] = changedChecklist;
+            onChange(newChecklist);
+            return;
+        }
+
+        // items moved between stages
+        const sourceChangedChecklist = {...newChecklist[checklistIndex]} as Checklist;
+        const destinationChangedChecklist = {...newChecklist[newChecklistIndex]} as Checklist;
+        const itemToMove = sourceChangedChecklist.items[checklistItemIndex];
+
+        // Remove from current index
+        const sourceChangedChecklistItems = Array.from(sourceChangedChecklist.items);
+        sourceChangedChecklistItems.splice(checklistItemIndex, 1);
+
+        // Add in new index
+        const destinationChangedChecklistItems = Array.from(destinationChangedChecklist.items);
+        destinationChangedChecklistItems.splice(newChecklistItemIndex, 0, itemToMove);
+
+        sourceChangedChecklist.items = sourceChangedChecklistItems;
+        destinationChangedChecklist.items = destinationChangedChecklistItems;
+
+        newChecklist[checklistIndex] = sourceChangedChecklist;
+        newChecklist[newChecklistIndex] = destinationChangedChecklist;
+
+        onChange(newChecklist);
+    };
+
+    const onAddChecklist = () => {
+        const checklist = emptyChecklist();
+        checklist.title = 'New stage';
+        const newChecklist = [...propChecklist, checklist];
+
+        onChange(newChecklist);
+    };
+
+    const onChangeChecklist = (checklistIndex: number, checklist: Checklist) => {
+        const newChecklist = [...propChecklist];
+        newChecklist[checklistIndex] = checklist;
+
+        onChange(newChecklist);
+    };
+    const onRemoveChecklist = (checklistIndex: number) => {
+        const newChecklist = [...propChecklist];
+        newChecklist.splice(checklistIndex, 1);
+
+        onChange(newChecklist);
+    };
+
+    return (
+        <div className='multi-checklist-editor'>
+            <DragDropContext onDragEnd={onDragEnd}>
+                <Droppable
+                    droppableId='columns'
+                    direction='vertical'
+                    type='checklist'
+                >
+                    {(droppableProvided: DroppableProvided) => (
+                        <div
+                            ref={droppableProvided.innerRef}
+                            {...droppableProvided.droppableProps}
+                        >
+                            {propChecklist?.map((checklist: Checklist, checklistIndex: number) => (
+                                <div
+                                    key={checklist.title + checklistIndex}
+                                >
+                                    <ChecklistEditor
+                                        checklist={checklist}
+                                        checklistIndex={checklistIndex}
+
+                                        onChange={(newChecklist: Checklist) => {
+                                            onChangeChecklist(checklistIndex, newChecklist);
+                                        }}
+                                        onRemove={() => {
+                                            onRemoveChecklist(checklistIndex);
+                                        }}
+                                    />
+                                </div>
+                            ))}
+                            {droppableProvided.placeholder}
+                        </div>
+                    )}
+                </Droppable>
+
+                <div className='new-stage'>
+                    <a
+                        href='#'
+                        onClick={onAddChecklist}
+                    >
+                        <i className='icon icon-plus'/>
+                        {'Add new stage'}
+                    </a>
+                </div>
+            </DragDropContext>
+        </div>
+    );
+};

--- a/webapp/src/components/rhs/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details.tsx
@@ -88,8 +88,8 @@ const RHSIncidentDetails: FC<Props> = (props: Props) => {
                     {props.incident.playbook.checklists?.map((checklist: Checklist, index: number) => (
                         <ChecklistDetails
                             checklist={checklist}
-                            enableEditChecklistItems={true}
                             key={checklist.title + index}
+
                             onChange={(itemNum: number, checked: boolean) => {
                                 if (checked) {
                                     checkItem(props.incident.id, index, itemNum);


### PR DESCRIPTION
#### Summary
* Adding support to reorder playbook stages
* RHS does not allow reodering checklist-items between stages

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-26773

#### Reorder stages
![Jul-09-2020 15-38-29](https://user-images.githubusercontent.com/25732808/87083244-4dd4d500-c1fa-11ea-8f35-7605548d5114.gif)


#### Stages in RHS
![Jul-09-2020 15-40-13](https://user-images.githubusercontent.com/25732808/87083394-87a5db80-c1fa-11ea-9d28-682c4ef0a8bf.gif)
