### PR TITLE
MM-36267 - Fix for: Tiny straight line in empty timeline in dark theme

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline.tsx
@@ -35,7 +35,7 @@ const TimelineLine = styled.ul`
 `;
 
 const NoEventsNotice = styled.div`
-    margin: 35px 20px 0 20px;
+    margin: 35px 20px 35px;
     font-size: 14px;
     font-weight: 600;
 `;
@@ -53,6 +53,14 @@ const Timeline = (props: Props) => {
         return (
             <NoEventsNotice>
                 {'Timeline events are displayed here as they occur. Hover over an event to remove it.'}
+            </NoEventsNotice>
+        );
+    }
+
+    if (props.filteredEvents.length === 0) {
+        return (
+            <NoEventsNotice>
+                {'There are no Timeline events matching those filters.'}
             </NoEventsNotice>
         );
     }


### PR DESCRIPTION
#### Summary
- Fixed the blank timeline visible line bug
- Added a notice -- same as in the Runs list, and using the same language

![image](https://user-images.githubusercontent.com/1490756/132749729-3f38bbd2-f59e-47a1-b038-5c35707b4dd4.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-36267

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
