### PR TITLE
MM-27684 Allow dragging of steps inside blank stages.

### DIFF
--- a/webapp/src/components/backstage/stage_edit.tsx
+++ b/webapp/src/components/backstage/stage_edit.tsx
@@ -128,7 +128,7 @@ export const StageEditor = (props: Props): React.ReactElement => {
                             <DragPlaceholderText
                                 onClick={handleAddChecklistItem}
                             >
-                                {'Drag step here or click for new.'}
+                                {'Drag and drop an existing step or click to create a new step.'}
                             </DragPlaceholderText>
                         )}
                         {droppableProvided.placeholder}


### PR DESCRIPTION
#### Summary
Adds a box for dragging within an empty stage so you can drag steps there. 
![image](https://user-images.githubusercontent.com/3191642/90939042-7508ef80-e3bf-11ea-86a7-e4989c813368.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27684

