### PR TITLE
MM-37703 - Fix for: Task assignee dropdown is cut off by center channel

### DIFF
--- a/webapp/src/components/profile/profile_selector.scss
+++ b/webapp/src/components/profile/profile_selector.scss
@@ -14,12 +14,6 @@
         }
     }
 
-    .profile-dropdown.show-on-right {
-        .playbook-run-user-select__container {
-            right: 0;
-        }
-    }
-
     .playbook-run-user-select__menu-list {
         padding: 0 0 12px;
         border: none;

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -5,7 +5,7 @@ import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import ReactSelect, {ActionTypes, ControlProps, StylesConfig} from 'react-select';
 import classNames from 'classnames';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {GlobalState} from 'mattermost-redux/types/store';
@@ -308,13 +308,17 @@ const Blanket = styled.div`
 `;
 
 interface ChildContainerProps {
-    moveUp?: number
+    moveUp?: number;
+    showOnRight?: boolean;
 }
 
 const ChildContainer = styled.div<ChildContainerProps>`
     margin: 4px 0 0;
     min-width: 20rem;
     top: ${(props) => 27 - (props.moveUp || 0)}px;
+    ${(props) => props.showOnRight && css`
+        right: -55px;
+    `}
 `;
 
 const Dropdown = ({children, isOpen, showOnRight, moveUp, target, onClose}: DropdownProps) => {
@@ -323,7 +327,7 @@ const Dropdown = ({children, isOpen, showOnRight, moveUp, target, onClose}: Drop
     }
 
     const classes = classNames('PlaybookRunFilter', 'profile-dropdown',
-        'PlaybookRunFilter--active', 'profile-dropdown--active', {'show-on-right': showOnRight});
+        'PlaybookRunFilter--active', 'profile-dropdown--active');
 
     return (
         <ProfileDropdown className={classes}>
@@ -331,6 +335,7 @@ const Dropdown = ({children, isOpen, showOnRight, moveUp, target, onClose}: Drop
             <ChildContainer
                 className='playbook-run-user-select__container'
                 moveUp={moveUp}
+                showOnRight={showOnRight}
             >
                 {children}
             </ChildContainer>


### PR DESCRIPTION
#### Summary
- removed scss, replaced with styled component logic. 
- instead of `right: 0` use `right: -55` -- this will fit the largest possible profile selector width
- See the ticket for what it used to look like (or try it out in a channel, eg: https://community-release.mattermost.com/private-core/channels/playbooks-plugin-and-others-broken-on-daily )

![image](https://user-images.githubusercontent.com/1490756/134076203-6528d4f2-b43b-4ea2-9e0f-12af8dda2050.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-37703
- 
#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
