### PR TITLE
MM-37999

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/rhs/home_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/home_spec.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
 describe('playbook run rhs > home', () => {
     let testTeam;
     let testUser;
@@ -26,7 +34,7 @@ describe('playbook run rhs > home', () => {
                 teamId: testTeam.id,
                 title: 'Team Playbook',
                 memberIDs: [],
-            })
+            });
 
             // # Navigate to the application
             cy.visit(`/${testTeam.name}/`);
@@ -37,15 +45,14 @@ describe('playbook run rhs > home', () => {
             });
 
             // * Verify the playbook is shown
-            cy.findByText('Team Playbook').should('exist')
+            cy.findByText('Team Playbook').should('exist');
         });
-        
         it('starter templates', () => {
-            // # templates are defined in `webapp/src/components/backstage/template_selector.tsx`
+            // templates are defined in `webapp/src/components/backstage/template_selector.tsx`
             const templateNames = [
-                'Blank', 
-                'Product Release', 
-                'Customer Onboarding', 
+                'Blank',
+                'Product Release',
+                'Customer Onboarding',
                 'Service Reliability Incident'
             ];
 

--- a/tests-e2e/cypress/integration/frontstage/rhs/home_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/home_spec.js
@@ -1,0 +1,66 @@
+describe('playbook run rhs > home', () => {
+    let testTeam;
+    let testUser;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Turn off growth onboarding screens
+            cy.apiUpdateConfig({
+                ServiceSettings: {EnableOnboardingFlow: false},
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    describe('shows available', () => {
+        it('team playbook', () => {
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Team Playbook',
+                memberIDs: [],
+            })
+
+            // # Navigate to the application
+            cy.visit(`/${testTeam.name}/`);
+
+            // # Click the icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click({force: true});
+            });
+
+            // * Verify the playbook is shown
+            cy.findByText('Team Playbook').should('exist')
+        });
+        
+        it('starter templates', () => {
+            // # templates are defined in `webapp/src/components/backstage/template_selector.tsx`
+            const templateNames = [
+                'Blank', 
+                'Product Release', 
+                'Customer Onboarding', 
+                'Service Reliability Incident'
+            ];
+
+            // # Navigate to the application
+            cy.visit(`/${testTeam.name}/`);
+
+            // # Click the icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click({force: true});
+            });
+
+            // * Verify the templates are shown
+            templateNames.forEach((name) => {
+                cy.findByText(name).should('exist');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hello y'all. :wave: 

Kept it pretty basic. I also attempted to add a third test wherein a private playbook is created and the test validates that it is _not_ shown to a non-member, but I was having some trouble with API 403s and left it out for now. I used `playbook_list_permissions_spec.js` for guidance, but I noticed that test actually fails similarly when run. If that DOES seem like a good test to have, let me know and I dig a bit more around that.

#### Summary
-  adds a new spec for Playbooks Home

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37999

#### Checklist
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests updated~~