### PR TITLE
MM-37326: Inline editing

### DIFF
--- a/client/playbook_run.go
+++ b/client/playbook_run.go
@@ -203,7 +203,6 @@ type GetPlaybookRunsResults struct {
 // StatusUpdateOptions are the fields required to update a playbook run's status
 type StatusUpdateOptions struct {
 	Status            Status `json:"status"`
-	Description       string `json:"description"`
 	Message           string `json:"message"`
 	ReminderInSeconds int64  `json:"reminder"`
 }

--- a/client/playbook_runs.go
+++ b/client/playbook_runs.go
@@ -118,11 +118,10 @@ func (s *PlaybookRunService) Create(ctx context.Context, opts PlaybookRunCreateO
 	return playbookRun, nil
 }
 
-func (s *PlaybookRunService) UpdateStatus(ctx context.Context, playbookRunID string, status Status, description, message string, reminderInSeconds int64) error {
+func (s *PlaybookRunService) UpdateStatus(ctx context.Context, playbookRunID string, status Status, message string, reminderInSeconds int64) error {
 	updateURL := fmt.Sprintf("runs/%s/status", playbookRunID)
 	opts := StatusUpdateOptions{
 		Status:            status,
-		Description:       description,
 		Message:           message,
 		ReminderInSeconds: reminderInSeconds,
 	}

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -918,7 +918,6 @@ func (h *PlaybookRunHandler) updateDescription(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	playbookRun.Description = requestBody.Description
 	if err := h.playbookRunService.UpdateDescription(playbookRunID, requestBody.Description); err != nil {
 		h.HandleErrorWithCode(w, http.StatusInternalServerError, "unable to update description", err)
 		return

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -665,12 +665,6 @@ func (h *PlaybookRunHandler) status(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	options.Description = strings.TrimSpace(options.Description)
-	if options.Description == "" {
-		h.HandleErrorWithCode(w, http.StatusBadRequest, "description must not be empty", errors.New("description field empty"))
-		return
-	}
-
 	options.Message = strings.TrimSpace(options.Message)
 	if options.Message == "" {
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "message must not be empty", errors.New("message field empty"))
@@ -735,15 +729,6 @@ func (h *PlaybookRunHandler) updateStatusDialog(w http.ResponseWriter, r *http.R
 	if options.Message == "" {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(fmt.Sprintf(`{"errors": {"%s":"This field is required."}}`, app.DialogFieldMessageKey)))
-		return
-	}
-
-	if description, ok := request.Submission[app.DialogFieldDescriptionKey]; ok {
-		options.Description = strings.TrimSpace(description.(string))
-	}
-	if options.Description == "" {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"errors": {"%s":"This field is required."}}`, app.DialogFieldDescriptionKey)))
 		return
 	}
 

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -71,7 +71,7 @@ func NewPlaybookRunHandler(router *mux.Router, playbookRunService app.PlaybookRu
 	playbookRunRouterAuthorized.HandleFunc("/no-retrospective-button", handler.noRetrospectiveButton).Methods(http.MethodPost)
 	playbookRunRouterAuthorized.HandleFunc("/timeline/{eventID:[A-Za-z0-9]+}", handler.removeTimelineEvent).Methods(http.MethodDelete)
 	playbookRunRouterAuthorized.HandleFunc("/check-and-send-message-on-join/{channel_id:[A-Za-z0-9]+}", handler.checkAndSendMessageOnJoin).Methods(http.MethodGet)
-	playbookRunRouterAuthorized.HandleFunc("/update-description", handler.updateDescription).Methods(http.MethodPatch)
+	playbookRunRouterAuthorized.HandleFunc("/update-description", handler.updateDescription).Methods(http.MethodPut)
 
 	channelRouter := playbookRunsRouter.PathPrefix("/channel").Subrouter()
 	channelRouter.HandleFunc("/{channel_id:[A-Za-z0-9]+}", handler.getPlaybookRunByChannel).Methods(http.MethodGet)

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -904,8 +904,8 @@ func (h *PlaybookRunHandler) updateDescription(w http.ResponseWriter, r *http.Re
 		Description string `json:"description"`
 	}{}
 
-	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook run description", err)
+	if err2 := json.NewDecoder(r.Body).Decode(&requestBody); err2 != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook run description", err2)
 		return
 	}
 

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -900,9 +900,9 @@ func (h *PlaybookRunHandler) updateDescription(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	requestBody := struct {
+	var requestBody struct {
 		Description string `json:"description"`
-	}{}
+	}
 
 	if err2 := json.NewDecoder(r.Body).Decode(&requestBody); err2 != nil {
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook run description", err2)

--- a/server/api/playbook_runs_test.go
+++ b/server/api/playbook_runs_test.go
@@ -1452,14 +1452,13 @@ func TestPlaybookRuns(t *testing.T) {
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_CREATE_POST).Return(true)
 
 		updateOptions := app.StatusUpdateOptions{
-			Status:      "Active",
-			Message:     "test message",
-			Description: "test description",
-			Reminder:    600 * time.Second,
+			Status:   "Active",
+			Message:  "test message",
+			Reminder: 600 * time.Second,
 		}
 		playbookRunService.EXPECT().UpdateStatus("playbookRunID", "testUserID", updateOptions).Return(nil)
 
-		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", icClient.StatusActive, "test description", "test message", 600)
+		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", icClient.StatusActive, "test message", 600)
 		require.NoError(t, err)
 	})
 
@@ -1483,7 +1482,7 @@ func TestPlaybookRuns(t *testing.T) {
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_CREATE_POST).Return(true)
 
-		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", "Arrrrrrrctive", "test description", "test message", 600)
+		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", "Arrrrrrrctive", "test message", 600)
 		requireErrorWithStatusCode(t, err, http.StatusBadRequest)
 	})
 
@@ -1507,7 +1506,7 @@ func TestPlaybookRuns(t *testing.T) {
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_CREATE_POST).Return(false)
 
-		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", icClient.StatusActive, "test description", "test message", 600)
+		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", icClient.StatusActive, "test message", 600)
 		requireErrorWithStatusCode(t, err, http.StatusForbidden)
 	})
 
@@ -1531,7 +1530,7 @@ func TestPlaybookRuns(t *testing.T) {
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_CREATE_POST).Return(true)
 
-		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", icClient.StatusActive, "test description", "  \t   \r   \t  \r\r  ", 600)
+		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", icClient.StatusActive, "  \t   \r   \t  \r\r  ", 600)
 		requireErrorWithStatusCode(t, err, http.StatusBadRequest)
 	})
 
@@ -1555,31 +1554,7 @@ func TestPlaybookRuns(t *testing.T) {
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_CREATE_POST).Return(true)
 
-		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", "\t   \r  ", "test description", "test message", 600)
-		requireErrorWithStatusCode(t, err, http.StatusBadRequest)
-	})
-
-	t.Run("update playbook run status, description empty", func(t *testing.T) {
-		reset(t)
-		setDefaultExpectations(t)
-		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
-
-		teamID := model.NewId()
-		testPlaybookRun := app.PlaybookRun{
-			ID:          "playbookRunID",
-			OwnerUserID: "testUserID",
-			TeamID:      teamID,
-			Name:        "playbookRunName",
-			ChannelID:   "channelID",
-		}
-
-		playbookRunService.EXPECT().GetPlaybookRunIDForChannel(testPlaybookRun.ChannelID).Return(testPlaybookRun.ID, nil)
-		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		playbookRunService.EXPECT().GetPlaybookRun(testPlaybookRun.ID).Return(&testPlaybookRun, nil).Times(2)
-		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_CREATE_POST).Return(true)
-
-		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", "Active", "  \r \n  ", "test message", 600)
+		err := c.PlaybookRuns.UpdateStatus(context.TODO(), "playbookRunID", "\t   \r  ", "test message", 600)
 		requireErrorWithStatusCode(t, err, http.StatusBadRequest)
 	})
 }

--- a/server/app/mocks/mock_playbook_run_service.go
+++ b/server/app/mocks/mock_playbook_run_service.go
@@ -516,6 +516,20 @@ func (mr *MockPlaybookRunServiceMockRecorder) ToggleCheckedState(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleCheckedState", reflect.TypeOf((*MockPlaybookRunService)(nil).ToggleCheckedState), arg0, arg1, arg2, arg3)
 }
 
+// UpdateDescription mocks base method
+func (m *MockPlaybookRunService) UpdateDescription(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDescription", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDescription indicates an expected call of UpdateDescription
+func (mr *MockPlaybookRunServiceMockRecorder) UpdateDescription(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDescription", reflect.TypeOf((*MockPlaybookRunService)(nil).UpdateDescription), arg0, arg1)
+}
+
 // UpdateRetrospective mocks base method
 func (m *MockPlaybookRunService) UpdateRetrospective(arg0, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -377,6 +377,9 @@ type PlaybookRunService interface {
 	// CheckAndSendMessageOnJoin checks if userID has viewed channelID and sends
 	// playbooRun.MessageOnJoin if it exists. Returns true if the message was sent.
 	CheckAndSendMessageOnJoin(userID, playbookRunID, channelID string) bool
+
+	// UpdateDescription updates the description of the specified playbook run.
+	UpdateDescription(playbookRunID, description string) error
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -154,10 +154,9 @@ type UpdateOptions struct {
 // StatusUpdateOptions encapsulates the fields that can be set when updating an playbook run's status
 // NOTE: changes made to this should be reflected in the client package.
 type StatusUpdateOptions struct {
-	Status      string        `json:"status"`
-	Description string        `json:"description"`
-	Message     string        `json:"message"`
-	Reminder    time.Duration `json:"reminder"`
+	Status   string        `json:"status"`
+	Message  string        `json:"message"`
+	Reminder time.Duration `json:"reminder"`
 }
 
 // Metadata tracks ancillary metadata about a playbook run.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -759,7 +759,6 @@ func (s *PlaybookRunServiceImpl) UpdateStatus(playbookRunID, userID string, opti
 		})
 
 	playbookRunToModify.PreviousReminder = options.Reminder
-	playbookRunToModify.Description = options.Description
 	playbookRunToModify.LastStatusUpdateAt = post.CreateAt
 
 	if err = s.store.UpdatePlaybookRun(playbookRunToModify); err != nil {
@@ -1924,12 +1923,6 @@ func (s *PlaybookRunServiceImpl) newUpdatePlaybookRunDialog(description, message
 				Options:     statusOptions,
 				Optional:    false,
 				Default:     status,
-			},
-			{
-				DisplayName: "Description",
-				Name:        DialogFieldDescriptionKey,
-				Type:        "textarea",
-				Default:     description,
 			},
 			{
 				DisplayName: "Change since last update",

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1641,6 +1641,22 @@ func (s *PlaybookRunServiceImpl) CheckAndSendMessageOnJoin(userID, givenPlaybook
 	return true
 }
 
+func (s *PlaybookRunServiceImpl) UpdateDescription(playbookRunID, description string) error {
+	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get playbook run")
+	}
+
+	playbookRun.Description = description
+	if err = s.store.UpdatePlaybookRun(playbookRun); err != nil {
+		return errors.Wrap(err, "failed to update playbook run")
+	}
+
+	s.poster.PublishWebsocketEventToChannel(playbookRunUpdatedWSEvent, playbookRun, playbookRun.ChannelID)
+
+	return nil
+}
+
 // UserHasLeftChannel is called when userID has left channelID. If actorID is not blank, userID
 // was removed from the channel by actorID.
 func (s *PlaybookRunServiceImpl) UserHasLeftChannel(userID, channelID, actorID string) {

--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -388,10 +388,9 @@ func TestUpdateStatus(t *testing.T) {
 			WebhookOnStatusUpdateURL: server.URL,
 		}
 		statusUpdateOptions := app.StatusUpdateOptions{
-			Status:      app.StatusActive,
-			Description: "latest-description",
-			Message:     "latest-message",
-			Reminder:    0,
+			Status:   app.StatusActive,
+			Message:  "latest-message",
+			Reminder: 0,
 		}
 		siteURL := "http://example.com"
 		channelID := "channel_id"

--- a/server/app/reminder.go
+++ b/server/app/reminder.go
@@ -168,7 +168,7 @@ func (s *PlaybookRunServiceImpl) ResetReminderTimer(playbookRunID string) error 
 
 	playbookRunToModify.PreviousReminder = 0
 	if err = s.store.UpdatePlaybookRun(playbookRunToModify); err != nil {
-		return errors.Wrapf(err, "failed to update playbook run after removing reminder post id")
+		return errors.Wrapf(err, "failed to update playbook run after resetting reminder timer")
 	}
 
 	s.poster.PublishWebsocketEventToChannel(playbookRunUpdatedWSEvent, playbookRunToModify, playbookRunToModify.ChannelID)

--- a/tests-e2e/cypress/integration/frontstage/rhs/latest_update_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/latest_update_spec.js
@@ -232,11 +232,10 @@ describe('playbook run rhs > latest update', () => {
                 // # Type the invalid data
                 cy.findByTestId('messageinput').clear().type(' {enter} {enter}  ');
 
-                // # Enter valid status and description
+                // # Enter valid status
                 cy.findAllByTestId('autoCompleteSelector').eq(0).within(() => {
                     cy.get('input').type('Reported', {delay: 200}).type('{enter}');
                 });
-                cy.findByTestId('descriptioninput').clear().type('description');
 
                 // # Submit the dialog.
                 cy.get('#interactiveDialogSubmit').click();

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -136,7 +136,7 @@ Cypress.Commands.add('verifyEphemeralMessage', (message, isCompactMode, needsToS
 /**
  * Update the status of the current playbook run through the slash command.
  */
-Cypress.Commands.add('updateStatus', (message, reminder, status, description) => {
+Cypress.Commands.add('updateStatus', (message, reminder, status) => {
     // # Run the slash command to update status.
     cy.executeSlashCommand('/playbook update');
 
@@ -164,15 +164,6 @@ Cypress.Commands.add('updateStatus', (message, reminder, status, description) =>
                 cy.get('input').type(reminder, {delay: 200}).type('{enter}');
             });
         }
-
-        let actualDescription = description;
-        if (!description) {
-            actualDescription = 'description ' + Date.now();
-        }
-
-        // # remove and enter new description
-        cy.findByTestId('descriptioninput').clear();
-        cy.findByTestId('descriptioninput').type(actualDescription);
 
         // # Submit the dialog.
         cy.get('#interactiveDialogSubmit').click();

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -47,7 +47,10 @@ import {
     ShowPostMenuModal,
     HIDE_POST_MENU_MODAL,
     HidePostMenuModal,
-    SetHasViewedChannel, SET_HAS_VIEWED_CHANNEL,
+    SetHasViewedChannel,
+    SET_HAS_VIEWED_CHANNEL,
+    SetRHSAboutCollapsedState,
+    SET_RHS_ABOUT_COLLAPSED_STATE,
 } from './types/actions';
 
 import {clientExecuteCommand} from './client';
@@ -214,4 +217,10 @@ export const setHasViewedChannel = (channelId: string): SetHasViewedChannel => (
     type: SET_HAS_VIEWED_CHANNEL,
     channelId,
     hasViewed: true,
+});
+
+export const setRHSAboutCollapsedState = (channelId: string, collapsed: boolean): SetRHSAboutCollapsedState => ({
+    type: SET_RHS_ABOUT_COLLAPSED_STATE,
+    channelId,
+    collapsed,
 });

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -407,6 +407,13 @@ export const promptForFeedback = async () => {
     }
 };
 
+export const changeChannelName = async (channelId: string, newName: string) => {
+    await doFetchWithoutResponse(`/api/v4/channels/${channelId}/patch`, {
+        method: 'PUT',
+        body: JSON.stringify({display_name: newName}),
+    });
+};
+
 export const doGet = async <TData = any>(url: string) => {
     const {data} = await doFetchWithResponse<TData>(url, {method: 'get'});
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -414,6 +414,13 @@ export const changeChannelName = async (channelId: string, newName: string) => {
     });
 };
 
+export const updatePlaybookRunDescription = async (playbookRunId: string, newDescription: string) => {
+    await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunId}/update-description`, {
+        method: 'PATCH',
+        body: JSON.stringify({description: newDescription}),
+    });
+};
+
 export const doGet = async <TData = any>(url: string) => {
     const {data} = await doFetchWithResponse<TData>(url, {method: 'get'});
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -416,7 +416,7 @@ export const changeChannelName = async (channelId: string, newName: string) => {
 
 export const updatePlaybookRunDescription = async (playbookRunId: string, newDescription: string) => {
     await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunId}/update-description`, {
-        method: 'PATCH',
+        method: 'PUT',
         body: JSON.stringify({description: newDescription}),
     });
 };

--- a/webapp/src/components/assets/icons/clock.tsx
+++ b/webapp/src/components/assets/icons/clock.tsx
@@ -15,8 +15,6 @@ const Svg = styled(Icon)`
 
 const Clock = (props : {className?: string}) => (
     <Svg
-        width='34'
-        height='34'
         viewBox='0 0 34 34'
         fill='none'
         xmlns='http://www.w3.org/2000/svg'

--- a/webapp/src/components/assets/icons/exclamation.tsx
+++ b/webapp/src/components/assets/icons/exclamation.tsx
@@ -15,8 +15,6 @@ const Svg = styled(Icon)`
 
 const Exclamation = (props : {className?: string}) => (
     <Svg
-        width='38'
-        height='37'
         viewBox='0 0 38 37'
         fill='none'
         xmlns='http://www.w3.org/2000/svg'

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -46,11 +46,11 @@ const RHSAbout = (props: Props) => {
         .filter((p) => p.id !== props.playbookRun.owner_user_id && !p.is_bot)
         .map((p) => p.id);
 
-    const onTitleEdit = async (value: string) => {
+    const onTitleEdit = (value: string) => {
         changeChannelName(props.playbookRun.channel_id, value);
     };
 
-    const onDescriptionEdit = async (value: string) => {
+    const onDescriptionEdit = (value: string) => {
         updatePlaybookRunDescription(props.playbookRun.id, value);
     };
 
@@ -105,7 +105,7 @@ const RHSAbout = (props: Props) => {
 
 interface DescriptionProps {
     value: string;
-    onEdit: () => void;
+    onEdit: (value: string) => void;
 }
 
 const Description = (props: DescriptionProps) => {

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useRef, useEffect} from 'react';
+import React from 'react';
+import {useDispatch, useSelector} from 'react-redux';
 import styled from 'styled-components';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
+import {PlaybookRun} from 'src/types/playbook_run';
 import {setOwner, changeChannelName, updatePlaybookRunDescription} from 'src/client';
 import ProfileSelector from 'src/components/profile/profile_selector';
 import RHSPostUpdate from 'src/components/rhs/rhs_post_update';
@@ -15,17 +17,20 @@ import {HoverMenu} from 'src/components/rhs/rhs_shared';
 import RHSAboutButtons from 'src/components/rhs/rhs_about_buttons';
 import RHSAboutTitle, {DefaultRenderedTitle} from 'src/components/rhs/rhs_about_title';
 import RHSAboutDescription from 'src/components/rhs/rhs_about_description';
+import {currentRHSAboutCollapsedState} from 'src/selectors';
+import {setRHSAboutCollapsedState} from 'src/actions';
 
 interface Props {
     playbookRun: PlaybookRun;
 }
 
 const RHSAbout = (props: Props) => {
+    const dispatch = useDispatch();
+    const channelId = useSelector(getCurrentChannelId);
     const profilesInChannel = useProfilesInCurrentChannel();
+    const collapsed = useSelector(currentRHSAboutCollapsedState);
 
-    const [collapsed, setCollapsed] = useState(false);
-
-    const toggleCollapsed = () => setCollapsed(!collapsed);
+    const toggleCollapsed = () => dispatch(setRHSAboutCollapsedState(channelId, !collapsed));
 
     const fetchUsers = async () => {
         return profilesInChannel;
@@ -55,7 +60,7 @@ const RHSAbout = (props: Props) => {
     };
 
     return (
-        <Container tabIndex={0} >
+        <Container tabIndex={0}>
             <ButtonsRow>
                 <RHSAboutButtons
                     playbookRun={props.playbookRun}

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useRef} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import styled from 'styled-components';
-import {useDispatch} from 'react-redux';
 
 import {PlaybookRun} from 'src/types/playbook_run';
 
@@ -118,12 +117,18 @@ const Description = (props: DescriptionProps) => {
     const textareaRef = useRef(null);
 
     const saveAndClose = () => {
-        props.onEdit(editedValue);
+        const newValue = editedValue.trim();
+        setEditedValue(newValue);
+        props.onEdit(newValue);
         setEditing(false);
     };
 
     useClickOutsideRef(textareaRef, saveAndClose);
-    useKeyPress('Contrl+Enter', saveAndClose);
+    useKeyPress((e: KeyboardEvent) => e.ctrlKey && e.key === 'Enter', saveAndClose);
+
+    useEffect(() => {
+        setEditedValue(props.value || placeholder);
+    }, [props.value]);
 
     if (!editing) {
         return (
@@ -138,15 +143,24 @@ const Description = (props: DescriptionProps) => {
             value={editedValue}
             ref={textareaRef}
             onChange={(e) => setEditedValue(e.target.value)}
+            autoFocus={true}
+            onFocus={(e) => {
+                const val = e.target.value;
+                e.target.value = '';
+                e.target.value = val;
+            }}
+            rows={editedValue.split('\n').length}
         />
     );
 };
 
 const DescriptionTextArea = styled.textarea`
+    resize: none;
     width: 100%;
-    height: 100px;
+    height: max-content;
     padding: 4px 8px;
-    margin-bottom: 2px;
+    margin-top: -2px;
+    margin-bottom: 9px;
 
     border: none;
     border-radius: 5px;
@@ -158,6 +172,8 @@ const DescriptionTextArea = styled.textarea`
         box-shadow: none;
     }
 
+    font-size: 14px;
+    line-height: 15px;
     color: var(--center-channel-color);
 `;
 
@@ -218,6 +234,10 @@ const Title = (props: TitleProps) => {
 
     const inputRef = useRef(null);
 
+    useEffect(() => {
+        setEditedValue(props.value);
+    }, [props.value]);
+
     const saveAndClose = () => {
         props.onEdit(editedValue);
         setEditing(false);
@@ -228,7 +248,7 @@ const Title = (props: TitleProps) => {
 
     if (!editing) {
         return (
-            <RenderedTitle onClick={() => setEditing(true)}>
+            <RenderedTitle onClick={() => setEditing(true)} >
                 {editedValue}
             </RenderedTitle>
         );
@@ -240,15 +260,23 @@ const Title = (props: TitleProps) => {
             ref={inputRef}
             onChange={(e) => setEditedValue(e.target.value)}
             value={editedValue}
+            maxLength={59}
+            autoFocus={true}
+            onFocus={(e) => {
+                const val = e.target.value;
+                e.target.value = '';
+                e.target.value = val;
+            }}
         />
     );
 };
 
 const TitleInput = styled.input`
-    width: 100%;
+    width: calc(100% - 75px);
     height: 30px;
     padding: 4px 8px;
-    margin-bottom: 2px;
+    margin-bottom: 5px;
+    margin-top: -3px;
 
     border: none;
     border-radius: 5px;
@@ -267,6 +295,15 @@ const TitleInput = styled.input`
 `;
 
 const RenderedTitle = styled(PaddedContent)`
+    max-width: 100%;
+    ${Container}:focus-within &, ${Container}:hover & {
+        max-width: calc(100% - 75px);
+    }
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
     height: 30px;
     line-height: 24px;
 
@@ -292,6 +329,7 @@ const RenderedDescription = styled(PaddedContent)`
     border-radius: 5px;
 
     margin-bottom: 16px;
+    line-height: 20px;
 `;
 
 const Row = styled(PaddedContent)`

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -10,11 +10,11 @@ import {setOwner, changeChannelName, updatePlaybookRunDescription} from 'src/cli
 import ProfileSelector from 'src/components/profile/profile_selector';
 import RHSPostUpdate from 'src/components/rhs/rhs_post_update';
 import {useProfilesInCurrentChannel} from 'src/hooks';
-import PostText from 'src/components/post_text';
 import RHSParticipants from 'src/components/rhs/rhs_participants';
 import {HoverMenu} from 'src/components/rhs/rhs_shared';
 import RHSAboutButtons from 'src/components/rhs/rhs_about_buttons';
-import {useClickOutsideRef, useKeyPress} from 'src/hooks/general';
+import RHSAboutTitle, {DefaultRenderedTitle} from 'src/components/rhs/rhs_about_title';
+import RHSAboutDescription from 'src/components/rhs/rhs_about_description';
 
 interface Props {
     playbookRun: PlaybookRun;
@@ -63,13 +63,14 @@ const RHSAbout = (props: Props) => {
                     toggleCollapsed={toggleCollapsed}
                 />
             </ButtonsRow>
-            <Title
+            <RHSAboutTitle
                 value={props.playbookRun.name}
                 onEdit={onTitleEdit}
+                renderedTitle={RenderedTitle}
             />
             {!collapsed &&
             <>
-                <Description
+                <RHSAboutDescription
                     value={props.playbookRun.description}
                     onEdit={onDescriptionEdit}
                 />
@@ -102,80 +103,6 @@ const RHSAbout = (props: Props) => {
         </Container>
     );
 };
-
-interface DescriptionProps {
-    value: string;
-    onEdit: (value: string) => void;
-}
-
-const Description = (props: DescriptionProps) => {
-    const placeholder = 'No description yet. Click here to edit it.';
-
-    const [editing, setEditing] = useState(false);
-    const [editedValue, setEditedValue] = useState(props.value || placeholder);
-
-    const textareaRef = useRef(null);
-
-    const saveAndClose = () => {
-        const newValue = editedValue.trim();
-        setEditedValue(newValue);
-        props.onEdit(newValue);
-        setEditing(false);
-    };
-
-    useClickOutsideRef(textareaRef, saveAndClose);
-    useKeyPress((e: KeyboardEvent) => e.ctrlKey && e.key === 'Enter', saveAndClose);
-
-    useEffect(() => {
-        setEditedValue(props.value || placeholder);
-    }, [props.value]);
-
-    if (!editing) {
-        return (
-            <RenderedDescription onClick={() => setEditing(true)}>
-                <PostText text={editedValue}/>
-            </RenderedDescription>
-        );
-    }
-
-    return (
-        <DescriptionTextArea
-            value={editedValue}
-            ref={textareaRef}
-            onChange={(e) => setEditedValue(e.target.value)}
-            autoFocus={true}
-            onFocus={(e) => {
-                const val = e.target.value;
-                e.target.value = '';
-                e.target.value = val;
-            }}
-            rows={editedValue.split('\n').length}
-        />
-    );
-};
-
-const DescriptionTextArea = styled.textarea`
-    resize: none;
-    width: 100%;
-    height: max-content;
-    padding: 4px 8px;
-    margin-top: -2px;
-    margin-bottom: 9px;
-
-    border: none;
-    border-radius: 5px;
-    box-shadow: none;
-
-    background: rgba(var(--center-channel-color-rgb), 0.04);
-
-    &:focus {
-        box-shadow: none;
-    }
-
-    font-size: 14px;
-    line-height: 15px;
-    color: var(--center-channel-color);
-`;
 
 const Container = styled.div`
     margin-top: 3px;
@@ -219,124 +146,18 @@ const ButtonsRow = styled(HoverMenu)`
     }
 `;
 
-const PaddedContent = styled.div`
-    padding: 0 8px; 
-`;
-
-interface TitleProps {
-    onEdit: (newTitle: string) => void;
-    value: string;
-}
-
-const Title = (props: TitleProps) => {
-    const [editing, setEditing] = useState(false);
-    const [editedValue, setEditedValue] = useState(props.value);
-
-    const inputRef = useRef(null);
-
-    useEffect(() => {
-        setEditedValue(props.value);
-    }, [props.value]);
-
-    const saveAndClose = () => {
-        props.onEdit(editedValue);
-        setEditing(false);
-    };
-
-    useClickOutsideRef(inputRef, saveAndClose);
-    useKeyPress('Enter', saveAndClose);
-
-    if (!editing) {
-        return (
-            <RenderedTitle onClick={() => setEditing(true)} >
-                {editedValue}
-            </RenderedTitle>
-        );
-    }
-
-    return (
-        <TitleInput
-            type={'text'}
-            ref={inputRef}
-            onChange={(e) => setEditedValue(e.target.value)}
-            value={editedValue}
-            maxLength={59}
-            autoFocus={true}
-            onFocus={(e) => {
-                const val = e.target.value;
-                e.target.value = '';
-                e.target.value = val;
-            }}
-        />
-    );
-};
-
-const TitleInput = styled.input`
-    width: calc(100% - 75px);
-    height: 30px;
-    padding: 4px 8px;
-    margin-bottom: 5px;
-    margin-top: -3px;
-
-    border: none;
-    border-radius: 5px;
-    box-shadow: none;
-
-    background: rgba(var(--center-channel-color-rgb), 0.04);
-
-    &:focus {
-        box-shadow: none;
-    }
-
-    color: var(--center-channel-color);
-    font-size: 18px;
-    line-height: 24px;
-    font-weight: 600;
-`;
-
-const RenderedTitle = styled(PaddedContent)`
-    max-width: 100%;
+const RenderedTitle = styled(DefaultRenderedTitle)`
     ${Container}:focus-within &, ${Container}:hover & {
         max-width: calc(100% - 75px);
     }
-
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    height: 30px;
-    line-height: 24px;
-
-    font-size: 18px;
-    font-weight: 600;
-
-    color: var(--center-channel-color);
-
-    :hover {
-        cursor: text;
-    }
-
-    border-radius: 5px;
-
-    margin-bottom: 2px;
 `;
 
-const RenderedDescription = styled(PaddedContent)`
-    :hover {
-        cursor: text;
-    }
-
-    border-radius: 5px;
-
-    margin-bottom: 16px;
-    line-height: 20px;
-`;
-
-const Row = styled(PaddedContent)`
+const Row = styled.div`
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
 
+    padding: 0 8px;
     margin-bottom: 30px;
 `;
 
@@ -359,11 +180,6 @@ const MemberSectionTitle = styled.div`
     line-height: 16px;
 
     color: rgba(var(--center-channel-color-rgb), 0.72)
-`;
-
-const NoDescription = styled.div`
-    color: rgba(var(--center-channel-color-rgb), 0.64);
-    margin-bottom: 10px;
 `;
 
 export default RHSAbout;

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -108,7 +108,7 @@ const Container = styled.div`
     margin-top: 3px;
     padding: 16px 12px;
 
-    :hover, :focus-within {
+    :hover {
         background-color: rgba(var(--center-channel-color-rgb), 0.04);
     }
 `;
@@ -141,13 +141,13 @@ const ButtonsRow = styled(HoverMenu)`
 
     display: none;
 
-    ${Container}:focus-within &, ${Container}:hover & {
+    ${Container}:hover & {
         display: block;
     }
 `;
 
 const RenderedTitle = styled(DefaultRenderedTitle)`
-    ${Container}:focus-within &, ${Container}:hover & {
+    ${Container}:hover & {
         max-width: calc(100% - 75px);
     }
 `;

--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState, useRef, useEffect} from 'react';
+import styled from 'styled-components';
+
+import PostText from 'src/components/post_text';
+import {useClickOutsideRef, useKeyPress} from 'src/hooks/general';
+
+interface DescriptionProps {
+    value: string;
+    onEdit: (value: string) => void;
+}
+
+const RHSAboutDescription = (props: DescriptionProps) => {
+    const placeholder = 'No description yet. Click here to edit it.';
+
+    const [editing, setEditing] = useState(false);
+    const [editedValue, setEditedValue] = useState(props.value || placeholder);
+
+    const textareaRef = useRef(null);
+
+    const saveAndClose = () => {
+        const newValue = editedValue.trim();
+        setEditedValue(newValue);
+        props.onEdit(newValue);
+        setEditing(false);
+    };
+
+    useClickOutsideRef(textareaRef, saveAndClose);
+    useKeyPress((e: KeyboardEvent) => e.ctrlKey && e.key === 'Enter', saveAndClose);
+
+    useEffect(() => {
+        setEditedValue(props.value || placeholder);
+    }, [props.value]);
+
+    if (!editing) {
+        return (
+            <RenderedDescription onClick={() => setEditing(true)}>
+                <PostText text={editedValue}/>
+            </RenderedDescription>
+        );
+    }
+
+    return (
+        <DescriptionTextArea
+            value={editedValue}
+            ref={textareaRef}
+            onChange={(e) => setEditedValue(e.target.value)}
+            autoFocus={true}
+            onFocus={(e) => {
+                const val = e.target.value;
+                e.target.value = '';
+                e.target.value = val;
+            }}
+            rows={editedValue.split('\n').length}
+        />
+    );
+};
+
+const DescriptionTextArea = styled.textarea`
+    resize: none;
+    width: 100%;
+    height: max-content;
+    padding: 4px 8px;
+    margin-top: -2px;
+    margin-bottom: 9px;
+
+    border: none;
+    border-radius: 5px;
+    box-shadow: none;
+
+    background: rgba(var(--center-channel-color-rgb), 0.04);
+
+    &:focus {
+        box-shadow: none;
+    }
+
+    font-size: 14px;
+    line-height: 15px;
+    color: var(--center-channel-color);
+`;
+
+const RenderedDescription = styled.div`
+    margin-bottom: 16px;
+    padding: 0 8px;
+
+    line-height: 20px;
+
+    border-radius: 5px;
+
+    :hover {
+        cursor: text;
+    }
+`;
+
+export default RHSAboutDescription;

--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -42,6 +42,11 @@ const RHSAboutDescription = (props: DescriptionProps) => {
         );
     }
 
+    const computeHeight = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+        e.target.style.height = '5px';
+        e.target.style.height = (e.target.scrollHeight) + 'px';
+    };
+
     return (
         <DescriptionTextArea
             value={editedValue}
@@ -52,8 +57,9 @@ const RHSAboutDescription = (props: DescriptionProps) => {
                 const val = e.target.value;
                 e.target.value = '';
                 e.target.value = val;
+                computeHeight(e);
             }}
-            rows={editedValue.split('\n').length}
+            onInput={computeHeight}
         />
     );
 };
@@ -77,7 +83,7 @@ const DescriptionTextArea = styled.textarea`
     }
 
     font-size: 14px;
-    line-height: 15px;
+    line-height: 20px;
     color: var(--center-channel-color);
 `;
 

--- a/webapp/src/components/rhs/rhs_about_title.tsx
+++ b/webapp/src/components/rhs/rhs_about_title.tsx
@@ -1,0 +1,109 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState, useRef, useEffect} from 'react';
+import styled, {StyledComponent} from 'styled-components';
+
+import {useClickOutsideRef, useKeyPress} from 'src/hooks/general';
+
+interface Props {
+    onEdit: (newTitle: string) => void;
+    value: string;
+    renderedTitle?: StyledComponent<'div', any, {}, never>;
+}
+
+const RHSAboutTitle = (props: Props) => {
+    const [editing, setEditing] = useState(false);
+    const [editedValue, setEditedValue] = useState(props.value);
+
+    const inputRef = useRef(null);
+
+    useEffect(() => {
+        setEditedValue(props.value);
+    }, [props.value]);
+
+    const saveAndClose = () => {
+        props.onEdit(editedValue);
+        setEditing(false);
+    };
+
+    useClickOutsideRef(inputRef, saveAndClose);
+    useKeyPress('Enter', saveAndClose);
+
+    if (!editing) {
+        const RenderedTitle = props.renderedTitle ?? DefaultRenderedTitle;
+
+        return (
+            <RenderedTitle onClick={() => setEditing(true)} >
+                {editedValue}
+            </RenderedTitle>
+        );
+    }
+
+    return (
+        <TitleInput
+            type={'text'}
+            ref={inputRef}
+            onChange={(e) => setEditedValue(e.target.value)}
+            value={editedValue}
+            maxLength={59}
+            autoFocus={true}
+            onFocus={(e) => {
+                const val = e.target.value;
+                e.target.value = '';
+                e.target.value = val;
+            }}
+        />
+    );
+};
+
+const TitleInput = styled.input`
+    width: calc(100% - 75px);
+    height: 30px;
+    padding: 4px 8px;
+    margin-bottom: 5px;
+    margin-top: -3px;
+
+    border: none;
+    border-radius: 5px;
+    box-shadow: none;
+
+    background: rgba(var(--center-channel-color-rgb), 0.04);
+
+    &:focus {
+        box-shadow: none;
+    }
+
+    color: var(--center-channel-color);
+    font-size: 18px;
+    line-height: 24px;
+    font-weight: 600;
+`;
+
+export const DefaultRenderedTitle = styled.div`
+    padding: 0 8px;
+
+    max-width: 100%;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    height: 30px;
+    line-height: 24px;
+
+    font-size: 18px;
+    font-weight: 600;
+
+    color: var(--center-channel-color);
+
+    :hover {
+        cursor: text;
+    }
+
+    border-radius: 5px;
+
+    margin-bottom: 2px;
+`;
+
+export default RHSAboutTitle;

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -4,15 +4,13 @@ import {
     useEffect,
     useRef,
     useState,
+    useMemo,
 } from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import moment from 'moment';
 
-import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
-import {PermissionsOptions} from 'mattermost-redux/selectors/entities/roles_helpers';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {GlobalState} from 'mattermost-redux/types/store';
-import {Team} from 'mattermost-redux/types/teams';
 import {
     getProfilesInCurrentChannel,
     getCurrentUserId,
@@ -52,12 +50,20 @@ import {
 /**
  * Hook that calls handler when targetKey is pressed.
  */
-export function useKeyPress(targetKey: string, handler: () => void) {
+export function useKeyPress(targetKey: string | ((e: KeyboardEvent) => boolean), handler: () => void) {
+    const predicate: (e: KeyboardEvent) => boolean = useMemo(() => {
+        if (typeof targetKey === 'string') {
+            return (e: KeyboardEvent) => e.key === targetKey;
+        }
+
+        return targetKey;
+    }, [targetKey]);
+
     // Add event listeners
     useEffect(() => {
         // If pressed key is our target key then set to true
-        function downHandler({key}: KeyboardEvent) {
-            if (key === targetKey) {
+        function downHandler(e: KeyboardEvent) {
+            if (predicate(e)) {
                 handler();
             }
         }
@@ -68,7 +74,7 @@ export function useKeyPress(targetKey: string, handler: () => void) {
         return () => {
             window.removeEventListener('keydown', downHandler);
         };
-    }, [handler, targetKey]);
+    }, [handler, predicate]);
 }
 
 /**

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -34,10 +34,16 @@ import {
     PlaybookDeleted,
     ReceivedTeamNumPlaybooks,
     RECEIVED_TEAM_NUM_PLAYBOOKS,
-    ReceivedGlobalSettings, RECEIVED_GLOBAL_SETTINGS,
-    ShowPostMenuModal, HidePostMenuModal,
-    SHOW_POST_MENU_MODAL, HIDE_POST_MENU_MODAL,
-    SetHasViewedChannel, SET_HAS_VIEWED_CHANNEL,
+    ReceivedGlobalSettings,
+    RECEIVED_GLOBAL_SETTINGS,
+    ShowPostMenuModal,
+    HidePostMenuModal,
+    SHOW_POST_MENU_MODAL,
+    HIDE_POST_MENU_MODAL,
+    SetHasViewedChannel,
+    SET_HAS_VIEWED_CHANNEL,
+    SetRHSAboutCollapsedState,
+    SET_RHS_ABOUT_COLLAPSED_STATE,
 } from 'src/types/actions';
 
 import {GlobalSettings} from './types/settings';
@@ -244,6 +250,18 @@ const hasViewedByChannel = (state: Record<string, boolean> = {}, action: SetHasV
     }
 };
 
+const rhsAboutCollapsedByChannel = (state: Record<string, boolean> = {}, action: SetRHSAboutCollapsedState) => {
+    switch (action.type) {
+    case SET_RHS_ABOUT_COLLAPSED_STATE:
+        return {
+            ...state,
+            [action.channelId]: action.collapsed,
+        };
+    default:
+        return state;
+    }
+};
+
 export default combineReducers({
     toggleRHSFunction,
     rhsOpen,
@@ -255,4 +273,5 @@ export default combineReducers({
     globalSettings,
     postMenuModalVisibility,
     hasViewedByChannel,
+    rhsAboutCollapsedByChannel,
 });

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -164,3 +164,13 @@ export const isTeamEdition = createSelector(
     getConfig,
     (config) => config.BuildEnterpriseReady !== 'true',
 );
+
+const rhsAboutCollapsedState = (state: GlobalState): Record<string, boolean> => pluginState(state).rhsAboutCollapsedByChannel;
+
+export const currentRHSAboutCollapsedState = createSelector(
+    getCurrentChannelId,
+    rhsAboutCollapsedState,
+    (channelId, stateByChannel) => {
+        return stateByChannel[channelId] ?? false;
+    },
+);

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -27,6 +27,7 @@ export const RECEIVED_GLOBAL_SETTINGS = pluginId + '_received_global_settings';
 export const SHOW_POST_MENU_MODAL = pluginId + '_show_post_menu_modal';
 export const HIDE_POST_MENU_MODAL = pluginId + '_hide_post_menu_modal';
 export const SET_HAS_VIEWED_CHANNEL = pluginId + '_set_has_viewed';
+export const SET_RHS_ABOUT_COLLAPSED_STATE = pluginId + '_set_rhs_about_collapsed_state';
 
 export interface ReceivedToggleRHSAction {
     type: typeof RECEIVED_TOGGLE_RHS_ACTION;
@@ -117,4 +118,10 @@ export interface SetHasViewedChannel {
     type: typeof SET_HAS_VIEWED_CHANNEL;
     channelId: string;
     hasViewed: boolean;
+}
+
+export interface SetRHSAboutCollapsedState {
+    type: typeof SET_RHS_ABOUT_COLLAPSED_STATE;
+    channelId: string;
+    collapsed: boolean;
 }


### PR DESCRIPTION
#### Summary
This PR makes both the title and the description editable inline. It also removes the Description field from the interactive dialog, making the inline edition the only way to change the description.

https://user-images.githubusercontent.com/3924815/127485888-f2872e2b-5982-4071-9bef-8278045123ce.mp4

When editing the title, hitting `Enter` closes the edition and saves the new title. For the description, I chose `Ctrl+Enter` for that. Both the title and description are automatically saved whenever the user clicks outside of the input area.

As you can see in the video and in the code, changing the run name is actually a channel name change. It was the most straightforward way to do it given the time constraints.

This branch is based off of #656, I'll change it to master as soon as that one's merged.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37326

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
