### PR TITLE
MM-37699: improved finished run semantics

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -80,7 +80,7 @@ describe('playbook run rhs', () => {
             });
 
             // # Open the flagged posts RHS
-            cy.get('.icon-bookmark-outline').click({force: true});
+            cy.get('#channelHeaderFlagButton').click({force: true});
 
             // # Open the playbook run channel from the LHS.
             cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -77,22 +77,22 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            }).then(() => {
-                // # Open the flagged posts RHS
-                cy.get('#channelHeaderFlagButton').click({force: true});
-
-                // # Open the playbook run channel from the LHS.
-                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-                // # Wait until the channel loads enough to show the post textbox.
-                cy.get('#post-create').should('exist');
-
-                // # Wait a bit longer to be confident.
-                cy.wait(TIMEOUTS.TWO_SEC);
-
-                // * Verify the playbook run RHS is not open.
-                cy.get('#rhsContainer').should('not.exist');
             });
+
+            // # Open the flagged posts RHS
+            cy.get('#channelHeaderFlagButton').click({force: true});
+
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+            // # Wait until the channel loads enough to show the post textbox.
+            cy.get('#post-create').should('exist');
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
         });
 
         it('when navigating directly to a finished playbook run channel', () => {
@@ -107,17 +107,17 @@ describe('playbook run rhs', () => {
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
                 // # End the playbook run
-                return cy.apiFinishRun(playbookRun.id);
-            }).then(() => {
-                // # Navigate directly to the application and the playbook run channel
-                cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
-
-                // # Wait a bit longer to be confident.
-                cy.wait(TIMEOUTS.TWO_SEC);
-
-                // * Verify the playbook run RHS is not open.
-                cy.get('#rhsContainer').should('not.exist');
+                cy.apiFinishRun(playbookRun.id);
             });
+
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
         });
 
         it('for an existing, finished playbook run channel opened from the lhs', () => {
@@ -133,23 +133,23 @@ describe('playbook run rhs', () => {
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
                 // # End the playbook run
-                return cy.apiFinishRun(playbookRun.id);
-            }).then(() => {
-                // # Navigate to a channel without a playbook run.
-                cy.visit(`/${testTeam.name}/channels/off-topic`);
-
-                // # Ensure the channel is loaded before continuing (allows redux to sync).
-                cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-                // # Open the playbook run channel from the LHS.
-                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-                // # Wait a bit longer to be confident.
-                cy.wait(TIMEOUTS.TWO_SEC);
-
-                // * Verify the playbook run RHS is not open.
-                cy.get('#rhsContainer').should('not.exist');
+                cy.apiFinishRun(playbookRun.id);
             });
+
+            // # Navigate to a channel without a playbook run.
+            cy.visit(`/${testTeam.name}/channels/off-topic`);
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
         });
 
         it('for a new, finished playbook run channel opened from the lhs', () => {
@@ -173,17 +173,17 @@ describe('playbook run rhs', () => {
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
                 // # End the playbook run
-                return cy.apiFinishRun(playbookRun.id);
-            }).then(() => {
-                // # Open the playbook run channel from the LHS.
-                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-                // # Wait a bit longer to be confident.
-                cy.wait(TIMEOUTS.TWO_SEC);
-
-                // * Verify the playbook run RHS is not open.
-                cy.get('#rhsContainer').should('not.exist');
+                cy.apiFinishRun(playbookRun.id);
             });
+
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
         });
     });
 
@@ -198,14 +198,14 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            }).then(() => {
-                // # Navigate directly to the application and the playbook run channel
-                cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+            });
 
-                // * Verify the playbook run RHS is open.
-                cy.get('#rhsContainer').should('exist').within(() => {
-                    cy.findByText(playbookRunName).should('exist');
-                });
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // * Verify the playbook run RHS is open.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText(playbookRunName).should('exist');
             });
         });
 
@@ -228,14 +228,14 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            }).then(() => {
-                // # Open the playbook run channel from the LHS.
-                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+            });
 
-                // * Verify the playbook run RHS is open.
-                cy.get('#rhsContainer').should('exist').within(() => {
-                    cy.findByText(playbookRunName).should('exist');
-                });
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+            // * Verify the playbook run RHS is open.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText(playbookRunName).should('exist');
             });
         });
 
@@ -249,20 +249,20 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            }).then(() => {
-                // # Navigate to a channel without a playbook run.
-                cy.visit(`/${testTeam.name}/channels/off-topic`);
+            });
 
-                // # Ensure the channel is loaded before continuing (allows redux to sync).
-                cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+            // # Navigate to a channel without a playbook run.
+            cy.visit(`/${testTeam.name}/channels/off-topic`);
 
-                // # Open the playbook run channel from the LHS.
-                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
 
