### PR TITLE
MM-38122 Update plugin ID

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	apiVersion = "v0"
-	manifestID = "com.mattermost.plugin-incident-management"
+	manifestID = "playbooks"
 	userAgent  = "go-client/" + apiVersion
 )
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-    "id": "com.mattermost.plugin-incident-management",
+    "id": "playbooks",
     "name": "Playbooks",
     "description": "The playbooks plugin",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "playbooks",
     "name": "Playbooks",
-    "description": "The playbooks plugin",
+    "description": "Mattermost Playbooks enable reliable and repeatable processes for your teams using checklists, automation, and retrospectives.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
     "icon_path": "assets/plugin_icon.svg",

--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -7,7 +7,7 @@ info:
     url: https://mattermost.com/
     email: support@mattermost.com
 servers:
-  - url: http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0
+  - url: http://localhost:8065/plugins/playbooks/api/v0
 paths:
   /runs:
     get:
@@ -110,7 +110,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -172,7 +172,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs' \
+            curl -X POST 'http://localhost:8065/plugins/playbooks/api/v0/runs' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -H 'Content-Type: application/json'\
             -d '{"name": "Server down in EU cluster", "description": "There is one server in the EU cluster that is not responding since April 12.", "owner_user_id": "bqnbdf8uc0a8yz4i39qrpgkvtg", "team_id": "61ji2mpflefup3cnuif80r5rde", "playbook_id": "0y4a0ntte97cxvfont8y84wa7x"}'
@@ -294,7 +294,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/owners?team_id=ni8duypfe7bamprxqeffd563gy' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/owners?team_id=ni8duypfe7bamprxqeffd563gy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -391,7 +391,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/channels?team_id=ni8duypfe7bamprxqeffd563gy' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/channels?team_id=ni8duypfe7bamprxqeffd563gy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -476,7 +476,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/channel/hwrmiyzj3kadcilh3ukfcnsbt6' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/channel/hwrmiyzj3kadcilh3ukfcnsbt6' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -509,7 +509,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/mx3xyzdojfgyfdx8sc8of1gdme' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/mx3xyzdojfgyfdx8sc8of1gdme' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -551,7 +551,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PATCH 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/mx3xyzdojfgyfdx8sc8of1gdme' \
+            curl -X PATCH 'http://localhost:8065/plugins/playbooks/api/v0/runs/mx3xyzdojfgyfdx8sc8of1gdme' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -H 'Content-Type: application/json'\
             -d '{"active_stage": 2}'
@@ -582,7 +582,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/details' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/details' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -615,7 +615,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/end' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/end' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -641,7 +641,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/end' \
+            curl -X POST 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/end' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -668,7 +668,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/end' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/end' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -713,7 +713,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/update-status' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/update-status' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
             -d '{"message": "Finishing playbook run because the issue was solved."}'
       responses:
@@ -745,7 +745,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/finish' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/finish' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -785,7 +785,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/1igmynxs77ywmcbwbsujzktter/owner' \
+            curl -X POST 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/owner' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"owner_id": "hx7fqtqxp7nn8129t7e505ls6s"}'
       responses:
@@ -916,7 +916,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/twcqg0a2m37ydi6ebge3j9ev5z/checklists/1/add' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/twcqg0a2m37ydi6ebge3j9ev5z/checklists/1/add' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Gather information from customer."}'
       responses:
@@ -973,7 +973,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/yj74zsk7dvtsv6ndsynsps3g5s/checklists/1/reorder' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/yj74zsk7dvtsv6ndsynsps3g5s/checklists/1/reorder' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"item_num": 0, "new_location": 2}'
       responses:
@@ -1036,7 +1036,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/6t7jdgyqr7b5sk24zkauhmrb06/checklists/1/item/0' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/6t7jdgyqr7b5sk24zkauhmrb06/checklists/1/item/0' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Gather information from server's logs.", "command": "/jira update ticket"}'
       responses:
