### PR TITLE
MM-38775: Remove dependency on playbook in Update Status modal

### DIFF
--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -1443,10 +1443,13 @@ paths:
                     type: string
                     description: User ID of the playbook member.
                     example: ilh6s1j4yefbdhxhtlzt179i6m
-                broadcast_channel_id:
-                  description: The ID of the channel where all the status updates will be broadcasted. The team of the broadcast channel must be the same as the playbook's team.
-                  type: string
-                  example: 2zh7rpashwfwapwaqyslmhwbax
+                broadcast_channel_ids:
+                  description: The IDs of the channels where all the status updates will be broadcasted. The team of the broadcast channel must be the same as the playbook's team.
+                  type: array
+                  items:
+                    type: string
+                    description: ID of the broadcast channel.
+                    example: 2zh7rpashwfwapwaqyslmhwbax
                 invited_user_ids:
                   description: A list with the IDs of the members to be automatically invited to the playbook run's channel as soon as the playbook run is created.
                   type: array

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -381,6 +381,7 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 		playbookRun.Description = pb.Description
 		playbookRun.ReminderMessageTemplate = pb.ReminderMessageTemplate
 		playbookRun.PreviousReminder = time.Duration(pb.ReminderTimerDefaultSeconds) * time.Second
+		playbookRun.ReminderTimerDefaultSeconds = pb.ReminderTimerDefaultSeconds
 
 		playbookRun.InvitedUserIDs = []string{}
 		playbookRun.InvitedGroupIDs = []string{}

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -90,6 +90,10 @@ type PlaybookRun struct {
 	// playbook run for the first time.
 	ReminderMessageTemplate string `json:"reminder_message_template"`
 
+	// ReminderTimerDefaultSeconds is the expected default interval, in seconds,
+	// between every status update
+	ReminderTimerDefaultSeconds int64 `json:"reminder_timer_default_seconds"`
+
 	// InvitedUserIDs, if not empty, is an array containing the identifiers of the users that were
 	// automatically invited to the playbook run when it was created.
 	InvitedUserIDs []string `json:"invited_user_ids"`

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1238,4 +1238,20 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.31.0"),
+		toVersion:   semver.MustParse("0.32.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if e.DriverName() == model.DatabaseDriverMysql {
+				if err := addColumnToMySQLTable(e, "IR_Incident", "ReminderTimerDefaultSeconds", "BIGINT NOT NULL DEFAULT 0"); err != nil {
+					return errors.Wrapf(err, "failed adding column ReminderTimerDefaultSeconds to table IR_Incident")
+				}
+			} else {
+				if err := addColumnToPGTable(e, "IR_Incident", "ReminderTimerDefaultSeconds", "BIGINT NOT NULL DEFAULT 0"); err != nil {
+					return errors.Wrapf(err, "failed adding column ReminderTimerDefaultSeconds to table IR_Incident")
+				}
+			}
+			return nil
+		},
+	},
 }

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -140,7 +140,7 @@ func NewPlaybookRunStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQ
 		Select("i.ID", "c.DisplayName AS Name", "i.Description", "i.CommanderUserID AS OwnerUserID", "i.TeamID", "i.ChannelID",
 			"i.CreateAt", "i.EndAt", "i.DeleteAt", "i.PostID", "i.PlaybookID", "i.ReporterUserID", "i.CurrentStatus", "i.LastStatusUpdateAt",
 			"i.ChecklistsJSON", "COALESCE(i.ReminderPostID, '') ReminderPostID", "i.PreviousReminder",
-			"COALESCE(ReminderMessageTemplate, '') ReminderMessageTemplate", "ConcatenatedInvitedUserIDs", "ConcatenatedInvitedGroupIDs", "DefaultCommanderID AS DefaultOwnerID",
+			"COALESCE(ReminderMessageTemplate, '') ReminderMessageTemplate", "ReminderTimerDefaultSeconds", "ConcatenatedInvitedUserIDs", "ConcatenatedInvitedGroupIDs", "DefaultCommanderID AS DefaultOwnerID",
 			"ConcatenatedBroadcastChannelIDs", "WebhookOnCreationURL", "Retrospective", "MessageOnJoin", "RetrospectivePublishedAt", "RetrospectiveReminderIntervalSeconds",
 			"RetrospectiveWasCanceled", "WebhookOnStatusUpdateURL", "ExportChannelOnFinishedEnabled",
 			"COALESCE(CategoryName, '') CategoryName").
