### PR TITLE
Bumping @redocly/openapi-cli version

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -18,4 +18,4 @@ endif
 ## Runs the redocly server.
 .PHONY: api-server
 api-server:
-	npx @redocly/openapi-cli@0.12.16 preview-docs server/api/api.yaml
+	npx @redocly/openapi-cli@1.0.0-beta.3 preview-docs server/api/api.yaml


### PR DESCRIPTION
Looks like openapi-cli fixed their latest beta https://github.com/Redocly/openapi-cli/issues/163. Bumping @redocly/openapi-cli version