### PR TITLE
MM-37526: Fix the newline render fix

### DIFF
--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -107,7 +107,9 @@ const RenderedDescription = styled.div`
         cursor: text;
     }
 
-    white-space: pre-wrap;
+    p {
+        white-space: pre-wrap;
+    }
 `;
 
 export default RHSAboutDescription;


### PR DESCRIPTION
#### Summary

#667 fixed the spacing of new lines in paragraphs, but broke it in lists. It turns out I had to isolate the `white-space` only to `p` elements.

| BEFORE 	| AFTER 	|
|---	|---	|
| ![image](https://user-images.githubusercontent.com/3924815/128144935-1af7ab56-38c1-4719-85ac-d48d8968c5d3.png) 	| ![image](https://user-images.githubusercontent.com/3924815/128144666-761df579-d13c-498a-a13b-7178b7a0a5ff.png) 	|

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37526

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
