### PR TITLE
MM-38929: Add a navbar under the playbook name to switch between Preview and Usage

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -15,6 +15,8 @@ import {Team} from 'mattermost-redux/types/teams';
 import {Theme} from 'mattermost-redux/types/preferences';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
+import Playbook from 'src/components/backstage/playbooks/playbook';
+
 import {promptForFeedback} from 'src/client';
 
 import PlaybookRunBackstage
@@ -27,7 +29,6 @@ import {ErrorPageTypes} from 'src/constants';
 import {pluginErrorUrl} from 'src/browser_routing';
 import PlaybookIcon from 'src/components/assets/icons/playbook_icon';
 
-import PlaybookBackstage from 'src/components/backstage/playbooks/playbook_backstage';
 import {useExperimentalFeaturesEnabled, useForceDocumentTitle} from 'src/hooks';
 import CloudModal from 'src/components/cloud_modal';
 
@@ -175,7 +176,7 @@ const Backstage = () => {
                         />
                     </Route>
                     <Route path={`${match.url}/playbooks/:playbookId`}>
-                        <PlaybookBackstage/>
+                        <Playbook/>
                     </Route>
                     <Route path={`${match.url}/playbooks`}>
                         <PlaybookList/>

--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -1,56 +1,258 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import {Switch, Route, Redirect, Link, NavLink, useRouteMatch, useLocation} from 'react-router-dom';
 import styled from 'styled-components';
+import React, {useEffect, useState} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {Switch, Route, Redirect, NavLink, useRouteMatch, useLocation} from 'react-router-dom';
 
+import Icon from '@mdi/react';
+import {mdiClipboardPlayOutline} from '@mdi/js';
+
+import {getTeam} from 'mattermost-redux/selectors/entities/teams';
+import {Team} from 'mattermost-redux/types/teams';
+import {GlobalState} from 'mattermost-redux/types/store';
+
+import {navigateToUrl, navigateToPluginUrl, pluginErrorUrl} from 'src/browser_routing';
+import {useExperimentalFeaturesEnabled, useForceDocumentTitle} from 'src/hooks';
 import PlaybookBackstage from 'src/components/backstage/playbooks/playbook_backstage';
-import {useExperimentalFeaturesEnabled} from 'src/hooks';
+
+import {SecondaryButtonLargerRight} from 'src/components/backstage/playbook_runs/shared';
+import {clientFetchPlaybook, telemetryEventForPlaybook} from 'src/client';
+import {ErrorPageTypes} from 'src/constants';
+import {PlaybookWithChecklist} from 'src/types/playbook';
+import {startPlaybookRunById} from 'src/actions';
+import {PrimaryButton} from 'src/components/assets/buttons';
+import ClipboardsPlay from 'src/components/assets/icons/clipboards_play';
+import {RegularHeading} from 'src/styles/headings';
+
+interface MatchParams {
+    playbookId: string
+}
+
+const FetchingStateType = {
+    loading: 'loading',
+    fetched: 'fetched',
+    notFound: 'notfound',
+};
 
 const Playbook = () => {
-    const match = useRouteMatch();
+    const dispatch = useDispatch();
+    const location = useLocation();
+    const match = useRouteMatch<MatchParams>();
     const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled();
+    const [playbook, setPlaybook] = useState<PlaybookWithChecklist | null>(null);
+    const [fetchingState, setFetchingState] = useState(FetchingStateType.loading);
+    const team = useSelector<GlobalState, Team>((state) => getTeam(state, playbook?.team_id || ''));
 
-    if (!experimentalFeaturesEnabled) {
-        return <PlaybookBackstage/>;
-    }
+    useForceDocumentTitle(playbook?.title ? (playbook.title + ' - Playbooks') : 'Playbooks');
 
     const activeNavItemStyle = {
         color: 'var(--button-bg)',
         boxShadow: 'inset 0px -2px 0px 0px var(--button-bg)',
     };
 
+    const goToPlaybooks = () => {
+        navigateToPluginUrl('/playbooks');
+    };
+
+    const goToEdit = () => {
+        navigateToUrl(location.pathname + '/edit');
+    };
+
+    const runPlaybook = () => {
+        if (playbook?.id) {
+            telemetryEventForPlaybook(playbook.id, 'playbook_dashboard_run_clicked');
+            navigateToUrl(`/${team.name || ''}/_playbooks/${playbook?.id || ''}/run`);
+        }
+    };
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const playbookId = match.params.playbookId;
+            if (playbookId) {
+                try {
+                    const fetchedPlaybook = await clientFetchPlaybook(playbookId);
+                    setPlaybook(fetchedPlaybook!);
+                    setFetchingState(FetchingStateType.fetched);
+                } catch {
+                    setFetchingState(FetchingStateType.notFound);
+                }
+            }
+        };
+
+        fetchData();
+    }, [match.params.playbookId]);
+
+    if (fetchingState === FetchingStateType.loading) {
+        return null;
+    }
+
+    if (fetchingState === FetchingStateType.notFound || playbook === null) {
+        return <Redirect to={pluginErrorUrl(ErrorPageTypes.PLAYBOOKS)}/>;
+    }
+
+    let subTitle;
+    let accessIconClass;
+    if (playbook.member_ids.length === 1) {
+        subTitle = 'Only you can access this playbook';
+        accessIconClass = 'icon-lock-outline';
+    } else if (playbook.member_ids.length > 1) {
+        subTitle = `${playbook.member_ids.length} people can access this playbook`;
+        accessIconClass = 'icon-lock-outline';
+    } else if (team) {
+        accessIconClass = 'icon-globe';
+        subTitle = `Everyone in ${team.name} can access this playbook`;
+    } else {
+        accessIconClass = 'icon-globe';
+        subTitle = 'Everyone in this team can access this playbook';
+    }
+
+    const enableRunPlaybook = playbook?.delete_at === 0;
+
     return (
         <>
-            <Navbar>
-                <NavItem
-                    activeStyle={activeNavItemStyle}
-                    to={`${match.url}/preview`}
-                >{'Preview'}</NavItem>
-                <NavItem
-                    activeStyle={activeNavItemStyle}
-                    to={`${match.url}/usage`}
-                >{'Usage'}</NavItem>
-            </Navbar>
-            <Switch>
-                <Route
-                    exact={true}
-                    path={`${match.path}`}
-                >
-                    <Redirect to={`${match.url}/preview`}/>
-                </Route>
-                <Route path={`${match.path}/preview`}>
-                    <PlaybookBackstage/>
-                </Route>
-                <Route path={`${match.path}/usage`}>
-                    <PlaybookBackstage/>
-                </Route>
-            </Switch>
+            <TopContainer>
+                <TitleRow>
+                    <LeftArrow
+                        className='icon-arrow-left'
+                        onClick={goToPlaybooks}
+                    />
+                    <VerticalBlock>
+                        <Title>{playbook.title}</Title>
+                        <HorizontalBlock data-testid='playbookPermissionsDescription'>
+                            <i className={'icon ' + accessIconClass}/>
+                            <SubTitle>{subTitle}</SubTitle>
+                        </HorizontalBlock>
+                    </VerticalBlock>
+                    <SecondaryButtonLargerRight onClick={goToEdit}>
+                        <i className={'icon icon-pencil-outline'}/>
+                        {'Edit'}
+                    </SecondaryButtonLargerRight>
+                    <PrimaryButtonLarger
+                        onClick={runPlaybook}
+                        disabled={!enableRunPlaybook}
+                        data-testid='run-playbook'
+                    >
+                        <RightMarginedIcon
+                            path={mdiClipboardPlayOutline}
+                            size={1.25}
+                        />
+                        {'Run'}
+                    </PrimaryButtonLarger>
+                </TitleRow>
+            </TopContainer>
+            {(!experimentalFeaturesEnabled && <PlaybookBackstage playbook={playbook}/>) ||
+                <>
+                    <Navbar>
+                        <NavItem
+                            activeStyle={activeNavItemStyle}
+                            to={`${match.url}/preview`}
+                        >
+                            {'Preview'}
+                        </NavItem>
+                        <NavItem
+                            activeStyle={activeNavItemStyle}
+                            to={`${match.url}/usage`}
+                        >
+                            {'Usage'}
+                        </NavItem>
+                    </Navbar>
+                    <Switch>
+                        <Route
+                            exact={true}
+                            path={`${match.path}`}
+                        >
+                            <Redirect to={`${match.url}/preview`}/>
+                        </Route>
+                        <Route path={`${match.path}/preview`}>
+                            <PlaybookBackstage playbook={playbook}/>
+                        </Route>
+                        <Route path={`${match.path}/usage`}>
+                            <PlaybookBackstage playbook={playbook}/>
+                        </Route>
+                    </Switch>
+                </>
+            }
         </>
     );
 };
 
