### PR TITLE
Rename channel header button

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/channel_header_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/channel_header_spec.js
@@ -47,7 +47,7 @@ describe('channel header', () => {
     });
 
     describe('tooltip text', () => {
-        it('should show "Run Playbook" outside a playbook run channel', () => {
+        it('should show "Toggle Playbook List" outside a playbook run channel', () => {
             // # Navigate directly to a non-playbook run channel
             cy.visit(`/${testTeam.name}/channels/town-square`);
 
@@ -57,10 +57,10 @@ describe('channel header', () => {
             });
 
             // # Verify tooltip text
-            cy.get('#pluginTooltip').contains('Run Playbook');
+            cy.get('#pluginTooltip').contains('Toggle Playbook List');
         });
 
-        it('should show "View Run Details" inside a playbook run channel', () => {
+        it('should show "Toggle Run Details" inside a playbook run channel', () => {
             // # Navigate directly to a playbook run channel
             cy.visit(`/${testTeam.name}/channels/playbook-run`);
 
@@ -70,7 +70,7 @@ describe('channel header', () => {
             });
 
             // # Verify tooltip text
-            cy.get('#pluginTooltip').contains('View Run Details');
+            cy.get('#pluginTooltip').contains('Toggle Run Details');
         });
     });
 });

--- a/webapp/src/components/channel_header.tsx
+++ b/webapp/src/components/channel_header.tsx
@@ -50,10 +50,10 @@ export const ChannelHeaderButton = () => {
 export const ChannelHeaderText = () => {
     const currentChannelIsPlaybookRun = useSelector(inPlaybookRunChannel);
     if (currentChannelIsPlaybookRun) {
-        return 'View Run Details';
+        return 'Toggle Run Details';
     }
 
-    return 'Run Playbook';
+    return 'Toggle Playbook List';
 };
 
 export const ChannelHeaderTooltip = ChannelHeaderText;


### PR DESCRIPTION
#### Summary
Renaming channel header button.
If a channel is a run then: `Toggle Run Details`
If a channel is not a run then: `Toggle Playbook List`

