### PR TITLE
require client/v0.6.0, fixing repository name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/lib/pq v1.10.2
 	github.com/mattermost/mattermost-plugin-api v0.0.21-0.20210825201013-18b0ff361b38
-	github.com/mattermost/mattermost-plugin-playbooks/client v0.3.1
+	github.com/mattermost/mattermost-plugin-playbooks/client v0.6.0
 	github.com/mattermost/mattermost-server/v6 v6.0.0-20210825182941-ddfa6e2436d6
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.1+incompatible


### PR DESCRIPTION
#### Summary
Update to depend on `client/v0.6.0` (the tip of `master`) so that the repository names match up.

#### Ticket Link
N/A

#### Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