+const TopContainer = styled.div`
+    position: sticky;
+    z-index: 2;
+    top: 0;
+    background: var(--center-channel-bg);
+    width: 100%;
+    box-shadow: inset 0px -1px 0px var(--center-channel-color-16);
+`;
+
+const TitleRow = styled.div`
+    display: flex;
+    align-items: center;
+    margin: 0 32px;
+    height: 82px;
+`;
+
+const LeftArrow = styled.button`
+    display: block;
+    padding: 0;
+    border: none;
+    background: transparent;
+    font-size: 24px;
+    line-height: 24px;
+    cursor: pointer;
+    color: var(--center-channel-color-56);
+
+    &:hover {
+        background: var(--button-bg-08);
+        color: var(--button-bg);
+    }
+`;
+
+const VerticalBlock = styled.div`
+    display: flex;
+    flex-direction: column;
+    font-weight: 400;
+    padding: 0 16px 0 24px;
+`;
+
+const HorizontalBlock = styled.div`
+    display: flex;
+    flex-direction: row;
+    color: var(--center-channel-color-64);
+
+    > i {
+        font-size: 12px;
+        margin-left: -3px;
+    }
+`;
+
+const Title = styled.div`
+    ${RegularHeading}
+
+    font-size: 20px;
+    line-height: 28px;
+    color: var(--center-channel-color);
+`;
+
+const SubTitle = styled.div`
+    font-size: 11px;
+    line-height: 16px;
+`;
+
+const ClipboardsPlaySmall = styled(ClipboardsPlay)`
+    height: 18px;
+    width: auto;
+    margin-right: 7px;
+    color: var(--button-color);
+`;
+
+const PrimaryButtonLarger = styled(PrimaryButton)`
+    padding: 0 16px;
+    height: 36px;
+    margin-left: 12px;
+`;
 const Navbar = styled.nav`
     background: var(--center-channel-bg);
     height: 55px;
@@ -81,6 +283,10 @@ const NavItem = styled(NavLink)`
             text-decoration: none;
         }
     }
