### PR TITLE
MM-36266 - Fix: Incident commander can be changed to the incident bot

### DIFF
--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -295,7 +295,7 @@ type PlaybookRunService interface {
 	IsOwner(playbookRunID string, userID string) bool
 
 	// ChangeOwner processes a request from userID to change the owner for playbookRunID
-	// to ownerID. Changing to the same ownerID is a no-op.
+	// to ownerID. Changing to the same ownerID or to a bot is a no-op.
 	ChangeOwner(playbookRunID string, userID string, ownerID string) error
 
 	// ModifyCheckedState modifies the state of the specified checklist item
@@ -307,6 +307,7 @@ type PlaybookRunService interface {
 
 	// SetAssignee sets the assignee for the specified checklist item
 	// Idempotent, will not perform any actions if the checklist item is already assigned to assigneeID
+	// or if the assignee is a bot
 	SetAssignee(playbookRunID, userID, assigneeID string, checklistNumber, itemNumber int) error
 
 	// RunChecklistItemSlashCommand executes the slash command associated with the specified checklist item.

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -468,6 +468,11 @@ func (r *Runner) actionChangeOwner(args []string) {
 		return
 	}
 
+	if targetOwnerUser.IsBot {
+		r.postCommandResponse("Cannot assign ownership to a bot.")
+		return
+	}
+
 	if currentPlaybookRun.OwnerUserID == targetOwnerUser.Id {
 		r.postCommandResponse(fmt.Sprintf("User @%s is already owner of this playbook run.", targetOwnerUsername))
 		return

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -342,7 +342,7 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
     useTimeout(() => setRunning(false), running ? RunningTimeout : null);
 
     const fetchUsers = async () => {
-        return profilesInChannel;
+        return profilesInChannel.filter((p) => !p.is_bot);
     };
 
     const onAssigneeChange = async (userId?: string) => {

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -38,7 +38,7 @@ const RHSAbout = (props: Props) => {
     }
 
     const fetchUsers = async () => {
-        return profilesInChannel;
+        return profilesInChannel.filter((p) => !p.is_bot);
     };
 
     const onSelectedProfileChange = async (userId?: string) => {


### PR DESCRIPTION
#### Summary
- Remove bot from drop down menus, and disallow from command
- Chose to make changing owner or assignee through API be a no-op, to follow how we handle self-assignment

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-36266

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
