### PR TITLE
MM-38453 - Fix for: Text theming incorrect for actions->keyword input

### DIFF
--- a/webapp/src/components/backstage/automation/input_keywords.tsx
+++ b/webapp/src/components/backstage/automation/input_keywords.tsx
@@ -107,6 +107,7 @@ const selectStyles: StylesConfig = {
     control: (provided, {isDisabled}) => ({
         ...provided,
         backgroundColor: isDisabled ? 'rgba(var(--center-channel-bg-rgb),0.16)' : 'var(--center-channel-bg)',
+        border: '1px solid var(--center-channel-color-16)',
     }),
     placeholder: (provided) => ({
         ...provided,
@@ -115,6 +116,29 @@ const selectStyles: StylesConfig = {
     input: (provided) => ({
         ...provided,
         marginLeft: '8px',
+        color: 'var(--center-channel-color)',
+    }),
+    multiValue: (provided) => ({
+        ...provided,
+        backgroundColor: 'rgba(var(--center-channel-bg-rgb),0.50)',
+        borderRadius: '4px',
+    }),
+    multiValueLabel: (provided) => ({
+        ...provided,
+        backgroundColor: 'var(--center-channel-color-08)',
+        color: 'var(--center-channel-color)',
+    }),
+    multiValueRemove: (provided) => ({
+        ...provided,
+        backgroundColor: 'var(--center-channel-color-04)',
+        color: 'var(--center-channel-color-56)',
+        ':hover': {
+            backgroundColor: 'rgba(var(--button-bg-rgb), 0.12)',
+            color: 'var(--button-bg)',
+        },
+        ':active': {
+            backgroundColor: 'rgba(var(--button-bg-rgb), 0.16)',
+        },
     }),
 };
 


### PR DESCRIPTION
#### Summary
- Fix theming. Followed tertiary buttons and matched to the theming of the `x members` pill in the `Invite Members` selector below it.

- Denim:
![image](https://user-images.githubusercontent.com/1490756/132746871-66127012-efe2-4619-9630-a041cab37eff.png)

on highlighting the remove for the last item:
![image](https://user-images.githubusercontent.com/1490756/132746947-2e9291da-865e-4ac3-b914-5eece3f80631.png)

- Indigo:
![image](https://user-images.githubusercontent.com/1490756/132747057-8159c7fc-28a3-4a76-ba55-ab4421523330.png)
![image](https://user-images.githubusercontent.com/1490756/132747077-749a0d17-6954-4053-8964-6b8caa85a28e.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38453

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
