### PR TITLE
Updated playbook templates

### DIFF
--- a/server/api/telemetry.go
+++ b/server/api/telemetry.go
@@ -52,6 +52,9 @@ func NewTelemetryHandler(router *mux.Router, playbookRunService app.PlaybookRunS
 	playbookTelemetryRouterAuthorized.Use(handler.checkPlaybookViewPermissions)
 	playbookTelemetryRouterAuthorized.HandleFunc("/{id:[A-Za-z0-9]+}", handler.telemetryForPlaybook).Methods(http.MethodPost)
 
+	templateRouter := telemetryRouter.PathPrefix("/template").Subrouter()
+	templateRouter.HandleFunc("", handler.telemetryForTemplate)
+
 	return handler
 }
 
@@ -175,6 +178,32 @@ func (h *TelemetryHandler) telemetryForPlaybook(w http.ResponseWriter, r *http.R
 	}
 
 	h.playbookTelemetry.FrontendTelemetryForPlaybook(playbook, userID, params.Action)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *TelemetryHandler) telemetryForTemplate(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var params struct {
+		TemplateName string `json:"template_name"`
+		Action       string `json:"action"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode post body", err)
+		return
+	}
+
+	if params.TemplateName == "" {
+		h.HandleError(w, errors.New("must provide template_name"))
+		return
+	}
+	if params.Action == "" {
+		h.HandleError(w, errors.New("must provide action"))
+		return
+	}
+
+	h.playbookTelemetry.FrontendTelemetryForPlaybookTemplate(params.TemplateName, userID, params.Action)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -231,6 +231,9 @@ type PlaybookTelemetry interface {
 
 	// FrontendTelemetryForPlaybook tracks an event originating from the frontend
 	FrontendTelemetryForPlaybook(playbook Playbook, userID, action string)
+
+	// FrontendTelemetryForPlaybookTemplate tracks an event originating from the frontend
+	FrontendTelemetryForPlaybookTemplate(templateName string, userID, action string)
 }
 
 const (

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -105,6 +105,16 @@ func NewPlaybookStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLSt
 			"DeleteAt",
 			"NumStages",
 			"NumSteps",
+			`(
+				CASE WHEN InviteUsersEnabled THEN 1 ELSE 0 END +
+				CASE WHEN DefaultCommanderEnabled THEN 1 ELSE 0 END +
+				CASE WHEN AnnouncementChannelEnabled THEN 1 ELSE 0 END +
+				CASE WHEN WebhookOnCreationEnabled THEN 1 ELSE 0 END +
+				CASE WHEN MessageOnJoinEnabled THEN 1 ELSE 0 END +
+				CASE WHEN WebhookOnStatusUpdateEnabled THEN 1 ELSE 0 END +
+				CASE WHEN SignalAnyKeywordsEnabled THEN 1 ELSE 0 END +
+				CASE WHEN CategorizeChannelEnabled THEN 1 ELSE 0 END
+			) AS NumActions`,
 			"BroadcastChannelID",
 			"COALESCE(ReminderMessageTemplate, '') ReminderMessageTemplate",
 			"ReminderTimerDefaultSeconds",
@@ -290,7 +300,8 @@ func (p *playbookStore) GetPlaybooks() ([]app.Playbook, error) {
 				CASE WHEN p.WebhookOnCreationEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.MessageOnJoinEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.WebhookOnStatusUpdateEnabled THEN 1 ELSE 0 END +
-				CASE WHEN p.SignalAnyKeywordsEnabled THEN 1 ELSE 0 END
+				CASE WHEN p.SignalAnyKeywordsEnabled THEN 1 ELSE 0 END +
+				CASE WHEN p.CategorizeChannelEnabled THEN 1 ELSE 0 END
 			) AS NumActions`,
 		).
 		From("IR_Playbook AS p").
@@ -352,7 +363,8 @@ func (p *playbookStore) GetPlaybooksForTeam(requesterInfo app.RequesterInfo, tea
 				CASE WHEN p.WebhookOnCreationEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.MessageOnJoinEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.WebhookOnStatusUpdateEnabled THEN 1 ELSE 0 END +
-				CASE WHEN p.SignalAnyKeywordsEnabled THEN 1 ELSE 0 END
+				CASE WHEN p.SignalAnyKeywordsEnabled THEN 1 ELSE 0 END +
+				CASE WHEN p.CategorizeChannelEnabled THEN 1 ELSE 0 END
 			) AS NumActions`,
 		).
 		From("IR_Playbook AS p").

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -113,7 +113,8 @@ func NewPlaybookStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLSt
 				CASE WHEN MessageOnJoinEnabled THEN 1 ELSE 0 END +
 				CASE WHEN WebhookOnStatusUpdateEnabled THEN 1 ELSE 0 END +
 				CASE WHEN SignalAnyKeywordsEnabled THEN 1 ELSE 0 END +
-				CASE WHEN CategorizeChannelEnabled THEN 1 ELSE 0 END
+				CASE WHEN CategorizeChannelEnabled THEN 1 ELSE 0 END +
+				CASE WHEN ExportChannelOnArchiveEnabled THEN 1 ELSE 0 END
 			) AS NumActions`,
 			"BroadcastChannelID",
 			"COALESCE(ReminderMessageTemplate, '') ReminderMessageTemplate",
@@ -301,7 +302,8 @@ func (p *playbookStore) GetPlaybooks() ([]app.Playbook, error) {
 				CASE WHEN p.MessageOnJoinEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.WebhookOnStatusUpdateEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.SignalAnyKeywordsEnabled THEN 1 ELSE 0 END +
-				CASE WHEN p.CategorizeChannelEnabled THEN 1 ELSE 0 END
+				CASE WHEN p.CategorizeChannelEnabled THEN 1 ELSE 0 END +
+				CASE WHEN p.ExportChannelOnArchiveEnabled THEN 1 ELSE 0 END
 			) AS NumActions`,
 		).
 		From("IR_Playbook AS p").
@@ -364,7 +366,8 @@ func (p *playbookStore) GetPlaybooksForTeam(requesterInfo app.RequesterInfo, tea
 				CASE WHEN p.MessageOnJoinEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.WebhookOnStatusUpdateEnabled THEN 1 ELSE 0 END +
 				CASE WHEN p.SignalAnyKeywordsEnabled THEN 1 ELSE 0 END +
-				CASE WHEN p.CategorizeChannelEnabled THEN 1 ELSE 0 END
+				CASE WHEN p.CategorizeChannelEnabled THEN 1 ELSE 0 END +
+				CASE WHEN p.ExportChannelOnArchiveEnabled THEN 1 ELSE 0 END
 			) AS NumActions`,
 		).
 		From("IR_Playbook AS p").

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -125,6 +125,7 @@ func TestGetPlaybook(t *testing.T) {
 		WithCreateAt(1300).
 		WithChecklists([]int{1}).
 		WithMembers(append(multipleUserInfo(100), desmond, lucia)).
+		WithKeywords([]string{"keyword"}).
 		ToPlaybook()
 
 	playbooks := []app.Playbook{pb01, pb02, pb03, pb04, pb05, pb06, pb07, pb08}
@@ -303,6 +304,7 @@ func TestGetPlaybooks(t *testing.T) {
 		WithUpdateAt(0).
 		WithChecklists([]int{1}).
 		WithMembers(append(multipleUserInfo(100), desmond, lucia)).
+		WithKeywords([]string{"keyword"}).
 		ToPlaybook()
 
 	playbooks := []app.Playbook{pb01, pb02, pb03, pb04, pb05, pb06, pb07, pb08}
@@ -370,11 +372,14 @@ func TestGetPlaybooks(t *testing.T) {
 					actual[i].ID = ""
 				}
 
-				// remove the checklists from the expected playbooks--we don't return them in getPlaybooks
+				// remove data we don't bulk fetch from the expected playbooks
 				var expected []app.Playbook
 				for _, p := range testCase.expected {
 					tmp := p.Clone()
 					tmp.Checklists = nil
+					tmp.SignalAnyKeywords = nil
+					tmp.SignalAnyKeywordsEnabled = false
+					tmp.Clone()
 					expected = append(expected, tmp)
 				}
 
@@ -1721,6 +1726,7 @@ func (p *PlaybookBuilder) WithMembers(members []userInfo) *PlaybookBuilder {
 func (p *PlaybookBuilder) WithKeywords(keywords []string) *PlaybookBuilder {
 	p.SignalAnyKeywordsEnabled = true
 	p.SignalAnyKeywords = keywords
+	p.NumActions++
 
 	return p
 }

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -99,10 +99,12 @@ func (t *NoopTelemetry) StartTrial(userID string, action string) {
 
 // NotifyAdmins does nothing.
 func (t *NoopTelemetry) NotifyAdmins(userID string, action string) {
-
 }
 
 // FrontendTelemetryForPlaybook does nothing.
 func (t *NoopTelemetry) FrontendTelemetryForPlaybook(playbook app.Playbook, userID, action string) {
+}
 
+// FrontendTelemetryForPlaybookTemplate does nothing.
+func (t *NoopTelemetry) FrontendTelemetryForPlaybookTemplate(templateName string, userID, action string) {
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -317,6 +317,13 @@ func playbookProperties(playbook app.Playbook, userID string) map[string]interfa
 	}
 }
 
+func playbookTemplateProperties(templateName string, userID string) map[string]interface{} {
+	return map[string]interface{}{
+		"UserActualID": userID,
+		"TemplateName": templateName,
+	}
+}
+
 // CreatePlaybook tracks the creation of a playbook.
 func (t *RudderTelemetry) CreatePlaybook(playbook app.Playbook, userID string) {
 	properties := playbookProperties(playbook, userID)
@@ -341,6 +348,13 @@ func (t *RudderTelemetry) DeletePlaybook(playbook app.Playbook, userID string) {
 // FrontendTelemetryForPlaybook tracks an event originating from the frontend
 func (t *RudderTelemetry) FrontendTelemetryForPlaybook(playbook app.Playbook, userID, action string) {
 	properties := playbookProperties(playbook, userID)
+	properties["Action"] = action
+	t.track(eventFrontend, properties)
+}
+
+// FrontendTelemetryForPlaybookTemplate tracks a playbook template event originating from the frontend
+func (t *RudderTelemetry) FrontendTelemetryForPlaybookTemplate(templateName string, userID, action string) {
+	properties := playbookTemplateProperties(templateName, userID)
 	properties["Action"] = action
 	t.track(eventFrontend, properties)
 }

--- a/tests-e2e/cypress/integration/backstage/playbook_creation_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_creation_spec.js
@@ -64,9 +64,9 @@ describe('playbook creation button', () => {
         verifyPlaybookCreationPageOpened(url, playbookName);
     });
 
-    it('opens Service Outage Incident page from its template option', () => {
-        const url = 'playbooks/new?template_title=Service%20Outage%20Incident';
-        const playbookName = 'Service Outage Incident';
+    it('opens Service Reliability Incident page from its template option', () => {
+        const url = 'playbooks/new?template_title=Service%20Reliability%20Incident';
+        const playbookName = 'Service Reliability Incident';
 
         // # Open backstage
         cy.visit('/ad-1/com.mattermost.plugin-incident-management');
@@ -74,10 +74,10 @@ describe('playbook creation button', () => {
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();
 
-        // # Click 'Service Outage Incident'
-        cy.findByText('Service Outage Incident').click();
+        // # Click 'Service Reliability Incident'
+        cy.findByText('Service Reliability Incident').click();
 
-        // * Verify a new 'Service Outage Incident' creation page is opened
+        // * Verify a new 'Service Reliability Incident' creation page is opened
         verifyPlaybookCreationPageOpened(url, playbookName);
     });
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -312,6 +312,13 @@ export async function telemetryEventForPlaybook(playbookID: string, action: stri
     });
 }
 
+export async function telemetryEventForTemplate(templateName: string, action: string) {
+    await doFetchWithoutResponse(`${apiUrl}/telemetry/template`, {
+        method: 'POST',
+        body: JSON.stringify({template_name: templateName, action}),
+    });
+}
+
 export async function setGlobalSettings(settings: GlobalSettings) {
     await doFetchWithoutResponse(`${apiUrl}/settings`, {
         method: 'PUT',

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -15,6 +15,7 @@ import DotMenuIcon from 'src/components/assets/icons/dot_menu_icon';
 import TextWithTooltip from 'src/components/widgets/text_with_tooltip';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import TemplateSelector, {PresetTemplate} from 'src/components/backstage/template_selector';
+import {telemetryEventForTemplate} from 'src/client';
 
 import BackstageListHeader from 'src/components/backstage/backstage_list_header';
 import './playbook.scss';
@@ -147,6 +148,7 @@ const PlaybookList = () => {
             {canCreatePlaybooks &&
                 <TemplateSelector
                     onSelect={(template: PresetTemplate) => {
+                        telemetryEventForTemplate(template.title, 'click_template_icon');
                         create(template.title);
                     }}
                 />

--- a/webapp/src/components/backstage/template_selector.tsx
+++ b/webapp/src/components/backstage/template_selector.tsx
@@ -83,6 +83,7 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
+            num_actions: 2,
             create_public_playbook_run: false,
             message_on_join_enabled: true,
             message_on_join:
@@ -175,6 +176,7 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
+            num_actions: 2,
             create_public_playbook_run: false,
             message_on_join_enabled: true,
             message_on_join:
@@ -244,6 +246,7 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
+            num_actions: 3,
             create_public_playbook_run: false,
             message_on_join_enabled: true,
             message_on_join:

--- a/webapp/src/components/backstage/template_selector.tsx
+++ b/webapp/src/components/backstage/template_selector.tsx
@@ -3,8 +3,10 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import Icon from '@mdi/react';
+import {mdiRocketLaunchOutline, mdiHandshakeOutline, mdiCodeBraces} from '@mdi/js';
 
-import {DraftPlaybookWithChecklist, emptyPlaybook, newChecklistItem, defaultMessageOnJoin} from 'src/types/playbook';
+import {DraftPlaybookWithChecklist, emptyPlaybook, newChecklistItem} from 'src/types/playbook';
 import FileIcon from 'src/components/assets/icons/file_icon';
 import AlertIcon from 'src/components/assets/icons/alert_icon';
 import {useAllowPlaybookCreationInCurrentTeam} from 'src/hooks';
@@ -17,6 +19,10 @@ export interface PresetTemplate {
     template: DraftPlaybookWithChecklist;
 }
 
+const TemplateIcon = styled(Icon)`
+    color: var(--mention-highlight-link);
+`;
+
 export const PresetTemplates: PresetTemplate[] = [
     {
         title: 'Blank',
@@ -24,54 +30,274 @@ export const PresetTemplates: PresetTemplate[] = [
         template: emptyPlaybook(),
     },
     {
-        title: 'Service Outage Incident',
-        icon: <AlertIcon/>,
+        title: 'Product Release',
+        icon: (
+            <TemplateIcon
+                path={mdiRocketLaunchOutline}
+                size={2.5}
+            />
+        ),
         template: {
             ...emptyPlaybook(),
-            title: 'Service Outage Incident',
-            description: '### Summary\n\nDescribe the incident so that someone without prior knowledge can ramp up quickly. Two sentences is the ideal length.\n\n' +
-                '### Impact\n\nDescribe the customer and organizational impact of this incident.',
-            reminder_message_template: '### Incident update\n\nDescribe progress and changes to the incident since the last update.\n\n' +
-                '### Change to customer impact\n\nDescribe any changes to customer impact since the last update.',
-            message_on_join: defaultMessageOnJoin,
-            num_stages: 3,
+            title: 'Product Release',
+            num_stages: 4,
             checklists: [
                 {
-                    title: 'Triage',
+                    title: 'Prepare code',
                     items: [
-                        newChecklistItem('Announce incident type and resources', '', '/echo ""'),
-                        newChecklistItem('Acknowledge alert'),
-                        newChecklistItem('Get alert info'),
-                        newChecklistItem('Invite escalators'),
-                        newChecklistItem('Determine priority'),
-                        newChecklistItem('Update alert priority'),
-                        newChecklistItem('Create a JIRA ticket', '', '/jira create'),
-                        newChecklistItem('Find out who’s on call', '', '/genie whoisoncall'),
-                        newChecklistItem('Announce incident'),
-                        newChecklistItem('Invite on-call lead'),
+                        newChecklistItem('Triage and check for pending tickets and PRs to merge'),
+                        newChecklistItem('Start drafting changelog, feature documentation, and marketing materials'),
+                        newChecklistItem('Review and update project dependencies as needed'),
+                        newChecklistItem('QA prepares release testing assignments'),
+                        newChecklistItem('Merge database upgrade'),
                     ],
                 },
                 {
-                    title: 'Investigation',
+                    title: 'Release testing',
                     items: [
-                        newChecklistItem('Perform initial investigation'),
-                        newChecklistItem('Escalate to other on-call members (optional)'),
-                        newChecklistItem('Escalate to other engineering teams (optional)'),
+                        newChecklistItem('Cut a Release Candidate (RC-1)'),
+                        newChecklistItem('QA runs smoke tests on the pre-release build'),
+                        newChecklistItem('QA runs automated load tests and upgrade tests on the pre-release build'),
+                        newChecklistItem('Triage and merge regression bug fixes'),
+                    ],
+                },
+                {
+                    title: 'Prepare release for production',
+                    items: [
+                        newChecklistItem('QA final approves the release'),
+                        newChecklistItem('Cut the final release build and publish'),
+                        newChecklistItem('Deploy changelog, upgrade notes, and feature documentation'),
+                        newChecklistItem('Confirm minimum server requirements are updated in documentation'),
+                        newChecklistItem('Update release download links in relevant docs and webpages'),
+                        newChecklistItem('Publish announcements and marketing'),
+                    ],
+                },
+                {
+                    title: 'Post-release',
+                    items: [
+                        newChecklistItem('Schedule a release retrospective'),
+                        newChecklistItem('Add dates for the next release to the release calendar and communicate to stakeholders'),
+                        newChecklistItem('Compose release metrics'),
+                        newChecklistItem('Prepare security update communications'),
+                        newChecklistItem('Archive the incident channel and create a new one for the next release'),
+                    ],
+                },
+            ],
+            create_public_playbook_run: false,
+            message_on_join_enabled: true,
+            message_on_join:
+                'Hello and welcome!\n\n' +
+                'This channel was created as part of the **Product Release** playbook and is where conversations related to this release are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.',
+            categorize_channel_enabled: true,
+            description:
+                '**About**\n' +
+                '- Version number: TBD\n' +
+                '- Target-date: TBD\n' +
+                '\n' +
+                '**Resources**\n' +
+                '- Jira filtered view: [link TBC](#)\n' +
+                '- Blog post draft: [link TBC](#)\n',
+            reminder_message_template:
+                '**Changes since last update**\n' +
+                '\n' +
+                '**Outstanding PRs**\n' +
+                '\n',
+            reminder_timer_default_seconds: 24 * 60 * 60, // 24 hours
+            retrospective_template:
+                'Start\n' +
+                '\n' +
+                'Stop\n' +
+                '\n' +
+                'Keep\n' +
+                '\n',
+            retrospective_reminder_interval_seconds: 0, // Once
+        },
+    },
+    {
+        title: 'Customer Onboarding',
+        icon: (
+            <TemplateIcon
+                path={mdiHandshakeOutline}
+                size={2.5}
+            />
+        ),
+        template: {
+            ...emptyPlaybook(),
+            title: 'Customer Onboarding',
+            num_stages: 4,
+            checklists: [
+                {
+                    title: 'Sales to Post-Sales Handoff',
+                    items: [
+                        newChecklistItem('AE intro CSM and CSE to key contacts'),
+                        newChecklistItem('Create customer account Drive folder'),
+                        newChecklistItem('Welcome email within 24hr of Closed Won'),
+                        newChecklistItem('Schedule initial kickoff call with customer'),
+                        newChecklistItem('Create account plan (Tier 1 or 2)'),
+                        newChecklistItem('Send discovery Survey'),
+                    ],
+                },
+                {
+                    title: 'Customer Technical Onboarding',
+                    items: [
+                        newChecklistItem('Schedule technical discovery call'),
+                        newChecklistItem('Review current Zendesk tickets and updates'),
+                        newChecklistItem('Log customer technical details in Salesforce'),
+                        newChecklistItem('Confirm customer received technical discovery summary package'),
+                        newChecklistItem('Send current Mattermost “Pen Test” report to customer'),
+                        newChecklistItem('Schedule plugin/integration planning session'),
+                        newChecklistItem('Confirm data migration plans'),
+                        newChecklistItem('Extend Mattermost with integrations'),
+                        newChecklistItem('Confirm functional & load test plans'),
+                        newChecklistItem('Confirm team/channel organization'),
+                        newChecklistItem('Sign up for Mattermost blog for releases and announcements'),
+                        newChecklistItem('Confirm next upgrade version'),
+                    ],
+                },
+                {
+                    title: 'Go-Live',
+                    items: [
+                        newChecklistItem('Order Mattermost swag package for project team'),
+                        newChecklistItem('Confirm end-user roll-out plan'),
+                        newChecklistItem('Confirm customer go-live'),
+                        newChecklistItem('Perform post go-live retrospective'),
+                    ],
+                },
+                {
+                    title: 'Optional value prompts after go-live',
+                    items: [
+                        newChecklistItem('Intro playbooks and boards'),
+                        newChecklistItem('Inform upgrading Mattermost 101'),
+                        newChecklistItem('Share tips & tricks w/ DevOps focus'),
+                        newChecklistItem('Share tips & tricks w/ efficiency focus'),
+                        newChecklistItem('Schedule quarterly roadmap review w/ product team'),
+                        newChecklistItem('Review with executives (Tier 1 or 2)'),
+                    ],
+                },
+            ],
+            create_public_playbook_run: false,
+            message_on_join_enabled: true,
+            message_on_join:
+                'Hello and welcome!\n\n' +
+                'This channel was created as part of the **Customer Onboarding** playbook and is where conversations related to this customer are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.',
+            categorize_channel_enabled: true,
+            description:
+                '**About**\n' +
+                '- Account name: [TBD](#)\n' +
+                '- Salesforce opportunity: [TBD](#)\n' +
+                '- Order type:\n' +
+                '- Close date:\n' +
+                '\n' +
+                '**Team**\n' +
+                '- Sales Rep: @TBD\n' +
+                '- Customer Success Manager: @TBD\n',
+            retrospective_template:
+                'What went well?\n' +
+                '\n' +
+                'What could’ve gone better?\n' +
+                '\n' +
+                'What should be changed for next time?\n' +
+                '\n',
+            retrospective_reminder_interval_seconds: 0, // Once
+        },
+    },
+    {
+        title: 'Service Reliability Incident',
+        icon: <AlertIcon/>,
+        template: {
+            ...emptyPlaybook(),
+            title: 'Service Reliability Incident',
+            num_stages: 4,
+            checklists: [
+                {
+                    title: 'Setup for triage',
+                    items: [
+                        newChecklistItem('Add on-call engineer to channel'),
+                        newChecklistItem('Start bridge call', '', '/zoom start'),
+                        newChecklistItem('Update description with current situation'),
+                        newChecklistItem('Create an incident ticket', '', '/jira create'),
+                        newChecklistItem('Assign severity in description (ie. #sev-2)'),
+                        newChecklistItem('(If #sev-1) Notify @vip'),
+                    ],
+                },
+                {
+                    title: 'Investigate cause',
+                    items: [
+                        newChecklistItem('Add suspected causes here and check off if eliminated'),
                     ],
                 },
                 {
                     title: 'Resolution',
                     items: [
-                        newChecklistItem('Close alert'),
-                        newChecklistItem('End the incident', '', '/playbook end'),
-                        newChecklistItem('Schedule a post-mortem'),
-                        newChecklistItem('Record post-mortem action items'),
-                        newChecklistItem('Update playbook with learnings'),
-                        newChecklistItem('Export channel message history', '', '/export'),
-                        newChecklistItem('Archive this channel', '', ''),
+                        newChecklistItem('Confirm issue has been resolved'),
+                        newChecklistItem('Notify customer success managers'),
+                        newChecklistItem('(If sev-1) Notify leader team'),
+                    ],
+                },
+                {
+                    title: 'Retrospective',
+                    items: [
+                        newChecklistItem('Send out survey to participants'),
+                        newChecklistItem('Schedule post-mortem meeting'),
+                        newChecklistItem('Save key messages as timeline entries'),
+                        newChecklistItem('Publish retrospective report'),
                     ],
                 },
             ],
+            create_public_playbook_run: false,
+            message_on_join_enabled: true,
+            message_on_join:
+                'Hello and welcome!\n\n' +
+                'This channel was created as part of the **Service Reliability Incident** playbook and is where conversations related to this release are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.',
+            categorize_channel_enabled: true,
+            description:
+                '**Summary**\n' +
+                '\n' +
+                '**Customer impact**\n' +
+                '\n' +
+                '**About**\n' +
+                '- Severity: #sev-1/2/3\n' +
+                '- Responders:\n' +
+                '- ETA to resolution:\n',
+            reminder_message_template: '',
+            reminder_timer_default_seconds: 60 * 60, // 1 hour
+            retrospective_template:
+                '### Summary\n' +
+                'This should contain 2-3 sentences that give a reader an overview of what happened, what was the cause, and what was done. The briefer the better as this is what future teams will look at first for reference.\n' +
+                '\n' +
+                '### What was the impact?\n' +
+                'This section describes the impact of this playbook run as experienced by internal and external customers as well as stakeholders.\n' +
+                '\n' +
+                '### What were the contributing factors?\n' +
+                'This playbook may be a reactive protocol to a situation that is otherwise undesirable. If that\'s the case, this section explains the reasons that caused the situation in the first place. There may be multiple root causes - this helps stakeholders understand why.\n' +
+                '\n' +
+                '### What was done?\n' +
+                'This section tells the story of how the team collaborated throughout the event to achieve the outcome. This will help future teams learn from this experience on what they could try.\n' +
+                '\n' +
+                '### What did we learn?\n' +
+                'This section should include perspective from everyone that was involved to celebrate the victories and identify areas for improvement. For example: What went well? What didn\'t go well? What should be done differently next time?\n' +
+                '\n' +
+                '### Follow-up tasks\n' +
+                'This section lists the action items to turn learnings into changes that help the team become more proficient with iterations. It could include tweaking the playbook, publishing the retrospective, or other improvements. The best follow-ups will have a clear owner assigned as well as due date.\n' +
+                '\n' +
+                '### Timeline Highlights\n' +
+                'This section is a curated log that details the most important moments. It can contain key communications, screen shots, or other artifacts. Use the built-in timeline feature to help you retrace and replay the sequence of events.\n',
+            retrospective_reminder_interval_seconds: 24 * 60 * 60, // 24 hours
+            signal_any_keywords_enabled: true,
+            signal_any_keywords: ['sev-1', 'sev-2', '#incident', 'this is serious'],
+        },
+    },
+    {
+        title: 'Feature Swimlane',
+        icon: (
+            <TemplateIcon
+                path={mdiCodeBraces}
+                size={2.5}
+            />
+        ),
+        template: {
+            ...emptyPlaybook(),
+            title: 'Feature Swimlane',
         },
     },
 ];
@@ -121,7 +347,7 @@ const TemplateItemDiv = styled.div`
     overflow-x: auto;
     padding: 20px 0;
     > ${TemplateItemContainer.selector}:nth-child(n+1) {
-        margin-right: 32px;
+        margin-right: 24px;
     }
 `;
 

--- a/webapp/src/components/rhs/rhs_home.tsx
+++ b/webapp/src/components/rhs/rhs_home.tsx
@@ -22,6 +22,7 @@ import {
 } from 'src/components/rhs/rhs_shared';
 import {setRHSViewingPlaybookRun} from 'src/actions';
 import {currentPlaybookRun} from 'src/selectors';
+import {telemetryEventForTemplate} from 'src/client';
 
 import {AdminNotificationType} from 'src/constants';
 
@@ -205,6 +206,9 @@ const RHSHome = () => {
     const [isUpgradeModalShown, showUpgradeModal, hideUpgradeModal] = useUpgradeModalVisibility(false);
 
     const newPlaybook = (template?: DraftPlaybookWithChecklist) => {
+        if (template) {
+            telemetryEventForTemplate(template.title, 'use_template_option');
+        }
         if (allowPlaybookCreation) {
             create(template?.title);
         } else {


### PR DESCRIPTION
#### Summary
As per @itao's [proposal](https://docs.google.com/document/d/1pJscJCqiL3CDemsBN-V_3NRvOeapB3nbjE7eEKTwmGY/edit), replace the existing templates:
* Blank (unchanged)
* Product Release
* Customer Onboarding
* Service Reliability Incident (refreshed)
* Feature Swimlane (basically empty)

The existing template selector scrolls on demand, but to give a slightly better experience on a typical MacBook Pro, I reduced the required margin to avoid scrolling in this case:

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/1023171/127220165-17babf6b-11ed-4510-8d01-ccfd971e79c0.png">

On smaller screens, scrolling still works:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/1023171/127220224-53fe843d-85d2-4089-9b38-3398c9160edf.png">

And @calebroseland's updated RHS works beautifully with the new templates (though it seems like `num_actions` is hard-coded at the moment to `0`).

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1023171/127220267-6cad88d1-007b-43f3-9d2f-3943c3625547.png">

Telemetry is updated to track clicks on the template icons in the backstage, as well as the `Use template` option in the new RHS experience.

#### Ticket Link
None.

#### Checklist
- [x] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
