### PR TITLE
introduce dedicated duration component

### DIFF
--- a/webapp/src/components/rhs/duration.tsx
+++ b/webapp/src/components/rhs/duration.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {FC, useEffect, useState} from 'react';
+import moment from 'moment';
+
+interface DurationProps {
+    created_at: number;
+    ended_at: number;
+}
+
+const Duration: FC<DurationProps> = (props: DurationProps) => {
+    const [now, setNow] = useState(moment());
+
+    useEffect(() => {
+        const tick = () => {
+            setNow(moment());
+        };
+        const quarterSecond = 250;
+        const timerId = setInterval(tick, quarterSecond);
+
+        return () => {
+            clearInterval(timerId);
+        };
+    }, []);
+
+    const start = moment.unix(props.created_at);
+    const end = (props.ended_at && moment.unix(props.ended_at)) || now;
+
+    const duration = moment.duration(end.diff(start));
+    let durationString = '';
+    if (duration.days() > 0) {
+        durationString += duration.days() + 'd ';
+    }
+    if (duration.hours() > 0) {
+        durationString += duration.hours() + 'h ';
+    }
+    if (duration.minutes() > 0) {
+        durationString += duration.minutes() + 'm ';
+    }
+    durationString += duration.seconds() + 's';
+
+    return (
+        <div className='first-title'>
+            {'Duration'}
+            <div className='time'>{durationString}</div>
+        </div>
+    );
+};
+
+export default Duration;

--- a/webapp/src/components/rhs/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {FC, useEffect, useState} from 'react';
+import React, {FC, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import ReactSelect, {ActionMeta, OptionTypeBase, StylesConfig} from 'react-select';
 import Scrollbars from 'react-custom-scrollbars';
-import moment from 'moment';
 
 import {
     fetchUsersInChannel,
@@ -21,8 +20,10 @@ import ProfileSelector from 'src/components/profile/profile_selector';
 
 import {isMobile} from 'src/mobile';
 import {toggleRHS, endIncident, restartIncident} from 'src/actions';
+
 import 'src/components/checklist.scss';
 import './incident_details.scss';
+import Duration from './duration';
 
 interface Props {
     incident: Incident;
@@ -186,35 +187,6 @@ const RHSIncidentDetails: FC<Props> = (props: Props) => {
         );
     }
 
-    const [now, setNow] = useState(moment());
-    useEffect(() => {
-        const tick = () => {
-            setNow(moment());
-        };
-        const quarterSecond = 250;
-        const timerId = setInterval(tick, quarterSecond);
-
-        return () => {
-            clearInterval(timerId);
-        };
-    }, []);
-
-    const start = moment.unix(props.incident.created_at);
-    const end = (props.incident.ended_at && moment.unix(props.incident.ended_at)) || now;
-
-    const duration = moment.duration(end.diff(start));
-    let durationString = '';
-    if (duration.days() > 0) {
-        durationString += duration.days() + 'd ';
-    }
-    if (duration.hours() > 0) {
-        durationString += duration.hours() + 'h ';
-    }
-    if (duration.minutes() > 0) {
-        durationString += duration.minutes() + 'm ';
-    }
-    durationString += duration.seconds() + 's';
-
     return (
         <React.Fragment>
             <Scrollbars
@@ -242,10 +214,10 @@ const RHSIncidentDetails: FC<Props> = (props: Props) => {
                                 selfIsFirstOption={true}
                             />
                         </div>
-                        <div className='first-title'>
-                            {'Duration'}
-                            <div className='time'>{durationString}</div>
-                        </div>
+                        <Duration
+                            created_at={props.incident.created_at}
+                            ended_at={props.incident.ended_at}
+                        />
                     </div>
                     <div className='inner-container'>
                         <StageSelector


### PR DESCRIPTION
#### Summary
The inline duration component was rendering every second, changing the hooks and forcing a full re-render of the RHS every time. Move to a dedicated duration component that isolates the re-render to just that component, avoiding the user selector from re-rendering constantly and losing focus / preventing the use of the `No Assignee` feature:

Before:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/1023171/90943146-f5931480-e3ee-11ea-96e8-9131ce7e13c7.png">

After:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/1023171/90943131-e2804480-e3ee-11ea-9c0c-027d2e2e9df3.png">


Technically speaking, there is still the potential that a random re-render would temporarily break the component, and it's probably worth investigating that in the future.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-28032
Fixes: https://mattermost.atlassian.net/browse/MM-28036