### PR TITLE
[MM-36445] Changing elastic search docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ jobs:
           MINIO_ACCESS_KEY: minioaccesskey
           MINIO_SECRET_KEY: miniosecretkey
           MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
-      - image: mattermost/mattermost-elasticsearch-docker:6.5.1
+      - image: mattermost/mattermost-elasticsearch-docker:7.0.0
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
@@ -392,7 +392,7 @@ jobs:
           MINIO_ACCESS_KEY: minioaccesskey
           MINIO_SECRET_KEY: miniosecretkey
           MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
-      - image: mattermost/mattermost-elasticsearch-docker:6.5.1
+      - image: mattermost/mattermost-elasticsearch-docker:7.0.0
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
@@ -464,7 +464,7 @@ jobs:
           MINIO_ACCESS_KEY: minioaccesskey
           MINIO_SECRET_KEY: miniosecretkey
           MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
-      - image: mattermost/mattermost-elasticsearch-docker:6.5.1
+      - image: mattermost/mattermost-elasticsearch-docker:7.0.0
         environment:
           http.host: "0.0.0.0"
           http.port: 9200


### PR DESCRIPTION
#### Summary
Using es7 for pipeline because we no longer support es 5 & 6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36445

#### Related PRs
https://github.com/mattermost/enterprise/pull/1020

#### Checklist
- [NA] Telemetry updated
- [NA] Gated by experimental feature flag
- [NA] Unit tests updated