+`;
+
+const RightMarginedIcon = styled(Icon)`
+    margin-right: 0.5rem;
 `;
 
 export default Playbook;

--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -15,7 +15,7 @@ import {GlobalState} from 'mattermost-redux/types/store';
 
 import {navigateToUrl, navigateToPluginUrl, pluginErrorUrl} from 'src/browser_routing';
 import {useExperimentalFeaturesEnabled, useForceDocumentTitle} from 'src/hooks';
-import PlaybookBackstage from 'src/components/backstage/playbooks/playbook_backstage';
+import PlaybookUsage from 'src/components/backstage/playbooks/playbook_usage';
 
 import {SecondaryButtonLargerRight} from 'src/components/backstage/playbook_runs/shared';
 import {clientFetchPlaybook, telemetryEventForPlaybook} from 'src/client';
@@ -142,7 +142,7 @@ const Playbook = () => {
                     </PrimaryButtonLarger>
                 </TitleRow>
             </TopContainer>
-            {(!experimentalFeaturesEnabled && <PlaybookBackstage playbook={playbook}/>) ||
+            {(!experimentalFeaturesEnabled && <PlaybookUsage playbook={playbook}/>) ||
                 <>
                     <Navbar>
                         <NavItem
@@ -169,7 +169,7 @@ const Playbook = () => {
                             <h4>{'Site under construction'}</h4>
                         </Route>
                         <Route path={`${match.path}/usage`}>
-                            <PlaybookBackstage playbook={playbook}/>
+                            <PlaybookUsage playbook={playbook}/>
                         </Route>
                     </Switch>
                 </>

--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -163,10 +163,10 @@ const Playbook = () => {
                             exact={true}
                             path={`${match.path}`}
                         >
-                            <Redirect to={`${match.url}/preview`}/>
+                            <Redirect to={`${match.url}/usage`}/>
                         </Route>
                         <Route path={`${match.path}/preview`}>
-                            <PlaybookBackstage playbook={playbook}/>
+                            <h4>{'Site under construction'}</h4>
                         </Route>
                         <Route path={`${match.path}/usage`}>
                             <PlaybookBackstage playbook={playbook}/>

--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {Switch, Route, Redirect, Link, NavLink, useRouteMatch, useLocation} from 'react-router-dom';
+import styled from 'styled-components';
+
+import PlaybookBackstage from 'src/components/backstage/playbooks/playbook_backstage';
+import {useExperimentalFeaturesEnabled} from 'src/hooks';
+
+const Playbook = () => {
+    const match = useRouteMatch();
+    const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled();
+
+    if (!experimentalFeaturesEnabled) {
+        return <PlaybookBackstage/>;
+    }
+
+    const activeNavItemStyle = {
+        color: 'var(--button-bg)',
+        boxShadow: 'inset 0px -2px 0px 0px var(--button-bg)',
+    };
+
+    return (
+        <>
+            <Navbar>
+                <NavItem
+                    activeStyle={activeNavItemStyle}
+                    to={`${match.url}/preview`}
+                >{'Preview'}</NavItem>
+                <NavItem
+                    activeStyle={activeNavItemStyle}
+                    to={`${match.url}/usage`}
+                >{'Usage'}</NavItem>
+            </Navbar>
+            <Switch>
+                <Route
+                    exact={true}
+                    path={`${match.path}`}
+                >
+                    <Redirect to={`${match.url}/preview`}/>
+                </Route>
+                <Route path={`${match.path}/preview`}>
+                    <PlaybookBackstage/>
+                </Route>
+                <Route path={`${match.path}/usage`}>
+                    <PlaybookBackstage/>
+                </Route>
+            </Switch>
+        </>
+    );
+};
+
+const Navbar = styled.nav`
+    background: var(--center-channel-bg);
+    height: 55px;
+    width: 100%;
+    box-shadow: inset 0px -1px 0px 0px rgba(var(--center-channel-color-rgb), 0.16);
+
+    display: flex;
+    flex-direction: row;
+    padding-left: 80px;
+    margin: 0;
+`;
+
+const NavItem = styled(NavLink)`
+    display: flex;
+    align-items: center;
+    text-align: center;
+    padding: 0 25px;
+    font-weight: 600;
+
+    && {
+        color: rgba(var(--center-channel-color-rgb), 0.64);
+
+        :hover {
+            color: var(--button-bg);
+        }
+
+       :hover, :focus {
+            text-decoration: none;
+        }
+    }
+`;
+
+export default Playbook;

--- a/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
@@ -3,44 +3,15 @@
 
 import styled from 'styled-components';
 import React, {useEffect, useState} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
-import {Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 
-import Icon from '@mdi/react';
-import {mdiClipboardPlayOutline} from '@mdi/js';
-
-const RightMarginedIcon = styled(Icon)`
-    margin-right: 0.5rem;
-`;
-
-import {getTeam} from 'mattermost-redux/selectors/entities/teams';
-import {Team} from 'mattermost-redux/types/teams';
-import {GlobalState} from 'mattermost-redux/types/store';
-
-import {SecondaryButtonLargerRight} from 'src/components/backstage/playbook_runs/shared';
-import {clientFetchPlaybook, fetchPlaybookStats, telemetryEventForPlaybook} from 'src/client';
-import {navigateToUrl, navigateToPluginUrl, pluginErrorUrl} from 'src/browser_routing';
-import {BACKSTAGE_LIST_PER_PAGE, ErrorPageTypes} from 'src/constants';
+import {fetchPlaybookStats} from 'src/client';
+import {BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
 import {PlaybookWithChecklist} from 'src/types/playbook';
 import {EmptyPlaybookStats} from 'src/types/stats';
 import StatsView from 'src/components/backstage/playbooks/stats_view';
-import {startPlaybookRunById} from 'src/actions';
-import {PrimaryButton} from 'src/components/assets/buttons';
-import ClipboardsPlay from 'src/components/assets/icons/clipboards_play';
-import {useForceDocumentTitle, useRunsList} from 'src/hooks';
+import {useRunsList} from 'src/hooks';
 import RunList from '../runs_list/runs_list';
-import {RegularHeading} from 'src/styles/headings';
 import {PlaybookRunStatus} from 'src/types/playbook_run';
-
-interface MatchParams {
-    playbookId: string
-}
-
-const FetchingStateType = {
-    loading: 'loading',
-    fetched: 'fetched',
-    notFound: 'notfound',
-};
 
 const defaultPlaybookFetchParams = {
     page: 0,
@@ -56,127 +27,35 @@ const RunListContainer = styled.div`
     }
 `;
 
-const PlaybookBackstage = () => {
-    const dispatch = useDispatch();
-    const match = useRouteMatch<MatchParams>();
-    const location = useLocation();
-    const [playbook, setPlaybook] = useState<PlaybookWithChecklist | null>(null);
+interface Props {
+    playbook: PlaybookWithChecklist;
+}
+
+const PlaybookBackstage = (props: Props) => {
     const [filterPill, setFilterPill] = useState<JSX.Element | null>(null);
-    const [fetchingState, setFetchingState] = useState(FetchingStateType.loading);
     const [stats, setStats] = useState(EmptyPlaybookStats);
     const [playbookRuns, totalCount, fetchParams, setFetchParams] = useRunsList(defaultPlaybookFetchParams);
 
-    useForceDocumentTitle(playbook?.title ? (playbook.title + ' - Playbooks') : 'Playbooks');
-
     useEffect(() => {
-        const fetchData = async () => {
-            const playbookId = match.params.playbookId;
-            if (playbookId) {
-                try {
-                    const fetchedPlaybook = await clientFetchPlaybook(playbookId);
-                    setPlaybook(fetchedPlaybook!);
-                    setFetchParams((oldParams) => {
-                        return {...oldParams, playbook_id: fetchedPlaybook?.id};
-                    });
-                    setFetchingState(FetchingStateType.fetched);
-                } catch {
-                    setFetchingState(FetchingStateType.notFound);
-                }
-            }
-        };
-
         const fetchStats = async () => {
-            const playbookId = match.params.playbookId;
-            if (playbookId) {
-                try {
-                    const ret = await fetchPlaybookStats(playbookId);
-                    setStats(ret);
-                } catch {
-                    // Ignore any errors here. If it fails, it's most likely also failed to fetch
-                    // the playbook above.
-                }
+            try {
+                const ret = await fetchPlaybookStats(props.playbook.id);
+                setStats(ret);
+            } catch {
+                // Ignore any errors here. If it fails, it's most likely also failed to fetch
+                // the playbook above.
             }
         };
 
-        fetchData();
+        setFetchParams((oldParams) => {
+            return {...oldParams, playbook_id: props.playbook.id};
+        });
+
         fetchStats();
-    }, [match.params.playbookId, setFetchParams]);
-
-    const team = useSelector<GlobalState, Team>((state) => getTeam(state, playbook?.team_id || ''));
-
-    if (fetchingState === FetchingStateType.loading) {
-        return null;
-    }
-
-    if (fetchingState === FetchingStateType.notFound || playbook === null) {
-        return <Redirect to={pluginErrorUrl(ErrorPageTypes.PLAYBOOKS)}/>;
-    }
-
-    const goToPlaybooks = () => {
-        navigateToPluginUrl('/playbooks');
-    };
-
-    const goToEdit = () => {
-        navigateToUrl(location.pathname + '/edit');
-    };
-
-    const runPlaybook = () => {
-        if (playbook?.id) {
-            telemetryEventForPlaybook(playbook.id, 'playbook_dashboard_run_clicked');
-            navigateToUrl(`/${team.name || ''}/_playbooks/${playbook?.id || ''}/run`);
-        }
-    };
-
-    let subTitle;
-    let accessIconClass;
-    if (playbook.member_ids.length === 1) {
-        subTitle = 'Only you can access this playbook';
-        accessIconClass = 'icon-lock-outline';
-    } else if (playbook.member_ids.length > 1) {
-        subTitle = `${playbook.member_ids.length} people can access this playbook`;
-        accessIconClass = 'icon-lock-outline';
-    } else if (team) {
-        accessIconClass = 'icon-globe';
-        subTitle = `Everyone in ${team.name} can access this playbook`;
-    } else {
-        accessIconClass = 'icon-globe';
-        subTitle = 'Everyone in this team can access this playbook';
-    }
-
-    const enableRunPlaybook = playbook?.delete_at === 0;
+    }, [props.playbook.id, setFetchParams]);
 
     return (
         <OuterContainer>
-            <TopContainer>
-                <TitleRow>
-                    <LeftArrow
-                        className='icon-arrow-left'
-                        onClick={goToPlaybooks}
-                    />
-                    <VerticalBlock>
-                        <Title>{playbook.title}</Title>
-                        <HorizontalBlock data-testid='playbookPermissionsDescription'>
-                            <i className={'icon ' + accessIconClass}/>
-                            <SubTitle>{subTitle}</SubTitle>
-                        </HorizontalBlock>
-                    </VerticalBlock>
-                    <SecondaryButtonLargerRight onClick={goToEdit}>
-                        <i className={'icon icon-pencil-outline'}/>
-                        {'Edit'}
-                    </SecondaryButtonLargerRight>
-                    <PrimaryButtonLarger
-                        onClick={runPlaybook}
-                        disabled={!enableRunPlaybook}
-                        data-testid='run-playbook'
-                    >
-                        <RightMarginedIcon
-                            path={mdiClipboardPlayOutline}
-                            size={1.25}
-                        />
-                        {'Run'}
-                    </PrimaryButtonLarger>
-                </TitleRow>
-            </TopContainer>
             <BottomContainer>
                 <BottomInnerContainer>
                     <StatsView
@@ -206,82 +85,6 @@ const OuterContainer = styled.div`
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-`;
-
-const TopContainer = styled.div`
-    position: sticky;
-    z-index: 2;
-    top: 0;
-    background: var(--center-channel-bg);
-    width: 100%;
-    box-shadow: inset 0px -1px 0px var(--center-channel-color-16);
-`;
-
-const TitleRow = styled.div`
-    display: flex;
-    align-items: center;
-    margin: 0 32px;
-    height: 82px;
-`;
-
-const LeftArrow = styled.button`
-    display: block;
-    padding: 0;
-    border: none;
-    background: transparent;
-    font-size: 24px;
-    line-height: 24px;
-    cursor: pointer;
-    color: var(--center-channel-color-56);
-
-    &:hover {
-        background: var(--button-bg-08);
-        color: var(--button-bg);
-    }
-`;
-
-const VerticalBlock = styled.div`
-    display: flex;
-    flex-direction: column;
-    font-weight: 400;
-    padding: 0 16px 0 24px;
-`;
-
-const HorizontalBlock = styled.div`
-    display: flex;
-    flex-direction: row;
-    color: var(--center-channel-color-64);
-
-    > i {
-        font-size: 12px;
-        margin-left: -3px;
-    }
-`;
-
-const Title = styled.div`
-    ${RegularHeading}
-
-    font-size: 20px;
-    line-height: 28px;
-    color: var(--center-channel-color);
-`;
-
-const SubTitle = styled.div`
-    font-size: 11px;
-    line-height: 16px;
-`;
-
-const ClipboardsPlaySmall = styled(ClipboardsPlay)`
-    height: 18px;
-    width: auto;
-    margin-right: 7px;
-    color: var(--button-color);
-`;
-
-const PrimaryButtonLarger = styled(PrimaryButton)`
-    padding: 0 16px;
-    height: 36px;
-    margin-left: 12px;
 `;
 
 const BottomContainer = styled.div`

