### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,12 +16,12 @@ linters:
     - errcheck
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - unconvert
@@ -46,10 +46,9 @@ issues:
     - path: _test\.go
       linters:
         - goconst
-        - scopelint # https://github.com/kyoh86/scopelint/issues/4
         - unparam
         - gosec
     - linters:
-      - golint
+      - revive
       - gocritic
       path: "server/bot/logger.go"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 service:
-  golangci-lint-version: 1.21.0
+  golangci-lint-version: 1.42.0
 
 run:
   timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ ifneq ($(HAS_SERVER),)
 	fi; \
 
 	@echo Running golangci-lint
+	golangci-lint --version
 	golangci-lint run ./...
 endif
 

--- a/server/app/permissions.go
+++ b/server/app/permissions.go
@@ -232,11 +232,7 @@ func PlaybookLicensedFeatures(playbook Playbook, cfgService config.Service, play
 		return nil
 	}
 
-	if err := checkPlaybookIsNotUsingE10Features(playbook, playbookService); err != nil {
-		return err
-	}
-
-	return nil
+	return checkPlaybookIsNotUsingE10Features(playbook, playbookService)
 }
 
 func CreatePlaybook(userID string, playbook Playbook, cfgService config.Service, pluginAPI *pluginapi.Client, playbookService PlaybookService) error {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -609,7 +609,7 @@ func (s *PlaybookRunServiceImpl) AddPostToTimeline(playbookRunID, userID, postID
 	s.telemetry.AddPostToTimeline(playbookRunModified, userID)
 
 	if err = s.sendPlaybookRunToClient(playbookRunID); err != nil {
-		return err
+		return errors.Wrap(err, "failed to send playbook run to client")
 	}
 
 	return nil

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -985,7 +985,7 @@ func (s *PlaybookRunServiceImpl) exportChannelToFile(playbookRunName string, own
 	res := s.pluginAPI.Plugin.HTTP(req)
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return "", errors.New(fmt.Sprintf("There was an error when making a request to upload file with status code %s", strconv.Itoa(res.StatusCode)))
+		return "", errors.Errorf("There was an error when making a request to upload file with status code %s", strconv.Itoa(res.StatusCode))
 	}
 
 	file, err := s.pluginAPI.File.Upload(res.Body, fmt.Sprintf("%s.csv", playbookRunName), channelID)

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -635,7 +635,7 @@ func (s *PlaybookRunServiceImpl) RemoveTimelineEvent(playbookRunID, userID, even
 	s.telemetry.RemoveTimelineEvent(playbookRunModified, userID)
 
 	if err = s.sendPlaybookRunToClient(playbookRunID); err != nil {
-		return err
+		return errors.Wrap(err, "failed to send playbook run to client")
 	}
 
 	return nil
@@ -670,7 +670,7 @@ func (s *PlaybookRunServiceImpl) broadcastStatusUpdate(statusUpdate, playbookRun
 	broadcastedMsg += statusUpdate
 
 	if _, err := s.poster.PostMessage(playbookRun.BroadcastChannelID, broadcastedMsg); err != nil {
-		return err
+		return errors.Wrap(err, "failed to post broadcast message")
 	}
 
 	return nil
@@ -1176,7 +1176,7 @@ func (s *PlaybookRunServiceImpl) ChangeOwner(playbookRunID, userID, ownerID stri
 	s.telemetry.ChangeOwner(playbookRunToModify, userID)
 
 	if err = s.sendPlaybookRunToClient(playbookRunID); err != nil {
-		return err
+		return errors.Wrap(err, "failed to send playbook run to client")
 	}
 
 	return nil
@@ -1237,7 +1237,7 @@ func (s *PlaybookRunServiceImpl) ModifyCheckedState(playbookRunID, userID, newSt
 	}
 
 	if err = s.sendPlaybookRunToClient(playbookRunID); err != nil {
-		return err
+		return errors.Wrap(err, "failed to send playbook run to client")
 	}
 
 	return nil
@@ -1335,7 +1335,7 @@ func (s *PlaybookRunServiceImpl) SetAssignee(playbookRunID, userID, assigneeID s
 	}
 
 	if err = s.sendPlaybookRunToClient(playbookRunID); err != nil {
-		return err
+		return errors.Wrap(err, "failed to send playbook run to client")
 	}
 
 	return nil
@@ -1398,7 +1398,7 @@ func (s *PlaybookRunServiceImpl) RunChecklistItemSlashCommand(playbookRunID, use
 	}
 
 	if err = s.sendPlaybookRunToClient(playbookRunID); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to send playbook run to client")
 	}
 
 	return cmdResponse.TriggerId, nil

--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -61,10 +61,8 @@ func (b *Bot) DM(userID string, post *model.Post) error {
 	}
 	post.ChannelId = channel.Id
 	post.UserId = b.botUserID
-	if err := b.pluginAPI.Post.CreatePost(post); err != nil {
-		return err
-	}
-	return nil
+
+	return b.pluginAPI.Post.CreatePost(post)
 }
 
 // EphemeralPost sends an ephemeral message to a user


### PR DESCRIPTION
#### Summary
Update our `.golangci.yml` to avoid the warnings currently being emitted (and fix an improvement from the upgraded linters while we're at it):
![image](https://user-images.githubusercontent.com/1023171/130472163-d25d9254-2654-40b4-9db9-ecbc2fe06afb.png)

#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
