### PR TITLE
MM-28023 Don't remove empty stages/steps when save is pressed but is rejected.

### DIFF
--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -265,7 +265,6 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
 
         // It's possible there was actually nothing there.
         if (playbookExcludingEmpty.checklists.length === 0) {
-            updateChecklist(playbookExcludingEmpty.checklists);
             return;
         }
 


### PR DESCRIPTION
#### Summary
Don't remove empty stages/steps when save is pressed but is rejected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28023