@@ -361,6 +361,7 @@ func (s *playbookRunStore) CreatePlaybookRun(playbookRun *app.PlaybookRun) (*app
 			"ReminderPostID":                       rawPlaybookRun.ReminderPostID,
 			"PreviousReminder":                     rawPlaybookRun.PreviousReminder,
 			"ReminderMessageTemplate":              rawPlaybookRun.ReminderMessageTemplate,
+			"ReminderTimerDefaultSeconds":          rawPlaybookRun.ReminderTimerDefaultSeconds,
 			"CurrentStatus":                        rawPlaybookRun.CurrentStatus,
 			"LastStatusUpdateAt":                   rawPlaybookRun.LastStatusUpdateAt,
 			"ConcatenatedInvitedUserIDs":           rawPlaybookRun.ConcatenatedInvitedUserIDs,

--- a/tests-e2e/.eslintrc
+++ b/tests-e2e/.eslintrc
@@ -4,7 +4,7 @@
     "plugin:cypress/recommended",
     "plugin:react/recommended"
   ],
-  "plugins": ["mattermost", "import", "cypress, @typescript-eslint"],
+  "plugins": ["mattermost", "import", "cypress", "@typescript-eslint"],
   "globals": {
     "Cypress": true,
     "cy": true

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -103,7 +103,7 @@ export function promptUpdateStatus(
         const state = getState();
         const hasPermission = canIPostUpdateForRun(state, channelId, teamId);
 
-        dispatch(modals.openModal(makeUpdateRunStatusModalDefinition({playbookId, playbookRunId, channelId, hasPermission})));
+        dispatch(modals.openModal(makeUpdateRunStatusModalDefinition({playbookRunId, channelId, hasPermission})));
     };
 }
 

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -490,14 +490,6 @@ const PlaybookEdit = (props: Props) => {
         return dispatch(getProfilesInTeam(props.teamId || playbook.team_id, 0, PROFILE_CHUNK_SIZE, '', {active: true}));
     };
 