@@ -1079,7 +1079,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/zjy2q2iy2jafl0lo2oddos5xn7/checklists/1/item/2' \
+            curl -X DELETE 'http://localhost:8065/plugins/playbooks/api/v0/runs/zjy2q2iy2jafl0lo2oddos5xn7/checklists/1/item/2' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         204:
@@ -1140,7 +1140,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/7l37isroz4e63giev62hs318bn/checklists/1/item/2/state' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/7l37isroz4e63giev62hs318bn/checklists/1/item/2/state' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
             -d '{"new_state": "closed"}'
       responses:
@@ -1197,7 +1197,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/7l37isroz4e63giev62hs318bn/checklists/1/item/2/assignee' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/runs/7l37isroz4e63giev62hs318bn/checklists/1/item/2/assignee' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
             -d '{"asignee_id": "ruu86intseidqdxjojia41u7l1"}'
       responses:
@@ -1241,7 +1241,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/7l37isroz4e63giev62hs318bn/checklists/1/item/2/run' \
+            curl -X POST 'http://localhost:8065/plugins/playbooks/api/v0/runs/7l37isroz4e63giev62hs318bn/checklists/1/item/2/run' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -1281,7 +1281,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/runs/zjy2q2iy2jafl0lo2oddos5xn7/timeline/craxgf4r4trgzrtues3a1t74ac' \
+            curl -X DELETE 'http://localhost:8065/plugins/playbooks/api/v0/runs/zjy2q2iy2jafl0lo2oddos5xn7/timeline/craxgf4r4trgzrtues3a1t74ac' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         204:
@@ -1352,7 +1352,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks?team_id=08fmfasq5wit3qyfmq4mjk0rto&sort=title&direction=asc' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/playbooks?team_id=08fmfasq5wit3qyfmq4mjk0rto&sort=title&direction=asc' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -1493,7 +1493,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks' \
+            curl -X POST 'http://localhost:8065/plugins/playbooks/api/v0/playbooks' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Cloud PlaybookRuns", "description": "A playbook to follow when there is an playbook run regarding the availability of the cloud service.", "team_id": "p03rbi6viyztysbqnkvcqyel2i","create_public_playbook_run": true,"checklists": [{"title": "Triage issue","items": [{"title": "Gather information from customer."}]}]}'
       callbacks:
@@ -1572,7 +1572,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks/iz0g457ikesz55dhxcfa0fk9yy' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/playbooks/iz0g457ikesz55dhxcfa0fk9yy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -1609,7 +1609,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks/iz0g457ikesz55dhxcfa0fk9yy' \
+            curl -X PUT 'http://localhost:8065/plugins/playbooks/api/v0/playbooks/iz0g457ikesz55dhxcfa0fk9yy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Playbook","team_id": "ni8duypfe7bamprxqeffd563gy","create_public_playbook_run": true,"checklists": [{"title": "Title","items": [{"title": "Title"}]}]}'
       responses:
@@ -1639,7 +1639,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks/iz0g457ikesz55dhxcfa0fk9yy' \
+            curl -X DELETE 'http://localhost:8065/plugins/playbooks/api/v0/playbooks/iz0g457ikesz55dhxcfa0fk9yy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         204:
@@ -1989,7 +1989,7 @@ components:
             details_url:
               type: string
               description: Absolute URL to the playbook run's details.
-              example: http://example.com/ad-1/com.mattermost.plugin-incident-management/runs/playbookRunID
+              example: http://example.com/ad-1/playbooks/runs/playbookRunID
     WebhookOnStatusUpdatePayload:
       allOf:
         - $ref: '#/components/schemas/PlaybookRun'
@@ -2002,4 +2002,4 @@ components:
             details_url:
               type: string
               description: Absolute URL to the playbook run's details.
-              example: http://example.com/ad-1/com.mattermost.plugin-incident-management/runs/playbookRunID
+              example: http://example.com/ad-1/playbooks/runs/playbookRunID