-                // * Verify the playbook run RHS is open.
-                cy.get('#rhsContainer').should('exist').within(() => {
-                    cy.findByText(playbookRunName).should('exist');
-                });
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+            // * Verify the playbook run RHS is open.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText(playbookRunName).should('exist');
             });
         });
 

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -10,47 +10,43 @@ import * as TIMEOUTS from '../../../fixtures/timeouts';
 import users from '../../../fixtures/users.json';
 
 describe('playbook run rhs', () => {
-    const playbookName = 'Playbook (' + Date.now() + ')';
-    let teamId;
-    let userId;
-    let playbookId;
+    let testTeam;
+    let testUser;
+    let testPlaybook;
 
     before(() => {
-        // # Turn off growth onboarding screens
-        cy.apiLogin(users.sysadmin);
-        cy.apiUpdateConfig({
-            ServiceSettings: {EnableOnboardingFlow: false},
-        });
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
 
-        // # Login as user-1
-        cy.legacyApiLogin('user-1');
+            // # Turn off growth onboarding screens
+            cy.apiUpdateConfig({
+                ServiceSettings: {EnableOnboardingFlow: false},
+            });
 
-        cy.legacyApiGetTeamByName('ad-1').then((team) => {
-            teamId = team.id;
-            cy.legacyApiGetCurrentUser().then((user) => {
-                userId = user.id;
+            // # Login as testUser
+            cy.apiLogin(testUser);
 
-                // # Create a playbook
-                cy.apiCreateTestPlaybook({
-                    teamId: team.id,
-                    title: playbookName,
-                    userId: user.id,
-                }).then((playbook) => {
-                    playbookId = playbook.id;
-                });
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Playbook',
+                memberIDs: [],
+            }).then((playbook) => {
+                testPlaybook = playbook;
             });
         });
     });
 
     beforeEach(() => {
-        // # Login as user-1
-        cy.legacyApiLogin('user-1');
+        // # Login as testUser
+        cy.apiLogin(testUser);
     });
 
     describe('does not open', () => {
         it('when navigating to a non-playbook run channel', () => {
             // # Navigate to the application
-            cy.visit('/ad-1/');
+            cy.visit(`/${testTeam.name}/`);
 
             // # Select a channel without a playbook run.
             cy.get('#sidebarItem_off-topic').click({force: true});
@@ -67,7 +63,7 @@ describe('playbook run rhs', () => {
 
         it('when navigating to a playbook run channel with the RHS already open', () => {
             // # Navigate to the application.
-            cy.visit('/ad-1/');
+            cy.visit(`/${testTeam.name}/`);
 
             // # Select a channel without a playbook run.
             cy.get('#sidebarItem_off-topic').click({force: true});
@@ -77,20 +73,111 @@ describe('playbook run rhs', () => {
             const playbookRunName = 'Playbook Run (' + now + ')';
             const playbookRunChannelName = 'playbook-run-' + now;
             cy.apiRunPlaybook({
-                teamId,
-                playbookId,
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
                 playbookRunName,
-                ownerUserId: userId,
+                ownerUserId: testUser.id,
             });
 
             // # Open the flagged posts RHS
-            cy.get('#channelHeaderFlagButton').click({force: true});
+            cy.get('.icon-bookmark-outline').click({force: true});
 
             // # Open the playbook run channel from the LHS.
             cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
 
             // # Wait until the channel loads enough to show the post textbox.
             cy.get('#post-create').should('exist');
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
+        });
+
+        it('when navigating directly to a finished playbook run channel', () => {
+            // # Run the playbook
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            const playbookRunChannelName = 'playbook-run-' + now;
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                // # End the playbook run
+                cy.apiFinishRun(playbookRun.id);
+            });
+
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
+        });
+
+        it('for an existing, finished playbook run channel opened from the lhs', () => {
+            // # Run the playbook before loading the application
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            const playbookRunChannelName = 'playbook-run-' + now;
+
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                // # End the playbook run
+                cy.apiFinishRun(playbookRun.id);
+            });
+
+            // # Navigate to a channel without a playbook run.
+            cy.visit(`/${testTeam.name}/channels/off-topic`);
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+            // # Wait a bit longer to be confident.
+            cy.wait(TIMEOUTS.TWO_SEC);
+
+            // * Verify the playbook run RHS is not open.
+            cy.get('#rhsContainer').should('not.exist');
+        });
+
+        it('for a new, finished playbook run channel opened from the lhs', () => {
+            // # Navigate to the application.
+            cy.visit(`/${testTeam.name}/`);
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Select a channel without a playbook run.
+            cy.get('#sidebarItem_off-topic').click({force: true});
+
+            // # Run the playbook after loading the application
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            const playbookRunChannelName = 'playbook-run-' + now;
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                // # End the playbook run
+                cy.apiFinishRun(playbookRun.id);
+            });
+
+            // # Open the playbook run channel from the LHS.
+            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
 
             // # Wait a bit longer to be confident.
             cy.wait(TIMEOUTS.TWO_SEC);
@@ -107,62 +194,14 @@ describe('playbook run rhs', () => {
             const playbookRunName = 'Playbook Run (' + now + ')';
             const playbookRunChannelName = 'playbook-run-' + now;
             cy.apiRunPlaybook({
-                teamId,
-                playbookId,
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
                 playbookRunName,
-                ownerUserId: userId,
+                ownerUserId: testUser.id,
             });
 
             // # Navigate directly to the application and the playbook run channel
-            cy.visit('/ad-1/channels/' + playbookRunChannelName);
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
-            });
-        });
-
-        it('when navigating directly to a resolved playbook run channel', () => {
-            // # Run the playbook
-            const now = Date.now();
-            const playbookRunName = 'Playbook Run (' + now + ')';
-            const playbookRunChannelName = 'playbook-run-' + now;
-            cy.apiRunPlaybook({
-                teamId,
-                playbookId,
-                playbookRunName,
-                ownerUserId: userId,
-            }).then((playbookRun) => {
-                // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
-            });
-
-            // # Navigate directly to the application and the playbook run channel
-            cy.visit('/ad-1/channels/' + playbookRunChannelName);
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
-            });
-        });
-
-        it('when navigating directly to an archived playbook run channel', () => {
-            // # Run the playbook
-            const now = Date.now();
-            const playbookRunName = 'Playbook Run (' + now + ')';
-            const playbookRunChannelName = 'playbook-run-' + now;
-            cy.apiRunPlaybook({
-                teamId,
-                playbookId,
-                playbookRunName,
-                ownerUserId: userId,
-            }).then((playbookRun) => {
-                // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
-            });
-
-            // # Navigate directly to the application and the playbook run channel
-            cy.visit('/ad-1/channels/' + playbookRunChannelName);
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
 
             // * Verify the playbook run RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -172,7 +211,7 @@ describe('playbook run rhs', () => {
 
         it('for a new, ongoing playbook run channel opened from the lhs', () => {
             // # Navigate to the application.
-            cy.visit('/ad-1/');
+            cy.visit(`/${testTeam.name}/`);
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
@@ -185,76 +224,10 @@ describe('playbook run rhs', () => {
             const playbookRunName = 'Playbook Run (' + now + ')';
             const playbookRunChannelName = 'playbook-run-' + now;
             cy.apiRunPlaybook({
-                teamId,
-                playbookId,
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
                 playbookRunName,
-                ownerUserId: userId,
-            });
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
-            });
-        });
-
-        it('for a new, resolved playbook run channel opened from the lhs', () => {
-            // # Navigate to the application.
-            cy.visit('/ad-1/');
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Select a channel without a playbook run.
-            cy.get('#sidebarItem_off-topic').click({force: true});
-
-            // # Run the playbook after loading the application
-            const now = Date.now();
-            const playbookRunName = 'Playbook Run (' + now + ')';
-            const playbookRunChannelName = 'playbook-run-' + now;
-            cy.apiRunPlaybook({
-                teamId,
-                playbookId,
-                playbookRunName,
-                ownerUserId: userId,
-            }).then((playbookRun) => {
-                // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
-            });
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
-            });
-        });
-
-        it('for a new, archived playbook run channel opened from the lhs', () => {
-            // # Navigate to the application.
-            cy.visit('/ad-1/');
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Select a channel without a playbook run.
-            cy.get('#sidebarItem_off-topic').click({force: true});
-
-            // # Run the playbook after loading the application
-            const now = Date.now();
-            const playbookRunName = 'Playbook Run (' + now + ')';
-            const playbookRunChannelName = 'playbook-run-' + now;
-            cy.apiRunPlaybook({
-                teamId,
-                playbookId,
-                playbookRunName,
-                ownerUserId: userId,
-            }).then((playbookRun) => {
-                // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
+                ownerUserId: testUser.id,
             });
 
             // # Open the playbook run channel from the LHS.
@@ -272,76 +245,14 @@ describe('playbook run rhs', () => {
             const playbookRunName = 'Playbook Run (' + now + ')';
             const playbookRunChannelName = 'playbook-run-' + now;
             cy.apiRunPlaybook({
-                teamId,
-                playbookId,
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
                 playbookRunName,
-                ownerUserId: userId,
+                ownerUserId: testUser.id,
             });
 
             // # Navigate to a channel without a playbook run.
-            cy.visit('/ad-1/channels/off-topic');
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
-            });
-        });
-
-        it('for an existing, resolved playbook run channel opened from the lhs', () => {
-            // # Run the playbook before loading the application
-            const now = Date.now();
-            const playbookRunName = 'Playbook Run (' + now + ')';
-            const playbookRunChannelName = 'playbook-run-' + now;
-
-            cy.apiRunPlaybook({
-                teamId,
-                playbookId,
-                playbookRunName,
-                ownerUserId: userId,
-            }).then((playbookRun) => {
-                // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
-            });
-
-            // # Navigate to a channel without a playbook run.
-            cy.visit('/ad-1/channels/off-topic');
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
-            });
-        });
-
-        it('for an existing, archived playbook run channel opened from the lhs', () => {
-            // # Run the playbook before loading the application
-            const now = Date.now();
-            const playbookRunName = 'Playbook Run (' + now + ')';
-            const playbookRunChannelName = 'playbook-run-' + now;
-
-            cy.apiRunPlaybook({
-                teamId,
-                playbookId,
-                playbookRunName,
-                ownerUserId: userId,
-            }).then((playbookRun) => {
-                // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
-            });
-
-            // # Navigate to a channel without a playbook run.
-            cy.visit('/ad-1/channels/off-topic');
+            cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
@@ -357,14 +268,13 @@ describe('playbook run rhs', () => {
 
         it('when starting a playbook run', () => {
             // # Navigate to the application and a channel without a playbook run
-            cy.visit('/ad-1/channels/off-topic');
+            cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # Start a playbook run with a slash command
             const now = Date.now();
             const playbookRunName = 'Playbook Run (' + now + ')';
 
-            // const playbookRunChannelName = 'playbook-run-' + now;
-            cy.startPlaybookRunWithSlashCommand(playbookName, playbookRunName);
+            cy.startPlaybookRunWithSlashCommand("Playbook", playbookRunName);
 
             // * Verify the playbook run RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -379,7 +289,7 @@ describe('playbook run rhs', () => {
             cy.viewport('macbook-13');
 
             // # Navigate to the application and a channel without a playbook run
-            cy.visit('/ad-1/channels/off-topic');
+            cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # Click the icon
             cy.get('#channel-header').within(() => {

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -77,22 +77,22 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
+            }).then(() => {
+                // # Open the flagged posts RHS
+                cy.get('#channelHeaderFlagButton').click({force: true});
+
+                // # Open the playbook run channel from the LHS.
+                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+                // # Wait until the channel loads enough to show the post textbox.
+                cy.get('#post-create').should('exist');
+
+                // # Wait a bit longer to be confident.
+                cy.wait(TIMEOUTS.TWO_SEC);
+
+                // * Verify the playbook run RHS is not open.
+                cy.get('#rhsContainer').should('not.exist');
             });
-
-            // # Open the flagged posts RHS
-            cy.get('#channelHeaderFlagButton').click({force: true});
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // # Wait until the channel loads enough to show the post textbox.
-            cy.get('#post-create').should('exist');
-
-            // # Wait a bit longer to be confident.
-            cy.wait(TIMEOUTS.TWO_SEC);
-
-            // * Verify the playbook run RHS is not open.
-            cy.get('#rhsContainer').should('not.exist');
         });
 
         it('when navigating directly to a finished playbook run channel', () => {
@@ -107,17 +107,17 @@ describe('playbook run rhs', () => {
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
                 // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
+                return cy.apiFinishRun(playbookRun.id);
+            }).then(() => {
+                // # Navigate directly to the application and the playbook run channel
+                cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+                // # Wait a bit longer to be confident.
+                cy.wait(TIMEOUTS.TWO_SEC);
+
+                // * Verify the playbook run RHS is not open.
+                cy.get('#rhsContainer').should('not.exist');
             });
-
-            // # Navigate directly to the application and the playbook run channel
-            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
-
-            // # Wait a bit longer to be confident.
-            cy.wait(TIMEOUTS.TWO_SEC);
-
-            // * Verify the playbook run RHS is not open.
-            cy.get('#rhsContainer').should('not.exist');
         });
 
         it('for an existing, finished playbook run channel opened from the lhs', () => {
@@ -133,23 +133,23 @@ describe('playbook run rhs', () => {
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
                 // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
+                return cy.apiFinishRun(playbookRun.id);
+            }).then(() => {
+                // # Navigate to a channel without a playbook run.
+                cy.visit(`/${testTeam.name}/channels/off-topic`);
+
+                // # Ensure the channel is loaded before continuing (allows redux to sync).
+                cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+                // # Open the playbook run channel from the LHS.
+                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+                // # Wait a bit longer to be confident.
+                cy.wait(TIMEOUTS.TWO_SEC);
+
+                // * Verify the playbook run RHS is not open.
+                cy.get('#rhsContainer').should('not.exist');
             });
-
-            // # Navigate to a channel without a playbook run.
-            cy.visit(`/${testTeam.name}/channels/off-topic`);
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // # Wait a bit longer to be confident.
-            cy.wait(TIMEOUTS.TWO_SEC);
-
-            // * Verify the playbook run RHS is not open.
-            cy.get('#rhsContainer').should('not.exist');
         });
 
         it('for a new, finished playbook run channel opened from the lhs', () => {
@@ -173,17 +173,17 @@ describe('playbook run rhs', () => {
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
                 // # End the playbook run
-                cy.apiFinishRun(playbookRun.id);
+                return cy.apiFinishRun(playbookRun.id);
+            }).then(() => {
+                // # Open the playbook run channel from the LHS.
+                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
+
+                // # Wait a bit longer to be confident.
+                cy.wait(TIMEOUTS.TWO_SEC);
+
+                // * Verify the playbook run RHS is not open.
+                cy.get('#rhsContainer').should('not.exist');
             });
-
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // # Wait a bit longer to be confident.
-            cy.wait(TIMEOUTS.TWO_SEC);
-
-            // * Verify the playbook run RHS is not open.
-            cy.get('#rhsContainer').should('not.exist');
         });
     });
 
@@ -198,14 +198,14 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            });
+            }).then(() => {
+                // # Navigate directly to the application and the playbook run channel
+                cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
 
-            // # Navigate directly to the application and the playbook run channel
-            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
+                // * Verify the playbook run RHS is open.
+                cy.get('#rhsContainer').should('exist').within(() => {
+                    cy.findByText(playbookRunName).should('exist');
+                });
             });
         });
 
