### PR TITLE
MM-38188 Adding missing primary keys

### DIFF
--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1188,4 +1188,39 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.29.0"),
+		toVersion:   semver.MustParse("0.30.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if e.DriverName() == model.DatabaseDriverMysql {
+				if err := addPrimaryKey(e, sqlStore, "IR_PlaybookMember", "(MemberID, PlaybookID)"); err != nil {
+					return err
+				}
+				if err := addPrimaryKey(e, sqlStore, "IR_StatusPosts", "(IncidentID, PostID)"); err != nil {
+					return err
+				}
+				if err := addPrimaryKey(e, sqlStore, "IR_TimelineEvent", "(ID)"); err != nil {
+					return err
+				}
+				if err := addPrimaryKey(e, sqlStore, "IR_ViewedChannel", "(ChannelID, UserID)"); err != nil {
+					return err
+				}
+			} else {
+				if err := addPrimaryKey(e, sqlStore, "ir_playbookmember", "(MemberID, PlaybookID)"); err != nil {
+					return err
+				}
+				if err := addPrimaryKey(e, sqlStore, "ir_statusposts", "(IncidentID, PostID)"); err != nil {
+					return err
+				}
+				if err := addPrimaryKey(e, sqlStore, "ir_timelineevent", "(ID)"); err != nil {
+					return err
+				}
+				if err := addPrimaryKey(e, sqlStore, "ir_viewedchannel", "(ChannelID, UserID)"); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	},
 }

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -82,7 +82,6 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_PlaybookMember (
 						PlaybookID VARCHAR(26) NOT NULL REFERENCES IR_Playbook(ID),
 						MemberID VARCHAR(26) NOT NULL,
-						PRIMARY KEY (MemberID, PlaybookID),
 						INDEX IR_PlaybookMember_PlaybookID (PlaybookID),
 						INDEX IR_PlaybookMember_MemberID (MemberID)
 					)
