### PR TITLE
MM-37519: Make the owner section slightly narrower

### DIFF
--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -173,7 +173,7 @@ const MemberSection = styled.div`
 `;
 
 const OwnerSection = styled(MemberSection)`
-    max-width: calc(100% - 205px);
+    max-width: calc(100% - 210px);
 `;
 
 const ParticipantsSection = styled(MemberSection)`


### PR DESCRIPTION
#### Summary

The computation of the width in the owner section did not take into account the added border in the participants component, so it was resized when hovering over the participants. 

##### Before

https://user-images.githubusercontent.com/3924815/128148846-07ef4659-733c-4e9b-9895-21246d37bde6.mp4

##### After

https://user-images.githubusercontent.com/3924815/128148842-a44ad11d-7db9-4fe2-93cf-b4a5389704ed.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37519

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