@@ -228,14 +228,14 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            });
+            }).then(() => {
+                // # Open the playbook run channel from the LHS.
+                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
 
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
+                // * Verify the playbook run RHS is open.
+                cy.get('#rhsContainer').should('exist').within(() => {
+                    cy.findByText(playbookRunName).should('exist');
+                });
             });
         });
 
@@ -249,20 +249,20 @@ describe('playbook run rhs', () => {
                 playbookId: testPlaybook.id,
                 playbookRunName,
                 ownerUserId: testUser.id,
-            });
+            }).then(() => {
+                // # Navigate to a channel without a playbook run.
+                cy.visit(`/${testTeam.name}/channels/off-topic`);
 
-            // # Navigate to a channel without a playbook run.
-            cy.visit(`/${testTeam.name}/channels/off-topic`);
+                // # Ensure the channel is loaded before continuing (allows redux to sync).
+                cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
 
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+                // # Open the playbook run channel from the LHS.
+                cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
 
-            // # Open the playbook run channel from the LHS.
-            cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
-
-            // * Verify the playbook run RHS is open.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText(playbookRunName).should('exist');
+                // * Verify the playbook run RHS is open.
+                cy.get('#rhsContainer').should('exist').within(() => {
+                    cy.findByText(playbookRunName).should('exist');
+                });
             });
         });
 

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -172,6 +172,9 @@ describe('playbook run rhs', () => {
                 playbookRunName,
                 ownerUserId: testUser.id,
             }).then((playbookRun) => {
+                // # Wait a bit longer to avoid websocket events potentially being out-of-order.
+                cy.wait(TIMEOUTS.TWO_SEC);
+
                 // # End the playbook run
                 cy.apiFinishRun(playbookRun.id);
             });

