### PR TITLE
MM-38251: workaround "Run" from Playbooks

### DIFF
--- a/tests-e2e/cypress/integration/backstage/playbook_overview_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_overview_spec.js
@@ -101,4 +101,17 @@ describe('playbook overview', () => {
             cy.findByTestId('playbookPermissionsDescription').contains('2 people can access this playbook');
         });
     });
+
+    it('should switch to channels and prompt to run when clicking run', () => {
+        // # Navigate directly to the playbook
+        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
+
+        // # Click Run Playbook
+        cy.findByTestId('run-playbook').click({force: true});
+
+        // * Verify the playbook run creation dialog has opened
+        cy.get('#interactiveDialogModal').should('exist').within(() => {
+            cy.findByText('Start run').should('exist');
+        });
+    });
 });

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -81,7 +81,7 @@ export function startPlaybookRun(teamId: string, postId?: string) {
     };
 }
 
-export function startPlaybookRunById(teamId: string, playbookId: string) {
+export function startPlaybookRunById(teamId: string, playbookId: string, timeout = 0) {
     return async (dispatch: Dispatch<AnyAction>, getState: GetStateFunc) => {
         // Add unique id
         const clientId = generateId();
@@ -89,7 +89,14 @@ export function startPlaybookRunById(teamId: string, playbookId: string) {
 
         const command = `/playbook run-playbook ${playbookId} ${clientId}`;
 
-        await clientExecuteCommand(dispatch, getState, command, teamId);
+        // When dispatching from the playbooks product, the switch to channels resets the websocket
+        // connection, losing the event that opens this dialog. Allow the caller to specify a
+        // timeout as a gross workaround.
+        await new Promise((resolve) => setTimeout(() => {
+            clientExecuteCommand(dispatch, getState, command, teamId);
+            // eslint-disable-next-line no-undefined
+            resolve(undefined);
+        }, timeout));
     };
 }
 

--- a/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
@@ -123,7 +123,7 @@ const PlaybookBackstage = () => {
 
         if (playbook?.id) {
             telemetryEventForPlaybook(playbook.id, 'playbook_dashboard_run_clicked');
-            dispatch(startPlaybookRunById(team.id, playbook.id));
+            dispatch(startPlaybookRunById(team.id, playbook.id, 3000));
         }
     };
 
@@ -167,6 +167,7 @@ const PlaybookBackstage = () => {
                     <PrimaryButtonLarger
                         onClick={runPlaybook}
                         disabled={!enableRunPlaybook}
+                        data-testid='run-playbook'
                     >
                         <RightMarginedIcon
                             path={mdiClipboardPlayOutline}


### PR DESCRIPTION
#### Summary
Navigating to a playbook and clicking "Run" sometimes doesn't work, even if Channels has already loaded, because something is forcing the websocket to disconnect and reconnect on the transition to Channels, losing the interactive dialog event. Workaround this with a timeout on dispatching the event in question.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-38251

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