--- a/server/api/playbook_runs_test.go
+++ b/server/api/playbook_runs_test.go
@@ -43,7 +43,7 @@ func TestPlaybookRuns(t *testing.T) {
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/playbooks")
 		r.Header.Add("Mattermost-User-ID", mattermostUserID)
 
 		handler.ServeHTTP(w, r)

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -124,7 +124,7 @@ func TestPlaybooks(t *testing.T) {
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/playbooks")
 		r.Header.Add("Mattermost-User-ID", mattermostUserID)
 
 		handler.ServeHTTP(w, r)
@@ -1623,7 +1623,7 @@ func TestSortingPlaybooks(t *testing.T) {
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/playbooks")
 		r.Header.Add("Mattermost-User-ID", "testuserid")
 
 		handler.ServeHTTP(w, r)
@@ -1844,7 +1844,7 @@ func TestPagingPlaybooks(t *testing.T) {
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/playbooks")
 		r.Header.Add("Mattermost-User-ID", "testuserid")
 
 		handler.ServeHTTP(w, r)

--- a/server/api/settings_test.go
+++ b/server/api/settings_test.go
@@ -31,7 +31,7 @@ func TestGetSettings(t *testing.T) {
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/playbooks")
 		r.Header.Add("Mattermost-User-ID", mattermostUserID)
 
 		handler.ServeHTTP(w, r)
@@ -130,7 +130,7 @@ func TestSetSettings(t *testing.T) {
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/playbooks")
 		r.Header.Add("Mattermost-User-ID", mattermostUserID)
 
 		handler.ServeHTTP(w, r)

--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -324,7 +324,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		store.EXPECT().CreateTimelineEvent(gomock.AssignableToTypeOf(&app.TimelineEvent{}))
 		store.EXPECT().UpdatePlaybookRun(gomock.Any()).Return(nil)
 
-		configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "com.mattermost.plugin-incident-management"}).Times(2)
+		configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "playbooks"}).Times(2)
 		configService.EXPECT().GetConfiguration().Return(&config.Configuration{BotUserID: "bot_user_id"}).AnyTimes()
 
 		poster.EXPECT().PublishWebsocketEventToChannel("playbook_run_updated", gomock.Any(), "channel_id")
@@ -431,7 +431,7 @@ func TestUpdateStatus(t *testing.T) {
 		store.EXPECT().UpdateStatus(gomock.AssignableToTypeOf(&app.SQLStatusPost{})).Return(nil)
 		store.EXPECT().GetPlaybookRun(gomock.Any()).Return(playbookRun, nil).Times(4)
 
-		configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "com.mattermost.plugin-incident-management"}).Times(2)
+		configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "playbooks"}).Times(2)
 
 		poster.EXPECT().PublishWebsocketEventToChannel("playbook_run_updated", gomock.Any(), homeChannelID)
 

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -837,7 +837,7 @@ func (r *Runner) actionTestSelf(args []string) {
 	}
 
 	shortDescription := "A short description."
