### PR TITLE
MM-38255 - Fix for: Update content overlaps with the border of the text box

### DIFF
--- a/webapp/src/components/markdown_textbox.tsx
+++ b/webapp/src/components/markdown_textbox.tsx
@@ -81,11 +81,11 @@ const Wrapper = styled.div`
             padding: 12px 30px 12px 16px;
 
             transition: box-shadow ease-in-out .15s;
-            box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
+            box-shadow: 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
 
             border: medium none;
             &:focus:not(.textbox-preview-area) {
-                box-shadow: inset 0 0 0 2px var(--button-bg);
+                box-shadow: 0 0 0 2px var(--button-bg);
             }
         }
     }


### PR DESCRIPTION
#### Summary
- Render the border outside (avoids overlapping the textbox contents and the scrollbar)

![image](https://user-images.githubusercontent.com/1490756/134071434-168e5ef2-1ef2-4b98-9626-80d1f8a9ddc0.png)

![image](https://user-images.githubusercontent.com/1490756/134071396-e53c0613-0fec-4586-8b84-f4e1536d542d.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38255

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
