### PR TITLE
MM-38744 - Fix for: Broadcast stops if one channel is read-only

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -693,7 +693,8 @@ func (s *PlaybookRunServiceImpl) broadcastStatusUpdate(post *model.Post, playboo
 		post.Id = "" // Reset the ID so we avoid cloning the whole object
 		post.ChannelId = channelID
 		if err := s.postMessageToThreadAndSaveRootID(playbookRunID, channelID, post); err != nil {
-			return errors.Wrap(err, "failed to post broadcast message")
+			s.pluginAPI.Log.Warn("failed to broadcast the status update to channel",
+				"channel_id", channelID, "error", err.Error())
 		}
 	}
 


### PR DESCRIPTION
#### Summary
- Don't stop broadcasting. Incidentally, this is how the broadcast start and finish messages are treated (which is why those seemed to keep working).
- Making a judgement call that it's not worth mocking unit tests to simulate this, and e2e tests would not be a valuable use of time given the amount of other bugs we need to finish and the edge-case-ness of this bug.
- I did reproduce on a cloud test server (using `--version release-6.0`) and the PR fixes it.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38744

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
