### PR TITLE
MM-26163 - Standardize error JSON responses for all endpoints

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -58,7 +58,7 @@ func HandleError(w http.ResponseWriter, err error) {
 	HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", err)
 }
 
-// HandleErrorWithCode writes code, errTitle and err as json into the response.
+// HandleErrorWithCode writes code, errMsg and errDetails as json into the response.
 func HandleErrorWithCode(w http.ResponseWriter, code int, errMsg string, errDetails error) {
 	w.WriteHeader(code)
 	details := ""


### PR DESCRIPTION
#### Summary
* Returning standardized error JSON responses for all endpoints as per the [REST API design doc](https://docs.google.com/document/d/1Kp2PmE8CDNUSUiviui4GhL51z5OmYf5QqrcxFu2YFJU/edit#heading=h.wrlfyrjljio).
* Purposefully not including a `code` field as it'll be redundant and is not needed at the moment.

```
{
    message: "Incident not found :(",
    details: "Failed to open DB"
}
```

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-26163
