### PR TITLE
MM-38569: Fix timeline permalinks for deleted status posts

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item.tsx
@@ -3,15 +3,17 @@
 
 import React, {useState} from 'react';
 import {useDispatch} from 'react-redux';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 import moment, {duration, Moment} from 'moment';
 import {Team} from 'mattermost-redux/types/teams';
+
+import {DateTime} from 'luxon';
 
 import {TimelineEvent, TimelineEventType} from 'src/types/rhs';
 import {isMobile} from 'src/mobile';
 import {toggleRHS} from 'src/actions';
 import {ChannelNamesMap} from 'src/types/backstage';
-import {messageHtmlToComponent, formatText} from 'src/webapp_globals';
+import {messageHtmlToComponent, formatText, browserHistory, Timestamp} from 'src/webapp_globals';
 import {formatDuration} from 'src/components/formatted_duration';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {HoverMenu, HoverMenuButton} from 'src/components/rhs/rhs_shared';
@@ -62,13 +64,24 @@ const SummaryContainer = styled.div`
     min-height: 36px;
 `;
 
-const SummaryTitle = styled.div`
+const SummaryTitle = styled.div<{deleted: boolean}>`
     font-size: 12px;
     font-weight: 600;
 
-    :hover {
-        cursor: pointer;
-    }
+    ${({deleted}) => (deleted ? css`
+        text-decoration: line-through;
+    ` : css`
+        :hover {
+            cursor: pointer;
+        }
+    `)}
+
+`;
+
+const SummaryDeleted = styled.span`
+    font-size: 10px;
+    margin-top: 3px;
+    display: inline-block;
 `;
 
 const SummaryDetail = styled.div`
@@ -94,6 +107,9 @@ const TimelineEventItem = (props: Props) => {
         team: props.team,
         channelNamesMap: props.channelNames,
     };
+    const statusPostDeleted =
+        props.event.event_type === TimelineEventType.StatusUpdated &&
+        props.event.status_delete_at !== 0;
 
     const goToPost = (e: React.MouseEvent<Element, MouseEvent>, postId?: string) => {
         e.preventDefault();
@@ -101,8 +117,7 @@ const TimelineEventItem = (props: Props) => {
             return;
         }
 
-        // @ts-ignore
-        window.WebappUtils.browserHistory.push(`/_redirect/pl/${postId}`);
+        browserHistory.push(`/${props.team.name}/pl/${postId}`);
 
         if (isMobile()) {
             dispatch(toggleRHS());
@@ -211,9 +226,23 @@ const TimelineEventItem = (props: Props) => {
                 <i className={iconClass}/>
             </Circle>
             <SummaryContainer>
-                <SummaryTitle onClick={(e) => goToPost(e, props.event.post_id)}>
+                <SummaryTitle
+                    onClick={(e) => !statusPostDeleted && goToPost(e, props.event.post_id)}
+                    deleted={statusPostDeleted}
+                >
                     {summaryTitle}
                 </SummaryTitle>
+                {statusPostDeleted && (
+                    <SummaryDeleted>
+                        {'Status post deleted: '}
+                        <Timestamp
+                            value={props.event.status_delete_at}
+                            // eslint-disable-next-line no-undefined
+                            useDate={{...DateTime.DATE_MED, year: undefined}}
+                            useTime={DateTime.TIME_24_SIMPLE}
+                        />
+                    </SummaryDeleted>
+                )}
                 <SummaryDetail>{messageHtmlToComponent(formatText(summary, markdownOptions), true, {})}</SummaryDetail>
             </SummaryContainer>
             <ConfirmModal

--- a/webapp/src/types/rhs.ts
+++ b/webapp/src/types/rhs.ts
@@ -33,6 +33,9 @@ export interface TimelineEvent {
     subject_user_id: string;
     creator_user_id: string;
     subject_display_name?: string;
+
+    /** @remarks computed client-side */
+    status_delete_at?: number;
 }
 
 export interface TimelineEventsFilter {

--- a/webapp/src/webapp_globals.ts
+++ b/webapp/src/webapp_globals.ts
@@ -10,6 +10,7 @@ export const {
 
 export const {
     modals,
+    browserHistory,
 
     // @ts-ignore
 } = global.WebappUtils ?? {};


### PR DESCRIPTION
#### Summary
- [MM-38569](https://mattermost.atlassian.net/browse/MM-38569)
  - Prevent clicks on deleted status posts
  - Indicate deleted status posts with strikethrough and timestamp

<img width="372" alt="CleanShot 2021-09-22 at 09 33 37@2x" src="https://user-images.githubusercontent.com/11724372/134378791-71275ec0-c03d-4cf1-89a6-b56dfdbb2928.png">


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
