### PR TITLE
MM-38295: markdown inputs in playbook-edit

### DIFF
--- a/webapp/src/components/backstage/automation/message_on_join.tsx
+++ b/webapp/src/components/backstage/automation/message_on_join.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef} from 'react';
+import React from 'react';
 import styled from 'styled-components';
+
+import {StyledMarkdownTextbox} from 'src/components/backstage/styles';
 
 import {
     AutomationHeader,
@@ -10,42 +12,14 @@ import {
 } from 'src/components/backstage/automation/styles';
 import {Toggle} from 'src/components/backstage/automation/toggle';
 
-// @ts-ignore
-const AutocompleteTextbox = window.Components.Textbox;
-
-const AutocompleteWrapper = styled.div`
-    flex-grow: 1;
-    width: 300px;
-    max-height: 300px;
-
-    .custom-textarea {
-        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-        width: 100%;
-        resize: none;
-        min-height: 150px;
-        max-height: 260px;
-        overflow-y: auto;
-        background-color: rgb(var(--center-channel-bg-rgb));
-        border: none;
-        box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
-        border-radius: 4px;
-        padding: 16px 16px 0 16px;
-        font-size: 14px;
-        line-height: 20px;
-
-        &:focus {
-            box-shadow: inset 0 0 0 2px var(--button-bg);
-        }
-
-        &:disabled {
-            background-color: rgb(var(--center-channel-bg-rgb), 0.16) !important;
-            color: rgb(var(--center-channel-color-rgb), 0.7) !important;
-        }
-    }
+const TextboxWrapper = styled.div`
+    margin-top: 2rem;
+    width: 100%;
 `;
 
 const StyledAutomationHeader = styled(AutomationHeader)`
     align-items: start;
+    flex-direction: column;
 `;
 
 interface Props {
@@ -56,8 +30,6 @@ interface Props {
 }
 
 export const MessageOnJoin = (props: Props) => {
-    const textboxRef = useRef(null);
-
     return (
         <StyledAutomationHeader>
             <AutomationTitle>
@@ -67,27 +39,17 @@ export const MessageOnJoin = (props: Props) => {
                 />
                 <div>{'Send a welcome message'}</div>
             </AutomationTitle>
-            <AutocompleteWrapper>
-                <AutocompleteTextbox
-                    ref={textboxRef}
-                    createMessage={'Welcome message'}
-                    onChange={(e: React.FormEvent<HTMLInputElement>) => {
-                        if (e.target) {
-                            const input = e.target as HTMLInputElement;
-                            props.onChange(input.value);
-                        }
-                    }}
-                    suggestionListStyle={'top'}
-                    type={'text'}
-                    value={props.message}
-                    disabled={!props.enabled}
-
-                    // the following are required props but aren't used
-                    characterLimit={256}
-                    onKeyPress={() => true}
-                    openWhenEmpty={true}
-                />
-            </AutocompleteWrapper>
+            {props.enabled && (
+                <TextboxWrapper>
+                    <StyledMarkdownTextbox
+                        className={'playbook_welcome_message'}
+                        id={'playbook_welcome_message'}
+                        placeholder={'Welcome message'}
+                        value={props.message}
+                        setValue={props.onChange}
+                    />
+                </TextboxWrapper>
+            )}
         </StyledAutomationHeader>
     );
 };

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -28,13 +28,27 @@ import DefaultUpdateTimer from 'src/components/backstage/default_update_timer';
 import './playbook.scss';
 import {useAllowRetrospectiveAccess} from 'src/hooks';
 
+import MarkdownTextbox from 'src/components/markdown_textbox';
+
+const StyledMarkdownTextbox = styled(MarkdownTextbox)`
+    .custom-textarea {
+        background: white;
+        border-radius: 4px;
+        padding: 10px 25px 0 16px;
+        font-size: 14px;
+        line-height: 20px;
+    }
+    .textbox-preview-area {
+        z-index: auto;
+    }
+`;
+
 import EditableText from './editable_text';
 import SharePlaybook from './share_playbook';
 import {
     BackstageSubheader,
     BackstageSubheaderDescription,
     TabContainer,
-    StyledTextarea,
     StyledSelect,
 } from './styles';
 
@@ -584,13 +598,15 @@ const PlaybookEdit = (props: Props) => {
                                             {'This template helps to standardize the format for a concise description that explains each run to its stakeholders.'}
                                         </BackstageSubheaderDescription>
                                     </BackstageSubheader>
-                                    <StyledTextarea
+                                    <StyledMarkdownTextbox
+                                        className={'playbook_description'}
+                                        id={'playbook_description_edit'}
                                         placeholder={'Use Markdown to create a template.'}
                                         value={playbook.description}
-                                        onChange={(e) => {
+                                        setValue={(description: string) => {
                                             setPlaybook({
                                                 ...playbook,
-                                                description: e.target.value,
+                                                description,
                                             });
                                             setChangesMade(true);
                                         }}
@@ -603,13 +619,15 @@ const PlaybookEdit = (props: Props) => {
                                             {'This template helps to standardize the format for recurring updates that take place throughout each run to keep.'}
                                         </BackstageSubheaderDescription>
                                     </BackstageSubheader>
-                                    <StyledTextarea
+                                    <StyledMarkdownTextbox
+                                        className={'playbook_reminder_message'}
+                                        id={'playbook_reminder_message_edit'}
                                         placeholder={'Use Markdown to create a template.'}
                                         value={playbook.reminder_message_template}
-                                        onChange={(e) => {
+                                        setValue={(value: string) => {
                                             setPlaybook({
                                                 ...playbook,
-                                                reminder_message_template: e.target.value,
+                                                reminder_message_template: value,
                                             });
                                             setChangesMade(true);
                                         }}
@@ -645,13 +663,15 @@ const PlaybookEdit = (props: Props) => {
                                                     {'Default text for the retrospective.'}
                                                 </BackstageSubheaderDescription>
                                             </BackstageSubheader>
-                                            <StyledTextarea
+                                            <StyledMarkdownTextbox
+                                                className={'playbook_retrospective_template'}
+                                                id={'playbook_retrospective_template_edit'}
                                                 placeholder={'Enter retrospective template'}
                                                 value={playbook.retrospective_template}
-                                                onChange={(e) => {
+                                                setValue={(value: string) => {
                                                     setPlaybook({
                                                         ...playbook,
-                                                        retrospective_template: e.target.value,
+                                                        retrospective_template: value,
                                                     });
                                                     setChangesMade(true);
                                                 }}

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -28,27 +28,13 @@ import DefaultUpdateTimer from 'src/components/backstage/default_update_timer';
 import './playbook.scss';
 import {useAllowRetrospectiveAccess} from 'src/hooks';
 
-import MarkdownTextbox from 'src/components/markdown_textbox';
-
-const StyledMarkdownTextbox = styled(MarkdownTextbox)`
-    .custom-textarea {
-        background: white;
-        border-radius: 4px;
-        padding: 10px 25px 0 16px;
-        font-size: 14px;
-        line-height: 20px;
-    }
-    .textbox-preview-area {
-        z-index: auto;
-    }
-`;
-
 import EditableText from './editable_text';
 import SharePlaybook from './share_playbook';
 import {
     BackstageSubheader,
     BackstageSubheaderDescription,
     TabContainer,
+    StyledMarkdownTextbox,
     StyledSelect,
 } from './styles';
 

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -6,6 +6,7 @@ import AsyncSelect from 'react-select/async';
 import Select from 'react-select';
 
 import {RegularHeading} from 'src/styles/headings';
+import MarkdownTextbox from 'src/components/markdown_textbox';
 
 export const Banner = styled.div`
     color: var(--button-color);
@@ -70,6 +71,19 @@ export const StyledTextarea = styled.textarea`
 
     &:focus {
         box-shadow: inset 0 0 0 2px var(--button-bg);
+    }
+`;
+
+export const StyledMarkdownTextbox = styled(MarkdownTextbox)`
+    .custom-textarea {
+        background: white;
+        border-radius: 4px;
+        padding: 10px 25px 0 16px;
+        font-size: 14px;
+        line-height: 20px;
+    }
+    .textbox-preview-area {
+        z-index: auto;
     }
 `;
 

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -582,6 +582,7 @@ const ChecklistItemEditModal = (props: ChecklistItemEditModalProps) => {
                     value={description ?? ''}
                     setValue={setDescription}
                     channelId={props.channelId}
+                    createMessage='Task description'
                 />
             </FormContainer>
         </GenericModal>

--- a/webapp/src/components/command_input.tsx
+++ b/webapp/src/components/command_input.tsx
@@ -18,7 +18,7 @@ const AutocompleteWrapper = styled.div`
         padding-right: 30px;
     }
 
-    &&& {
+    && {
         input.custom-textarea.custom-textarea {
             transition: all 0.15s ease;
             border: none;
@@ -29,14 +29,6 @@ const AutocompleteWrapper = styled.div`
                 box-shadow: inset 0 0 0 2px var(--button-bg);
                 padding: 12px 30px 12px 16px;
             }
-        }
-
-        .GenericModal .modal-body .form-control.form-control {
-            border: none;
-        }
-
-        .modal-body.modal-body {
-            overflow: visible;
         }
     }
 `;

--- a/webapp/src/components/command_input.tsx
+++ b/webapp/src/components/command_input.tsx
@@ -1,36 +1,12 @@
 import React, {useEffect, useRef, useState} from 'react';
 
-import styled, {createGlobalStyle} from 'styled-components';
+import styled from 'styled-components';
 
 import {useUniqueId} from 'src/utils';
 
+import {Textbox as AutocompleteTextbox} from 'src/webapp_globals';
+
 import {BaseInput, InputTrashIcon} from './assets/inputs';
-
-// @ts-ignore
-const AutocompleteTextbox = window.Components.Textbox;
-
-const OverrideWebappStyle = createGlobalStyle`
-    input.custom-textarea.custom-textarea {
-        border: none;
-        box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
-        height: 40px;
-        min-height: 40px;
-    }
-
-    input.custom-textarea.custom-textarea:focus {
-        border: none;
-        box-shadow: inset 0 0 0 2px var(--button-bg);
-        padding: 12px 30px 12px 16px;
-    }
-
-    .GenericModal .modal-body .form-control.form-control {
-        border: none;
-    }
-
-    .modal-body.modal-body {
-        overflow: visible;
-    }
-`;
 
 const AutocompleteWrapper = styled.div`
     position: relative;
