### PR TITLE
MM-37592: fix rhs_home theme color

### DIFF
--- a/webapp/src/components/rhs/rhs_home.tsx
+++ b/webapp/src/components/rhs/rhs_home.tsx
@@ -123,7 +123,7 @@ const RunDetailDesc = styled.span<RunDetailProps>`
     ${({exists}) => (exists ? css`
         font-size: 14px;
         line-height: 20px;
-        color: var(--mention-color);
+        color: var(--button-bg);
     ` : css`
         color: '#6F6F73';
         font-size: 16px;


### PR DESCRIPTION
#### Summary
Use proper theme var

Broken
<img width="401" alt="CleanShot 2021-08-04 at 17 27 22@2x" src="https://user-images.githubusercontent.com/11724372/128263451-38676f73-92d9-410b-bea4-872f5ce09384.png">
Fixed
<img width="401" alt="CleanShot 2021-08-04 at 17 26 29@2x" src="https://user-images.githubusercontent.com/11724372/128263455-f7caa233-3cb9-4b50-969d-b234add8e6c9.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37592

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests updated~~