--- a/webapp/src/components/assets/buttons.tsx
+++ b/webapp/src/components/assets/buttons.tsx
@@ -78,7 +78,6 @@ export const TertiaryButton = styled.button`
     display: inline-flex;
     align-items: center;
     height: 40px;
-    color: var(--button-bg);
     border-radius: 4px;
     border: 0px;
     font-weight: 600;
@@ -87,18 +86,20 @@ export const TertiaryButton = styled.button`
     padding: 0 20px;
     transition: all 0.15s ease-out;
 
+    color: var(--button-bg);
     background: rgba(var(--button-bg-rgb), 0.08);
+
+    &:disabled {
+        color: rgba(var(--center-channel-color-rgb), 0.32);
+        background: rgba(var(--center-channel-color-rgb), 0.08);
+    }
 
     &:hover:enabled {
         background: rgba(var(--button-bg-rgb), 0.12);
     }
 
-    &:active  {
+    &:active:enabled  {
         background: rgba(var(--button-bg-rgb), 0.16);
-    }
-
-    &:disabled {
-        color: rgba(var(--center-channel-color-rgb), 0.08);
     }
 
     i {

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -48,6 +48,7 @@ interface ChecklistItemDetailsProps {
     onRedirect?: () => void;
     draggableProvided: DraggableProvided;
     dragging: boolean;
+    disabled: boolean;
 }
 
 const RunningTimeout = 1000;
@@ -185,6 +186,10 @@ export const CheckboxContainer = styled.div`
 
     input[type="checkbox"]:checked::before {
         transform: scale(1) rotate(0deg);
+    }
+
+    input[type="checkbox"]:disabled {
+        opacity: 0.38;
     }
 
     label {
@@ -381,13 +386,15 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                 data-testid='checkbox-item-container'
             >
                 <CheckboxContainer>
-                    {showMenu &&
+                    {showMenu && (!props.disabled || props.checklistItem.description !== '') &&
                     <HoverMenu>
-                        <HoverMenuButton
-                            title={'Drag me to reorder'}
-                            className={'icon icon-menu'}
-                            {...props.draggableProvided.dragHandleProps}
-                        />
+                        {!props.disabled &&
+                            <HoverMenuButton
+                                title={'Drag me to reorder'}
+                                className={'icon icon-menu'}
+                                {...props.draggableProvided.dragHandleProps}
+                            />
+                        }
                         {props.checklistItem.description !== '' &&
                         <StepDescription
                             text={props.checklistItem.description}
@@ -395,44 +402,49 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                             team={team}
                         />
                         }
-                        <ProfileSelector
-                            selectedUserId={props.checklistItem.assignee_id}
-                            onlyPlaceholder={true}
-                            placeholder={
-                                <HoverMenuButton
-                                    title={'Assign'}
-                                    className={'icon-account-plus-outline icon-16 btn-icon'}
+                        {!props.disabled &&
+                            <>
+                                <ProfileSelector
+                                    selectedUserId={props.checklistItem.assignee_id}
+                                    onlyPlaceholder={true}
+                                    placeholder={
+                                        <HoverMenuButton
+                                            title={'Assign'}
+                                            className={'icon-account-plus-outline icon-16 btn-icon'}
+                                        />
+                                    }
+                                    enableEdit={true}
+                                    getUsers={fetchUsers}
+                                    onSelectedChange={onAssigneeChange}
+                                    selfIsFirstOption={true}
+                                    customControl={ControlComponent}
+                                    customControlProps={{
+                                        showCustomReset: Boolean(assignee_id),
+                                        onCustomReset: resetAssignee,
+                                    }}
+                                    controlledOpenToggle={profileSelectorToggle}
+                                    showOnRight={true}
                                 />
-                            }
-                            enableEdit={true}
-                            getUsers={fetchUsers}
-                            onSelectedChange={onAssigneeChange}
-                            selfIsFirstOption={true}
-                            customControl={ControlComponent}
-                            customControlProps={{
-                                showCustomReset: Boolean(assignee_id),
-                                onCustomReset: resetAssignee,
-                            }}
-                            controlledOpenToggle={profileSelectorToggle}
-                            showOnRight={true}
-                        />
-                        <HoverMenuButton
-                            title={'Edit'}
-                            className={'icon-pencil-outline icon-16 btn-icon'}
-                            onClick={() => {
-                                setShowEditDialog(true);
-                            }}
-                        />
-                        <HoverMenuButton
-                            title={'Delete'}
-                            className={'icon-trash-can-outline icon-16 btn-icon'}
-                            onClick={() => {
-                                setShowDeleteConfirm(true);
-                            }}
-                        />
+                                <HoverMenuButton
+                                    title={'Edit'}
+                                    className={'icon-pencil-outline icon-16 btn-icon'}
+                                    onClick={() => {
+                                        setShowEditDialog(true);
+                                    }}
+                                />
+                                <HoverMenuButton
+                                    title={'Delete'}
+                                    className={'icon-trash-can-outline icon-16 btn-icon'}
+                                    onClick={() => {
+                                        setShowDeleteConfirm(true);
+                                    }}
+                                />
+                            </>
+                        }
                     </HoverMenu>
                     }
                     <ChecklistItemButton
+                        disabled={props.disabled}
                         item={props.checklistItem}
                         onChange={(item: ChecklistItemState) => {
                             if (props.onChange) {
@@ -457,18 +469,20 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                     {
                         props.checklistItem.command !== '' &&
                         <div ref={commandRef}>
-                            <Run
-                                data-testid={'run'}
-                                running={running}
-                                onClick={() => {
-                                    if (!running) {
-                                        setRunning(true);
-                                        clientRunChecklistItemSlashCommand(dispatch, props.playbookRunId, props.checklistNum, props.itemNum);
-                                    }
-                                }}
-                            >
-                                {props.checklistItem.command_last_run ? 'Rerun' : 'Run'}
-                            </Run>
+                            {!props.disabled &&
+                                <Run
+                                    data-testid={'run'}
+                                    running={running}
+                                    onClick={() => {
+                                        if (!running) {
+                                            setRunning(true);
+                                            clientRunChecklistItemSlashCommand(dispatch, props.playbookRunId, props.checklistNum, props.itemNum);
+                                        }
+                                    }}
+                                >
+                                    {props.checklistItem.command_last_run ? 'Rerun' : 'Run'}
+                                </Run>
+                            }
                             <Command>
                                 <TextWithTooltipWhenEllipsis
                                     id={props.checklistNum.toString(10)}

--- a/webapp/src/components/checklist_item_input.tsx
+++ b/webapp/src/components/checklist_item_input.tsx
@@ -130,6 +130,7 @@ export const ChecklistItemDescription = (props: ChecklistItemDescriptionProps) =
 interface ChecklistItemButtonProps {
     onChange: (item: ChecklistItemState) => void;
     item: ChecklistItem;
+    disabled: boolean;
 }
 
 export const ChecklistItemButton = (props: ChecklistItemButtonProps) => {
@@ -140,6 +141,7 @@ export const ChecklistItemButton = (props: ChecklistItemButtonProps) => {
             className='checkbox'
             type='checkbox'
             checked={isChecked}
+            disabled={props.disabled}
             onChange={() => {
                 if (isChecked) {
                     props.onChange(ChecklistItemState.Open);

--- a/webapp/src/components/rhs/collapsible_checklist.tsx
+++ b/webapp/src/components/rhs/collapsible_checklist.tsx
@@ -16,6 +16,7 @@ export interface Props {
     setCollapsed: (newState: boolean) => void;
     items: ChecklistItem[];
     children: React.ReactNode;
+    disabled: boolean;
 }
 
 const CollapsibleChecklist = ({
@@ -25,6 +26,7 @@ const CollapsibleChecklist = ({
     setCollapsed,
     items,
     children,
+    disabled,
 }: Props) => {
     const dispatch = useDispatch();
     const titleRef = useRef(null);
@@ -52,7 +54,7 @@ const CollapsibleChecklist = ({
                 </Title>
                 <TasksCompleted>{`${completed} / ${total} done`}</TasksCompleted>
                 {
-                    showMenu &&
+                    showMenu && !disabled &&
                     <AddNewTask
                         data-testid={'addNewTask'}
                         onClick={(e) => {

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
 import {setOwner, changeChannelName, updatePlaybookRunDescription} from 'src/client';
 import ProfileSelector from 'src/components/profile/profile_selector';
 import RHSPostUpdate from 'src/components/rhs/rhs_post_update';
@@ -59,6 +59,8 @@ const RHSAbout = (props: Props) => {
         updatePlaybookRunDescription(props.playbookRun.id, value);
     };
 
+    const isFinished = props.playbookRun.current_status === PlaybookRunStatus.Finished;
+
     return (
         <Container tabIndex={0}>
             <ButtonsRow>
@@ -88,7 +90,7 @@ const RHSAbout = (props: Props) => {
                             placeholder={'Assign the owner role'}
                             placeholderButtonClass={'NoAssignee-button'}
                             profileButtonClass={'Assigned-button'}
-                            enableEdit={true}
+                            enableEdit={!isFinished}
                             getUsers={fetchUsers}
                             onSelectedChange={onSelectedProfileChange}
                             selfIsFirstOption={true}

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -72,6 +72,7 @@ const RHSAbout = (props: Props) => {
                 value={props.playbookRun.name}
                 onEdit={onTitleEdit}
                 renderedTitle={RenderedTitle}
+                status={props.playbookRun.current_status}
             />
             {!collapsed &&
             <>

--- a/webapp/src/components/rhs/rhs_about_title.tsx
+++ b/webapp/src/components/rhs/rhs_about_title.tsx
@@ -11,14 +11,26 @@ import Permissions from 'mattermost-redux/constants/permissions';
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 
+import StatusBadge from 'src/components/backstage/playbook_runs/status_badge';
 import {useClickOutsideRef, useKeyPress} from 'src/hooks/general';
 import {SemiBoldHeading} from 'src/styles/headings';
+import {PlaybookRunStatus} from 'src/types/playbook_run';
 
 interface Props {
     onEdit: (newTitle: string) => void;
     value: string;
     renderedTitle?: StyledComponent<'div', any, {}, never>;
+    status: PlaybookRunStatus;
 }
+
+const TitleWrapper = styled.div`
+    display: flex;
+`;
+
+const StatusBadgeWrapper = styled(StatusBadge) `
+    margin-right: 75px;
+    top: -3px;
+`;
 
 const RHSAboutTitle = (props: Props) => {
     const [editing, setEditing] = useState(false);
@@ -60,9 +72,14 @@ const RHSAboutTitle = (props: Props) => {
         const RenderedTitle = props.renderedTitle ?? DefaultRenderedTitle;
 
         return (
-            <RenderedTitle onClick={onRenderedTitleClick} >
-                {editedValue}
-            </RenderedTitle>
+            <TitleWrapper>
+                <RenderedTitle onClick={onRenderedTitleClick}>
+                    {editedValue}
+                </RenderedTitle>
+                {props.status === PlaybookRunStatus.Finished &&
+                    <StatusBadgeWrapper status={PlaybookRunStatus.Finished}/>
+                }
+            </TitleWrapper>
         );
     }
 

--- a/webapp/src/components/rhs/rhs_checklists.tsx
+++ b/webapp/src/components/rhs/rhs_checklists.tsx
@@ -75,6 +75,7 @@ const RHSChecklists = (props: Props) => {
     const checklists = props.playbookRun.checklists || [];
     const FinishButton = allComplete(props.playbookRun.checklists) ? StyledPrimaryButton : StyledTertiaryButton;
     const active = props.playbookRun.current_status === PlaybookRunStatus.InProgress;
+    const finished = props.playbookRun.current_status === PlaybookRunStatus.Finished;
     const filterOptions = makeFilterOptions(checklistItemsFilter, preferredName);
 
     const selectOption = (value: string, checked: boolean) => {
@@ -127,6 +128,7 @@ const RHSChecklists = (props: Props) => {
                     index={checklistIndex}
                     collapsed={Boolean(checklistsState[checklistIndex])}
                     setCollapsed={(newState) => dispatch(setChecklistCollapsedState(channelId, checklistIndex, newState))}
+                    disabled={finished}
                 >
                     {visibleTasks(checklist, checklistItemsFilter, myUser.id) &&
                     <ChecklistContainer className='checklist'>
@@ -199,6 +201,7 @@ const RHSChecklists = (props: Props) => {
                                                                 }}
                                                                 draggableProvided={draggableProvided}
                                                                 dragging={snapshot.isDragging}
+                                                                disabled={finished}
                                                             />
                                                         )}
                                                     </Draggable>

--- a/webapp/src/components/rhs/rhs_post_update.tsx
+++ b/webapp/src/components/rhs/rhs_post_update.tsx
@@ -51,9 +51,9 @@ const RHSPostUpdate = (props: Props) => {
     if (isFinished) {
         icon = <Icon path={mdiFlagCheckered}/>;
     } else if (isDue) {
-        icon = <Exclamation />;
+        icon = <Exclamation/>;
     } else {
-        icon = <Clock />;
+        icon = <Clock/>;
     }
 
     return (

--- a/webapp/src/components/rhs/rhs_post_update.tsx
+++ b/webapp/src/components/rhs/rhs_post_update.tsx
@@ -47,13 +47,13 @@ const RHSPostUpdate = (props: Props) => {
 
     const timespec = (isDue || !isNextUpdateScheduled) ? PastTimeSpec : FutureTimeSpec;
 
-    let icon;
+    let icon: JSX.Element;
     if (isFinished) {
         icon = <Icon path={mdiFlagCheckered}/>;
     } else if (isDue) {
-        icon = Exclamation;
+        icon = <Exclamation />;
     } else {
-        icon = Clock;
+        icon = <Clock />;
     }
 
     return (

--- a/webapp/src/components/rhs/rhs_post_update_button.tsx
+++ b/webapp/src/components/rhs/rhs_post_update_button.tsx
@@ -11,6 +11,7 @@ interface Props {
     isDue: boolean;
     isNextUpdateScheduled: boolean;
     updatesExist: boolean;
+    disabled: boolean;
     onClick: () => void;
 }
 
@@ -26,6 +27,7 @@ const RHSPostUpdateButton = (props: Props) => {
     return (
         <ButtonComponent
             collapsed={props.collapsed}
+            disabled={props.disabled}
             onClick={props.onClick}
         >
             {'Post update'}

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -8,8 +8,9 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {fetchPlaybookRuns} from 'src/client';
+import {currentPlaybookRun, isPlaybookRunRHSOpen, inPlaybookRunChannel} from 'src/selectors';
+import {PlaybookRunStatus} from 'src/types/playbook_run';
 
-import {isPlaybookRunRHSOpen, inPlaybookRunChannel} from 'src/selectors';
 import {toggleRHS, receivedTeamPlaybookRuns, receivedDisabledOnTeam} from 'src/actions';
 
 export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
@@ -21,6 +22,7 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
         const state = store.getState();
         const currentChannel = getCurrentChannel(state);
         const currentTeam = getCurrentTeam(state);
+        const playbookRun = currentPlaybookRun(state);
 
         //@ts-ignore Views not in global state
         const mmRhsOpen = state.views.rhs.isSidebarOpen;
@@ -67,6 +69,11 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
 
         // Don't do anything unless we're in a playbook run channel.
         if (!currentChannelIsPlaybookRun) {
+            return;
+        }
+
+        // Don't do anything if the playbook run is finished.
+        if (playbookRun && playbookRun.current_status === PlaybookRunStatus.Finished) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
Improved finish semantics:
* Add a Finished tag next to the run name. 
* Disable the Post update button. 
* Change the icon in the update box to a chequered flag 
* Change text to Run finished X minutes/hours/days ago. 
* Disable the checkbox for all the tasks (checked and unchecked)
* Remove/disable options to Add task, reorder tasks, add/edit assignee, edit task, delete task. 
* Hide the ability to “Run” any associated slash command
* Don't open the RHS by default for finished runs

<img width="488" alt="CleanShot 2021-09-22 at 17 06 59@2x" src="https://user-images.githubusercontent.com/1023171/134414265-f138838f-d79f-427e-89c8-5908c89ce080.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37699

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
