### PR TITLE
MM-38443: ensure status post profiles loaded

### DIFF
--- a/tests-e2e/cypress/integration/backstage/playbook_run_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_run_details_spec.js
@@ -54,7 +54,6 @@ describe('backstage playbook run details', () => {
                 playbookRunName: 'visible user icons',
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
-                console.log('here', playbookRun.id);
                 cy.apiUpdateStatus({
                     playbookRunId: playbookRun.id,
                     userId: testUser.id,

--- a/tests-e2e/cypress/integration/backstage/playbook_run_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_run_details_spec.js
@@ -7,9 +7,35 @@
 // ***************************************************************
 
 describe('backstage playbook run details', () => {
+    let testTeam;
+    let testUser;
+    let testPublicPlaybook;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Public Playbook',
+                memberIDs: [],
+            }).then((playbook) => {
+                testPublicPlaybook = playbook;
+            });
+        });
+    });
+
     beforeEach(() => {
-        // # Login as user-1
-        cy.legacyApiLogin('user-1');
+        // # Size the viewport to show the RHS without covering posts.
+        cy.viewport('macbook-13');
+
+        // # Login as testUser
+        cy.apiLogin(testUser);
     });
 
     it('redirects to not found error if the playbook run is unknown', () => {
@@ -18,5 +44,38 @@ describe('backstage playbook run details', () => {
 
         // * Verify that the user has been redirected to the playbook runs not found error page
         cy.url().should('include', '/playbooks/error?type=playbook_runs');
+    });
+
+    describe('updates', () => {
+        it('should show user icons', () => {
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPublicPlaybook.id,
+                playbookRunName: 'visible user icons',
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                console.log('here', playbookRun.id);
+                cy.apiUpdateStatus({
+                    playbookRunId: playbookRun.id,
+                    userId: testUser.id,
+                    channelId: playbookRun.channel_id,
+                    teamId: testTeam.id,
+                    message: 'This is a status update',
+                    description: 'This is a description',
+                });
+
+                // # Visit the playbook run
+                cy.visit(`/playbooks/runs/${playbookRun.id}`);
+
+                // # Verify the status update is present
+                cy.findByTestId('updates').contains('This is a status update');
+
+                // # Verify the playbook user and icon is visible
+                cy.findByTestId('updates').find('img').should('be.visible').and(($img) => {
+                    // https://stackoverflow.com/questions/51246606/test-loading-of-image-in-cypress
+                    expect($img[0].naturalWidth).to.be.greaterThan(0);
+                });
+            });
+        });
     });
 });

--- a/tests-e2e/cypress/support/plugin/api_commands.js
+++ b/tests-e2e/cypress/support/plugin/api_commands.js
@@ -114,6 +114,7 @@ Cypress.Commands.add('apiUpdateStatus', (
         teamId,
         message,
         description,
+        reminder = '300',
     }) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -126,7 +127,7 @@ Cypress.Commands.add('apiUpdateStatus', (
             user_id: userId,
             channel_id: channelId,
             team_id: teamId,
-            submission: {message, description, reminder: '15'},
+            submission: {message, description, reminder},
             cancelled: false,
         },
     }).then((response) => {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates.tsx
@@ -48,7 +48,7 @@ const Updates = (props: Props) => {
     }
 
     return (
-        <TabPageContainer>
+        <TabPageContainer data-testid="updates">
             <Title>{'Updates'}</Title>
             {updates}
         </TabPageContainer>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates.tsx
@@ -48,7 +48,7 @@ const Updates = (props: Props) => {
     }
 
     return (
-        <TabPageContainer data-testid="updates">
+        <TabPageContainer data-testid='updates'>
             <Title>{'Updates'}</Title>
             {updates}
         </TabPageContainer>

--- a/webapp/src/components/rhs/post_card.tsx
+++ b/webapp/src/components/rhs/post_card.tsx
@@ -21,6 +21,7 @@ import {ChannelNamesMap} from 'src/types/backstage';
 import {promptUpdateStatus, toggleRHS} from 'src/actions';
 import ShowMore from 'src/components/rhs/show_more';
 import PostText from 'src/components/post_text';
+import {useEnsureProfiles} from 'src/hooks';
 
 const NoRecentUpdates = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.64);
@@ -69,6 +70,7 @@ const EditedIndicator = styled.div`
 function useAuthorInfo(userID: string) : [string, string] {
     const teamnameNameDisplaySetting = useSelector<GlobalState, string | undefined>(getTeammateNameDisplaySetting) || '';
     const user = useSelector<GlobalState, UserProfile>((state) => getUser(state, userID));
+    useEnsureProfiles([userID]);
 
     let profileUrl = '';
     let preferredName = '';


### PR DESCRIPTION
#### Summary
Ensure status updates from non-participants (i.e. typically the `playbook` bot) are loaded when displaying playbook run details.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-38443

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated~~