@@ -40,6 +16,27 @@ const AutocompleteWrapper = styled.div`
 
     input {
         padding-right: 30px;
+    }
+
+    &&& {
+        input.custom-textarea.custom-textarea {
+            border: none;
+            box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
+            height: 40px;
+            min-height: 40px;
+            &:focus {
+                box-shadow: inset 0 0 0 2px var(--button-bg);
+                padding: 12px 30px 12px 16px;
+            }
+        }
+
+        .GenericModal .modal-body .form-control.form-control {
+            border: none;
+        }
+
+        .modal-body.modal-body {
+            overflow: visible;
+        }
     }
 `;
 
@@ -75,7 +72,6 @@ const CommandInput = (props: CommandInputProps) => {
 
     return (
         <>
-            <OverrideWebappStyle/>
             <AutocompleteWrapper
                 onMouseOver={() => setHover(true)}
                 onMouseLeave={() => setHover(false)}

--- a/webapp/src/components/command_input.tsx
+++ b/webapp/src/components/command_input.tsx
@@ -20,6 +20,7 @@ const AutocompleteWrapper = styled.div`
 
     &&& {
         input.custom-textarea.custom-textarea {
+            transition: all 0.15s ease;
             border: none;
             box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
             height: 40px;

--- a/webapp/src/components/markdown_textbox.tsx
+++ b/webapp/src/components/markdown_textbox.tsx
@@ -51,6 +51,7 @@ const MarkdownTextbox = ({
                 createMessage={placeholder}
                 onKeyPress={() => true}
                 openWhenEmpty={true}
+                channelId={''}
                 {...textboxProps}
             />
             <StyledTextboxLinks

--- a/webapp/src/components/markdown_textbox.tsx
+++ b/webapp/src/components/markdown_textbox.tsx
@@ -18,7 +18,7 @@ const DEFAULT_CHAR_LIMIT = 4000;
 type Props = {
     value: string;
     setValue: (val: string) => void;
-    createMessage?: string;
+    placeholder?: string;
     id: string;
     className?: string;
 } & ComponentProps<typeof Textbox>;
@@ -27,6 +27,7 @@ const MarkdownTextbox = ({
     value,
     setValue,
     className,
+    placeholder = '',
     ...textboxProps
 }: Props) => {
     const [showPreview, setShowPreview] = useState(false);
@@ -47,7 +48,7 @@ const MarkdownTextbox = ({
                 useChannelMentions={false}
                 onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setValue(e.target.value)}
                 characterLimit={charLimit}
-                createMessage={''}
+                createMessage={placeholder}
                 onKeyPress={() => true}
                 openWhenEmpty={true}
                 {...textboxProps}

--- a/webapp/src/components/markdown_textbox.tsx
+++ b/webapp/src/components/markdown_textbox.tsx
@@ -77,6 +77,7 @@ const Wrapper = styled.div`
             min-height: 104px;
             max-height: 324px;
             overflow: auto;
+            padding: 12px 30px 12px 16px;
 
             transition: box-shadow ease-in-out .15s;
             box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);

--- a/webapp/src/components/markdown_textbox.tsx
+++ b/webapp/src/components/markdown_textbox.tsx
@@ -76,7 +76,14 @@ const Wrapper = styled.div`
             min-height: 104px;
             max-height: 324px;
             overflow: auto;
-            padding: 12px 30px 12px 16px;
+
+            transition: box-shadow ease-in-out .15s;
+            box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
+
+            border: medium none;
+            &:focus:not(.textbox-preview-area) {
+                box-shadow: inset 0 0 0 2px var(--button-bg);
+            }
         }
     }
 `;


### PR DESCRIPTION
#### Summary
- [MM-38295](https://mattermost.atlassian.net/browse/MM-38295): Adds markdown preview to template textareas in backstage `playbook_edit` by switching to `markdown_textarea`.
  - Description tempate
  - Status template
  - Retro template

![CleanShot 2021-09-15 at 12 30 26@2x](https://user-images.githubusercontent.com/11724372/133482173-463bf0f1-de34-47f0-a481-bd34c5aabca4.png)


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests updated~~