-	longDescription := `A very long description describing the item in a very descriptive way. Now with Markdown syntax! We have *italics* and **bold**. We have [external](http://example.com) and [internal links](/ad-1/com.mattermost.plugin-incident-management/playbooks). We have even links to channels: ~town-square. And links to users: @sysadmin, @user-1. We do have the usual headings and lists, of course:
+	longDescription := `A very long description describing the item in a very descriptive way. Now with Markdown syntax! We have *italics* and **bold**. We have [external](http://example.com) and [internal links](/ad-1/playbooks/playbooks). We have even links to channels: ~town-square. And links to users: @sysadmin, @user-1. We do have the usual headings and lists, of course:
 ## Unordered List
 - One
 - Two

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -195,6 +195,7 @@ func (p *Plugin) OnActivate() error {
 	go func() {
 		// Remove the prepackaged old versions of the plugin
 		_ = pluginAPIClient.Plugin.Remove("com.mattermost.plugin-incident-response")
+		_ = pluginAPIClient.Plugin.Remove("com.mattermost.plugin-incident-management")
 	}()
 
 	return nil

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1223,8 +1223,8 @@ var migrations = []Migration{
 		fromVersion: semver.MustParse("0.30.0"),
 		toVersion:   semver.MustParse("0.31.0"),
 		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
-			if _, err := e.Exec("UPDATE PluginKeyValueStore SET pluginid='playbooks' WHERE pluginid='com.mattermost.plugin-incident-management'"); err != nil {
-				return errors.Wrapf(err, "failed setting default value in column CategoryName of table IR_Playbook")
+			if _, err := e.Exec("UPDATE PluginKeyValueStore SET PluginId='playbooks' WHERE PluginId='com.mattermost.plugin-incident-management'"); err != nil {
+				return errors.Wrapf(err, "failed to migrate KV store plugin id")
 			}
 
 			return nil

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1219,4 +1219,15 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.30.0"),
+		toVersion:   semver.MustParse("0.31.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if _, err := e.Exec("UPDATE PluginKeyValueStore SET pluginid='playbooks' WHERE pluginid='com.mattermost.plugin-incident-management'"); err != nil {
+				return errors.Wrapf(err, "failed setting default value in column CategoryName of table IR_Playbook")
+			}
+
+			return nil
+		},
+	},
 }

--- a/server/sqlstore/store_test.go
+++ b/server/sqlstore/store_test.go
@@ -39,6 +39,8 @@ func TestMigrationIdempotency(t *testing.T) {
 			setupChannelsTable(t, db)
 			// Migration to 0.21.0 need the Posts table
 			setupPostsTable(t, db)
+			// Migration to 0.31.0 needs the PluginKeyValueStore
+			setupKVStoreTable(t, db)
 
 			// Apply each migration twice
 			for _, migration := range migrations {
@@ -70,6 +72,8 @@ func TestMigrationIdempotency(t *testing.T) {
 			setupChannelsTable(t, db)
 			// Migration to 0.21.0 need the Posts table
 			setupPostsTable(t, db)
+			// Migration to 0.31.0 needs the PluginKeyValueStore
+			setupKVStoreTable(t, db)
 
 			// Apply the whole set of migrations twice
 			for i := 0; i < 2; i++ {

--- a/tests-e2e/cypress/integration/backstage/backstage_spec.js
+++ b/tests-e2e/cypress/integration/backstage/backstage_spec.js
@@ -44,7 +44,7 @@ describe('backstage', () => {
 
     // it('opens statistics view by default', () => {
     //     // # Open the backstage
-    //     cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+    //     cy.visit('/ad-1/playbooks/stats');
 
     //     // * Verify that when backstage loads, the heading is visible and contains "Statistics"
     //     cy.findByTestId('titleStats').should('exist').contains('Statistics');

--- a/tests-e2e/cypress/integration/backstage/playbook_creation_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_creation_spec.js
@@ -134,7 +134,7 @@ describe('playbook creation button', () => {
 });
 
 function verifyPlaybookCreationPageOpened(url, playbookName) {
-    // * Verify the page url contains 'com.mattermost.plugin-incident-management/playbooks/new'
+    // * Verify the page url contains 'playbooks/playbooks/new'
     cy.url().should('include', url);
 
     // * Verify the playbook name matches the one provided

--- a/tests-e2e/cypress/support/api/cloud_default_config.json
+++ b/tests-e2e/cypress/support/api/cloud_default_config.json
@@ -249,7 +249,7 @@
             "com.mattermost.nps": {
                 "Enable": false
             },
-            "com.mattermost.plugin-incident-management": {
+            "playbooks": {
                 "Enable": true
             }
         }

--- a/tests-e2e/cypress/support/api/on_prem_default_config.json
+++ b/tests-e2e/cypress/support/api/on_prem_default_config.json
@@ -476,7 +476,7 @@
             "com.mattermost.nps": {
                 "Enable": false
             },
-            "com.mattermost.plugin-incident-management": {
+            "playbooks": {
                 "Enable": true
             }
         },

--- a/tests-e2e/cypress/support/api/plugin.js
+++ b/tests-e2e/cypress/support/api/plugin.js
@@ -142,7 +142,7 @@ const prepackagedPlugins = [
     'com.mattermost.custom-attributes',
     'github',
     'com.github.manland.mattermost-plugin-gitlab',
-    'com.mattermost.plugin-incident-management',
+    'playbooks',
     'jenkins',
     'jira',
     'com.mattermost.nps',

--- a/tests-e2e/cypress/support/plugin/api_commands.js
+++ b/tests-e2e/cypress/support/plugin/api_commands.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const playbookRunsEndpoint = '/plugins/com.mattermost.plugin-incident-management/api/v0/runs';
+const playbookRunsEndpoint = '/plugins/playbooks/api/v0/runs';
 
 /**
  * Get all playbook runs directly via API
@@ -9,7 +9,7 @@ const playbookRunsEndpoint = '/plugins/com.mattermost.plugin-incident-management
 Cypress.Commands.add('apiGetAllPlaybookRuns', (teamId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/plugins/com.mattermost.plugin-incident-management/api/v0/runs',
+        url: '/plugins/playbooks/api/v0/runs',
         qs: {team_id: teamId, per_page: 10000},
         method: 'GET',
     }).then((response) => {
@@ -24,7 +24,7 @@ Cypress.Commands.add('apiGetAllPlaybookRuns', (teamId) => {
 Cypress.Commands.add('apiGetAllInProgressPlaybookRuns', (teamId, userId = '') => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/plugins/com.mattermost.plugin-incident-management/api/v0/runs',
+        url: '/plugins/playbooks/api/v0/runs',
         qs: {team_id: teamId, status: 'InProgress', participant_id: userId},
         method: 'GET',
     }).then((response) => {
@@ -39,7 +39,7 @@ Cypress.Commands.add('apiGetAllInProgressPlaybookRuns', (teamId, userId = '') =>
 Cypress.Commands.add('apiGetPlaybookRunByName', (teamId, name) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/plugins/com.mattermost.plugin-incident-management/api/v0/runs',
+        url: '/plugins/playbooks/api/v0/runs',
         qs: {team_id: teamId, search_term: name},
         method: 'GET',
     }).then((response) => {
@@ -213,7 +213,7 @@ Cypress.Commands.add('apiCreatePlaybook', (
     }) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks',
+        url: '/plugins/playbooks/api/v0/playbooks',
         method: 'POST',
         body: {
             title,
@@ -285,7 +285,7 @@ Cypress.Commands.add('apiCreateTestPlaybook', (
 Cypress.Commands.add('verifyPlaybookCreated', (teamId, playbookTitle) => (
     cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/plugins/com.mattermost.plugin-incident-management/api/v0/playbooks',
+        url: '/plugins/playbooks/api/v0/playbooks',
         qs: {team_id: teamId, sort: 'title', direction: 'asc'},
         method: 'GET'
     }).then((response) => {

--- a/tests-e2e/db-setup/mm534.sql
+++ b/tests-e2e/db-setup/mm534.sql
@@ -2759,7 +2759,7 @@ COPY public.outgoingwebhooks (id, token, createat, updateat, deleteat, creatorid
 --
 
 COPY public.pluginkeyvaluestore (pluginid, pkey, pvalue, expireat) FROM stdin;
-com.mattermost.plugin-incident-management	mmi_botid	\\x706f663562657a6a6e6938796d6b6172337174657364357a3377	0
+playbooks	mmi_botid	\\x706f663562657a6a6e6938796d6b6172337174657364357a3377	0
 \.
 
 

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -114,7 +114,7 @@ if (targetIsDevServer) {
             proxy: [{
                 context: () => true,
                 bypass(req) {
-                    if (req.url.indexOf('/static/plugins/com.mattermost.plugin-incident-management/') === 0) {
+                    if (req.url.indexOf('/static/plugins/playbooks/') === 0) {
                         return '/main.js'; // return the webpacked asset
                     }
                     return null;


### PR DESCRIPTION
#### Summary
Updates the plugin id to `playbooks`.
Adds migration to kill off the old version of itself just like last time.

Server PR: https://github.com/mattermost/mattermost-server/pull/18392

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38122

#### Checklist
- [x] Telemetry updated
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests updated~~
