### PR TITLE
MM-38779: test with globalheader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,24 +229,6 @@ jobs:
           command: |
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -b "$(< ./dist/release-notes.md)" -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -delete ${CIRCLE_TAG} dist/*.tar.gz
 
-  test-MySQL56-Postgres96:
-    docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: mmuser
-          POSTGRES_DB: mattermost_test
-      - image: circleci/mysql:5.6.49
-        environment:
-          MYSQL_ROOT_PASSWORD: mostest
-          MYSQL_DATABASE: mattermost_test
-          MYSQL_USER: mmuser
-          MYSQL_PASSWORD: mostest
-    executor:
-      name: default
-    steps:
-      - test-with-db
-
   test-MySQL57-Postgres10:
     docker:
       - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
@@ -519,88 +501,17 @@ jobs:
     steps:
       - run-e2e-tests
 
-  e2e-cypress-tests-534:
-    resource_class: large
-    docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
-        environment:
-          TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
-      - image: circleci/postgres:10-alpine-ram
-        environment:
-          POSTGRES_USER: mmuser
-          POSTGRES_PASSWORD: mostest
-          POSTGRES_DB: mattermost_test
-      - image: mattermost/inbucket:release-1.2.0
-      - image: minio/minio:RELEASE.2019-10-11T00-38-09Z
-        command: "server /data"
-        environment:
-          MINIO_ACCESS_KEY: minioaccesskey
-          MINIO_SECRET_KEY: miniosecretkey
-          MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
-      - image: mattermost/mattermost-elasticsearch-docker:7.0.0
-        environment:
-          http.host: "0.0.0.0"
-          http.port: 9200
-          http.cors.enabled: "true"
-          http.cors.allow-origin: "http://localhost:1358,http://127.0.0.1:1358"
-          http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
-          http.cors.allow-credentials: "true"
-          transport.host: "127.0.0.1"
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-      - image: mattermost/mattermost-enterprise-edition:$MM_DOCKER_IMAGE_TAG
-        environment:
-          DB_HOST: localhost
-          DB_PORT_NUMBER: 5432
-          MM_DBNAME: mattermost_test
-          MM_USERNAME: mmuser
-          MM_PASSWORD: mostest
-          CI_INBUCKET_HOST: localhost
-          CI_INBUCKET_PORT: 10080
-          CI_MINIO_HOST: minio
-          IS_CI: true
-          MM_CLUSTERSETTINGS_READONLYCONFIG: false
-          MM_EMAILSETTINGS_SMTPSERVER: localhost
-          MM_EMAILSETTINGS_SMTPPORT: 10025
-          MM_ELASTICSEARCHSETTINGS_CONNECTIONURL: http://localhost:9200
-          MM_EXPERIMENTALSETTINGS_USENEWSAMLLIBRARY: true
-          MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
-          MM_SQLSETTINGS_DRIVERNAME: postgres
-          MM_PLUGINSETTINGS_ENABLEUPLOADS: true
-          MM_SERVICESETTINGS_SITEURL: http://localhost:8065
-          MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: false
-          MM_ANNOUNCEMENTSETTINGS_ADMINNOTICESENABLED: false
-    environment:
-      MM_DOCKER_IMAGE_TAG: 5.34.0
-      TYPE: NONE
-      PULL_REQUEST:
-      BROWSER: chrome
-      HEADLESS: true
-      DASHBOARD_ENABLE: false
-      FULL_REPORT: false
-      MM_SERVICESETTINGS_SITEURL: http://localhost:8065
-      MM_ADMIN_USERNAME: sysadmin
-      MM_ADMIN_PASSWORD: Sys@dmin-sample1
-    steps:
-      - run-e2e-tests
-
 workflows:
   version: 2
   ci:
     jobs:
       - lint
-      - test-MySQL56-Postgres96
       - test-MySQL57-Postgres10
       - test-MySQL8-Postgres11
       - test-MySQL-Postgres-latest
-      # 534 is broken at the moment (sql schema mismatch with what works on cloud and master)
-      # - e2e-cypress-tests-534
-#      - e2e-cypress-tests-cloud
+      - e2e-cypress-tests-cloud
       - e2e-cypress-tests-master
       - e2e-cypress-tests-master-with-global-header
-           # remove/comment this filters statement to include e2e tests on master for a PR branch
-#          filters:
-#            branches:
-#              ignore: /.*/
       - build:
           context: mattermost-plugin-incident-response-production
           filters:
@@ -613,7 +524,6 @@ workflows:
               only: master
           requires:
             - lint