@@ -141,7 +140,7 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_PlaybookMember (
 						PlaybookID TEXT NOT NULL REFERENCES IR_Playbook(ID),
 						MemberID TEXT NOT NULL,
-						PRIMARY KEY (MemberID, PlaybookID)
+						UNIQUE (PlaybookID, MemberID)
 					);
 				`); err != nil {
 					return errors.Wrapf(err, "failed creating table IR_PlaybookMember")
@@ -251,7 +250,6 @@ var migrations = []Migration{
 						IncidentID VARCHAR(26) NOT NULL REFERENCES IR_Incident(ID),
 						PostID VARCHAR(26) NOT NULL,
 						CONSTRAINT posts_unique UNIQUE (IncidentID, PostID),
-						PRIMARY KEY (IncidentID, PostID),
 						INDEX IR_StatusPosts_IncidentID (IncidentID),
 						INDEX IR_StatusPosts_PostID (PostID)
 					)
@@ -276,7 +274,7 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_StatusPosts (
 						IncidentID TEXT NOT NULL REFERENCES IR_Incident(ID),
 						PostID TEXT NOT NULL,
-						PRIMARY KEY (IncidentID, PostID)
+						UNIQUE (IncidentID, PostID)
 					);
 				`); err != nil {
 					return errors.Wrapf(err, "failed creating table IR_StatusPosts")
@@ -379,7 +377,7 @@ var migrations = []Migration{
 				if _, err := e.Exec(`
 					CREATE TABLE IF NOT EXISTS IR_TimelineEvent
 					(
-						ID            VARCHAR(26)   NOT NULL PRIMARY KEY,
+						ID            VARCHAR(26)   NOT NULL,
 						IncidentID    VARCHAR(26)   NOT NULL REFERENCES IR_Incident(ID),
 						CreateAt      BIGINT        NOT NULL,
 						DeleteAt      BIGINT        NOT NULL DEFAULT 0,
@@ -401,7 +399,7 @@ var migrations = []Migration{
 				if _, err := e.Exec(`
 					CREATE TABLE IF NOT EXISTS IR_TimelineEvent
 					(
-						ID            TEXT   NOT NULL PRIMARY KEY,
+						ID            TEXT   NOT NULL,
 						IncidentID    TEXT   NOT NULL REFERENCES IR_Incident(ID),
 						CreateAt      BIGINT NOT NULL,
 					    DeleteAt      BIGINT NOT NULL DEFAULT 0,
@@ -703,7 +701,6 @@ var migrations = []Migration{
 					(
 						ChannelID     VARCHAR(26) NOT NULL,
 						UserID        VARCHAR(26) NOT NULL,
-						PRIMARY KEY (ChannelID, UserID),
 						UNIQUE INDEX  IR_ViewedChannel_ChannelID_UserID (ChannelID, UserID)
 					)
 				` + MySQLCharset); err != nil {
@@ -726,8 +723,7 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_ViewedChannel
 					(
 						ChannelID TEXT NOT NULL,
-						UserID    TEXT NOT NULL,
-						PRIMARY KEY (ChannelID, UserID)
+						UserID    TEXT NOT NULL
 					)
 				`); err != nil {
 					return errors.Wrapf(err, "failed creating table IR_ViewedChannel")

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -82,6 +82,7 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_PlaybookMember (
 						PlaybookID VARCHAR(26) NOT NULL REFERENCES IR_Playbook(ID),
 						MemberID VARCHAR(26) NOT NULL,
+						PRIMARY KEY (MemberID, PlaybookID),
 						INDEX IR_PlaybookMember_PlaybookID (PlaybookID),
 						INDEX IR_PlaybookMember_MemberID (MemberID)
 					)
@@ -140,7 +141,7 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_PlaybookMember (
 						PlaybookID TEXT NOT NULL REFERENCES IR_Playbook(ID),
 						MemberID TEXT NOT NULL,
-						UNIQUE (PlaybookID, MemberID)
+						PRIMARY KEY (MemberID, PlaybookID)
 					);
 				`); err != nil {
 					return errors.Wrapf(err, "failed creating table IR_PlaybookMember")
@@ -250,6 +251,7 @@ var migrations = []Migration{
 						IncidentID VARCHAR(26) NOT NULL REFERENCES IR_Incident(ID),
 						PostID VARCHAR(26) NOT NULL,
 						CONSTRAINT posts_unique UNIQUE (IncidentID, PostID),
+						PRIMARY KEY (IncidentID, PostID),
 						INDEX IR_StatusPosts_IncidentID (IncidentID),
 						INDEX IR_StatusPosts_PostID (PostID)
 					)
@@ -274,7 +276,7 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_StatusPosts (
 						IncidentID TEXT NOT NULL REFERENCES IR_Incident(ID),
 						PostID TEXT NOT NULL,
-						UNIQUE (IncidentID, PostID)
+						PRIMARY KEY (IncidentID, PostID)
 					);
 				`); err != nil {
 					return errors.Wrapf(err, "failed creating table IR_StatusPosts")
@@ -377,7 +379,7 @@ var migrations = []Migration{
 				if _, err := e.Exec(`
 					CREATE TABLE IF NOT EXISTS IR_TimelineEvent
 					(
-						ID            VARCHAR(26)   NOT NULL,
+						ID            VARCHAR(26)   NOT NULL PRIMARY KEY,
 						IncidentID    VARCHAR(26)   NOT NULL REFERENCES IR_Incident(ID),
 						CreateAt      BIGINT        NOT NULL,
 						DeleteAt      BIGINT        NOT NULL DEFAULT 0,
@@ -399,7 +401,7 @@ var migrations = []Migration{
 				if _, err := e.Exec(`
 					CREATE TABLE IF NOT EXISTS IR_TimelineEvent
 					(
-						ID            TEXT   NOT NULL,
+						ID            TEXT   NOT NULL PRIMARY KEY,
 						IncidentID    TEXT   NOT NULL REFERENCES IR_Incident(ID),
 						CreateAt      BIGINT NOT NULL,
 					    DeleteAt      BIGINT NOT NULL DEFAULT 0,
@@ -701,6 +703,7 @@ var migrations = []Migration{
 					(
 						ChannelID     VARCHAR(26) NOT NULL,
 						UserID        VARCHAR(26) NOT NULL,
+						PRIMARY KEY (ChannelID, UserID),
 						UNIQUE INDEX  IR_ViewedChannel_ChannelID_UserID (ChannelID, UserID)
 					)
 				` + MySQLCharset); err != nil {
@@ -723,7 +726,8 @@ var migrations = []Migration{
 					CREATE TABLE IF NOT EXISTS IR_ViewedChannel
 					(
 						ChannelID TEXT NOT NULL,
-						UserID    TEXT NOT NULL
+						UserID    TEXT NOT NULL,
+						PRIMARY KEY (ChannelID, UserID)
 					)
 				`); err != nil {
 					return errors.Wrapf(err, "failed creating table IR_ViewedChannel")

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -144,7 +144,8 @@ func NewPlaybookStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLSt
 
 	memberIDsSelect := sqlStore.builder.
 		Select("PlaybookID", "MemberID").
-		From("IR_PlaybookMember")
+		From("IR_PlaybookMember").
+		OrderBy("MemberID ASC") // Entirely for consistancy for the tests
 
 	newStore := &playbookStore{
 		pluginAPI:       pluginAPI,

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -1132,6 +1132,7 @@ func TestUpdatePlaybook(t *testing.T) {
 					WithMembers([]userInfo{jon, andrew, bob}).ToPlaybook(),
 				update: func(old app.Playbook) app.Playbook {
 					old.MemberIDs = []string{matt.ID, bill.ID, alice.ID, jen.ID}
+					sort.Strings(old.MemberIDs)
 					return old
 				},
 				expectedErr: nil,
@@ -1142,6 +1143,7 @@ func TestUpdatePlaybook(t *testing.T) {
 					WithMembers([]userInfo{jon, andrew, bob}).ToPlaybook(),
 				update: func(old app.Playbook) app.Playbook {
 					old.MemberIDs = []string{jon.ID, andrew.ID, bob.ID, alice.ID}
+					sort.Strings(old.MemberIDs)
 					return old
 				},
 				expectedErr: nil,
@@ -1151,6 +1153,7 @@ func TestUpdatePlaybook(t *testing.T) {
 				playbook: NewPBBuilder().WithChecklists([]int{1, 2}).ToPlaybook(),
 				update: func(old app.Playbook) app.Playbook {
 					old.MemberIDs = []string{alice.ID, jen.ID}
+					sort.Strings(old.MemberIDs)
 					return old
 				},
 				expectedErr: nil,
@@ -1240,14 +1243,10 @@ func TestDeletePlaybook(t *testing.T) {
 			expected := pb02.Clone()
 			expected.ID = id
 
-			actual, err := playbookStore.Get(id)
-			require.NoError(t, err)
-			require.Equal(t, expected, actual)
-
 			err = playbookStore.Delete(id)
 			require.NoError(t, err)
 
-			actual, err = playbookStore.Get(id)
+			actual, err := playbookStore.Get(id)
 			require.NoError(t, err)
 			require.Greater(t, actual.DeleteAt, before)
 
@@ -1743,6 +1742,7 @@ func (p *PlaybookBuilder) WithMembers(members []userInfo) *PlaybookBuilder {
 	for i, member := range members {
 		p.MemberIDs[i] = member.ID
 	}
+	sort.Strings(p.MemberIDs)
 
 	return p
 }

--- a/server/sqlstore/store_test.go
+++ b/server/sqlstore/store_test.go
@@ -104,3 +104,62 @@ func TestHasConsistentCharset(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestHasPrimaryKeys(t *testing.T) {
+	t.Run("MySQL", func(t *testing.T) {
+		db := setupTestDB(t, model.DatabaseDriverMysql)
+		setupPlaybookStore(t, db) // To run the migrations and everything
+		tablesWithoutPrimaryKeys := []string{}
+		err := db.Select(&tablesWithoutPrimaryKeys, `
+			SELECT tab.table_name
+				   AS tablename
+			FROM   information_schema.tables tab
+				   LEFT JOIN information_schema.table_constraints tco
+						  ON tab.table_schema = tco.table_schema
+							 AND tab.table_name = tco.table_name
+							 AND tco.constraint_type = 'PRIMARY KEY'
+				   LEFT JOIN information_schema.key_column_usage kcu
+						  ON tco.constraint_schema = kcu.constraint_schema
+							 AND tco.constraint_name = kcu.constraint_name
+							 AND tco.table_name = kcu.table_name
+			WHERE  tab.table_schema NOT IN ( 'mysql', 'information_schema',
+											 'performance_schema',
+											 'sys' )
+			AND tab.table_schema = (SELECT DATABASE())
+			AND tco.constraint_name is NULL
+			GROUP  BY tab.table_schema,
+					  tab.table_name,
+					  tco.constraint_name
+		`)
+		require.Len(t, tablesWithoutPrimaryKeys, 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("Postgres", func(t *testing.T) {
+		db := setupTestDB(t, model.DatabaseDriverPostgres)
+		setupPlaybookStore(t, db) // To run the migrations and everything
+		tablesWithoutPrimaryKeys := []string{}
+		err := db.Select(&tablesWithoutPrimaryKeys, `
+			SELECT tab.table_name AS pk_name
+			FROM   information_schema.tables tab
+				   LEFT JOIN information_schema.table_constraints tco
+						  ON tco.table_schema = tab.table_schema
+							 AND tco.table_name = tab.table_name
+							 AND tco.constraint_type = 'PRIMARY KEY'
+				   LEFT JOIN information_schema.key_column_usage kcu
+						  ON kcu.constraint_name = tco.constraint_name
+							 AND kcu.constraint_schema = tco.constraint_schema
+							 AND kcu.constraint_name = tco.constraint_name
+			WHERE  tab.table_schema NOT IN ( 'pg_catalog', 'information_schema' )
+				   AND tab.table_type = 'BASE TABLE'
+				   AND tab.table_catalog = (SELECT current_database())
+				   AND tco.constraint_name is NULL
+			GROUP  BY tab.table_schema,
+					  tab.table_name,
+					  tco.constraint_name
+		`)
+		require.Len(t, tablesWithoutPrimaryKeys, 0)
+		require.NoError(t, err)
+	})
+
+}

--- a/server/sqlstore/support_for_test.go
+++ b/server/sqlstore/support_for_test.go
@@ -248,6 +248,7 @@ func setupChannelMembersTable(t *testing.T, db *sqlx.DB) {
 				notifyprops character varying(2000),
 				lastupdateat bigint,
 				schemeuser boolean,
+				PRIMARY KEY (ChannelId,UserId),
 				schemeadmin boolean
 			);
 		`)
@@ -298,6 +299,7 @@ func setupChannelsTable(t *testing.T, db *sqlx.DB) {
 				totalmsgcount bigint,
 				extraupdateat bigint,
 				creatorid character varying(26),
+				PRIMARY KEY (Id),
 				schemeid character varying(26)
 			);
 		`)
@@ -361,6 +363,7 @@ func setupPostsTable(t testing.TB, db *sqlx.DB) {
 				hashtags character varying(1000),
 				filenames character varying(4000),
 				fileids character varying(150),
+				PRIMARY KEY (Id),
 				hasreactions boolean
 			);
 		`)
@@ -414,7 +417,7 @@ func setupBotsTable(t testing.TB, db *sqlx.DB) {
 	if db.DriverName() == model.DatabaseDriverPostgres {
 		_, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS public.bots (
-				userid character varying(26) NOT NULL,
+				userid character varying(26) NOT NULL PRIMARY KEY,
 				description character varying(1024),
 			    ownerid character varying(190)
 			);
@@ -427,7 +430,7 @@ func setupBotsTable(t testing.TB, db *sqlx.DB) {
 	// handmade
 	_, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS Bots (
-				UserId varchar(26) NOT NULL,
+				UserId varchar(26) NOT NULL PRIMARY KEY,
 				Description varchar(1024),
 			    OwnerId varchar(190)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
#### Summary
Adds missing primary keys to IR_PlaybookMember, IR_StatusPosts, IR_TimelineEvent, IR_ViewedChannel
Esentally does:
```sql
ALTER TABLE IR_PlaybookMember ADD PRIMARY KEY (MemberID, PlaybookID);
ALTER TABLE IR_StatusPosts ADD PRIMARY KEY (IncidentID, PostID);
ALTER TABLE IR_TimelineEvent ADD PRIMARY KEY (ID);
ALTER TABLE IR_ViewedChannel ADD PRIMARY KEY (ChannelID, UserID);
```
with more steps.

Added a test so we don't make this mistake again.

#### Ticket Link
http://mattermost.atlassian.net/browse/MM-38188

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
