### PR TITLE
MM-38058 - Fix for: Playbook run's backstage button theme is incorrect

### DIFF
--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -196,8 +196,8 @@ interface PlaybookRunFilterButtonProps {
 export const PlaybookRunFilterButton = styled.button<PlaybookRunFilterButtonProps>`
     display: flex;
     align-items: center;
+    border: none;
     border-radius: 4px;
-    border: 1px solid var(--center-channel-color-16);
     color: var(--center-channel-color-56);
     background: transparent;
     cursor: pointer;

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -196,10 +196,10 @@ interface PlaybookRunFilterButtonProps {
 export const PlaybookRunFilterButton = styled.button<PlaybookRunFilterButtonProps>`
     display: flex;
     align-items: center;
-    border: none;
-    padding: 8px;
     border-radius: 4px;
+    border: 1px solid var(--center-channel-color-16);
     color: var(--center-channel-color-56);
+    background: transparent;
     cursor: pointer;
     font-weight: 600;
     font-size: 14px;


### PR DESCRIPTION
#### Summary
- Now looks like:
![image](https://user-images.githubusercontent.com/1490756/132716179-deb51809-e7d8-4296-827c-23ca450ea66f.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38058

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
