### PR TITLE
MM-36913 - Filter tasks w/ default (state saved per user)

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -50,11 +50,14 @@ import {
     SetHasViewedChannel,
     SET_HAS_VIEWED_CHANNEL,
     SET_CHECKLIST_COLLAPSED_STATE,
-    SetChecklistCollapsedState, SetAllChecklistsCollapsedState, SET_ALL_CHECKLISTS_COLLAPSED_STATE,
-} from './types/actions';
-
-import {clientExecuteCommand} from './client';
-import {GlobalSettings} from './types/settings';
+    SetChecklistCollapsedState,
+    SetAllChecklistsCollapsedState,
+    SET_ALL_CHECKLISTS_COLLAPSED_STATE,
+    SET_CHECKLIST_ITEMS_FILTER, SetChecklistItemsFilter,
+} from 'src/types/actions';
+import {clientExecuteCommand} from 'src/client';
+import {GlobalSettings} from 'src/types/settings';
+import {ChecklistItemsFilter} from 'src/types/playbook';
 
 export function startPlaybookRun(postId?: string) {
     return async (dispatch: Dispatch<AnyAction>, getState: GetStateFunc) => {
@@ -232,3 +235,10 @@ export const setAllChecklistsCollapsedState = (channelId: string, collapsed: boo
     numOfChecklists,
     collapsed,
 });
+
+export const setChecklistItemsFilter = (channelId: string, nextState: ChecklistItemsFilter): SetChecklistItemsFilter => ({
+    type: SET_CHECKLIST_ITEMS_FILTER,
+    channelId,
+    nextState,
+});
+

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useState, useRef} from 'react';
-import styled, {css} from 'styled-components';
+import styled, {css, StyledComponentBase} from 'styled-components';
 
 import {useKeyPress, useClickOutsideRef} from 'src/hooks';
 
@@ -10,7 +10,7 @@ interface DotMenuButtonProps {
     right?: boolean;
 }
 
-const DotMenuButton = styled.div<DotMenuButtonProps>`
+export const DotMenuButton = styled.div<DotMenuButtonProps>`
     display: inline-flex;
     padding: 0;
     background: transparent;
@@ -26,10 +26,6 @@ const DotMenuButton = styled.div<DotMenuButtonProps>`
        background: rgba(var(--center-channel-color-rgb), 0.08);
        color: rgba(var(--center-channel-color-rgb), 0.72);
     }
-
-    ${(props) => (props.right && css`
-        margin: 0 16px 0 auto;
-    `)}
 `;
 
 const DropdownMenuWrapper = styled.div`
@@ -83,6 +79,7 @@ interface DotMenuProps {
     left?: boolean;
     wide?: boolean;
     buttonRight?: boolean;
+    dotMenuButton?: StyledComponentBase<'div', any>;
 }
 
 const DotMenu = (props: DotMenuProps) => {
@@ -100,14 +97,15 @@ const DotMenu = (props: DotMenuProps) => {
         setOpen(false);
     });
 
+    const MenuButton = props.dotMenuButton ?? DotMenuButton;
+
     return (
-        <DotMenuButton
+        <MenuButton
             ref={rootRef}
             onClick={(e) => {
                 e.stopPropagation();
                 toggleOpen();
             }}
-            right={props.buttonRight}
         >
             {props.icon}
             <DropdownMenuWrapper>
@@ -123,7 +121,7 @@ const DotMenu = (props: DotMenuProps) => {
                     </DropdownMenu>
                 }
             </DropdownMenuWrapper>
-        </DotMenuButton>
+        </MenuButton>
     );
 };
 

--- a/webapp/src/components/multi_checkbox.tsx
+++ b/webapp/src/components/multi_checkbox.tsx
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import styled from 'styled-components';
+import styled, {StyledComponentBase} from 'styled-components';
 
-import DotMenu from 'src/components/dot_menu';
+import DotMenu, {DotMenuButton} from 'src/components/dot_menu';
 import {CheckboxContainer} from 'src/components/checklist_item';
 
 const IconWrapper = styled.div`
