### PR TITLE
MM-27257 - fix stage name display in select options

### DIFF
--- a/webapp/src/components/profile/profile_selector.scss
+++ b/webapp/src/components/profile/profile_selector.scss
@@ -33,9 +33,12 @@
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
     }
 
-    .incident-user-select__option--is-selected,
-    .incident-user-select__option--is-focused {
+    .incident-user-select__option--is-selected {
         background-color: var(--center-channel-color-08);
+    }
+
+    .incident-user-select__option--is-focused {
+        background-color: var(--center-channel-color-16);
         color: inherit;
     }
 

--- a/webapp/src/components/rhs/incident_details.scss
+++ b/webapp/src/components/rhs/incident_details.scss
@@ -30,9 +30,11 @@ $font-family: Open Sans;
             background-color: var(--center-channel-bg);
             color: var(--center-channel-color);
 
-            &__option--is-selected,
-            &__option--is-focused {
+            &__option--is-selected {
                 background-color: var(--center-channel-color-08);
+            }
+            &__option--is-focused {
+                background-color: var(--center-channel-color-16);
                 color: inherit;
             }
 

--- a/webapp/src/components/rhs/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details.tsx
@@ -3,7 +3,7 @@
 
 import React, {FC, useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux';
-import ReactSelect, {ActionMeta, OptionTypeBase} from 'react-select';
+import ReactSelect, {ActionMeta, OptionTypeBase, StylesConfig} from 'react-select';
 import Scrollbars from 'react-custom-scrollbars';
 import styled from 'styled-components';
 import moment from 'moment';
@@ -65,6 +65,18 @@ interface StageSelectorProps {
     onStageActivated: () => void;
 }
 
+const optionStyles: StylesConfig = {
+    option: (provided) => {
+        return {
+            ...provided,
+            wordBreak: 'break-word',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+        };
+    },
+};
+
 const StageSelector: FC<StageSelectorProps> = (props: StageSelectorProps) => {
     const isActive = (stageIdx: number) => {
         return stageIdx === props.activeStage;
@@ -97,6 +109,7 @@ const StageSelector: FC<StageSelectorProps> = (props: StageSelectorProps) => {
                 onChange={(option, action) => props.onStageSelected(option as Option, action as ActionMeta<OptionTypeBase>)}
                 className={'incident-stage-select'}
                 classNamePrefix={'incident-stage-select'}
+                styles={optionStyles}
             />
         </React.Fragment>
     );


### PR DESCRIPTION
#### Summary
- ellipsis-ing long stage names
- no, I'm not moving these files to styled components in this PR. :P
- I'm taking an opinionated stance on how we highlight options in the profile and stage select boxes. In master, you can't tell which is highlighted and which is selected, eg:
![image](https://user-images.githubusercontent.com/1490756/88711680-8b849980-d0e6-11ea-96f7-6982ab898d60.png)

Now the currently selected option is highlighted, but the currently hovered option is highlighted in a slightly lighter color:
![image](https://user-images.githubusercontent.com/1490756/88711492-3e082c80-d0e6-11ea-97c9-091009c12786.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27257

