### PR TITLE
MM-37545 - Fix for: Backstage actions icon misaligned

### DIFF
--- a/webapp/src/components/backstage/playbook.scss
+++ b/webapp/src/components/backstage/playbook.scss
@@ -81,7 +81,7 @@ $announcement-bar-height: 32px;
         }
 
         .action-col {
-            margin-left: -13px;
+            margin-left: -8px;
         }
     }
 }

--- a/webapp/src/components/backstage/playbook_list_row.tsx
+++ b/webapp/src/components/backstage/playbook_list_row.tsx
@@ -64,7 +64,7 @@ interface PlaybookActionMenuProps {
 
 const IconWrapper = styled.div`
     display: inline-flex;
-    padding: 10px 5px;
+    padding: 10px 5px 10px 3px;
 `;
 
 const PlaybookActionMenu = (props: PlaybookActionMenuProps) => {


### PR DESCRIPTION
#### Summary
- Fixed three-dot alignment inside
![image](https://user-images.githubusercontent.com/1490756/132706254-99389f44-a113-4c02-823b-887925951b2d.png)

- Also adjusted the three-dot horizontal alignment in the list to look nicer
![image](https://user-images.githubusercontent.com/1490756/132706283-52d9152a-fb07-433a-b028-90390467d180.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-37545

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
