### PR TITLE
handle no current channel

### DIFF
--- a/webapp/src/hooks.ts
+++ b/webapp/src/hooks.ts
@@ -33,6 +33,11 @@ export function useCurrentIncident(): [Incident | null, CurrentIncidentState] {
 
     useEffect(() => {
         const fetchIncident = async () => {
+            if (!currentChannel) {
+                setState(CurrentIncidentState.NotFound);
+                return;
+            }
+
             try {
                 setIncident(await fetchIncidentByChannel(currentChannel.id));
                 setState(CurrentIncidentState.Loaded);
@@ -44,7 +49,7 @@ export function useCurrentIncident(): [Incident | null, CurrentIncidentState] {
         };
         setState(CurrentIncidentState.Loading);
         fetchIncident();
-    }, [currentChannel.id]);
+    }, [currentChannel?.id]);
 
     useEffect(() => {
         const doUpdate = (updatedIncident: Incident) => {


### PR DESCRIPTION
#### Summary
It is possible for there to be no current channel, such as when browsing the system console. Handle this possibility within `useCurrentIncident`, fixing a UI breaksage that occurs when returning from the system console.

#### Ticket Link
None.