### PR TITLE
[MM-37314] Sync sidebar category update

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1705,6 +1705,13 @@ func (s *PlaybookRunServiceImpl) UserHasJoinedChannel(userID, channelID, actorID
 // createOrUpdatePlaybookRunSidebarCategory creates or updates a "Playbook Runs" sidebar category if
 // it does not already exist and adds the channel within the sidebar category
 func (s *PlaybookRunServiceImpl) createOrUpdatePlaybookRunSidebarCategory(userID, channelID, teamID, categoryName string) error {
+	// Wait for 5 seconds for the webapp to get the `user_added` event,
+	// finish channel categorization and update it's state in redux.
+	// Currently there is no way to detect when webapp finished the job.
+	// After that we can update the categories safely.
+	time.Sleep(5 * time.Second)
+
+	// Prevent a race condition on category updates, when user creates multiple runs at once.
 	s.categoryMutex.Lock()
 	defer s.categoryMutex.Unlock()
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -138,6 +138,11 @@ func (p *Plugin) OnActivate() error {
 
 	scheduler := cluster.GetJobOnceScheduler(p.API)
 
+	categoryMutex, err := cluster.NewMutex(p.API, "playbooks_category_mutex")
+	if err != nil {
+		return errors.Wrapf(err, "failed creating cluster mutex")
+	}
+
 	p.playbookRunService = app.NewPlaybookRunService(
 		pluginAPIClient,
 		playbookRunStore,
@@ -147,6 +152,7 @@ func (p *Plugin) OnActivate() error {
 		scheduler,
 		telemetryClient,
 		p.API,
+		categoryMutex,
 	)
 
 	if err = scheduler.SetCallback(p.playbookRunService.HandleReminder); err != nil {


### PR DESCRIPTION
#### Summary
After some research I was able to reproduce the autocategorization bug locally, but only when I'm trying to autocategorize 2 channels at once. That is if I start two playbook runs. There we have the race condition on an HA environment. When there are 2 concurrent calls of `UserHasJoinedChannel`: 
```go 
GetSidebarCategories()
change_categories
UpdateSidebarCategories()
```
will not work, because what might happen is 

```go 
GetSidebarCategories() //for the first channel on node1
GetSidebarCategories() //for the second channel on node2
change_categories //first channel is updated on node1
change_categories //second channel is updated on node2
UpdateSidebarCategories()//first channel info is saved to DB from node1
UpdateSidebarCategories()//second channel info is saved to DB from node2
```
Hence the data will be overwritten and first channel will not be autocategorized.
Solution here is to have the distributed lock.

P.S. I was not able to reproduce the same for the single channel. Server code seems to be Ok as well.

#### Ticket Link
  Fixes: https://mattermost.atlassian.net/browse/MM-37314


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [x] Unit tests updated