@@ -14,7 +14,7 @@ const IconWrapper = styled.div`
 
 const FilterCheckboxContainer = styled(CheckboxContainer)`
     margin: 0 34px 0 20px;
-    line-height: 30px;
+    line-height: 32px;
     align-items: center;
 
     input[type='checkbox'] {
@@ -36,9 +36,17 @@ const OptionDisplay = styled.div`
 `;
 
 const Divider = styled.div`
-    background: var(--center-channel-color-16);
+    background: var(--center-channel-color-08);
     height: 1px;
     margin: 8px 0;
+`;
+
+const Title = styled.div`
+    margin: 0 0 0 20px;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 28px;
+    color: var(--center-channel-color-56);
 `;
 
 export interface CheckboxOption {
@@ -51,21 +59,27 @@ export interface CheckboxOption {
 interface Props {
     options: CheckboxOption[];
     onselect: (value: string, checked: boolean) => void;
+    dotMenuButton?: StyledComponentBase<'div', any>;
+    icon?: JSX.Element;
 }
 
 const MultiCheckbox = (props: Props) => (
     <DotMenu
+        dotMenuButton={props.dotMenuButton ?? DotMenuButtonRight}
         icon={
+            props.icon ??
             <IconWrapper>
                 <i className='icon icon-filter-variant'/>
             </IconWrapper>
         }
         wide={true}
-        buttonRight={true}
     >
-        {props.options.map((option) => {
+        {props.options.map((option, idx) => {
             if (option.value === 'divider') {
-                return <Divider key={'divider'}/>;
+                return <Divider key={'divider' + idx}/>;
+            }
+            if (option.value === 'title') {
+                return <Title key={'title' + idx}>{option.display}</Title>;
             }
 
             const onClick = () => props.onselect(option.value, !option.selected);
@@ -87,5 +101,9 @@ const MultiCheckbox = (props: Props) => (
         })}
     </DotMenu>
 );
+
+const DotMenuButtonRight = styled(DotMenuButton)`
+    margin: 0 16px 0 auto;
+`;
 
 export default MultiCheckbox;

--- a/webapp/src/components/rhs/rhs_checklists.tsx
+++ b/webapp/src/components/rhs/rhs_checklists.tsx
@@ -255,7 +255,7 @@ const IconWrapper = styled.div`
 
 export default RHSChecklists;
 
-const makeFilterOptions = (filter: ChecklistItemsFilter, name: string) => {
+const makeFilterOptions = (filter: ChecklistItemsFilter, name: string): CheckboxOption[] => {
     return [
         {
             display: 'All tasks',
@@ -266,11 +266,11 @@ const makeFilterOptions = (filter: ChecklistItemsFilter, name: string) => {
         {
             value: 'divider',
             display: '',
-        } as CheckboxOption,
+        },
         {
             value: 'title',
             display: 'TASK STATE',
-        } as CheckboxOption,
+        },
         {
             display: 'Show checked tasks',
             value: 'checked',
@@ -280,11 +280,11 @@ const makeFilterOptions = (filter: ChecklistItemsFilter, name: string) => {
         {
             value: 'divider',
             display: '',
-        } as CheckboxOption,
+        },
         {
             value: 'title',
             display: 'ASSIGNEE',
-        } as CheckboxOption,
+        },
         {
             display: `Me (${name})`,
             value: 'me',

--- a/webapp/src/components/rhs/rhs_checklists.tsx
+++ b/webapp/src/components/rhs/rhs_checklists.tsx
@@ -6,30 +6,49 @@ import {useDispatch, useSelector} from 'react-redux';
 import styled from 'styled-components';
 import {
     DragDropContext,
-    Droppable,
-    DroppableProvided,
     Draggable,
     DraggableProvided,
-    DropResult,
     DraggableStateSnapshot,
+    Droppable,
+    DroppableProvided,
+    DropResult,
 } from 'react-beautiful-dnd';
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import {PlaybookRun} from 'src/types/playbook_run';
 import {
-    toggleRHS,
     playbookRunUpdated,
     setAllChecklistsCollapsedState,
     setChecklistCollapsedState,
+    setChecklistItemsFilter,
+    toggleRHS,
 } from 'src/actions';
-import {ChecklistItem, ChecklistItemState, Checklist} from 'src/types/playbook';
-import {setChecklistItemState, clientReorderChecklist} from 'src/client';
+import {
+    Checklist,
+    ChecklistItem,
+    ChecklistItemsFilter,
+    ChecklistItemState,
+} from 'src/types/playbook';
+import {
+    clientReorderChecklist,
+    setChecklistItemState,
+    telemetryEventForPlaybookRun,
+} from 'src/client';
 import {ChecklistItemDetails} from 'src/components/checklist_item';
 import {isMobile} from 'src/mobile';
 import CollapsibleChecklist from 'src/components/rhs/collapsible_checklist';
 import {HoverMenu, HoverMenuButton} from 'src/components/rhs/rhs_shared';
-import {currentChecklistAllCollapsed, currentChecklistCollapsedState} from 'src/selectors';
+import {
+    currentChecklistAllCollapsed,
+    currentChecklistCollapsedState,
+    currentChecklistItemsFilter,
+} from 'src/selectors';
+import MultiCheckbox, {CheckboxOption} from 'src/components/multi_checkbox';
+import {DotMenuButton} from 'src/components/dot_menu';
 
 // disable all react-beautiful-dnd development warnings
 // @ts-ignore
@@ -44,8 +63,29 @@ const RHSChecklists = (props: Props) => {
     const channelId = useSelector(getCurrentChannelId);
     const checklistsState = useSelector(currentChecklistCollapsedState);
     const allCollapsed = useSelector(currentChecklistAllCollapsed);
+    const checklistItemsFilter = useSelector(currentChecklistItemsFilter);
+    const myUser = useSelector(getCurrentUser);
+    const teamnameNameDisplaySetting = useSelector(getTeammateNameDisplaySetting) || '';
+    const preferredName = displayUsername(myUser, teamnameNameDisplaySetting);
     const [showMenu, setShowMenu] = useState(false);
     const checklists = props.playbookRun.checklists || [];
+    const filterOptions = makeFilterOptions(checklistItemsFilter, preferredName);
+
+    const selectOption = (value: string, checked: boolean) => {
+        telemetryEventForPlaybookRun(props.playbookRun.id, 'checklists_filter_selected');
+
+        if (checklistItemsFilter.all && value !== 'all') {
+            return;
+        }
+        if (isLastCheckedValueInBottomCategory(value, checked, checklistItemsFilter)) {
+            return;
+        }
+
+        dispatch(setChecklistItemsFilter(channelId, {
+            ...checklistItemsFilter,
+            [value]: checked,
+        }));
+    };
 
     return (
         <InnerContainer
@@ -59,6 +99,16 @@ const RHSChecklists = (props: Props) => {
                         title={allCollapsed ? 'Expand' : 'Collapse'}
                         className={(allCollapsed ? 'icon-arrow-expand' : 'icon-arrow-collapse') + ' icon-16 btn-icon'}
                         onClick={() => dispatch(setAllChecklistsCollapsedState(channelId, !allCollapsed, checklists.length))}
+                    />
+                    <MultiCheckbox
+                        options={filterOptions}
+                        onselect={selectOption}
+                        dotMenuButton={StyledDotMenuButton}
+                        icon={
+                            <IconWrapper>
+                                <i className='icon icon-filter-variant'/>
+                            </IconWrapper>
+                        }
                     />
                 </HoverRow>
             }
@@ -111,33 +161,42 @@ const RHSChecklists = (props: Props) => {
                                         ref={droppableProvided.innerRef}
                                         {...droppableProvided.droppableProps}
                                     >
-                                        {checklist.items.map((checklistItem: ChecklistItem, index: number) => (
-                                            <Draggable
-                                                key={checklistItem.title + index}
-                                                draggableId={checklistItem.title + index}
-                                                index={index}
-                                            >
-                                                {(draggableProvided: DraggableProvided, snapshot: DraggableStateSnapshot) => (
-                                                    <ChecklistItemDetails
-                                                        checklistItem={checklistItem}
-                                                        checklistNum={checklistIndex}
-                                                        itemNum={index}
-                                                        channelId={props.playbookRun.channel_id}
-                                                        playbookRunId={props.playbookRun.id}
-                                                        onChange={(newState: ChecklistItemState) => {
-                                                            setChecklistItemState(props.playbookRun.id, checklistIndex, index, newState);
-                                                        }}
-                                                        onRedirect={() => {
-                                                            if (isMobile()) {
-                                                                dispatch(toggleRHS());
-                                                            }
-                                                        }}
-                                                        draggableProvided={draggableProvided}
-                                                        dragging={snapshot.isDragging}
-                                                    />
-                                                )}
-                                            </Draggable>
-                                        ))}
+                                        {checklist.items
+                                            .map((checklistItem: ChecklistItem, index: number) => {
+                                                // filtering here because we need to maintain the index values
+                                                // because we refer to checklist items by their index
+                                                if (!showItem(checklistItem, checklistItemsFilter, myUser.id)) {
+                                                    return null;
+                                                }
+
+                                                return (
+                                                    <Draggable
+                                                        key={checklistItem.title + index}
+                                                        draggableId={checklistItem.title + index}
+                                                        index={index}
+                                                    >
+                                                        {(draggableProvided: DraggableProvided, snapshot: DraggableStateSnapshot) => (
+                                                            <ChecklistItemDetails
+                                                                checklistItem={checklistItem}
+                                                                checklistNum={checklistIndex}
+                                                                itemNum={index}
+                                                                channelId={props.playbookRun.channel_id}
+                                                                playbookRunId={props.playbookRun.id}
+                                                                onChange={(newState: ChecklistItemState) => {
+                                                                    setChecklistItemState(props.playbookRun.id, checklistIndex, index, newState);
+                                                                }}
+                                                                onRedirect={() => {
+                                                                    if (isMobile()) {
+                                                                        dispatch(toggleRHS());
+                                                                    }
+                                                                }}
+                                                                draggableProvided={draggableProvided}
+                                                                dragging={snapshot.isDragging}
+                                                            />
+                                                        )}
+                                                    </Draggable>
+                                                );
+                                            })}
                                         {droppableProvided.placeholder}
                                     </div>
                                 )}
@@ -178,4 +237,104 @@ const HoverRow = styled(HoverMenu)`
     right: 15px;
 `;
 
+const StyledDotMenuButton = styled(DotMenuButton)`
+    display: inline-block;
+    width: 28px;
+    height: 28px;
+
+    &:hover {
+        background: var(--button-bg-08);
+        color: var(--button-bg);
+    }
+`;
+
+const IconWrapper = styled.div`
+    padding: 6px 0 0 2px;
+    margin: 0;
+`;
+
 export default RHSChecklists;
+
+const makeFilterOptions = (filter: ChecklistItemsFilter, name: string) => {
+    return [
+        {
+            display: 'All tasks',
+            value: 'all',
+            selected: filter.all,
+            disabled: false,
+        },
+        {
+            value: 'divider',
+            display: '',
+        } as CheckboxOption,
+        {
+            value: 'title',
+            display: 'TASK STATE',
+        } as CheckboxOption,
+        {
+            display: 'Show checked tasks',
+            value: 'checked',
+            selected: filter.checked,
+            disabled: filter.all,
+        },
+        {
+            value: 'divider',
+            display: '',
+        } as CheckboxOption,
+        {
+            value: 'title',
+            display: 'ASSIGNEE',
+        } as CheckboxOption,
+        {
+            display: `Me (${name})`,
+            value: 'me',
+            selected: filter.me,
+            disabled: filter.all,
+        },
+        {
+            display: 'Unassigned',
+            value: 'unassigned',
+            selected: filter.unassigned,
+            disabled: filter.all,
+        },
+        {
+            display: 'Others',
+            value: 'others',
+            selected: filter.others,
+            disabled: filter.all,
+        },
+    ];
+};
+
+const showItem = (checklistItem: ChecklistItem, filter: ChecklistItemsFilter, myId: string) => {
+    if (filter.all) {
+        return true;
+    }
+    if (!filter.checked && checklistItem.state === ChecklistItemState.Closed) {
+        return false;
+    }
+    if (!filter.me && checklistItem.assignee_id === myId) {
+        return false;
+    }
+    if (!filter.unassigned && checklistItem.assignee_id === '') {
+        return false;
+    }
+    if (!filter.others && checklistItem.assignee_id !== myId) {
+        return false;
+    }
+    return true;
+};
+
+// isLastCheckedValueInBottomCategory returns true only if this value is in the bottom category and
+// it is the last checked value. We don't want to allow the user to deselect all the options in
+// the bottom category.
+const isLastCheckedValueInBottomCategory = (value: string, nextState: boolean, filter: ChecklistItemsFilter) => {
+    const inBottomCategory = (val: string) => val === 'me' || val === 'unassigned' || val === 'others';
+    if (!inBottomCategory(value)) {
+        return false;
+    }
+    const numChecked = ['me', 'unassigned', 'others'].reduce((accum, cur) => (
+        (inBottomCategory(cur) && filter[cur]) ? accum + 1 : accum
+    ), 0);
+    return numChecked === 1 && filter[value];
+};

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -4,9 +4,7 @@
 import {combineReducers} from 'redux';
 
 import {PlaybookRun} from 'src/types/playbook_run';
-
 import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
-
 import {
     RECEIVED_TOGGLE_RHS_ACTION,
     ReceivedToggleRHSAction,
@@ -45,10 +43,10 @@ import {
     SetChecklistCollapsedState,
     SetAllChecklistsCollapsedState,
     SET_CHECKLIST_COLLAPSED_STATE,
-    SET_ALL_CHECKLISTS_COLLAPSED_STATE,
+    SET_ALL_CHECKLISTS_COLLAPSED_STATE, SetChecklistItemsFilter, SET_CHECKLIST_ITEMS_FILTER,
 } from 'src/types/actions';
-
-import {GlobalSettings} from './types/settings';
+import {GlobalSettings} from 'src/types/settings';
+import {ChecklistItemsFilter} from 'src/types/playbook';
 
 function toggleRHSFunction(state = null, action: ReceivedToggleRHSAction) {
     switch (action.type) {
@@ -284,6 +282,18 @@ const checklistCollapsedState = (
     }
 };
 
+const checklistItemsFilterByChannel = (state: Record<string, ChecklistItemsFilter> = {}, action: SetChecklistItemsFilter) => {
+    switch (action.type) {
+    case SET_CHECKLIST_ITEMS_FILTER:
+        return {
+            ...state,
+            [action.channelId]: action.nextState,
+        };
+    default:
+        return state;
+    }
+};
+
 export default combineReducers({
     toggleRHSFunction,
     rhsOpen,
@@ -296,4 +306,5 @@ export default combineReducers({
     postMenuModalVisibility,
     hasViewedByChannel,
     checklistCollapsedState,
+    checklistItemsFilterByChannel,
 });

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -16,12 +16,11 @@ import {$ID, IDMappedObjects, Dictionary} from 'mattermost-redux/types/utilities
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {pluginId} from 'src/manifest';
-
 import {PlaybookRun, playbookRunIsActive} from 'src/types/playbook_run';
 import {RHSState, TimelineEventsFilter, TimelineEventsFilterDefault} from 'src/types/rhs';
 import {findLastUpdated} from 'src/utils';
-
-import {GlobalSettings} from './types/settings';
+import {GlobalSettings} from 'src/types/settings';
+import {ChecklistItemsFilter, ChecklistItemsFilterDefault} from 'src/types/playbook';
 
 //@ts-ignore GlobalState is not complete
 const pluginState = (state: GlobalState) => state['plugins-' + pluginId] || {};
@@ -84,6 +83,11 @@ export const currentChecklistAllCollapsed = createSelector(
         return true;
     },
 );
+
+export const currentChecklistItemsFilter = (state: GlobalState): ChecklistItemsFilter => {
+    const channelId = getCurrentChannelId(state);
+    return pluginState(state).checklistItemsFilterByChannel[channelId] || ChecklistItemsFilterDefault;
+};
 
 export const myActivePlaybookRunsList = createSelector(
     getCurrentTeamId,

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -4,11 +4,10 @@
 import Integrations from 'mattermost-redux/action_types/integrations';
 
 import {PlaybookRun} from 'src/types/playbook_run';
-
 import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
 import {pluginId} from 'src/manifest';
-
-import {GlobalSettings} from './settings';
+import {GlobalSettings} from 'src/types/settings';
+import {ChecklistItemsFilter} from 'src/types/playbook';
 
 export const RECEIVED_TOGGLE_RHS_ACTION = pluginId + '_toggle_rhs';
 export const SET_RHS_OPEN = pluginId + '_set_rhs_open';
@@ -29,6 +28,7 @@ export const HIDE_POST_MENU_MODAL = pluginId + '_hide_post_menu_modal';
 export const SET_HAS_VIEWED_CHANNEL = pluginId + '_set_has_viewed';
 export const SET_CHECKLIST_COLLAPSED_STATE = pluginId + '_set_checklist_collapsed_state';
 export const SET_ALL_CHECKLISTS_COLLAPSED_STATE = pluginId + '_set_all_checklists_collapsed_state';
+export const SET_CHECKLIST_ITEMS_FILTER = pluginId + '_set_checklist_items_filter';
 
 export interface ReceivedToggleRHSAction {
     type: typeof RECEIVED_TOGGLE_RHS_ACTION;
@@ -133,4 +133,10 @@ export interface SetAllChecklistsCollapsedState {
     channelId: string;
     numOfChecklists: number;
     collapsed: boolean;
+}
+
+export interface SetChecklistItemsFilter {
+    type: typeof SET_CHECKLIST_ITEMS_FILTER;
+    channelId: string;
+    nextState: ChecklistItemsFilter;
 }

--- a/webapp/src/types/playbook.ts
+++ b/webapp/src/types/playbook.ts
@@ -153,6 +153,22 @@ export const newChecklistItem = (title = '', description = '', command = '', sta
     state,
 });
 
+export interface ChecklistItemsFilter extends Record<string, boolean> {
+    all: boolean;
+    checked: boolean;
+    me: boolean;
+    unassigned: boolean;
+    others: boolean;
+}
+
+export const ChecklistItemsFilterDefault: ChecklistItemsFilter = {
+    all: false,
+    checked: false,
+    me: true,
+    unassigned: true,
+    others: true,
+};
+
 // eslint-disable-next-line
 export function isPlaybook(arg: any): arg is PlaybookWithChecklist {
     return (


### PR DESCRIPTION
#### Summary
- Adds a filter to the checklist task list. Works as described in the figma and in the thread: https://community-daily.mattermost.com/core/pl/4y149srtu7bm3jp5gg1wjzuzhr
- State is saved per user per channel (until webapp refresh)
- The bottom group must always have one option selected, so the user cannot uncheck the last value in the bottom group.

Looks like:
<img width="765" alt="Screen Shot 2021-07-26 at 3 53 37 PM" src="https://user-images.githubusercontent.com/1490756/127050382-40ba6824-d9f1-406f-a550-45b08cc79591.png">

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-36913
- https://mattermost.atlassian.net/browse/MM-36914 (state saved per user)

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [x] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
