### PR TITLE
MM-27661 - Deleting a playbook on page 2 causes the playbook list to disappear

### DIFF
--- a/webapp/src/components/backstage/playbook/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook/playbook_list.tsx
@@ -103,7 +103,7 @@ const PlaybookList: FC = () => {
             // Go back to previous page if the last item on this page was just deleted
             page = Math.max(Math.min(result.page_count - 1, page), 0);
 
-            // Setting the page here results in fetching the playbooks using the effect above
+            // Setting the page here results in fetching playbooks through the fetchParams dependency of the effect above
             setPage(page);
 
             hideConfirmModal();


### PR DESCRIPTION
#### Summary
* Rolls back to the previous page if user deletes the last item from the current page.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-27661


#### Screenshot
![2020-08-11 at 1 20 PM](https://user-images.githubusercontent.com/25732808/89928205-796e2500-dbd5-11ea-9388-e78935c63a0d.gif)

