### PR TITLE
MM-37526: Render newlines in the description text

### DIFF
--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -98,6 +98,8 @@ const RenderedDescription = styled.div`
     :hover {
         cursor: text;
     }
+
+    white-space: pre-wrap;
 `;
 
 export default RHSAboutDescription;


### PR DESCRIPTION
#### Summary

This adds the `white-space: pre-wrap` style to the rendered description, as done in [the `post` class in webapp](https://github.com/mattermost/mattermost-webapp/blob/master/sass/components/_post.scss#L1076) to effectively render new lines in the source text as new lines.

https://user-images.githubusercontent.com/3924815/127861317-07fa9874-d5a7-425e-bf4d-ec817cdfb99c.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37526

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
