### PR TITLE
MM-38731 - Fix for: Old status update dialog partially exposed in web/desktop

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -836,16 +836,16 @@ func (h *PlaybookRunHandler) reminderButtonDismiss(w http.ResponseWriter, r *htt
 	ReturnJSON(w, nil, http.StatusOK)
 }
 
-func (h *PlaybookRunHandler) removeReminderPost(w http.ResponseWriter, userID, playbookID, channelID string) {
-	storedPlaybookID, err := h.playbookRunService.GetPlaybookRunIDForChannel(channelID)
+func (h *PlaybookRunHandler) removeReminderPost(w http.ResponseWriter, userID, playbookRunID, channelID string) {
+	storedPlaybookRunID, err := h.playbookRunService.GetPlaybookRunIDForChannel(channelID)
 	if err != nil {
 		h.log.Errorf("reminderButtonDismiss: no playbook run for requestData's channelID: %s", channelID)
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "no playbook run for requestData's channelID", err)
 		return
 	}
-	if storedPlaybookID != playbookID {
+	if storedPlaybookRunID != playbookRunID {
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "error removing reminder",
-			fmt.Errorf("storedPlaybookRunID: %s for channelID: %s did not match playbookID in url path: %s", storedPlaybookID, channelID, playbookID))
+			fmt.Errorf("storedPlaybookRunID: %s for channelID: %s did not match playbookID in url path: %s", storedPlaybookRunID, channelID, playbookRunID))
 		return
 	}
 
@@ -858,13 +858,13 @@ func (h *PlaybookRunHandler) removeReminderPost(w http.ResponseWriter, userID, p
 		return
 	}
 
-	if err := h.playbookRunService.RemoveReminderPost(playbookID); err != nil {
+	if err := h.playbookRunService.RemoveReminderPost(playbookRunID); err != nil {
 		h.log.Errorf("reminderButtonDismiss: error removing reminder for channelID: %s; error: %s", channelID, err.Error())
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "error removing reminder", err)
 		return
 	}
 