-            - test-MySQL56-Postgres96
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
@@ -628,7 +538,6 @@ workflows:
               ignore: /.*/
           requires:
             - lint
-            - test-MySQL56-Postgres96
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
@@ -643,7 +552,6 @@ workflows:
               ignore: /.*/
           requires:
             - lint
-            - test-MySQL56-Postgres96
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,24 @@ jobs:
           command: |
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -b "$(< ./dist/release-notes.md)" -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -delete ${CIRCLE_TAG} dist/*.tar.gz
 
+  test-MySQL56-Postgres10:
+    docker:
+      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: circleci/postgres:10-alpine
+        environment:
+          POSTGRES_USER: mmuser
+          POSTGRES_DB: mattermost_test
+      - image: circleci/mysql:5.6.49
+        environment:
+          MYSQL_ROOT_PASSWORD: mostest
+          MYSQL_DATABASE: mattermost_test
+          MYSQL_USER: mmuser
+          MYSQL_PASSWORD: mostest
+    executor:
+      name: default
+    steps:
+      - test-with-db
+
   test-MySQL57-Postgres10:
     docker:
       - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
@@ -506,6 +524,7 @@ workflows:
   ci:
     jobs:
       - lint
+      - test-MySQL56-Postgres10
       - test-MySQL57-Postgres10
       - test-MySQL8-Postgres11
       - test-MySQL-Postgres-latest
@@ -524,6 +543,7 @@ workflows:
               only: master
           requires:
             - lint
+            - test-MySQL56-Postgres10
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
@@ -538,6 +558,7 @@ workflows:
               ignore: /.*/
           requires:
             - lint
+            - test-MySQL56-Postgres10
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
@@ -552,6 +573,7 @@ workflows:
               ignore: /.*/
           requires:
             - lint
+            - test-MySQL56-Postgres10
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,79 @@ jobs:
     steps:
       - run-e2e-tests
 
+  e2e-cypress-tests-master-with-global-header:
+    resource_class: xlarge
+    docker:
+      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+        environment:
+          TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
+      - image: circleci/postgres:10-alpine-ram
+        environment:
+          POSTGRES_USER: mmuser
+          POSTGRES_PASSWORD: mostest
+          POSTGRES_DB: mattermost_test
+      - image: mattermost/inbucket:release-1.2.0
+      - image: minio/minio:RELEASE.2019-10-11T00-38-09Z
+        command: "server /data"
+        environment:
+          MINIO_ACCESS_KEY: minioaccesskey
+          MINIO_SECRET_KEY: miniosecretkey
+          MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+      - image: mattermost/mattermost-elasticsearch-docker:7.0.0
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+        environment:
+          http.host: "0.0.0.0"
+          http.port: 9200
+          http.cors.enabled: "true"
+          http.cors.allow-origin: "http://localhost:1358,http://127.0.0.1:1358"
+          http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
+          http.cors.allow-credentials: "true"
+          transport.host: "127.0.0.1"
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      - image: mattermost/mattermost-enterprise-edition:$MM_DOCKER_IMAGE_TAG
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+        environment:
+          DB_HOST: localhost
+          DB_PORT_NUMBER: 5432
+          MM_DBNAME: mattermost_test
+          MM_USERNAME: mmuser
+          MM_PASSWORD: mostest
+          CI_INBUCKET_HOST: localhost
+          CI_INBUCKET_PORT: 10080
+          CI_MINIO_HOST: minio
+          IS_CI: true
+          MM_CLUSTERSETTINGS_READONLYCONFIG: false
+          MM_EMAILSETTINGS_SMTPSERVER: localhost
+          MM_EMAILSETTINGS_SMTPPORT: 10025
+          MM_ELASTICSEARCHSETTINGS_CONNECTIONURL: http://localhost:9200
+          MM_EXPERIMENTALSETTINGS_USENEWSAMLLIBRARY: true
+          MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+          MM_SQLSETTINGS_DRIVERNAME: postgres
+          MM_PLUGINSETTINGS_ENABLEUPLOADS: true
+          MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+          MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: false
+          MM_ANNOUNCEMENTSETTINGS_ADMINNOTICESENABLED: false
+          MM_SERVICESETTINGS_ENABLELEGACYSIDEBAR: true
+          MM_TEAMSETTINGS_MAXUSERSPERTEAM: 10000
+          MM_FEATUREFLAGS_GLOBALHEADER: true
+    environment:
+      MM_DOCKER_IMAGE_TAG: master
+      TYPE: NONE
+      PULL_REQUEST:
+      BROWSER: chrome
+      HEADLESS: true
+      DASHBOARD_ENABLE: false
+      FULL_REPORT: false
+      MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+      MM_ADMIN_USERNAME: sysadmin
+      MM_ADMIN_PASSWORD: Sys@dmin-sample1
+    steps:
+      - run-e2e-tests
+
   e2e-cypress-tests-534:
     resource_class: large
     docker:
