### PR TITLE
Removed all instances of 'an playbook'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To quickly test Mattermost Playbooks, use the following test commands to create 
 
   * An example command looks like: `/playbook test create-playbooks 5`
 
-- `/playbook test create-playbook-run [playbook ID] [timestamp] [playbook run name]` - Provide the ID of an existing playbook to which the current user has access, a timestamp, and an playbook run name. The command creates an ongoing playbook run with the creation date set to the specified timestamp.
+- `/playbook test create-playbook-run [playbook ID] [timestamp] [playbook run name]` - Provide the ID of an existing playbook to which the current user has access, a timestamp, and a playbook run name. The command creates an ongoing playbook run with the creation date set to the specified timestamp.
 
   * An example command looks like: `/playbook test create-playbook-run 6utgh6qg7p8ndeef9edc583cpc 2020-11-23 PR-Testing`
 

--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -199,7 +199,7 @@ paths:
   /runs/dialog:
     post:
       summary: Create a new playbook run from dialog
-      description: This is an internal endpoint to create an playbook run from the submission of an interactive dialog, filled by a user in the webapp. See [Interactive Dialogs](https://docs.mattermost.com/developer/interactive-dialogs.html) for more information.
+      description: This is an internal endpoint to create a playbook run from the submission of an interactive dialog, filled by a user in the webapp. See [Interactive Dialogs](https://docs.mattermost.com/developer/interactive-dialogs.html) for more information.
       operationId: createPlaybookRunFromDialog
       security:
         - BearerAuth: []
@@ -315,7 +315,7 @@ paths:
   /runs/channels:
     get:
       summary: Get playbook run channels
-      description: Get all channels associated with an playbook run, filtered by team, status, owner, name and/or members, and sorted by ID, name, status, creation date, end date, team, or owner ID.
+      description: Get all channels associated with a playbook run, filtered by team, status, owner, name and/or members, and sorted by ID, name, status, creation date, end date, team, or owner ID.
       operationId: getChannels
       security:
         - BearerAuth: []
@@ -376,7 +376,7 @@ paths:
             type: string
         - name: search_term
           in: query
-          description: The returned list will contain only the channels associated to an playbook run whose name contains the search term.
+          description: The returned list will contain only the channels associated to a playbook run whose name contains the search term.
           required: false
           example: "server down"
           schema:
@@ -492,7 +492,7 @@ paths:
 
   /runs/{id}:
     get:
-      summary: Get an playbook run
+      summary: Get a playbook run
       operationId: getPlaybookRun
       security:
         - BearerAuth: []
@@ -523,7 +523,7 @@ paths:
         500:
           $ref: "#/components/schemas/500"
     patch:
-      summary: Update an playbook run
+      summary: Update a playbook run
       operationId: updatePlaybookRun
       security:
         - BearerAuth: []
@@ -598,7 +598,7 @@ paths:
 
   /runs/{id}/end:
     put:
-      summary: End an playbook run
+      summary: End a playbook run
       operationId: endPlaybookRun
       security:
         - BearerAuth: []
@@ -623,8 +623,8 @@ paths:
         500:
           $ref: "#/components/schemas/500"
     post:
-      summary: End an playbook run from dialog
-      description: This is an internal endpoint to end an playbook run via a confirmation dialog, submitted by a user in the webapp.
+      summary: End a playbook run from dialog
+      description: This is an internal endpoint to end a playbook run via a confirmation dialog, submitted by a user in the webapp.
       operationId: endPlaybookRunDialog
       security:
         - BearerAuth: []
@@ -651,7 +651,7 @@ paths:
 
   /runs/{id}/restart:
     put:
-      summary: Restart an playbook run
+      summary: Restart a playbook run
       operationId: restartPlaybookRun
       security:
         - BearerAuth: []
@@ -678,7 +678,7 @@ paths:
 
   /runs/{id}/status:
     post:
-      summary: Update an playbook run's status
+      summary: Update a playbook run's status
       operationId: status
       security:
         - BearerAuth: []
@@ -835,7 +835,7 @@ paths:
 
   /runs/{id}/checklists/{checklist}/add:
     put:
-      summary: Add an item to an playbook run's checklist
+      summary: Add an item to a playbook run's checklist
       description: The most common pattern to add a new item is to only send its title as the request payload. By default, it is an open item, with no assignee and no slash command.
       operationId: addChecklistItem
       security:
@@ -931,7 +931,7 @@ paths:
 
   /runs/{id}/checklists/{checklist}/reorder:
     put:
-      summary: Reorder an item in an playbook run's checklist
+      summary: Reorder an item in a playbook run's checklist
       operationId: reoderChecklistItem
       security:
         - BearerAuth: []
@@ -986,7 +986,7 @@ paths:
 
   /runs/{id}/checklists/{checklist}/item/{item}:
     put:
-      summary: Update an item of an playbook run's checklist
+      summary: Update an item of a playbook run's checklist
       description: Update the title and the slash command of an item in one of the playbook run's checklists.
       operationId: itemRename
       security:
@@ -1048,7 +1048,7 @@ paths:
           $ref: "#/components/schemas/500"
 
     delete:
-      summary: Delete an item of an playbook run's checklist
+      summary: Delete an item of a playbook run's checklist
       operationId: itemDelete
       security:
         - BearerAuth: []
@@ -1394,7 +1394,7 @@ paths:
                 description:
                   type: string
                   description: The description of the playbook.
-                  example: A playbook to follow when there is an playbook run regarding the availability of the cloud service.
+                  example: A playbook to follow when there is a playbook run regarding the availability of the cloud service.
                 team_id:
                   type: string
                   description: The identifier of the team where the playbook is in.
@@ -1495,13 +1495,13 @@ paths:
           source: |
             curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
-            -d '{"title": "Cloud PlaybookRuns", "description": "A playbook to follow when there is an playbook run regarding the availability of the cloud service.", "team_id": "p03rbi6viyztysbqnkvcqyel2i","create_public_playbook_run": true,"checklists": [{"title": "Triage issue","items": [{"title": "Gather information from customer."}]}]}'
+            -d '{"title": "Cloud PlaybookRuns", "description": "A playbook to follow when there is a playbook run regarding the availability of the cloud service.", "team_id": "p03rbi6viyztysbqnkvcqyel2i","create_public_playbook_run": true,"checklists": [{"title": "Triage issue","items": [{"title": "Gather information from customer."}]}]}'
       callbacks:
         playbookRunCreation:
           "{$request.body#/webhook_on_creation_url}":
             post:
               summary: PlaybookRun's creation outgoing webhook.
-              description: When an playbook run is created with this playbook, a POST request is sent to the URL configured in webhook_on_creation_url. The webhook is considered successful if your server returns a response code within the 200-299 range. Otherwise, the webhook is considered failed, and a warning message is posted in the playbook run's channel. No retries are made.
+              description: When a playbook run is created with this playbook, a POST request is sent to the URL configured in webhook_on_creation_url. The webhook is considered successful if your server returns a response code within the 200-299 range. Otherwise, the webhook is considered failed, and a warning message is posted in the playbook run's channel. No retries are made.
               operationId: webhookOncreation
               requestBody:
                 required: true
@@ -1516,7 +1516,7 @@ paths:
           "{$request.body#/webhook_on_status_update_url}":
             post:
               summary: PlaybookRun's status update outgoing webhook.
-              description: When an playbook run's status is updated, a POST request is sent to the URL configured in webhook_on_status_update_url. The webhook is considered successful if your server returns a response code within the 200-299 range. Otherwise, the webhook is considered failed, and a warning message is posted in the playbook run's channel. No retries are made.
+              description: When a playbook run's status is updated, a POST request is sent to the URL configured in webhook_on_status_update_url. The webhook is considered successful if your server returns a response code within the 200-299 range. Otherwise, the webhook is considered failed, and a warning message is posted in the playbook run's channel. No retries are made.
               operationId: webhookOnStatusUpdate
               requestBody:
                 required: true
@@ -1830,7 +1830,7 @@ components:
         description:
           type: string
           description: The description of the playbook.
-          example: A playbook to follow when there is an playbook run regarding the availability of the cloud service.
+          example: A playbook to follow when there is a playbook run regarding the availability of the cloud service.
         team_id:
           type: string
           description: The identifier of the team where the playbook is in.

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -16,9 +16,9 @@ const (
 	StatusFinished   = "Finished"
 )
 
-// PlaybookRun holds the detailed information of an playbook run.
+// PlaybookRun holds the detailed information of a playbook run.
 //
-// NOTE: When adding a column to the db, search for "When adding an Playbook Run column" to see where
+// NOTE: When adding a column to the db, search for "When adding a Playbook Run column" to see where
 // that column needs to be added in the sqlstore code.
 type PlaybookRun struct {
 	// ID is the unique identifier of the playbook run.
@@ -216,7 +216,7 @@ type StatusPost struct {
 type UpdateOptions struct {
 }
 
-// StatusUpdateOptions encapsulates the fields that can be set when updating an playbook run's status
+// StatusUpdateOptions encapsulates the fields that can be set when updating a playbook run's status
 // NOTE: changes made to this should be reflected in the client package.
 type StatusUpdateOptions struct {
 	Message  string        `json:"message"`

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -342,7 +342,7 @@ func (s *playbookRunStore) CreatePlaybookRun(playbookRun *app.PlaybookRun) (*app
 		return nil, err
 	}
 
-	// When adding an PlaybookRun column #2: add to the SetMap
+	// When adding a PlaybookRun column #2: add to the SetMap
 	_, err = s.store.execBuilder(s.store.db, sq.
 		Insert("IR_Incident").
 		SetMap(map[string]interface{}{
@@ -404,7 +404,7 @@ func (s *playbookRunStore) UpdatePlaybookRun(playbookRun *app.PlaybookRun) error
 		return err
 	}
 
-	// When adding an PlaybookRun column #3: add to this SetMap (if it is a column that can be updated)
+	// When adding a PlaybookRun column #3: add to this SetMap (if it is a column that can be updated)
 	_, err = s.store.execBuilder(s.store.db, sq.
 		Update("IR_Incident").
 		SetMap(map[string]interface{}{
@@ -659,7 +659,7 @@ func (s *playbookRunStore) GetPlaybookRunIDForChannel(channelID string) (string,
 	return id, nil
 }
 
-// GetHistoricalPlaybookRunParticipantsCount returns the count of all members of an playbook run's channel
+// GetHistoricalPlaybookRunParticipantsCount returns the count of all members of a playbook run's channel
 // since the beginning of the playbook run, excluding bots.
 func (s *playbookRunStore) GetHistoricalPlaybookRunParticipantsCount(channelID string) (int64, error) {
 	query := s.queryBuilder.

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -65,7 +65,7 @@ describe('playbook run rhs', () => {
             cy.get('#rhsContainer').should('not.exist');
         });
 
-        it('when navigating to an playbook run channel with the RHS already open', () => {
+        it('when navigating to a playbook run channel with the RHS already open', () => {
             // # Navigate to the application.
             cy.visit('/ad-1/');
 

--- a/tests-e2e/cypress/integration/frontstage/slash_command/info_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command/info_spec.js
@@ -87,7 +87,7 @@ describe('slash command > info', () => {
     });
 
     describe('/playbook info', () => {
-        it('should show an error when not in an playbook run channel', () => {
+        it('should show an error when not in a playbook run channel', () => {
             // # Navigate to a non-playbook run channel.
             cy.visit('/ad-1/channels/town-square');
 
@@ -102,7 +102,7 @@ describe('slash command > info', () => {
             // # Navigate directly to the application and the playbook run channel.
             cy.visit('/ad-1/channels/' + playbookRunChannelName);
 
-            // # Close the RHS, which is opened by default when navigating to an playbook run channel.
+            // # Close the RHS, which is opened by default when navigating to a playbook run channel.
             cy.get('#searchResultsCloseButton').click();
 
             // * Verify that the RHS is indeed closed.

--- a/tests-e2e/cypress/integration/frontstage/slash_command/owner_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command/owner_spec.js
@@ -87,7 +87,7 @@ describe('slash command > owner', () => {
     });
 
     describe('/playbook owner', () => {
-        it('should show an error when not in an playbook run channel', () => {
+        it('should show an error when not in a playbook run channel', () => {
             // # Navigate to a non-playbook run channel
             cy.visit('/ad-1/channels/town-square');
 
@@ -111,7 +111,7 @@ describe('slash command > owner', () => {
     });
 
     describe('/playbook owner @username', () => {
-        it('should show an error when not in an playbook run channel', () => {
+        it('should show an error when not in a playbook run channel', () => {
             // # Navigate to a non-playbook run channel
             cy.visit('/ad-1/channels/town-square');
 

--- a/tests-e2e/cypress/support/plugin/api_commands.js
+++ b/tests-e2e/cypress/support/plugin/api_commands.js
@@ -49,7 +49,7 @@ Cypress.Commands.add('apiGetPlaybookRunByName', (teamId, name) => {
 });
 
 /**
- * Get an playbook run directly via API
+ * Get a playbook run directly via API
  * @param {String} playbookRunId
  * All parameters required
  */
@@ -65,7 +65,7 @@ Cypress.Commands.add('apiGetPlaybookRun', (playbookRunId) => {
 });
 
 /**
- * Start an playbook run directly via API.
+ * Start a playbook run directly via API.
  */
 Cypress.Commands.add('apiRunPlaybook', (
     {
@@ -105,7 +105,7 @@ Cypress.Commands.add('apiFinishRun', (playbookRunId) => {
     });
 });
 
-// Update an playbook run's status programmatically.
+// Update a playbook run's status programmatically.
 Cypress.Commands.add('apiUpdateStatus', (
     {
         playbookRunId,
@@ -136,7 +136,7 @@ Cypress.Commands.add('apiUpdateStatus', (
 });
 
 /**
- * Change the owner of an playbook run directly via API
+ * Change the owner of a playbook run directly via API
  * @param {String} playbookRunId
  * @param {String} userId
  * All parameters required

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -70,7 +70,7 @@ export async function fetchPlaybookRun(id: string) {
     if (process.env.NODE_ENV !== 'production') {
         if (!isPlaybookRun(data)) {
             // eslint-disable-next-line no-console
-            console.error('expected an PlaybookRun in fetchPlaybookRun, received:', data);
+            console.error('expected a PlaybookRun in fetchPlaybookRun, received:', data);
         }
     }
 
@@ -132,7 +132,7 @@ export async function fetchPlaybookRunByChannel(channelId: string) {
     if (process.env.NODE_ENV !== 'production') {
         if (!isPlaybookRun(data)) {
             // eslint-disable-next-line no-console
-            console.error('expected an PlaybookRun in fetchPlaybookRun, received:', data);
+            console.error('expected a PlaybookRun in fetchPlaybookRun, received:', data);
         }
     }
 

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -86,7 +86,7 @@ function rhsState(state = RHSState.ViewingPlaybookRun, action: SetRHSState) {
     }
 }
 
-// myPlaybookRunsByTeam is a map of teamId->{channelId->playbookRuns} for which the current user is an playbook run member. Note
+// myPlaybookRunsByTeam is a map of teamId->{channelId->playbookRuns} for which the current user is a playbook run member. Note
 // that it is lazy loaded on team change, but will also track incremental updates as provided by
 // websocket events.
 // Aditnally it handles the plugin being disabled on the team

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -65,7 +65,7 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
             return;
         }
 
-        // Don't do anything unless we're in an playbook run channel.
+        // Don't do anything unless we're in a playbook run channel.
         if (!currentChannelIsPlaybookRun) {
             return;
         }


### PR DESCRIPTION
Signed-off-by: Paul Rothrock <paul@movetoiceland.com>

#### Summary

Replaced all instances of "an playbook" with "a playbook" in strings and comments

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
