### PR TITLE
MM-27009 - Show workflow duration

### DIFF
--- a/webapp/src/components/rhs/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details.tsx
@@ -172,7 +172,8 @@ const RHSIncidentDetails: FC<Props> = (props: Props) => {
         const tick = () => {
             setNow(moment());
         };
-        const timerId = setInterval(() => tick(), 1000);
+        const quarterSecond = 250;
+        const timerId = setInterval(tick, quarterSecond);
 
         return () => {
             clearInterval(timerId);


### PR DESCRIPTION
#### Summary
- Does what it says.
- There isn't a convenient momentjs function for this (https://github.com/moment/moment/issues/463), but it's just a bit of code to do what we want.

### UX review questions:
- I assumed you wanted to hide leading 0's, like: `2h 3m 4s` instead of `0d 2h 3m 4s`. 
- I also  assumed you wanted to hide internal 0's, like: `1d 3m 4s` instead of `1d 0h 3m 4s`. Let me know if you want to show internal 0's. (Personally, I think we /should/ show the internal 0s -- it's less cognitive load.)

Looks like:
![image](https://user-images.githubusercontent.com/1490756/88582569-eea9f980-d01c-11ea-879b-0b92e46cdf28.png)
![image](https://user-images.githubusercontent.com/1490756/88582637-0da88b80-d01d-11ea-9954-f6caf8e5c344.png)


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27014