### PR TITLE
Recursively document PlaybookRunWebhookPayload

### DIFF
--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -99,7 +99,7 @@ func (p Playbook) MarshalJSON() ([]byte, error) {
 	return json.Marshal(old)
 }
 
-// Checklist represents a checklist in a playbook
+// Checklist represents a checklist in a playbook.
 type Checklist struct {
 	// ID is the identifier of the checklist.
 	ID string `json:"id"`
@@ -117,7 +117,7 @@ func (c Checklist) Clone() Checklist {
 	return newChecklist
 }
 
-// ChecklistItem represents an item in a checklist
+// ChecklistItem represents an item in a checklist.
 type ChecklistItem struct {
 	// ID is the identifier of the checklist item.
 	ID string `json:"id"`
@@ -137,7 +137,7 @@ type ChecklistItem struct {
 	// state was modified. The empty string if it was never modified.
 	StateModifiedPostID string `json:"state_modified_post_id"`
 
-	// AssigneeID is the identifier of the user to which this item is assigned to.
+	// AssigneeID is the identifier of the user to whom this item is assigned.
 	AssigneeID string `json:"assignee_id"`
 
 	// AssigneeModified is the timestamp, in milliseconds since epoch, of the last time the item's

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -101,13 +101,13 @@ func (p Playbook) MarshalJSON() ([]byte, error) {
 
 // Checklist represents a checklist in a playbook
 type Checklist struct {
-	// Identifier of the checklist.
+	// ID is the identifier of the checklist.
 	ID string `json:"id"`
 
-	// Name of the checklist.
+	// Title is the name of the checklist.
 	Title string `json:"title"`
 
-	// Array of all the items in the checklist.
+	// Items is an array of all the items in the checklist.
 	Items []ChecklistItem `json:"items"`
 }
 
@@ -119,42 +119,43 @@ func (c Checklist) Clone() Checklist {
 
 // ChecklistItem represents an item in a checklist
 type ChecklistItem struct {
-	// Identifier of the checklist item.
+	// ID is the identifier of the checklist item.
 	ID string `json:"id"`
 
-	// Name of the checklist item.
+	// Title is the content of the checklist item.
 	Title string `json:"title"`
 
-	// State of the checklist item: "closed" if it's checked, the empty string otherwise.
+	// State is the state of the checklist item: "closed" if it's checked, the empty string
+	// otherwise.
 	State string `json:"state"`
 
-	// Timestamp, in milliseconds since epoch, of the last time the item's state was modified
-	// 0 if it was never modified.
+	// StateModified is the timestamp, in milliseconds since epoch, of the last time the item's
+	// state was modified. 0 if it was never modified.
 	StateModified int64 `json:"state_modified"`
 
-	// Identifier of the post that announced the last time the item's state was modified.
-	// The empty string if it was never modified.
+	// StateModifiedPostID is the identifier of the post that announced the last time the item's
+	// state was modified. The empty string if it was never modified.
 	StateModifiedPostID string `json:"state_modified_post_id"`
 
-	// Identifier of the user to which this item is assigned to.
+	// AssigneeID is the identifier of the user to which this item is assigned to.
 	AssigneeID string `json:"assignee_id"`
 
-	// Timestamp, in milliseconds since epoch, of the last time the item's assignee was modified.
-	// 0 if it was never modified.
+	// AssigneeModified is the timestamp, in milliseconds since epoch, of the last time the item's
+	// assignee was modified. 0 if it was never modified.
 	AssigneeModified int64 `json:"assignee_modified"`
 
-	// Identifier of the post that announced the last time the item's assignee was modified.
-	// The empty string if it was never modified.
+	// AssigneeModifiedPostID is the identifier of the post that announced the last time the item's
+	// assignee was modified. The empty string if it was never modified.
 	AssigneeModifiedPostID string `json:"assignee_modified_post_id"`
 
-	// If not empty, the slash command that can be run as part of this item.
+	// Command, if not empty, is the slash command that can be run as part of this item.
 	Command string `json:"command"`
 
-	// Timestamp, in milliseconds since epoch, of the last time the item's slash command was run.
-	// 0 if it was never run.
+	// CommandLastRun is the timestamp, in milliseconds since epoch, of the last time the item's
+	// slash command was run. 0 if it was never run.
 	CommandLastRun int64 `json:"command_last_run"`
 
-	// Markdown content of the long description of the item.
+	// Description is a string with the markdown content of the long description of the item.
 	Description string `json:"description"`
 }
 

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -101,8 +101,13 @@ func (p Playbook) MarshalJSON() ([]byte, error) {
 
 // Checklist represents a checklist in a playbook
 type Checklist struct {
-	ID    string          `json:"id"`
-	Title string          `json:"title"`
+	// Identifier of the checklist.
+	ID string `json:"id"`
+
+	// Name of the checklist.
+	Title string `json:"title"`
+
+	// Array of all the items in the checklist.
 	Items []ChecklistItem `json:"items"`
 }
 
@@ -114,17 +119,43 @@ func (c Checklist) Clone() Checklist {
 
 // ChecklistItem represents an item in a checklist
 type ChecklistItem struct {
-	ID                     string `json:"id"`
-	Title                  string `json:"title"`
-	State                  string `json:"state"`
-	StateModified          int64  `json:"state_modified"`
-	StateModifiedPostID    string `json:"state_modified_post_id"`
-	AssigneeID             string `json:"assignee_id"`
-	AssigneeModified       int64  `json:"assignee_modified"`
+	// Identifier of the checklist item.
+	ID string `json:"id"`
+
+	// Name of the checklist item.
+	Title string `json:"title"`
+
+	// State of the checklist item: "closed" if it's checked, the empty string otherwise.
+	State string `json:"state"`
+
+	// Timestamp, in milliseconds since epoch, of the last time the item's state was modified
+	// 0 if it was never modified.
+	StateModified int64 `json:"state_modified"`
+
+	// Identifier of the post that announced the last time the item's state was modified.
+	// The empty string if it was never modified.
+	StateModifiedPostID string `json:"state_modified_post_id"`
+
+	// Identifier of the user to which this item is assigned to.
+	AssigneeID string `json:"assignee_id"`
+
+	// Timestamp, in milliseconds since epoch, of the last time the item's assignee was modified.
+	// 0 if it was never modified.
+	AssigneeModified int64 `json:"assignee_modified"`
+
+	// Identifier of the post that announced the last time the item's assignee was modified.
+	// The empty string if it was never modified.
 	AssigneeModifiedPostID string `json:"assignee_modified_post_id"`
-	Command                string `json:"command"`
-	CommandLastRun         int64  `json:"command_last_run"`
-	Description            string `json:"description"`
+
+	// If not empty, the slash command that can be run as part of this item.
+	Command string `json:"command"`
+
+	// Timestamp, in milliseconds since epoch, of the last time the item's slash command was run.
+	// 0 if it was never run.
+	CommandLastRun int64 `json:"command_last_run"`
+
+	// Markdown content of the long description of the item.
+	Description string `json:"description"`
 }
 
 type GetPlaybooksResults struct {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -23,127 +23,135 @@ const (
 // NOTE: when adding a column to the db, search for "When adding an Playbook Run column" to see where
 // that column needs to be added in the sqlstore code.
 type PlaybookRun struct {
-	// Unique identifier of the playbook run.
+	// ID is the unique identifier of the playbook run.
 	ID string `json:"id"`
 
-	// Name of the playbook run's channel.
+	// Name is the name of the playbook run's channel.
 	Name string `json:"name"`
 
-	// A short description in markdown describing what the run is.
+	// Description is a short string in markdown describing what the run is.
 	Description string `json:"description"`
 
-	// User identifier of the playbook run's owner.
+	// OwnerUserID is the user identifier of the playbook run's owner.
 	OwnerUserID string `json:"owner_user_id"`
 
-	// User identifier of the playbook run's reporter; i.e., the user that created the run.
+	// ReporterUserID is the user identifier of the playbook run's reporter; i.e., the user that created the run.
 	ReporterUserID string `json:"reporter_user_id"`
 
-	// Identifier of the team the playbook run lives in.
+	// TeamID is the identifier of the team the playbook run lives in.
 	TeamID string `json:"team_id"`
 
-	// Identifier of the playbook run's channel.
+	// ChannelID is the identifier of the playbook run's channel.
 	ChannelID string `json:"channel_id"`
 
-	// Timestamp, in milliseconds since epoch, of when the playbook run was created.
+	// CreateAt is the timestamp, in milliseconds since epoch, of when the playbook run was created.
 	CreateAt int64 `json:"create_at"`
 
-	// Timestamp, in milliseconds since epoch, of when the playbook run was ended.
+	// EndAt is the timestamp, in milliseconds since epoch, of when the playbook run was ended.
 	// If 0, the run is still ongoing.
 	EndAt int64 `json:"end_at"`
 
-	// Deprecated field.
+	// Deprecated: preserved for backwards compatibility with v1.2.
 	DeleteAt int64 `json:"delete_at"`
 
-	// Deprecated field.
+	// Deprecated: preserved for backwards compatibility with v1.2.
 	ActiveStage int `json:"active_stage"`
 
-	// Deprecated field.
+	// Deprecated: preserved for backwards compatibility with v1.2.
 	ActiveStageTitle string `json:"active_stage_title"`
 
-	// If not empty, the identifier of the post from which this playbook run was originally created.
+	// PostID, if not empty, is the identifier of the post from which this playbook run was originally created.
 	PostID string `json:"post_id"`
 
-	// Identifier of the playbook from which this run was created.
+	// PlaybookID is the identifier of the playbook from which this run was created.
 	PlaybookID string `json:"playbook_id"`
 
-	// Array of checklists in the run.
+	// Checklists is an array of the checklists in the run.
 	Checklists []Checklist `json:"checklists"`
 
-	// Array of all the status updates posted in this run.
+	// StatusPosts is an array of all the status updates posted in the run.
 	StatusPosts []StatusPost `json:"status_posts"`
 
-	// The current status of the playbook run. It can be Reported, Active, Resolved or Archived.
+	// CurrentStatus is the current status of the playbook run.
+	// It can be Reported, Active, Resolved or Archived.
 	CurrentStatus string `json:"current_status"`
 
-	// Timestamp, in milliseconds since epoch, of when the last status update was posted.
+	// LastStatusUpdateAt is the timestamp, in milliseconds since epoch, of the time the last
+	// status update was posted.
 	LastStatusUpdateAt int64 `json:"last_status_update_at"`
 
-	// If not empty, the identifier of the reminder posted to the channel to update the status.
+	// ReminderPostID, if not empty, is the identifier of the reminder posted to the channel to
+	// update the status.
 	ReminderPostID string `json:"reminder_post_id"`
 
-	// If not empty, the time.Duration (nanoseconds) at which the next scheduled status update will
-	// be posted
+	// PreviousReminder, if not empty, is the time.Duration (nanoseconds) at which the next
+	// scheduled status update will be posted
 	PreviousReminder time.Duration `json:"previous_reminder"`
 
-	// If not empty, the identifier of the channel to which all status updates are broadcasted.
+	// BroadcastChannelID, if not empty, is the identifier of the channel to which all status
+	// updates are broadcasted.
 	BroadcastChannelID string `json:"broadcast_channel_id"`
 
-	// If not empty, the template shown when updating the status of the playbook run for the first
-	// time.
+	// ReminderMessageTemplate, ifnot empty, is the template shown when updating the status of the
+	// playbook run for the first time.
 	ReminderMessageTemplate string `json:"reminder_message_template"`
 
-	// If not empty, an array containing the identifiers of the users that were automatically
-	// invited to the playbook run when it was created.
+	// InvitedUserIDs, if not empty, is an array containing the identifiers of the users that were
+	// automatically invited to the playbook run when it was created.
 	InvitedUserIDs []string `json:"invited_user_ids"`
 
-	// If not empty, an array containing the identifiers of the user groups that were automatically
-	// invited to the playbook run when it was created.
+	// InvitedGroupIDs, if not empty, is an array containing the identifiers of the user groups that
+	// were automatically invited to the playbook run when it was created.
 	InvitedGroupIDs []string `json:"invited_group_ids"`
 
-	// Array of events saved to the timeline of the playbook run.
+	// TimelineEvents is an array of the events saved to the timeline of the playbook run.
 	TimelineEvents []TimelineEvent `json:"timeline_events"`
 
-	// If not empty, the identifier of the user that was automatically assigned as owner of the
-	// playbook run when it was created.
+	// DefaultOwnerID, if not empty, is the identifier of the user that was automatically assigned
+	// as owner of the playbook run when it was created.
 	DefaultOwnerID string `json:"default_owner_id"`
 
-	// If not empty, the identifier of the channel where the playbook run creation was announced in.
+	// AnnouncementChannelID, if not empty, is the identifier of the channel where the playbook run
+	// creation was announced in.
 	AnnouncementChannelID string `json:"announcement_channel_id"`
 
-	// If not empty, the URL to which a POST request is made with the whole playbook run as payload
-	// when the run is created.
+	// WebhookOnCreationURL, if not empty, is the URL to which a POST request is made with the whole
+	// playbook run as payload when the run is created.
 	WebhookOnCreationURL string `json:"webhook_on_creation_url"`
 
-	// If not empty, the URL to which a POST request is made with the whole playbook run as payload
-	// every time the status of the playbook run is updated.
+	// WebhookOnStatusUpdateURL, if not empty, is the URL to which a POST request is made with the
+	// whole playbook run as payload every time the status of the playbook run is updated.
 	WebhookOnStatusUpdateURL string `json:"webhook_on_status_update_url"`
 
-	// The contents of the currently saved retrospective. If RetrospectivePublishedAt is different
-	// than 0, this the published retrospective.
+	// Retrospective is a string containing the currently saved retrospective.
+	// If RetrospectivePublishedAt is different than 0, this is the final published retrospective.
 	Retrospective string `json:"retrospective"`
 
-	// Timestamp, in milliseconds since epoch, of the last time a retrospective was published.
-	// If 0, the retrospective has not been published yet.
+	// RetrospectivePublishedAt is the timestamp, in milliseconds since epoch, of the last time a
+	// retrospective was published. If 0, the retrospective has not been published yet.
 	RetrospectivePublishedAt int64 `json:"retrospective_published_at"`
 
-	// True if the retrospective was canceled. False otherwise.
+	// RetrospectiveWasCanceled is true if the retrospective was canceled, false otherwise.
 	RetrospectiveWasCanceled bool `json:"retrospective_was_canceled"`
 
-	// Inteval, in seconds, between subsequent reminders to fill the retrospective.
+	// RetrospectiveReminderIntervalSeconds is the inteval, in seconds, between subsequent reminders
+	// to fill the retrospective.
 	RetrospectiveReminderIntervalSeconds int64 `json:"retrospective_reminder_interval_seconds"`
 
-	// If not empty, the message shown to every user that joins the channel of the playbook run.
+	// MessageOnJoin, if not empty, is the message shown to every user that joins the channel of
+	// the playbook run.
 	MessageOnJoin string `json:"message_on_join"`
 
-	// True if the channel is exported when the status is updated to Archived.
+	// ExportChannelOnArchiveEnabled is true if the channel is exported when the status is updated
+	// to Archived, false otherwies.
 	ExportChannelOnArchiveEnabled bool `json:"export_channel_on_archive_enabled"`
 
-	// Array of identifiers of all the participants in the playbook run. A participant is right now
-	// a member of the playbook run channel that is not a bot.
+	// ParticipantIDs is an array of the identifiers of all the participants in the playbook run.
+	// A participant is right now a member of the playbook run channel that is not a bot.
 	ParticipantIDs []string `json:"participant_ids"`
 
-	// If true, the channel is automatically categorized in the Playbook Runs category for every
-	// user that joins the playbook run channel.
+	// CategorizeChannelEnabled is true if the channel is automatically categorized in the Playbook
+	// Runs category for every user that joins the playbook run channel.
 	CategorizeChannelEnabled bool `json:"categorize_channel_enabled"`
 }
 
@@ -227,18 +235,19 @@ func (i *PlaybookRun) ResolvedAt() int64 {
 }
 
 type StatusPost struct {
-	// Identifier of the post containing the status update.
+	// ID is the identifier of the post containing the status update.
 	ID string `json:"id"`
 
-	// Status of the playbook run after this update was posted.
+	// Status is the status of the playbook run after this update was posted.
 	// It can be "Reported", "Active", "Resolved" and "Archived".
 	Status string `json:"status"`
 
-	// Timestamp, in milliseconds since epoch, of the time this status update was posted.
+	// CreateAt is the timestamp, in milliseconds since epoch, of the time this status update was
+	// posted.
 	CreateAt int64 `json:"create_at"`
 
-	// Timestamp, in milliseconds since epoch, of the time the post containing this status update
-	// was deleted. 0 if it was never deleted.
+	// DeleteAt is the timestamp, in milliseconds since epoch, of the time the post containing this
+	// status update was deleted. 0 if it was never deleted.
 	DeleteAt int64 `json:"delete_at"`
 }
 
@@ -278,42 +287,43 @@ const (
 )
 
 type TimelineEvent struct {
-	// Identifier of this event.
+	// ID is the identifier of this event.
 	ID string `json:"id"`
 
-	// Identifier of the playbook run this event lives in.
+	// PlaybookRunID is the identifier of the playbook run this event lives in.
 	PlaybookRunID string `json:"playbook_run_id"`
 
-	// Timestamp, in milliseconds since epoch, of the time this event was created.
+	// CreateAt is the timestamp, in milliseconds since epoch, of the time this event was created.
 	CreateAt int64 `json:"create_at"`
 
-	// Timestamp, in milliseconds since epoch, of the time this event was deleted.
+	// DeleteAt is the timestamp, in milliseconds since epoch, of the time this event was deleted.
 	// 0 if it was never deleted.
 	DeleteAt int64 `json:"delete_at"`
 
-	// Timestamp, in milliseconds since epoch, of the actual situation this event is describing.
+	// EventAt is the timestamp, in milliseconds since epoch, of the actual situation this event is
+	// describing.
 	EventAt int64 `json:"event_at"`
 
-	// Type of this event. It can be "incident_created", "task_state_modified", "status_updated",
-	// "owner_changed", "assignee_changed", "ran_slash_command", "event_from_post",
-	// "user_joined_left", "published_retrospective" or "canceled_retrospective".
+	// EventType is the type of this event. It can be "incident_created", "task_state_modified",
+	// "status_updated", "owner_changed", "assignee_changed", "ran_slash_command",
+	// "event_from_post", "user_joined_left", "published_retrospective" or "canceled_retrospective".
 	EventType timelineEventType `json:"event_type"`
 
-	// Short description of the event.
+	// Summary is a short description of the event.
 	Summary string `json:"summary"`
 
-	// Longer description of the event.
+	// Details is the longer description of the event.
 	Details string `json:"details"`
 
-	// If not empty, identifier of the post announcing in the channel this event happened.
-	// If the event is of type "event_from_post", this is the identifier of such post.
+	// PostID, f not empty, is the identifier of the post announcing in the channel this event
+	// happened. If the event is of type "event_from_post", this is the identifier of such post.
 	PostID string `json:"post_id"`
 
-	// Identifier of the user involved in the event. For example, if the event is of type
-	// "owner_changed", this is the identifier of the new owner.
+	// SubjectUserID is the identifier of the user involved in the event. For example, if the event
+	// is of type "owner_changed", this is the identifier of the new owner.
 	SubjectUserID string `json:"subject_user_id"`
 
-	// Identifier of the user that created the event.
+	// CreatorUserID is the identifier of the user that created the event.
 	CreatorUserID string `json:"creator_user_id"`
 }
 

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -23,43 +23,128 @@ const (
 // NOTE: when adding a column to the db, search for "When adding an Playbook Run column" to see where
 // that column needs to be added in the sqlstore code.
 type PlaybookRun struct {
-	ID                                   string          `json:"id"`
-	Name                                 string          `json:"name"` // Retrieved from playbook run channel
-	Description                          string          `json:"description"`
-	OwnerUserID                          string          `json:"owner_user_id"`
-	ReporterUserID                       string          `json:"reporter_user_id"`
-	TeamID                               string          `json:"team_id"`
-	ChannelID                            string          `json:"channel_id"`
-	CreateAt                             int64           `json:"create_at"` // Retrieved from playbook run channel
-	EndAt                                int64           `json:"end_at"`
-	DeleteAt                             int64           `json:"delete_at"` // Retrieved from playbook run channel
-	ActiveStage                          int             `json:"active_stage"`
-	ActiveStageTitle                     string          `json:"active_stage_title"`
-	PostID                               string          `json:"post_id"`
-	PlaybookID                           string          `json:"playbook_id"`
-	Checklists                           []Checklist     `json:"checklists"`
-	StatusPosts                          []StatusPost    `json:"status_posts"`
-	CurrentStatus                        string          `json:"current_status"`
-	LastStatusUpdateAt                   int64           `json:"last_status_update_at"`
-	ReminderPostID                       string          `json:"reminder_post_id"`
-	PreviousReminder                     time.Duration   `json:"previous_reminder"`
-	BroadcastChannelID                   string          `json:"broadcast_channel_id"`
-	ReminderMessageTemplate              string          `json:"reminder_message_template"`
-	InvitedUserIDs                       []string        `json:"invited_user_ids"`
-	InvitedGroupIDs                      []string        `json:"invited_group_ids"`
-	TimelineEvents                       []TimelineEvent `json:"timeline_events"`
-	DefaultOwnerID                       string          `json:"default_owner_id"`
-	AnnouncementChannelID                string          `json:"announcement_channel_id"`
-	WebhookOnCreationURL                 string          `json:"webhook_on_creation_url"`
-	WebhookOnStatusUpdateURL             string          `json:"webhook_on_status_update_url"`
-	Retrospective                        string          `json:"retrospective"`
-	RetrospectivePublishedAt             int64           `json:"retrospective_published_at"` // The last time a retrospective was published. 0 if never published.
-	RetrospectiveWasCanceled             bool            `json:"retrospective_was_canceled"`
-	RetrospectiveReminderIntervalSeconds int64           `json:"retrospective_reminder_interval_seconds"`
-	MessageOnJoin                        string          `json:"message_on_join"`
-	ExportChannelOnArchiveEnabled        bool            `json:"export_channel_on_archive_enabled"`
-	ParticipantIDs                       []string        `json:"participant_ids"`
-	CategorizeChannelEnabled             bool            `json:"categorize_channel_enabled"`
+	// Unique identifier of the playbook run.
+	ID string `json:"id"`
+
+	// Name of the playbook run's channel.
+	Name string `json:"name"`
+
+	// A short description in markdown describing what the run is.
+	Description string `json:"description"`
+
+	// User identifier of the playbook run's owner.
+	OwnerUserID string `json:"owner_user_id"`
+
+	// User identifier of the playbook run's reporter; i.e., the user that created the run.
+	ReporterUserID string `json:"reporter_user_id"`
+
+	// Identifier of the team the playbook run lives in.
+	TeamID string `json:"team_id"`
+
+	// Identifier of the playbook run's channel.
+	ChannelID string `json:"channel_id"`
+
+	// Timestamp, in milliseconds since epoch, of when the playbook run was created.
+	CreateAt int64 `json:"create_at"`
+
+	// Timestamp, in milliseconds since epoch, of when the playbook run was ended.
+	// If 0, the run is still ongoing.
+	EndAt int64 `json:"end_at"`
+
+	// Deprecated field.
+	DeleteAt int64 `json:"delete_at"`
+
+	// Deprecated field.
+	ActiveStage int `json:"active_stage"`
+
+	// Deprecated field.
+	ActiveStageTitle string `json:"active_stage_title"`
+
+	// If not empty, the identifier of the post from which this playbook run was originally created.
+	PostID string `json:"post_id"`
+
+	// Identifier of the playbook from which this run was created.
+	PlaybookID string `json:"playbook_id"`
+
+	// Array of checklists in the run.
+	Checklists []Checklist `json:"checklists"`
+
+	// Array of all the status updates posted in this run.
+	StatusPosts []StatusPost `json:"status_posts"`
+
+	// The current status of the playbook run. It can be Reported, Active, Resolved or Archived.
+	CurrentStatus string `json:"current_status"`
+
+	// Timestamp, in milliseconds since epoch, of when the last status update was posted.
+	LastStatusUpdateAt int64 `json:"last_status_update_at"`
+
+	// If not empty, the identifier of the reminder posted to the channel to update the status.
+	ReminderPostID string `json:"reminder_post_id"`
+
+	// If not empty, the time.Duration (nanoseconds) at which the next scheduled status update will
+	// be posted
+	PreviousReminder time.Duration `json:"previous_reminder"`
+
+	// If not empty, the identifier of the channel to which all status updates are broadcasted.
+	BroadcastChannelID string `json:"broadcast_channel_id"`
+
+	// If not empty, the template shown when updating the status of the playbook run for the first
+	// time.
+	ReminderMessageTemplate string `json:"reminder_message_template"`
+
+	// If not empty, an array containing the identifiers of the users that were automatically
+	// invited to the playbook run when it was created.
+	InvitedUserIDs []string `json:"invited_user_ids"`
+
+	// If not empty, an array containing the identifiers of the user groups that were automatically
+	// invited to the playbook run when it was created.
+	InvitedGroupIDs []string `json:"invited_group_ids"`
+
+	// Array of events saved to the timeline of the playbook run.
+	TimelineEvents []TimelineEvent `json:"timeline_events"`
+
+	// If not empty, the identifier of the user that was automatically assigned as owner of the
+	// playbook run when it was created.
+	DefaultOwnerID string `json:"default_owner_id"`
+
+	// If not empty, the identifier of the channel where the playbook run creation was announced in.
+	AnnouncementChannelID string `json:"announcement_channel_id"`
+
+	// If not empty, the URL to which a POST request is made with the whole playbook run as payload
+	// when the run is created.
+	WebhookOnCreationURL string `json:"webhook_on_creation_url"`
+
+	// If not empty, the URL to which a POST request is made with the whole playbook run as payload
+	// every time the status of the playbook run is updated.
+	WebhookOnStatusUpdateURL string `json:"webhook_on_status_update_url"`
+
+	// The contents of the currently saved retrospective. If RetrospectivePublishedAt is different
+	// than 0, this the published retrospective.
+	Retrospective string `json:"retrospective"`
+
+	// Timestamp, in milliseconds since epoch, of the last time a retrospective was published.
+	// If 0, the retrospective has not been published yet.
+	RetrospectivePublishedAt int64 `json:"retrospective_published_at"`
+
+	// True if the retrospective was canceled. False otherwise.
+	RetrospectiveWasCanceled bool `json:"retrospective_was_canceled"`
+
+	// Inteval, in seconds, between subsequent reminders to fill the retrospective.
+	RetrospectiveReminderIntervalSeconds int64 `json:"retrospective_reminder_interval_seconds"`
+
+	// If not empty, the message shown to every user that joins the channel of the playbook run.
+	MessageOnJoin string `json:"message_on_join"`
+
+	// True if the channel is exported when the status is updated to Archived.
+	ExportChannelOnArchiveEnabled bool `json:"export_channel_on_archive_enabled"`
+
+	// Array of identifiers of all the participants in the playbook run. A participant is right now
+	// a member of the playbook run channel that is not a bot.
+	ParticipantIDs []string `json:"participant_ids"`
+
+	// If true, the channel is automatically categorized in the Playbook Runs category for every
+	// user that joins the playbook run channel.
+	CategorizeChannelEnabled bool `json:"categorize_channel_enabled"`
 }
 
 func (i *PlaybookRun) Clone() *PlaybookRun {
@@ -142,10 +227,19 @@ func (i *PlaybookRun) ResolvedAt() int64 {
 }
 
 type StatusPost struct {
-	ID       string `json:"id"`
-	Status   string `json:"status"`
-	CreateAt int64  `json:"create_at"`
-	DeleteAt int64  `json:"delete_at"`
+	// Identifier of the post containing the status update.
+	ID string `json:"id"`
+
+	// Status of the playbook run after this update was posted.
+	// It can be "Reported", "Active", "Resolved" and "Archived".
+	Status string `json:"status"`
+
+	// Timestamp, in milliseconds since epoch, of the time this status update was posted.
+	CreateAt int64 `json:"create_at"`
+
+	// Timestamp, in milliseconds since epoch, of the time the post containing this status update
+	// was deleted. 0 if it was never deleted.
+	DeleteAt int64 `json:"delete_at"`
 }
 
 type UpdateOptions struct {
@@ -184,17 +278,43 @@ const (
 )
 
 type TimelineEvent struct {
-	ID            string            `json:"id"`
-	PlaybookRunID string            `json:"playbook_run_id"`
-	CreateAt      int64             `json:"create_at"`
-	DeleteAt      int64             `json:"delete_at"`
-	EventAt       int64             `json:"event_at"`
-	EventType     timelineEventType `json:"event_type"`
-	Summary       string            `json:"summary"`
-	Details       string            `json:"details"`
-	PostID        string            `json:"post_id"`
-	SubjectUserID string            `json:"subject_user_id"`
-	CreatorUserID string            `json:"creator_user_id"`
+	// Identifier of this event.
+	ID string `json:"id"`
+
+	// Identifier of the playbook run this event lives in.
+	PlaybookRunID string `json:"playbook_run_id"`
+
+	// Timestamp, in milliseconds since epoch, of the time this event was created.
+	CreateAt int64 `json:"create_at"`
+
+	// Timestamp, in milliseconds since epoch, of the time this event was deleted.
+	// 0 if it was never deleted.
+	DeleteAt int64 `json:"delete_at"`
+
+	// Timestamp, in milliseconds since epoch, of the actual situation this event is describing.
+	EventAt int64 `json:"event_at"`
+
+	// Type of this event. It can be "incident_created", "task_state_modified", "status_updated",
+	// "owner_changed", "assignee_changed", "ran_slash_command", "event_from_post",
+	// "user_joined_left", "published_retrospective" or "canceled_retrospective".
+	EventType timelineEventType `json:"event_type"`
+
+	// Short description of the event.
+	Summary string `json:"summary"`
+
+	// Longer description of the event.
+	Details string `json:"details"`
+
+	// If not empty, identifier of the post announcing in the channel this event happened.
+	// If the event is of type "event_from_post", this is the identifier of such post.
+	PostID string `json:"post_id"`
+
+	// Identifier of the user involved in the event. For example, if the event is of type
+	// "owner_changed", this is the identifier of the new owner.
+	SubjectUserID string `json:"subject_user_id"`
+
+	// Identifier of the user that created the event.
+	CreatorUserID string `json:"creator_user_id"`
 }
 
 // GetPlaybookRunsResults collects the results of the GetPlaybookRuns call: the list of PlaybookRuns matching

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -20,7 +20,7 @@ const (
 
 // PlaybookRun holds the detailed information of an playbook run.
 //
-// NOTE: when adding a column to the db, search for "When adding an Playbook Run column" to see where
+// NOTE: When adding a column to the db, search for "When adding an Playbook Run column" to see where
 // that column needs to be added in the sqlstore code.
 type PlaybookRun struct {
 	// ID is the unique identifier of the playbook run.
@@ -29,7 +29,7 @@ type PlaybookRun struct {
 	// Name is the name of the playbook run's channel.
 	Name string `json:"name"`
 
-	// Description is a short string in markdown describing what the run is.
+	// Description is a short string, in Markdown, describing what the run is.
 	Description string `json:"description"`
 
 	// OwnerUserID is the user identifier of the playbook run's owner.
@@ -85,7 +85,7 @@ type PlaybookRun struct {
 	ReminderPostID string `json:"reminder_post_id"`
 
 	// PreviousReminder, if not empty, is the time.Duration (nanoseconds) at which the next
-	// scheduled status update will be posted
+	// scheduled status update will be posted.
 	PreviousReminder time.Duration `json:"previous_reminder"`
 
 	// BroadcastChannelID, if not empty, is the identifier of the channel to which all status
@@ -112,7 +112,7 @@ type PlaybookRun struct {
 	DefaultOwnerID string `json:"default_owner_id"`
 
 	// AnnouncementChannelID, if not empty, is the identifier of the channel where the playbook run
-	// creation was announced in.
+	// creation was announced.
 	AnnouncementChannelID string `json:"announcement_channel_id"`
 
 	// WebhookOnCreationURL, if not empty, is the URL to which a POST request is made with the whole
@@ -131,10 +131,10 @@ type PlaybookRun struct {
 	// retrospective was published. If 0, the retrospective has not been published yet.
 	RetrospectivePublishedAt int64 `json:"retrospective_published_at"`
 
-	// RetrospectiveWasCanceled is true if the retrospective was canceled, false otherwise.
+	// RetrospectiveWasCanceled is true if the retrospective was cancelled, false otherwise.
 	RetrospectiveWasCanceled bool `json:"retrospective_was_canceled"`
 
-	// RetrospectiveReminderIntervalSeconds is the inteval, in seconds, between subsequent reminders
+	// RetrospectiveReminderIntervalSeconds is the interval, in seconds, between subsequent reminders
 	// to fill the retrospective.
 	RetrospectiveReminderIntervalSeconds int64 `json:"retrospective_reminder_interval_seconds"`
 
@@ -143,15 +143,15 @@ type PlaybookRun struct {
 	MessageOnJoin string `json:"message_on_join"`
 
 	// ExportChannelOnArchiveEnabled is true if the channel is exported when the status is updated
-	// to Archived, false otherwies.
+	// to "Archived", false otherwise.
 	ExportChannelOnArchiveEnabled bool `json:"export_channel_on_archive_enabled"`
 
 	// ParticipantIDs is an array of the identifiers of all the participants in the playbook run.
-	// A participant is right now a member of the playbook run channel that is not a bot.
+	// A participant is any member of the playbook run channel that isn't a bot.
 	ParticipantIDs []string `json:"participant_ids"`
 
-	// CategorizeChannelEnabled is true if the channel is automatically categorized in the Playbook
-	// Runs category for every user that joins the playbook run channel.
+	// CategorizeChannelEnabled is true if the channel is automatically categorized in the playbook
+	// runs category for every user that joins the playbook run channel.
 	CategorizeChannelEnabled bool `json:"categorize_channel_enabled"`
 }
 
@@ -239,7 +239,7 @@ type StatusPost struct {
 	ID string `json:"id"`
 
 	// Status is the status of the playbook run after this update was posted.
-	// It can be "Reported", "Active", "Resolved" and "Archived".
+	// It can be "Reported", "Active", "Resolved", or "Archived".
 	Status string `json:"status"`
 
 	// CreateAt is the timestamp, in milliseconds since epoch, of the time this status update was
@@ -306,7 +306,7 @@ type TimelineEvent struct {
 
 	// EventType is the type of this event. It can be "incident_created", "task_state_modified",
 	// "status_updated", "owner_changed", "assignee_changed", "ran_slash_command",
-	// "event_from_post", "user_joined_left", "published_retrospective" or "canceled_retrospective".
+	// "event_from_post", "user_joined_left", "published_retrospective", or "canceled_retrospective".
 	EventType timelineEventType `json:"event_type"`
 
 	// Summary is a short description of the event.
@@ -315,8 +315,8 @@ type TimelineEvent struct {
 	// Details is the longer description of the event.
 	Details string `json:"details"`
 
-	// PostID, f not empty, is the identifier of the post announcing in the channel this event
-	// happened. If the event is of type "event_from_post", this is the identifier of such post.
+	// PostID, if not empty, is the identifier of the post announcing in the channel this event
+	// happened. If the event is of type "event_from_post", this is the identifier of that post.
 	PostID string `json:"post_id"`
 
 	// SubjectUserID is the identifier of the user involved in the event. For example, if the event

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -180,7 +180,6 @@ func (s *PlaybookRunServiceImpl) broadcastPlaybookRunCreation(playbook *Playbook
 
 // PlaybookRunWebhookPayload is the body of the payload sent via playbook run webhooks.
 type PlaybookRunWebhookPayload struct {
-	// Playbook run.
 	PlaybookRun
 
 	// Absolute URL of the playbook run channel.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -178,15 +178,15 @@ func (s *PlaybookRunServiceImpl) broadcastPlaybookRunCreation(playbook *Playbook
 	return nil
 }
 
-// Payload sent with playbook run webhooks.
+// PlaybookRunWebhookPayload is the body of the payload sent via playbook run webhooks.
 type PlaybookRunWebhookPayload struct {
 	// Playbook run.
 	PlaybookRun
 
 	// Absolute URL of the playbook run channel.
-	ChannelURL string `json:"channel_url"`
+	// ChannelURL is the absolute URL of the playbook run channel.
 
-	// Absolute URL of the playbook run overview page.
+	// DetailsURL is the absolute URL of the playbook run overview page.
 	DetailsURL string `json:"details_url"`
 }
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -182,8 +182,8 @@ func (s *PlaybookRunServiceImpl) broadcastPlaybookRunCreation(playbook *Playbook
 type PlaybookRunWebhookPayload struct {
 	PlaybookRun
 
-	// Absolute URL of the playbook run channel.
 	// ChannelURL is the absolute URL of the playbook run channel.
+	ChannelURL string `json:"channel_url"`
 
 	// DetailsURL is the absolute URL of the playbook run overview page.
 	DetailsURL string `json:"details_url"`

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -178,6 +178,18 @@ func (s *PlaybookRunServiceImpl) broadcastPlaybookRunCreation(playbook *Playbook
 	return nil
 }
 
+// Payload sent with playbook run webhooks.
+type PlaybookRunWebhookPayload struct {
+	// Playbook run.
+	PlaybookRun
+
+	// Absolute URL of the playbook run channel.
+	ChannelURL string `json:"channel_url"`
+
+	// Absolute URL of the playbook run overview page.
+	DetailsURL string `json:"details_url"`
+}
+
 // sendWebhookOnCreation sends a POST request to the creation webhook URL.
 // It blocks until a response is received.
 func (s *PlaybookRunServiceImpl) sendWebhookOnCreation(playbookRun PlaybookRun) error {
@@ -201,11 +213,7 @@ func (s *PlaybookRunServiceImpl) sendWebhookOnCreation(playbookRun PlaybookRun) 
 
 	detailsURL := getDetailsURL(*siteURL, team.Name, s.configService.GetManifest().Id, playbookRun.ID)
 
-	payload := struct {
-		PlaybookRun
-		ChannelURL string `json:"channel_url"`
-		DetailsURL string `json:"details_url"`
-	}{
+	payload := PlaybookRunWebhookPayload{
 		PlaybookRun: playbookRun,
 		ChannelURL:  channelURL,
 		DetailsURL:  detailsURL,
@@ -705,11 +713,7 @@ func (s *PlaybookRunServiceImpl) sendWebhookOnUpdateStatus(playbookRun PlaybookR
 
 	detailsURL := getDetailsURL(*siteURL, team.Name, s.configService.GetManifest().Id, playbookRun.ID)
 
-	payload := struct {
-		PlaybookRun
-		ChannelURL string `json:"channel_url"`
-		DetailsURL string `json:"details_url"`
-	}{
+	payload := PlaybookRunWebhookPayload{
 		PlaybookRun: playbookRun,
 		ChannelURL:  channelURL,
 		DetailsURL:  detailsURL,

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -1070,11 +1070,6 @@ func TestCreateAndGetPlaybookRun(t *testing.T) {
 				ExpectedErr: nil,
 			},
 			{
-				Name:        "Deleted playbook run",
-				PlaybookRun: NewBuilder(t).WithDeleteAt(model.GetMillis()).ToPlaybookRun(),
-				ExpectedErr: nil,
-			},
-			{
 				Name:        "PlaybookRun with one checklist and 10 items",
 				PlaybookRun: NewBuilder(t).WithChecklists([]int{10}).ToPlaybookRun(),
 				ExpectedErr: nil,
@@ -1980,12 +1975,6 @@ func (ib *PlaybookRunBuilder) ToPlaybookRun() *app.PlaybookRun {
 
 func (ib *PlaybookRunBuilder) WithCreateAt(createAt int64) *PlaybookRunBuilder {
 	ib.playbookRun.CreateAt = createAt
-
-	return ib
-}
-
-func (ib *PlaybookRunBuilder) WithDeleteAt(deleteAt int64) *PlaybookRunBuilder {
-	ib.playbookRun.DeleteAt = deleteAt
 
 	return ib
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -125,7 +125,7 @@ func playbookRunProperties(playbookRun *app.PlaybookRun, userID string) map[stri
 		"ChannelID":               playbookRun.ChannelID,
 		"CreateAt":                playbookRun.CreateAt,
 		"EndAt":                   playbookRun.EndAt,
-		"DeleteAt":                playbookRun.DeleteAt,
+		"DeleteAt":                playbookRun.DeleteAt, //nolint
 		"PostID":                  playbookRun.PostID,
 		"PlaybookID":              playbookRun.PlaybookID,
 		"NumChecklists":           len(playbookRun.Checklists),

--- a/server/telemetry/rudder_test.go
+++ b/server/telemetry/rudder_test.go
@@ -446,7 +446,7 @@ func TestPlaybookRunProperties(t *testing.T) {
 		"ChannelID":               dummyPlaybookRun.ChannelID,
 		"CreateAt":                dummyPlaybookRun.CreateAt,
 		"EndAt":                   dummyPlaybookRun.EndAt,
-		"DeleteAt":                dummyPlaybookRun.DeleteAt,
+		"DeleteAt":                dummyPlaybookRun.DeleteAt, //nolint
 		"PostID":                  dummyPlaybookRun.PostID,
 		"PlaybookID":              dummyPlaybookRun.PlaybookID,
 		"NumChecklists":           2,


### PR DESCRIPTION
#### Summary
This was meant to come with the long-awaited API docs rework, but as documenting the public structs is something we'll need to do sooner or later, and there are customers asking for documentation on the webhooks payload, I started simply documenting the structs, so @justinegeffen can point directly to the code in the documentation, while the rework finally comes.

I'm open to how to document some of the fields such as ID (maybe not document them at all?).

#### Ticket Link
--

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
