### PR TITLE
MM-38872 - Telemetry for the todo message

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2450,7 +2450,7 @@ func buildAssignedTaskMessageAndTotal(runs []AssignedRun, siteURL string) (strin
 		if numTasks > 1 {
 			taskPlural += "s"
 		}
-		message += fmt.Sprintf("- You have %d assigned %s in [%s](%s/%s/channels/%s):\n",
+		message += fmt.Sprintf("- You have %d assigned %s in [%s](%s/%s/channels/%s?telem=todo_assignedtask_clicked):\n",
 			numTasks, taskPlural, run.ChannelDisplayName, siteURL, run.TeamName, run.ChannelName)
 
 		for _, task := range run.Tasks {
@@ -2476,7 +2476,7 @@ func buildRunsInProgressMessage(runs []RunLink, siteURL string) string {
 	message := fmt.Sprintf("\n##### Runs in Progress\nYou have %d %s currently in progress:\n", total, runPlural)
 
 	for _, run := range runs {
-		message += fmt.Sprintf("- [%s](%s/%s/channels/%s)\n",
+		message += fmt.Sprintf("- [%s](%s/%s/channels/%s?telem=todo_runsinprogress_clicked)\n",
 			run.ChannelDisplayName, siteURL, run.TeamName, run.ChannelName)
 	}
 
@@ -2498,7 +2498,7 @@ func buildRunsOverdueMessage(runs []RunLink, siteURL string) string {
 	message := fmt.Sprintf("\n##### Overdue Status Updates\nYou have %d %s overdue for status update:\n", total, runPlural)
 
 	for _, run := range runs {
-		message += fmt.Sprintf("- [%s](%s/%s/channels/%s)\n",
+		message += fmt.Sprintf("- [%s](%s/%s/channels/%s?telem=todo_overduestatus_clicked)\n",
 			run.ChannelDisplayName, siteURL, run.TeamName, run.ChannelName)
 	}
 

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -14,9 +14,23 @@ import {
 import {currentPlaybookRun} from 'src/selectors';
 import RHSAbout from 'src/components/rhs/rhs_about';
 import RHSChecklists from 'src/components/rhs/rhs_checklists';
+import {browserHistory} from 'src/webapp_globals';
+import {telemetryEventForPlaybookRun} from 'src/client';
 
 const RHSRunDetails = () => {
     const playbookRun = useSelector(currentPlaybookRun);
+    const url = new URL(window.location.href);
+    const searchParams = new URLSearchParams(url.searchParams);
+
+    if (searchParams.has('telem') && playbookRun) {
+        const action = searchParams.get('telem');
+        if (action) {
+            telemetryEventForPlaybookRun(playbookRun.id, action);
+        }
+        searchParams.delete('telem');
+        url.search = searchParams.toString();
+        browserHistory.push({pathname: url.pathname, search: url.search});
+    }
 
     if (!playbookRun) {
         return null;

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -29,7 +29,7 @@ const RHSRunDetails = () => {
         }
         searchParams.delete('telem');
         url.search = searchParams.toString();
-        browserHistory.push({pathname: url.pathname, search: url.search});
+        browserHistory.replace({pathname: url.pathname, search: url.search});
     }
 
     if (!playbookRun) {


### PR DESCRIPTION
#### Summary
- Will record interactions with each of the todo list sections. We can total the number of interactions, group based on unique userId, and by section (to see which section is most useful).
- If found, the search param is removed from the url (leaves other search params untouched)
- I added it to the RHSRunDetails component so that in the future we can use this params method to scroll to and/or highlight specific checklist items (e.g., click on the checklist item due, and we'll take you right to that item -- or as close as possible to that)
- cc @stephenvanhemmen 

#### Progress: 
- POC ✅ 
- Include list of ongoing runs ✅ 
- Include list of overdue updates ✅ 
- Send digest once a day when user logs on ✅ 
- Telemetry (<--- we're here)
- Design polish
- e2e tests (once we have a firmed up design)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38872

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [x] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
