### PR TITLE
MM-37893: calc global header height in backstage

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -43,7 +43,8 @@ import {applyTheme} from './css_utils';
 
 const BackstageContainer = styled.div`
     background: var(--center-channel-bg);
-    height: 100%;
+    // The container should take up all vertical real estate, less the height of the global header.
+    height: calc(100% - 40px);
     display: flex;
     flex-direction: column;
     overflow-y: auto;


### PR DESCRIPTION
#### Summary
Compensate for the 40px consumed by the backstage header, allowing the full content on the backstage to be displayed. Previously, page navigation controls rendered outside the viewport and could not be reached.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-37893

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