--- a/webapp/src/components/backstage/playbooks/playbook_usage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_usage.tsx
@@ -31,7 +31,7 @@ interface Props {
     playbook: PlaybookWithChecklist;
 }
 
-const PlaybookBackstage = (props: Props) => {
+const PlaybookUsage = (props: Props) => {
     const [filterPill, setFilterPill] = useState<JSX.Element | null>(null);
     const [stats, setStats] = useState(EmptyPlaybookStats);
     const [playbookRuns, totalCount, fetchParams, setFetchParams] = useRunsList(defaultPlaybookFetchParams);
@@ -108,4 +108,4 @@ const BottomInnerContainer = styled.div`
     }
 `;
 
-export default PlaybookBackstage;
+export default PlaybookUsage;


### PR DESCRIPTION
#### Summary
This is the first PR in the Playbook Preview epic. It lays the groundwork for the actual development, but it does not do much on itself:

- Add a navigation bar to switch between the (yet to be implemented) Preview page and the Usage page. This is behind the Experimental Features flag.
- Refactor the `PlaybookBackstage` component: it is now named `PlaybookUsage`, and it only contains the logic to display the usage page. The rest of the code, used to render the bar with the playbook name, the left arrow to get back to the playbooks list and the Edit and Run buttons have been added to the new Playbook component.
- Add a `Playbook component`, which is in charge of:
  - Rendering the bar with the playbook name and the Edit and Run buttons (the Edit button will be moved to the Preview page soon, as per the designs).
  - Rendering the navigation bar to switch between the Preview and Usage tabs
  - Handling the logic to show one of those two tabs (with the new `/playbooks/playbooks/:playbookId/{preview, usage}` routes), redirecting to `/playbooks/playbooks/:playbookId/usage` when the plain `/playbooks/playbooks/:playbookId` is visited. This default will change soon (the design is to show `/preview` as the default, but as it is empty as of today, we will have `/usage` as the default while I finish the actual implementation of that view).
  
![image](https://user-images.githubusercontent.com/3924815/136046369-596a7a72-691e-4646-8462-35f8f80e9af9.png)

#### Plan
1. Add a navigation bar with Preview and Usage tabs <-- we're here
2. Implement the layout of the Preview page
3. Add the sticky navigation widget
4. Remove the Experimental Feature flag and make /preview the default view
5. Add telemetry


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38929

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [X] Gated by experimental feature flag
- [ ] ~~Unit tests updated~~
