### PR TITLE
MM-37890: fix missing file icon

### DIFF
--- a/webapp/src/components/assets/icons/file_icon.tsx
+++ b/webapp/src/components/assets/icons/file_icon.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 const FileIcon = (props: React.PropsWithoutRef<JSX.IntrinsicElements['i']>): JSX.Element => (
-    <i className={`icon icon-file-outline icon-32 ${props.className}`}/>
+    <i className={`icon icon-file-generic-outline icon-32 ${props.className}`}/>
 );
 
 export default FileIcon;


### PR DESCRIPTION
#### Summary
Restore the missing file icon for the blank template:
<img width="226" alt="image" src="https://user-images.githubusercontent.com/1023171/129745661-83280cf7-98db-41ca-978a-e9e4ad2e396b.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37890

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
