### PR TITLE
MM-37529: Fix clicking on links in the description

### DIFF
--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -36,7 +36,15 @@ const RHSAboutDescription = (props: DescriptionProps) => {
 
     if (!editing) {
         return (
-            <RenderedDescription onClick={() => setEditing(true)}>
+            <RenderedDescription
+                onClick={(event: React.MouseEvent<HTMLElement>) => {
+                    // Enter edit mode only if the user is not clicking a link
+                    const targetNode = event.target as Node;
+                    if (targetNode.nodeName !== 'A') {
+                        setEditing(true);
+                    }
+                }}
+            >
                 <PostText text={editedValue}/>
             </RenderedDescription>
         );

--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -37,7 +37,7 @@ const RHSAboutDescription = (props: DescriptionProps) => {
     if (!editing) {
         return (
             <RenderedDescription
-                onClick={(event: React.MouseEvent<HTMLElement>) => {
+                onClick={(event) => {
                     // Enter edit mode only if the user is not clicking a link
                     const targetNode = event.target as Node;
                     if (targetNode.nodeName !== 'A') {


### PR DESCRIPTION
#### Summary

This PR prevents entering the edit mode in the RHS description when the user clicks on a link (or a user mention or a channel link).

https://user-images.githubusercontent.com/3924815/127852459-e8759b58-89cc-4715-bcf0-4a7f415ab267.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37529

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
