### PR TITLE
MM-38908: When clicking Run, navigate to the new URL provided by webapp

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
     "icon_path": "assets/plugin_icon.svg",
-    "min_server_version": "5.38.0",
+    "min_server_version": "6.0.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
@@ -121,11 +121,9 @@ const PlaybookBackstage = () => {
     };
 
     const runPlaybook = () => {
-        navigateToUrl(`/${team.name || ''}`);
-
         if (playbook?.id) {
             telemetryEventForPlaybook(playbook.id, 'playbook_dashboard_run_clicked');
-            dispatch(startPlaybookRunById(team.id, playbook.id, 3000));
+            navigateToUrl(`/${team.name || ''}/_playbooks/${playbook?.id || ''}/run`);
         }
     };
 


### PR DESCRIPTION
#### Summary
Use the new URL provided by webapp. See [the PR](https://github.com/mattermost/mattermost-webapp/pull/9012) there for more information.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38908

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
