### PR TITLE
MM-37569: Prevent empty title and use Esc to discard changes

### DIFF
--- a/webapp/src/components/rhs/rhs_about_title.tsx
+++ b/webapp/src/components/rhs/rhs_about_title.tsx
@@ -16,6 +16,8 @@ const RHSAboutTitle = (props: Props) => {
     const [editing, setEditing] = useState(false);
     const [editedValue, setEditedValue] = useState(props.value);
 
+    const invalidValue = editedValue.length < 2;
+
     const inputRef = useRef(null);
 
     useEffect(() => {
@@ -23,12 +25,20 @@ const RHSAboutTitle = (props: Props) => {
     }, [props.value]);
 
     const saveAndClose = () => {
-        props.onEdit(editedValue);
+        if (!invalidValue) {
+            props.onEdit(editedValue);
+            setEditing(false);
+        }
+    };
+
+    const discardAndClose = () => {
+        setEditedValue(props.value);
         setEditing(false);
     };
 
     useClickOutsideRef(inputRef, saveAndClose);
     useKeyPress('Enter', saveAndClose);
+    useKeyPress('Escape', discardAndClose);
 
     if (!editing) {
         const RenderedTitle = props.renderedTitle ?? DefaultRenderedTitle;
@@ -41,19 +51,26 @@ const RHSAboutTitle = (props: Props) => {
     }
 
     return (
-        <TitleInput
-            type={'text'}
-            ref={inputRef}
-            onChange={(e) => setEditedValue(e.target.value)}
-            value={editedValue}
-            maxLength={59}
-            autoFocus={true}
-            onFocus={(e) => {
-                const val = e.target.value;
-                e.target.value = '';
-                e.target.value = val;
-            }}
-        />
+        <>
+            <TitleInput
+                type={'text'}
+                ref={inputRef}
+                onChange={(e) => setEditedValue(e.target.value)}
+                value={editedValue}
+                maxLength={59}
+                autoFocus={true}
+                onFocus={(e) => {
+                    const val = e.target.value;
+                    e.target.value = '';
+                    e.target.value = val;
+                }}
+            />
+            {invalidValue &&
+            <ErrorMessage>
+                {'Run name must have at least two characters'}
+            </ErrorMessage>
+            }
+        </>
     );
 };
 
@@ -78,6 +95,16 @@ const TitleInput = styled.input`
     font-size: 18px;
     line-height: 24px;
     font-weight: 600;
+`;
+
+const ErrorMessage = styled.div`
+    color: var(--dnd-indicator);
+
+    font-size: 12px;
+    line-height: 16px;
+
+    margin-bottom: 12px;
+    margin-left: 8px;
 `;
 
 export const DefaultRenderedTitle = styled.div`


### PR DESCRIPTION
#### Summary
This PR polishes the title editing experience: the title can no longer become empty (an error is shown if the name has less than two characters, and the user cannot save it, only discard the changes) and hitting `Esc` discards the changes and disables the edit mode.

https://user-images.githubusercontent.com/3924815/128179238-2d3d01e5-c5a7-4dcc-b98f-a2bde2e272f7.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37569

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