-    const handleBroadcastInput = (channelId: string | undefined) => {
-        setPlaybook({
-            ...playbook,
-            broadcast_channel_id: channelId || '',
-        });
-        setChangesMade(true);
-    };
-
     if (!props.isNew) {
         switch (fetchingState) {
         case FetchingStateType.notFound:

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -176,7 +176,7 @@ const useDefaultMessage = (
     }
     if (run && !lastStatusPostMeta) {
         // run loaded and was no last status post, but there might be a message template
-        return playbook?.reminder_message_template;
+        return run.reminder_message_template;
     }
 
     return null;

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -210,8 +210,8 @@ export const useReminderTimerOption = (
                 value = optionFromSeconds(nearest(run.previous_reminder * 1e-9, 60));
             }
 
-            if (playbook.reminder_timer_default_seconds) {
-                const defaultReminderOption = optionFromSeconds(playbook.reminder_timer_default_seconds);
+            if (run.reminder_timer_default_seconds) {
+                const defaultReminderOption = optionFromSeconds(run.reminder_timer_default_seconds);
                 if (!options.find((o) => ms(o.value) === ms(defaultReminderOption.value))) {
                     // don't duplicate an option that exists already
                     options.push(defaultReminderOption);

--- a/webapp/src/types/playbook.ts
+++ b/webapp/src/types/playbook.ts
@@ -20,7 +20,6 @@ export interface Playbook {
 
 export interface PlaybookWithChecklist extends Playbook {
     checklists: Checklist[];
-    broadcast_channel_id: string;
     reminder_message_template: string;
     reminder_timer_default_seconds: number;
     invited_user_ids: string[];
@@ -106,7 +105,6 @@ export function emptyPlaybook(): DraftPlaybookWithChecklist {
         last_run_at: 0,
         checklists: [emptyChecklist()],
         member_ids: [],
-        broadcast_channel_id: '',
         reminder_message_template: '',
         reminder_timer_default_seconds: 0,
         invited_user_ids: [],
@@ -184,7 +182,7 @@ export function isPlaybook(arg: any): arg is PlaybookWithChecklist {
         typeof arg.delete_at === 'number' &&
         arg.checklists && Array.isArray(arg.checklists) && arg.checklists.every(isChecklist) &&
         arg.member_ids && Array.isArray(arg.member_ids) && arg.checklists.every((id: any) => typeof id === 'string') &&
-        typeof arg.broadcast_channel_id === 'string' &&
+        arg.broadcast_channel_ids && Array.isArray(arg.broadcast_channel_ids) && arg.broadcast_channel_ids.every((id: any) => typeof id === 'string') &&
         typeof arg.reminder_message_template == 'string' &&
         typeof arg.reminder_timer_default_seconds == 'number' &&
         arg.invited_user_ids && Array.isArray(arg.invited_user_ids) && arg.invited_user_ids.every((id: any) => typeof id === 'string') &&

--- a/webapp/src/types/playbook_run.ts
+++ b/webapp/src/types/playbook_run.ts
@@ -22,6 +22,7 @@ export interface PlaybookRun {
     last_status_update_at: number;
     reminder_post_id: string;
     reminder_message_template: string;
+    reminder_timer_default_seconds: number;
 
     /** Previous reminder timer as nanoseconds */
     previous_reminder: number;
@@ -79,6 +80,7 @@ export function isPlaybookRun(arg: any): arg is PlaybookRun {
         arg.status_posts && Array.isArray(arg.status_posts) && arg.status_posts.every(isStatusPost) &&
         typeof arg.reminder_post_id === 'string' &&
         typeof arg.reminder_message_template === 'string' &&
+        typeof arg.reminder_timer_default_seconds === 'number' &&
         arg.broadcast_channel_ids && Array.isArray(arg.broadcast_channel_ids) && arg.broadcast_channel_ids.every(isString) &&
         arg.timeline_events && Array.isArray(arg.timeline_events) && arg.timeline_events.every(isTimelineEvent) &&
         arg.participant_ids && Array.isArray(arg.participant_ids) && arg.participant_ids.every(isString)) &&

--- a/webapp/src/types/playbook_run.ts
+++ b/webapp/src/types/playbook_run.ts
@@ -24,7 +24,7 @@ export interface PlaybookRun {
 
     /** Previous reminder timer as nanoseconds */
     previous_reminder: number;
-    broadcast_channel_id: string;
+    broadcast_channel_ids: string[];
     timeline_events: TimelineEvent[];
     retrospective: string;
     retrospective_published_at: number;
@@ -77,7 +77,7 @@ export function isPlaybookRun(arg: any): arg is PlaybookRun {
         arg.checklists && Array.isArray(arg.checklists) && arg.checklists.every(isChecklist) &&
         arg.status_posts && Array.isArray(arg.status_posts) && arg.status_posts.every(isStatusPost) &&
         typeof arg.reminder_post_id === 'string' &&
-        typeof arg.broadcast_channel_id === 'string' &&
+        arg.broadcast_channel_ids && Array.isArray(arg.broadcast_channel_ids) && arg.broadcast_channel_ids.every(isString) &&
         arg.timeline_events && Array.isArray(arg.timeline_events) && arg.timeline_events.every(isTimelineEvent) &&
         arg.participant_ids && Array.isArray(arg.participant_ids) && arg.participant_ids.every(isString)) &&
         typeof arg.last_status_update_at === 'number' &&

--- a/webapp/src/types/playbook_run.ts
+++ b/webapp/src/types/playbook_run.ts
@@ -21,6 +21,7 @@ export interface PlaybookRun {
     current_status: PlaybookRunStatus;
     last_status_update_at: number;
     reminder_post_id: string;
+    reminder_message_template: string;
 
     /** Previous reminder timer as nanoseconds */
     previous_reminder: number;
@@ -77,6 +78,7 @@ export function isPlaybookRun(arg: any): arg is PlaybookRun {
         arg.checklists && Array.isArray(arg.checklists) && arg.checklists.every(isChecklist) &&
         arg.status_posts && Array.isArray(arg.status_posts) && arg.status_posts.every(isStatusPost) &&
         typeof arg.reminder_post_id === 'string' &&
+        typeof arg.reminder_message_template === 'string' &&
         arg.broadcast_channel_ids && Array.isArray(arg.broadcast_channel_ids) && arg.broadcast_channel_ids.every(isString) &&
         arg.timeline_events && Array.isArray(arg.timeline_events) && arg.timeline_events.every(isTimelineEvent) &&
         arg.participant_ids && Array.isArray(arg.participant_ids) && arg.participant_ids.every(isString)) &&


### PR DESCRIPTION
#### Summary

The bug (see the ticket) was caused by `playbook` being undefined: the request to fetch it failed because the user does not have permissions to open the playbook, so it was not set.

This affected the line below, in the call to `GenericModal`. The value of the `isConfirmDisabled` field was set to false because playbook was undefined.
```ts
isConfirmDisabled={!(hasPermission && message?.trim() && currentUserId && channelId && playbook?.team_id)}
```

This PR completely removes the dependency on the playbook in the Update Status modal: everything should be in the playbook run, as we cannot rely on the current information of a playbook, which has potentially been changed between the run creation and the time we fetch that information.

For doing that, I had to add the `ReminderTimerDefaultSeconds` field to the `PlaybookRun` model. Although `PreviousReminder` does have the same information when the run is created, it is changed as soon as an update is posted. Having this info lets us add it to the options list in the _Timer for next update_, as shown in the screenshot (`15 days` is not a hardcoded value in the list, but the one retrieved from the playbook)

![image](https://user-images.githubusercontent.com/3924815/134539965-bc6b933e-62ac-46c8-93b6-1018244551a8.png)

Apart from that, I've removed every old mention to `broadcast_channel_id` (in singular). We still had a couple of them there.

I'm adding an E2E test while you guys review this :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38775

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
