### PR TITLE
MM-37542: Support dynamic channel header tooltip

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/channel_header_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/channel_header_spec.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+describe('channel header', () => {
+    let testTeam;
+    let testUser;
+    let testPlaybook;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Turn off growth onboarding screens
+            cy.apiUpdateConfig({
+                ServiceSettings: {EnableOnboardingFlow: false},
+            });
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+
+            // # Create a playbook
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Playbook',
+                userId: testUser.id,
+            }).then((playbook) => {
+                testPlaybook = playbook;
+
+                // # Start a playbook run
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: testPlaybook.id,
+                    playbookRunName: 'Playbook Run',
+                    ownerUserId: testUser.id,
+                });
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Size the viewport to show the RHS without covering posts.
+        cy.viewport('macbook-13');
+
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    describe('tooltip text', () => {
+        it('should show "Run Playbook" outside a playbook run channel', () => {
+            // # Navigate directly to a non-playbook run channel
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // # Hover over the channel header icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').trigger('mouseover');
+            });
+
+            // # Verify tooltip text
+            cy.get('#pluginTooltip').contains('Run Playbook');
+        });
+
+        it('should show "View Run Details" inside a playbook run channel', () => {
+            // # Navigate directly to a playbook run channel
+            cy.visit(`/${testTeam.name}/channels/playbook-run`);
+
+            // # Hover over the channel header icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').trigger('mouseover');
+            });
+
+            // # Verify tooltip text
+            cy.get('#pluginTooltip').contains('View Run Details');
+        });
+    });
+});

--- a/webapp/src/components/channel_header.tsx
+++ b/webapp/src/components/channel_header.tsx
@@ -1,14 +1,13 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import React, {useRef, FC} from 'react';
+import React, {useRef} from 'react';
 import {useSelector} from 'react-redux';
-
 import {createGlobalStyle} from 'styled-components';
 
-import {isPlaybookRunRHSOpen, isDisabledOnCurrentTeam} from 'src/selectors';
+import IncidentIcon, {Ref as PlaybookRunIconRef} from 'src/components/assets/icons/incident_icon';
 
-import IncidentIcon, {Ref as PlaybookRunIconRef} from './incident_icon';
+import {isPlaybookRunRHSOpen, isDisabledOnCurrentTeam, inPlaybookRunChannel} from 'src/selectors';
 
 const DisabledStyle = createGlobalStyle`
     .plugin-icon-hide {
@@ -16,7 +15,7 @@ const DisabledStyle = createGlobalStyle`
     }
 `;
 
-const ChannelHeaderButton = () => {
+export const ChannelHeaderButton = () => {
     const myRef = useRef<PlaybookRunIconRef>(null);
     const isRHSOpen = useSelector(isPlaybookRunRHSOpen);
     const disabled = useSelector(isDisabledOnCurrentTeam);
@@ -48,4 +47,13 @@ const ChannelHeaderButton = () => {
     );
 };
 
-export default ChannelHeaderButton;
+export const ChannelHeaderText = () => {
+    const currentChannelIsPlaybookRun = useSelector(inPlaybookRunChannel);
+    if (currentChannelIsPlaybookRun) {
+        return 'View Run Details';
+    }
+
+    return 'Run Playbook';
+};
+
+export const ChannelHeaderTooltip = ChannelHeaderText;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -19,7 +19,7 @@ import {makeSlashCommandHook} from 'src/slash_command';
 import {RetrospectiveFirstReminder, RetrospectiveReminder} from './components/retrospective_reminder_posts';
 
 import {pluginId} from './manifest';
-import ChannelHeaderButton from './components/assets/icons/channel_header_button';
+import {ChannelHeaderButton, ChannelHeaderText, ChannelHeaderTooltip} from './components/channel_header';
 import RightHandSidebar from './components/rhs/rhs_main';
 import RHSTitle from './components/rhs/rhs_title';
 import {AttachToPlaybookRunPostMenu, StartPlaybookRunPostMenu} from './components/post_menu';
@@ -111,7 +111,7 @@ export default class Plugin {
             // Store the toggleRHS action to use later
             store.dispatch(setToggleRHSAction(boundToggleRHSAction));
 
-            r.registerChannelHeaderButtonAction(ChannelHeaderButton, boundToggleRHSAction, 'Playbook', 'Playbook');
+            r.registerChannelHeaderButtonAction(ChannelHeaderButton, boundToggleRHSAction, ChannelHeaderText, ChannelHeaderTooltip);
             r.registerPostDropdownMenuComponent(StartPlaybookRunPostMenu);
             r.registerPostDropdownMenuComponent(AttachToPlaybookRunPostMenu);
             r.registerRootComponent(PostMenuModal);


### PR DESCRIPTION
#### Summary
Show "Run Playbook" when outside a playbook run channel, and "View Run Details" when inside. Depends on https://github.com/mattermost/mattermost-webapp/pull/8617 before the e2e tests will pass.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-37542

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
