### PR TITLE
Fixing primary key test

### DIFF
--- a/server/sqlstore/migrations_utils.go
+++ b/server/sqlstore/migrations_utils.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
 	"github.com/jmoiron/sqlx"
@@ -141,11 +142,18 @@ var dropColumnPG = func(e sqlx.Ext, tableName, colName string) error {
 
 func addPrimaryKey(e sqlx.Ext, sqlStore *SQLStore, tableName, primaryKey string) error {
 	hasPK := 0
+
+	dbSelectionLine := "AND tco.table_schema = (SELECT DATABASE())"
+	if e.DriverName() == model.DatabaseDriverPostgres {
+		dbSelectionLine = "AND tco.table_catalog = (SELECT current_database())"
+	}
+
 	if err := sqlStore.db.Get(&hasPK, fmt.Sprintf(`
 		SELECT 1 FROM information_schema.table_constraints tco
 		WHERE tco.table_name = '%s'
+		%s
 		AND tco.constraint_type = 'PRIMARY KEY'
-	`, tableName)); err != nil && err != sql.ErrNoRows {
+	`, tableName, dbSelectionLine)); err != nil && err != sql.ErrNoRows {
 		return errors.Wrap(err, "unable to determine if a primary key exists")
 	}
 

--- a/server/sqlstore/store_test.go
+++ b/server/sqlstore/store_test.go
@@ -122,10 +122,7 @@ func TestHasPrimaryKeys(t *testing.T) {
 						  ON tco.constraint_schema = kcu.constraint_schema
 							 AND tco.constraint_name = kcu.constraint_name
 							 AND tco.table_name = kcu.table_name
-			WHERE  tab.table_schema NOT IN ( 'mysql', 'information_schema',
-											 'performance_schema',
-											 'sys' )
-			AND tab.table_schema = (SELECT DATABASE())
+			WHERE tab.table_schema = (SELECT DATABASE())
 			AND tco.constraint_name is NULL
 			GROUP  BY tab.table_schema,
 					  tab.table_name,


### PR DESCRIPTION
#### Summary
Fixes the primary key test. 
The test was not incorrect. The addPrimaryKey migration's check for migration complete did not restrict itself to the selected DB. As a result it would not run if the migration had already been run on anouther DB. This fixes that error. 
