### PR TITLE
MM-26810: Be consistent with rest of Mattermost telemetry

### DIFF
--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -119,8 +119,8 @@ func (t *RudderTelemetry) EndIncident(incdnt *incident.Incident) {
 
 func checklistItemProperties(incidentID, userID string) map[string]interface{} {
 	return map[string]interface{}{
-		"IncidentID": incidentID,
-		"UserID":     userID,
+		"IncidentID":   incidentID,
+		"UserActualID": userID,
 	}
 }
 

--- a/server/telemetry/rudder_test.go
+++ b/server/telemetry/rudder_test.go
@@ -152,8 +152,8 @@ func assertPayload(t *testing.T, actual rudderPayload, expectedEvent string) {
 	} else {
 		require.Contains(t, properties, "IncidentID")
 		require.Equal(t, properties["IncidentID"], dummyIncidentID)
-		require.Contains(t, properties, "UserID")
-		require.Equal(t, properties["UserID"], dummyUserID)
+		require.Contains(t, properties, "UserActualID")
+		require.Equal(t, properties["UserActualID"], dummyUserID)
 	}
 }
 


### PR DESCRIPTION
#### Summary
As per https://github.com/mattermost/mattermost-plugin-api/pull/62, we need to change `UserID` to `UserActualID` in order to be consistent with the rest of Mattermost telemetry.

(Maybe we should think about using the mattermost-plugin-api telemetry package soon)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26810