@@ -523,6 +596,7 @@ workflows:
       # - e2e-cypress-tests-534
 #      - e2e-cypress-tests-cloud
       - e2e-cypress-tests-master
+      - e2e-cypress-tests-master-with-global-header
            # remove/comment this filters statement to include e2e tests on master for a PR branch
 #          filters:
 #            branches:

--- a/tests-e2e/cypress/integration/frontstage/playbook_run_automation_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/playbook_run_automation_spec.js
@@ -78,7 +78,7 @@ describe('playbook run automation', () => {
                 // * Verify that no users were invited
                 cy.getFirstPostId().then((id) => {
                     cy.get(`#postMessageText_${id}`)
-                        .contains('You were added to the channel by @playbook.')
+                        .contains('You were added to the channel by @playbooks.')
                         .should('not.contain', 'joined the channel');
                 });
             });
@@ -122,7 +122,7 @@ describe('playbook run automation', () => {
 
                         cy.get(`#postMessageText_${id}`).contains('@aaron.medina');
                         cy.get(`#postMessageText_${id}`).contains('@alice.johnston');
-                        cy.get(`#postMessageText_${id}`).contains('added to the channel by @playbook.');
+                        cy.get(`#postMessageText_${id}`).contains('added to the channel by @playbooks.');
                     });
                 });
             });
@@ -161,7 +161,7 @@ describe('playbook run automation', () => {
                     // * Verify that no users were invited
                     cy.getFirstPostId().then((id) => {
                         cy.get(`#postMessageText_${id}`)
-                            .contains('You were added to the channel by @playbook.')
+                            .contains('You were added to the channel by @playbooks.')
                             .should('not.contain', 'joined the channel');
                     });
                 });
@@ -457,7 +457,7 @@ describe('playbook run automation', () => {
                     // * Verify that the channel is created and that the first post exists.
                     cy.getFirstPostId().then((id) => {
                         cy.get(`#postMessageText_${id}`)
-                            .contains('You were added to the channel by @playbook.')
+                            .contains('You were added to the channel by @playbooks.')
                             .should('not.contain', 'joined the channel');
                     });
 
@@ -502,7 +502,7 @@ describe('playbook run automation', () => {
                     // * Verify that the channel is created and that the first post exists.
                     cy.getFirstPostId().then((id) => {
                         cy.get(`#postMessageText_${id}`)
-                            .contains('You were added to the channel by @playbook.')
+                            .contains('You were added to the channel by @playbooks.')
                             .should('not.contain', 'joined the channel');
                     });
 

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -183,7 +183,7 @@ describe('playbook run rhs', () => {
             cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});
 
             // # Wait a bit longer to be confident.
-            cy.wait(TIMEOUTS.TWO_SEC);
+            cy.wait(TIMEOUTS.FIVE_SEC);
 
             // * Verify the playbook run RHS is not open.
             cy.get('#rhsContainer').should('not.exist');

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -80,7 +80,7 @@ describe('playbook run rhs', () => {
             });
 
             // # Open the flagged posts RHS
-             cy.get("body").then($body => {
+            cy.get("body").then($body => {
                 if ($body.find("#channelHeaderFlagButton").length > 0) {
                     cy.get('#channelHeaderFlagButton').click({force: true});
                 } else {

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -80,7 +80,13 @@ describe('playbook run rhs', () => {
             });
 
             // # Open the flagged posts RHS
-            cy.get('#channelHeaderFlagButton').click({force: true});
+             cy.get("body").then($body => {
+                if ($body.find("#channelHeaderFlagButton").length > 0) {
+                    cy.get('#channelHeaderFlagButton').click({force: true});
+                } else {
+                    cy.findByRole('button', {name: 'Select to toggle a list of saved posts.'}).click({force: true});
+                }
+            });
 
             // # Open the playbook run channel from the LHS.
             cy.get(`#sidebarItem_${playbookRunChannelName}`).click({force: true});


### PR DESCRIPTION
#### Summary
Add a test that exercises our e2e suite with the global header enabled. Fix a recent regression in the e2e tests around the bot rename. Clean up some CircleCI stuff while we're in there.

The one failing test should be fixed with https://github.com/mattermost/mattermost-server/pull/18464.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38779

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
