### PR TITLE
MM-27185: fix backstage styling regression

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -47,26 +47,28 @@ const BackstageSidebarMenu = styled.div`
 `;
 
 const SidebarNavLink = styled(NavLink)`
-    display: block;
-    border-radius: 4px 0 0 4px;
-    height: 48px;
-    padding-left: 1.6rem;
-    line-height: 48px;
-    opacity: 0.56;
-    color: var(--sidebar-text);
-
-    &:hover {
-        opacity: 1;
-        cursor: pointer;
-    }
-
-    &.active {
-        background: var(--center-channel-bg);
-        color: var(--center-channel-color);
-        opacity: 1;
+    &&& {
+        display: block;
+        border-radius: 4px 0 0 4px;
+        height: 48px;
+        padding-left: 1.6rem;
+        line-height: 48px;
+        opacity: 0.56;
+        color: var(--sidebar-text);
 
         &:hover {
-            cursor: default;
+            opacity: 1;
+            cursor: pointer;
+        }
+
+        &.active {
+            background: var(--center-channel-bg);
+            color: var(--center-channel-color);
+            opacity: 1;
+
+            &:hover {
+                cursor: default;
+            }
         }
     }
 `;


### PR DESCRIPTION
#### Summary
Leverage styled components [recommended pattern](https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity) to overcome the `.app__body a` and related rules that currently override our styled components for the backstage navigation sidebar.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-27185