### PR TITLE
MM-38722: Fix UpgradeModal misalignment by exposing inner components in GenericModal

### DIFF
--- a/webapp/src/components/backstage/upgrade_modal.tsx
+++ b/webapp/src/components/backstage/upgrade_modal.tsx
@@ -3,7 +3,7 @@ import {useSelector} from 'react-redux';
 
 import styled from 'styled-components';
 
-import GenericModal from 'src/components/widgets/generic_modal';
+import GenericModal, {DefaultFooterContainer} from 'src/components/widgets/generic_modal';
 import {requestTrialLicense, postMessageToAdmins} from 'src/client';
 import UpgradeModalFooter from 'src/components/backstage/upgrade_modal_footer';
 
@@ -102,6 +102,7 @@ const UpgradeModal = (props: Props) => {
                     isCloud={isServerCloud}
                 />
             )}
+            components={{FooterContainer}}
         >
             <Content>
                 <UpgradeModalIllustrationWrapper
@@ -142,6 +143,10 @@ const SizedGenericModal = styled(GenericModal)`
         margin-bottom: 48px;
         padding: 0;
     }
+`;
+
+const FooterContainer = styled(DefaultFooterContainer)`
+    align-items: center;
 `;
 
 export default UpgradeModal;

--- a/webapp/src/components/widgets/generic_modal.tsx
+++ b/webapp/src/components/widgets/generic_modal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import styled from 'styled-components';
+import styled, {StyledComponentBase} from 'styled-components';
 import classNames from 'classnames';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
@@ -24,6 +24,9 @@ type Props = {
     autoCloseOnConfirmButton?: boolean;
     enforceFocus?: boolean;
     footer?: React.ReactNode;
+    components?: Partial<{
+        FooterContainer: typeof DefaultFooterContainer;
+    }>;
 };
 
 type State = {
@@ -103,6 +106,8 @@ export default class GenericModal extends React.PureComponent<Props, State> {
             );
         }
 
+        const FooterContainer = this.props.components?.FooterContainer || DefaultFooterContainer;
+
         return (
             <StyledModal
                 dialogClassName={classNames('a11y__modal GenericModal', this.props.className)}
@@ -180,7 +185,7 @@ const Buttons = styled.div`
     gap: 10px;
 `;
 
-const FooterContainer = styled.div`
+export const DefaultFooterContainer = styled.div`
     display: flex;
     flex-direction: column;
     align-items: flex-end;


### PR DESCRIPTION
#### Summary
#699 changed the styling of the GenericModal footer. This PR changes it back for the upgrade modal, maintaining the checklist item edit modal and the post update modal with the buttons at the right.

I exposed the inner components of GenericModal so callers can define their own styles for each piece. Right now I'm only exposing `FooterContainer` to minimize risks, but I think it's a good way of giving flexibility to generic components.

![image](https://user-images.githubusercontent.com/3924815/134389181-6bc2b432-a3f0-4fe1-8557-8c187aab0190.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38722

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
