### PR TITLE
RHS Redesign Keyboard A11y

### DIFF
--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -32,6 +32,8 @@ import {ChannelNamesMap} from 'src/types/backstage';
 import {ChecklistItem, ChecklistItemState} from 'src/types/playbook';
 import TextWithTooltipWhenEllipsis from 'src/components/widgets/text_with_tooltip_when_ellipsis';
 
+import {visuallyHidden} from 'src/styles';
+
 import CommandInput from './command_input';
 import GenericModal from './widgets/generic_modal';
 import {BaseInput} from './assets/inputs';
@@ -79,6 +81,14 @@ const ItemContainer = styled.div`
     :first-child {
         padding-top: 0.4rem;
     }
+
+    &:not(.dragging):not(:hover) ${HoverMenu}:not(:focus-within) {
+        ${visuallyHidden}
+    }
+
+    [data-rbd-scroll-container-context-id] & ${HoverMenu} {
+        display: none;
+    }
 `;
 
 const ExtrasRow = styled.div`
@@ -109,7 +119,7 @@ export const CheckboxContainer = styled.div`
     display: flex;
     position: relative;
 
-    button {
+    button:not(.btn-icon) {
         width: 53px;
         height: 29px;
         border: 1px solid #166DE0;
@@ -125,13 +135,13 @@ export const CheckboxContainer = styled.div`
         color: #166DE0;
         cursor: pointer;
         margin-right: 13px;
-    }
 
-    button:disabled {
-        border: 0px;
-        color: var(--button-color);
-        background: var(--center-channel-color-56);
-        cursor: default;
+        &:disabled {
+            border: 0px;
+            color: var(--button-color);
+            background: var(--center-channel-color-56);
+            cursor: default;
+        }
     }
 
     &:hover {
@@ -256,8 +266,7 @@ const StepDescription = (props: StepDescriptionProps): React.ReactElement<StepDe
         <>
             <HoverMenuButton
                 title={'Description'}
-                tabIndex={0}
-                className={'icon-information-outline icon-16 btn-icon'}
+                iconClassName={'icon-information-outline icon-16 btn-icon'}
                 ref={target}
                 onClick={() => setShowTooltip(!showTooltip)}
             />
@@ -326,7 +335,6 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
 
     const [running, setRunning] = useState(false);
     const [lastRun, setLastRun] = useState(props.checklistItem.command_last_run);
-    const [showMenu, setShowMenu] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [showEditDialog, setShowEditDialog] = useState(false);
 
@@ -369,14 +377,27 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
             <ItemContainer
                 ref={props.draggableProvided.innerRef}
                 {...props.draggableProvided.draggableProps}
-                onMouseEnter={() => setShowMenu(true)}
-                onMouseLeave={() => setShowMenu(false)}
                 data-testid='checkbox-item-container'
+                className={props.dragging ? 'dragging' : ''}
             >
                 <CheckboxContainer>
-                    {showMenu &&
+                    <ChecklistItemButton
+                        item={props.checklistItem}
+                        onChange={(item: ChecklistItemState) => {
+                            if (props.onChange) {
+                                props.onChange(item);
+                            }
+                        }}
+                    />
+                    <label title={title}>
+                        <div
+                            onClick={((e) => handleFormattedTextClick(e, relativeTeamUrl))}
+                        >
+                            {messageHtmlToComponent(formatText(title, markdownOptions), true, {})}
+                        </div>
+                    </label>
                     <HoverMenu>
-                        <HoverMenuButton
+                        <i
                             title={'Drag me to reorder'}
                             className={'icon icon-menu'}
                             {...props.draggableProvided.dragHandleProps}
@@ -394,7 +415,7 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                             placeholder={
                                 <HoverMenuButton
                                     title={'Assign'}
-                                    className={'icon-account-plus-outline icon-16 btn-icon'}
+                                    iconClassName={'icon-account-plus-outline icon-16'}
                                 />
                             }
                             enableEdit={true}
@@ -411,35 +432,19 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                         />
                         <HoverMenuButton
                             title={'Edit'}
-                            className={'icon-pencil-outline icon-16 btn-icon'}
+                            iconClassName={'icon-pencil-outline icon-16'}
                             onClick={() => {
                                 setShowEditDialog(true);
                             }}
                         />
                         <HoverMenuButton
                             title={'Delete'}
-                            className={'icon-trash-can-outline icon-16 btn-icon'}
+                            iconClassName={'icon-trash-can-outline icon-16'}
                             onClick={() => {
                                 setShowDeleteConfirm(true);
                             }}
                         />
                     </HoverMenu>
-                    }
-                    <ChecklistItemButton
-                        item={props.checklistItem}
-                        onChange={(item: ChecklistItemState) => {
-                            if (props.onChange) {
-                                props.onChange(item);
-                            }
-                        }}
-                    />
-                    <label title={title}>
-                        <div
-                            onClick={((e) => handleFormattedTextClick(e, relativeTeamUrl))}
-                        >
-                            {messageHtmlToComponent(formatText(title, markdownOptions), true, {})}
-                        </div>
-                    </label>
                 </CheckboxContainer>
                 <ExtrasRow>
                     {props.checklistItem.assignee_id &&

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -17,6 +17,8 @@ import {updateStatus} from 'src/actions';
 import RHSParticipants from 'src/components/rhs/rhs_participants';
 import {HoverMenu, HoverMenuButton} from 'src/components/rhs/rhs_shared';
 
+import {visuallyHidden} from 'src/styles';
+
 interface Props {
     playbookRun: PlaybookRun;
 }
@@ -53,11 +55,14 @@ const RHSAbout = (props: Props) => {
                     href={'#'}
                     tabIndex={0}
                     role={'button'}
-                    onClick={() => dispatch(updateStatus())}
+                    onClick={(e) => {
+                        e.preventDefault();
+                        dispatch(updateStatus());
+                    }}
                     onKeyDown={(e) => {
                         // Handle Enter and Space as clicking on the button
-                        if (e.keyCode === 13 || e.keyCode === 32) {
-                            dispatch(updateStatus());
+                        if (e.keyCode === 32) {
+                            e.currentTarget.click();
                         }
                     }}
                 >{'Click here'}</a>
@@ -86,7 +91,7 @@ const RHSAbout = (props: Props) => {
         .map((p) => p.id);
 
     return (
-        <Container tabIndex={0} >
+        <Container>
             <Buttons
                 collapsed={collapsed}
                 toggleCollapsed={toggleCollapsed}
@@ -155,16 +160,8 @@ const Buttons = ({collapsed, toggleCollapsed} : ButtonsProps) => {
         <ButtonsRow>
             <HoverMenuButton
                 title={collapsed ? 'Expand' : 'Collapse'}
-                className={(collapsed ? 'icon-arrow-expand' : 'icon-arrow-collapse') + ' icon-16 btn-icon'}
-                tabIndex={0}
-                role={'button'}
+                iconClassName={(collapsed ? 'icon-arrow-expand' : 'icon-arrow-collapse') + ' icon-16 btn-icon'}
                 onClick={toggleCollapsed}
-                onKeyDown={(e) => {
-                    // Handle Enter and Space as clicking on the button
-                    if (e.keyCode === 13 || e.keyCode === 32) {
-                        toggleCollapsed();
-                    }
-                }}
             />
         </ButtonsRow>
     );
@@ -174,15 +171,13 @@ const ButtonsRow = styled(HoverMenu)`
     top: 9px;
     right: 12px;
 
-    display: none;
-
-    ${Container}:focus-within &, ${Container}:hover & {
-        display: block;
+    ${Container}:not(:focus-within):not(:hover) &:not(:focus):not(:hover) {
+        ${visuallyHidden}
     }
 `;
 
 const PaddedContent = styled.div`
-    padding: 0 8px; 
+    padding: 0 8px;
 `;
 
 const Title = styled(PaddedContent)`

--- a/webapp/src/components/rhs/rhs_shared.tsx
+++ b/webapp/src/components/rhs/rhs_shared.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {forwardRef, HTMLAttributes, Ref} from 'react';
 import styled, {css} from 'styled-components';
 
 import Profile from 'src/components/profile/profile';
@@ -112,7 +112,22 @@ export const HoverMenu = styled.div`
     z-index: 2;
 `;
 
-export const HoverMenuButton = styled.i`
+type IconButtonProps = {iconClassName: string} & HTMLAttributes<HTMLButtonElement>;
+
+const IconButton = forwardRef((
+    {iconClassName, ...attrs}: IconButtonProps,
+    ref: Ref<HTMLButtonElement>,
+) => (
+    <button
+        ref={ref}
+        {...attrs}
+        className={'btn-icon ' + attrs.className}
+    >
+        <i className={iconClassName}/>
+    </button>
+));
+
+export const HoverMenuButton = styled(IconButton)`
     display: inline-block;
     cursor: pointer;
     width: 28px;

--- a/webapp/src/components/widgets/icon.tsx
+++ b/webapp/src/components/widgets/icon.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+type Props = {
+    color: string;
+}
+
+const icons = require.context('src/components/assets/icons', false, /!(*icon)\.tsx$/);
+
+console.log(icons);
+
+const Icon = () => {
+
+};
+
+export default Icon;

--- a/webapp/src/styles.ts
+++ b/webapp/src/styles.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {css} from 'styled-components';
+
+/**
+ * Visually hide while leaving accessible
+ * @source {@link https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/}
+ */
+export const visuallyHidden = css`
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+`;


### PR DESCRIPTION
#### Summary

This adds a css fragment `visuallyHidden` that visually hides something without removing it from the accessibility tree, so that `tabIndex` remains consistant when tabbing through items that typically only show themselves when hovering in the general vicinity. 

- Added `visuallyHidden` to checklist item hover menu, this keeps activeElement consistent when opening/closing modals
![CleanShot 2021-07-28 at 15 01 55](https://user-images.githubusercontent.com/11724372/127389953-9093e721-b878-44af-806a-d3433b0c6702.gif)

This also keeps other hover menus from briefly appearing as items are rearranged. 
![CleanShot 2021-07-28 at 15 23 40](https://user-images.githubusercontent.com/11724372/127390862-98ebfdec-46a2-4b04-b9b1-766a6bc0ffd8.gif)



- Added `visuallyHidden` top expand/collapse button in `RHSAbout`; removed contain `tabIndex` on container
<img width="410" alt="CleanShot 2021-07-28 at 15 10 14@2x" src="https://user-images.githubusercontent.com/11724372/127390107-3d4490ac-1caf-4770-9227-fd8f7ba5f405.png">



#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests update~~
