### PR TITLE
Fixing kvstore migration.

### DIFF
--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1223,8 +1223,16 @@ var migrations = []Migration{
 		fromVersion: semver.MustParse("0.30.0"),
 		toVersion:   semver.MustParse("0.31.0"),
 		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
-			if _, err := e.Exec("UPDATE PluginKeyValueStore SET PluginId='playbooks' WHERE PluginId='com.mattermost.plugin-incident-management'"); err != nil {
-				return errors.Wrapf(err, "failed to migrate KV store plugin id")
+			// Best effort migration so we just log the error to avoid killing the plugin.
+			if e.DriverName() == model.DatabaseDriverMysql {
+				if _, err := e.Exec("UPDATE IGNORE PluginKeyValueStore SET PluginId='playbooks' WHERE PluginId='com.mattermost.plugin-incident-management'"); err != nil {
+					sqlStore.log.Debugf("%w", errors.Wrapf(err, "failed to migrate KV store plugin id"))
+				}
+			} else {
+
+				if _, err := e.Exec("UPDATE PluginKeyValueStore k SET PluginId='playbooks' WHERE PluginId='com.mattermost.plugin-incident-management' AND NOT EXISTS ( SELECT 1 FROM PluginKeyValueStore WHERE PluginId='playbooks' AND PKey = k.PKey )"); err != nil {
+					sqlStore.log.Debugf("%w", errors.Wrapf(err, "failed to migrate KV store plugin id"))
+				}
 			}
 
 			return nil


### PR DESCRIPTION
#### Summary
Migration of KV store is not as easy as I initially anticipated because we actually use the KV store before we use the DB. So there will be a duplicate entry for the bot ID in the KV store which breaks the simple query. 
The modifications here ignore duplicate entries which of course is different between MySQL and PostgreSQL. I also changed the migration to be best effort to not block the plugin from starting if there is a problem.
