### PR TITLE
MM-37698: Simplify CSS and fix layout movement

### DIFF
--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useState, useRef, useEffect} from 'react';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 import PostText from 'src/components/post_text';
 import {useClickOutsideRef, useKeyPress} from 'src/hooks/general';
@@ -78,34 +78,11 @@ const RHSAboutDescription = (props: DescriptionProps) => {
     );
 };
 
-const DescriptionTextArea = styled.textarea`
-    resize: none;
-    width: 100%;
-    height: max-content;
-    padding: 4px 8px;
-    margin-top: -2px;
-    margin-bottom: 9px;
-
-    border: none;
-    border-radius: 5px;
-    box-shadow: none;
-
-    background: rgba(var(--center-channel-color-rgb), 0.04);
-
-    &:focus {
-        box-shadow: none;
-    }
-
-    font-size: 14px;
-    line-height: 20px;
-    color: var(--center-channel-color);
-`;
-
 const PlaceholderText = styled.span`
     opacity: 0.5;
 `;
 
-const RenderedDescription = styled.div`
+const commonDescriptionStyle = css`
     margin-bottom: 16px;
     padding: 2px 8px;
 
@@ -119,6 +96,36 @@ const RenderedDescription = styled.div`
 
     p {
         white-space: pre-wrap;
+    }
+
+    font-size: 14px;
+    line-height: 20px;
+    color: var(--center-channel-color);
+`;
+
+const RenderedDescription = styled.div`
+    ${commonDescriptionStyle}
+
+    p:last-child {
+        margin-bottom: 0;
+    }
+`;
+
+const DescriptionTextArea = styled.textarea`
+    ${commonDescriptionStyle}
+
+    display: block;
+    resize: none;
+    width: 100%;
+
+    border: none;
+    border-radius: 5px;
+    box-shadow: none;
+
+    background: rgba(var(--center-channel-color-rgb), 0.04);
+
+    &:focus {
+        box-shadow: none;
     }
 `;
 


### PR DESCRIPTION
#### Summary
Re-use the same CSS in both the rendered description and the editable textarea to simplify the code. The fix for the layout movement is just the `display: block` line, as `textarea` elements are `display: inline-block` by default, and the change between those two `display` values was creating that slight vertical movement.

Tested on Firefox and Chromium.

https://user-images.githubusercontent.com/3924815/128687904-ff3e1e26-b75b-45ff-afac-a21b61da6f14.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37698

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