-	if err := h.playbookRunService.ResetReminderTimer(playbookID); err != nil {
+	if err := h.playbookRunService.ResetReminderTimer(playbookRunID); err != nil {
 		h.log.Errorf("reminderButtonDismiss: error resetting reminder for channelID: %s; error: %s", channelID, err.Error())
 		h.HandleErrorWithCode(w, http.StatusInternalServerError, "error resetting reminder", err)
 		return

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -69,6 +69,7 @@ func NewPlaybookRunHandler(router *mux.Router, playbookRunService app.PlaybookRu
 	playbookRunRouterAuthorized.HandleFunc("/finish-dialog", handler.finishDialog).Methods(http.MethodPost)
 	playbookRunRouterAuthorized.HandleFunc("/update-status-dialog", handler.updateStatusDialog).Methods(http.MethodPost)
 	playbookRunRouterAuthorized.HandleFunc("/reminder/button-update", handler.reminderButtonUpdate).Methods(http.MethodPost)
+	playbookRunRouterAuthorized.HandleFunc("/reminder", handler.reminderDelete).Methods(http.MethodDelete)
 	playbookRunRouterAuthorized.HandleFunc("/reminder/button-dismiss", handler.reminderButtonDismiss).Methods(http.MethodPost)
 	playbookRunRouterAuthorized.HandleFunc("/no-retrospective-button", handler.noRetrospectiveButton).Methods(http.MethodPost)
 	playbookRunRouterAuthorized.HandleFunc("/timeline/{eventID:[A-Za-z0-9]+}", handler.removeTimelineEvent).Methods(http.MethodDelete)
@@ -801,23 +802,54 @@ func (h *PlaybookRunHandler) reminderButtonUpdate(w http.ResponseWriter, r *http
 	ReturnJSON(w, nil, http.StatusOK)
 }
 
+// reminderButtonDismiss handles the DELETE /runs/{id}/reminder endpoint, called when a
+// user clicks on the reminder custom_update_status dismiss button
+func (h *PlaybookRunHandler) reminderDelete(w http.ResponseWriter, r *http.Request) {
+	playbookRunID := mux.Vars(r)["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+	var payload struct {
+		ChannelID string `json:"channel_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		h.HandleError(w, err)
+		return
+	}
+
+	h.removeReminderPost(w, userID, playbookRunID, payload.ChannelID)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // reminderButtonDismiss handles the POST /runs/{id}/reminder/button-dismiss endpoint, called when a
 // user clicks on the reminder interactive button
 func (h *PlaybookRunHandler) reminderButtonDismiss(w http.ResponseWriter, r *http.Request) {
+	playbookRunID := mux.Vars(r)["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
 	requestData := model.PostActionIntegrationRequestFromJson(r.Body)
 	if requestData == nil {
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "missing request data", nil)
 		return
 	}
 
-	playbookRunID, err := h.playbookRunService.GetPlaybookRunIDForChannel(requestData.ChannelId)
+	h.removeReminderPost(w, userID, playbookRunID, requestData.ChannelId)
+
+	ReturnJSON(w, nil, http.StatusOK)
+}
+
+func (h *PlaybookRunHandler) removeReminderPost(w http.ResponseWriter, userID, playbookID, channelID string) {
+	storedPlaybookID, err := h.playbookRunService.GetPlaybookRunIDForChannel(channelID)
 	if err != nil {
-		h.log.Errorf("reminderButtonDismiss: no playbook run for requestData's channelID: %s", requestData.ChannelId)
+		h.log.Errorf("reminderButtonDismiss: no playbook run for requestData's channelID: %s", channelID)
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "no playbook run for requestData's channelID", err)
 		return
 	}
+	if storedPlaybookID != playbookID {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "error removing reminder",
+			fmt.Errorf("storedPlaybookRunID: %s for channelID: %s did not match playbookID in url path: %s", storedPlaybookID, channelID, playbookID))
+		return
+	}
 
-	if err = app.EditPlaybookRun(requestData.UserId, requestData.ChannelId, h.pluginAPI); err != nil {
+	if err := app.EditPlaybookRun(userID, channelID, h.pluginAPI); err != nil {
 		if errors.Is(err, app.ErrNoPermissions) {
 			ReturnJSON(w, nil, http.StatusForbidden)
 			return
@@ -826,19 +858,17 @@ func (h *PlaybookRunHandler) reminderButtonDismiss(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if err = h.playbookRunService.RemoveReminderPost(playbookRunID); err != nil {
-		h.log.Errorf("reminderButtonDismiss: error removing reminder for channelID: %s; error: %s", requestData.ChannelId, err.Error())
+	if err := h.playbookRunService.RemoveReminderPost(playbookID); err != nil {
+		h.log.Errorf("reminderButtonDismiss: error removing reminder for channelID: %s; error: %s", channelID, err.Error())
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "error removing reminder", err)
 		return
 	}
 
-	if err = h.playbookRunService.ResetReminderTimer(playbookRunID); err != nil {
-		h.log.Errorf("reminderButtonDismiss: error resetting reminder for channelID: %s; error: %s", requestData.ChannelId, err.Error())
+	if err := h.playbookRunService.ResetReminderTimer(playbookID); err != nil {
+		h.log.Errorf("reminderButtonDismiss: error resetting reminder for channelID: %s; error: %s", channelID, err.Error())
 		h.HandleErrorWithCode(w, http.StatusInternalServerError, "error resetting reminder", err)
 		return
 	}
-
-	ReturnJSON(w, nil, http.StatusOK)
 }
 
 func (h *PlaybookRunHandler) noRetrospectiveButton(w http.ResponseWriter, r *http.Request) {

--- a/server/app/reminder.go
+++ b/server/app/reminder.go
@@ -93,9 +93,17 @@ func (s *PlaybookRunServiceImpl) handleStatusUpdateReminder(playbookRunID string
 		},
 	}
 
-	post, err := s.poster.PostMessageWithAttachments(playbookRunToModify.ChannelID, attachments,
-		"@%s, please provide a status update.", owner.Username)
-	if err != nil {
+	post := &model.Post{
+		Message:   fmt.Sprintf("@%s, please provide a status update.", owner.Username),
+		ChannelId: playbookRunToModify.ChannelID,
+		Type:      "custom_update_status",
+		Props: map[string]interface{}{
+			"targetUsername": owner.Username,
+		},
+	}
+	model.ParseSlackAttachment(post, attachments)
+
+	if err := s.poster.PostMessageToThread("", post); err != nil {
 		s.logger.Errorf(errors.Wrap(err, "HandleReminder error posting reminder message").Error())
 		return
 	}

--- a/server/bot/bot.go
+++ b/server/bot/bot.go
@@ -39,7 +39,7 @@ type Poster interface {
 	// If the rootPostID is blank, or the rootPost is deleted, it will create a standalone post. The
 	// returned post's RootID (or ID, if there was no root post) should be used as the rootID for
 	// future use (i.e., save that if you want to continue the thread).
-	PostMessageToThread(channelID string, post *model.Post) error
+	PostMessageToThread(rootPostID string, post *model.Post) error
 
 	// PostMessageWithAttachments posts a message with slack attachments to channelID. Returns the post id if
 	// posting was successful. Often used to include post actions.

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -484,6 +484,15 @@ export const doPost = async <TData = any>(url: string, body = {}) => {
     return data;
 };
 
+export const doDelete = async <TData = any>(url: string, body = {}) => {
+    const {data} = await doFetchWithResponse<TData>(url, {
+        method: 'DELETE',
+        body,
+    });
+
+    return data;
+};
+
 export const doPut = async <TData = any>(url: string, body = {}) => {
     const {data} = await doFetchWithResponse<TData>(url, {
         method: 'PUT',

--- a/webapp/src/components/update_request_post.tsx
+++ b/webapp/src/components/update_request_post.tsx
@@ -14,10 +14,11 @@ import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {currentPlaybookRun} from 'src/selectors';
 import PostText from 'src/components/post_text';
-import {DestructiveButton, TertiaryButton} from 'src/components/assets/buttons';
+import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 import {promptUpdateStatus} from 'src/actions';
 import {doDelete} from 'src/client';
 import {pluginId} from 'src/manifest';
+import {CustomPostContainer} from 'src/components/custom_post_styles';
 
 interface Props {
     post: Post;
@@ -40,7 +41,7 @@ export const UpdateRequestPost = (props: Props) => {
                 team={team}
             />
             <Container>
-                <PostUpdateDestructiveButton
+                <PostUpdatePrimaryButton
                     onClick={() => {
                         dispatch(promptUpdateStatus(
                             team.id,
@@ -51,7 +52,7 @@ export const UpdateRequestPost = (props: Props) => {
                     }}
                 >
                     {'Post update'}
-                </PostUpdateDestructiveButton>
+                </PostUpdatePrimaryButton>
                 <Spacer/>
                 <PostUpdateTertiaryButton onClick={() => doDelete(dismissUrl, dismissBody)}>
                     {'Dismiss'}
@@ -67,7 +68,7 @@ const PostUpdateButtonCommon = css`
     max-width: 135px;
 `;
 
-const PostUpdateDestructiveButton = styled(DestructiveButton)`
+const PostUpdatePrimaryButton = styled(PrimaryButton)`
     ${PostUpdateButtonCommon}
 `;
 
@@ -78,12 +79,13 @@ const PostUpdateTertiaryButton = styled(TertiaryButton)`
 const Spacer = styled.div`
     flex-grow: 0;
     flex-shrink: 0;
-    width: 18px;
+    width: 12px;
 `;
 
-const Container = styled.div`
+const Container = styled(CustomPostContainer)`
     display: flex;
     flex-direction: row;
+    padding: 12px;
 `;
 
 const StyledPostText = styled(PostText)`

--- a/webapp/src/components/update_request_post.tsx
+++ b/webapp/src/components/update_request_post.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import styled, {css} from 'styled-components';
+
+import {Post} from 'mattermost-redux/types/posts';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {Channel} from 'mattermost-redux/types/channels';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {Team} from 'mattermost-redux/types/teams';
+import {getTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {currentPlaybookRun} from 'src/selectors';
+import PostText from 'src/components/post_text';
+import {DestructiveButton, TertiaryButton} from 'src/components/assets/buttons';
+import {promptUpdateStatus} from 'src/actions';
+import {doDelete} from 'src/client';
+import {pluginId} from 'src/manifest';
+
+interface Props {
+    post: Post;
+}
+
+export const UpdateRequestPost = (props: Props) => {
+    const dispatch = useDispatch();
+    const channel = useSelector<GlobalState, Channel>((state) => getChannel(state, props.post.channel_id));
+    const team = useSelector<GlobalState, Team>((state) => getTeam(state, channel.team_id));
+    const currentRun = useSelector(currentPlaybookRun);
+    const targetUsername = props.post.props.targetUsername ?? '';
+    const playbookId = currentRun?.id;
+    const dismissUrl = `/plugins/${pluginId}/api/v0/runs/${playbookId}/reminder`;
+    const dismissBody = JSON.stringify({channel_id: channel.id});
+
+    return (
+        <>
+            <StyledPostText
+                text={`@${targetUsername}, please provide a status update.`}
+                team={team}
+            />
+            <Container>
+                <PostUpdateDestructiveButton
+                    onClick={() => {
+                        dispatch(promptUpdateStatus(
+                            team.id,
+                            playbookId,
+                            currentRun?.playbook_id,
+                            props.post.channel_id,
+                        ));
+                    }}
+                >
+                    {'Post update'}
+                </PostUpdateDestructiveButton>
+                <Spacer/>
+                <PostUpdateTertiaryButton onClick={() => doDelete(dismissUrl, dismissBody)}>
+                    {'Dismiss'}
+                </PostUpdateTertiaryButton>
+            </Container>
+        </>
+    );
+};
+
+const PostUpdateButtonCommon = css`
+    justify-content: center;
+    flex: 1;
+    max-width: 135px;
+`;
+
+const PostUpdateDestructiveButton = styled(DestructiveButton)`
+    ${PostUpdateButtonCommon}
+`;
+
+const PostUpdateTertiaryButton = styled(TertiaryButton)`
+    ${PostUpdateButtonCommon}
+`;
+
+const Spacer = styled.div`
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 18px;
+`;
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+const StyledPostText = styled(PostText)`
+    margin-bottom: 8px;
+`;

--- a/webapp/src/components/update_request_post.tsx
+++ b/webapp/src/components/update_request_post.tsx
@@ -29,8 +29,8 @@ export const UpdateRequestPost = (props: Props) => {
     const team = useSelector<GlobalState, Team>((state) => getTeam(state, channel.team_id));
     const currentRun = useSelector(currentPlaybookRun);
     const targetUsername = props.post.props.targetUsername ?? '';
-    const playbookId = currentRun?.id;
-    const dismissUrl = `/plugins/${pluginId}/api/v0/runs/${playbookId}/reminder`;
+    const playbookRunId = currentRun?.id;
+    const dismissUrl = `/plugins/${pluginId}/api/v0/runs/${playbookRunId}/reminder`;
     const dismissBody = JSON.stringify({channel_id: channel.id});
 
     return (
@@ -44,7 +44,7 @@ export const UpdateRequestPost = (props: Props) => {
                     onClick={() => {
                         dispatch(promptUpdateStatus(
                             team.id,
-                            playbookId,
+                            playbookRunId,
                             currentRun?.playbook_id,
                             props.post.channel_id,
                         ));

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -3,34 +3,30 @@
 
 import React from 'react';
 import {Store, Unsubscribe} from 'redux';
+import {Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 import {debounce} from 'debounce';
-
-import {GlobalState} from 'mattermost-redux/types/store';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {Client4} from 'mattermost-redux/client';
 
 //@ts-ignore Webapp imports don't work properly
 import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {Client4} from 'mattermost-redux/client';
 import WebsocketEvents from 'mattermost-redux/constants/websocket';
-
-import {Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 
 import {makeRHSOpener} from 'src/rhs_opener';
 import {makeSlashCommandHook} from 'src/slash_command';
-
-import {RetrospectiveFirstReminder, RetrospectiveReminder} from './components/retrospective_reminder_posts';
-
-import {pluginId} from './manifest';
-import {ChannelHeaderButton, ChannelHeaderText, ChannelHeaderTooltip} from './components/channel_header';
-import RightHandSidebar from './components/rhs/rhs_main';
-import RHSTitle from './components/rhs/rhs_title';
-import {AttachToPlaybookRunPostMenu, StartPlaybookRunPostMenu} from './components/post_menu';
-import Backstage from './components/backstage/backstage';
-import PostMenuModal from './components/post_menu_modal';
+import {RetrospectiveFirstReminder, RetrospectiveReminder} from 'src/components/retrospective_reminder_posts';
+import {pluginId} from 'src/manifest';
+import {ChannelHeaderButton, ChannelHeaderText, ChannelHeaderTooltip} from 'src/components/channel_header';
+import RightHandSidebar from 'src/components/rhs/rhs_main';
+import RHSTitle from 'src/components/rhs/rhs_title';
+import {AttachToPlaybookRunPostMenu, StartPlaybookRunPostMenu} from 'src/components/post_menu';
+import Backstage from 'src/components/backstage/backstage';
+import PostMenuModal from 'src/components/post_menu_modal';
 import {
     setToggleRHSAction, actionSetGlobalSettings,
-} from './actions';
-import reducer from './reducer';
+} from 'src/actions';
+import reducer from 'src/reducer';
 import {
     handleReconnect,
     handleWebsocketPlaybookRunUpdated,
@@ -41,19 +37,20 @@ import {
     handleWebsocketUserRemoved,
     handleWebsocketPostEditedOrDeleted,
     handleWebsocketChannelUpdated, handleWebsocketChannelViewed,
-} from './websocket_events';
+} from 'src/websocket_events';
 import {
     WEBSOCKET_PLAYBOOK_RUN_UPDATED,
     WEBSOCKET_PLAYBOOK_RUN_CREATED,
     WEBSOCKET_PLAYBOOK_CREATED,
     WEBSOCKET_PLAYBOOK_DELETED,
-} from './types/websocket_events';
-import RegistryWrapper from './registry_wrapper';
-import SystemConsoleEnabledTeams from './system_console_enabled_teams';
-import {makeUpdateMainMenu} from './make_update_main_menu';
-import {fetchGlobalSettings, setSiteUrl} from './client';
-import {CloudUpgradePost} from './components/cloud_upgrade_post';
-import {UpdatePost} from './components/update_post';
+} from 'src/types/websocket_events';
+import RegistryWrapper from 'src/registry_wrapper';
+import SystemConsoleEnabledTeams from 'src/system_console_enabled_teams';
+import {makeUpdateMainMenu} from 'src/make_update_main_menu';
+import {fetchGlobalSettings, setSiteUrl} from 'src/client';
+import {CloudUpgradePost} from 'src/components/cloud_upgrade_post';
+import {UpdatePost} from 'src/components/update_post';
+import {UpdateRequestPost} from 'src/components/update_request_post';
 
 const GlobalHeaderCenter = () => {
     return null;
@@ -153,6 +150,7 @@ export default class Plugin {
             r.registerPostTypeComponent('custom_retro_rem', RetrospectiveReminder);
             r.registerPostTypeComponent('custom_cloud_upgrade', CloudUpgradePost);
             r.registerPostTypeComponent('custom_run_update', UpdatePost);
+            r.registerPostTypeComponent('custom_update_status', UpdateRequestPost);
 
             return r.unregister;
         };


### PR DESCRIPTION
#### Summary
- Trigger the new style dialog using a custom post - it works for webapp and automatically falls back to the interactive dialog for mobile

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38731

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
