### PR TITLE
tweak case of "Finished runs" and "Run name"

### DIFF
--- a/tests-e2e/cypress/integration/backstage/playbook_run_list_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_run_list_spec.js
@@ -171,7 +171,7 @@ describe('backstage playbook run list', () => {
         });
     });
 
-    describe('filters Finished Runs correctly', () => {
+    describe('filters Finished runs correctly', () => {
         before(() => {
             // # Login as testUser
             cy.apiLogin(testUser);

--- a/webapp/src/components/backstage/runs_list/filters.tsx
+++ b/webapp/src/components/backstage/runs_list/filters.tsx
@@ -134,7 +134,7 @@ const Filters = ({fetchParams, setFetchParams, fixedTeam}: Props) => {
             />
             <CheckboxInput
                 testId={'finished-runs'}
-                text={'Finished Runs'}
+                text={'Finished runs'}
                 checked={(fetchParams.statuses?.length ?? 0) > 1}
                 onChange={setFinishedRuns}
             />

--- a/webapp/src/components/backstage/runs_list/run_list_header.tsx
+++ b/webapp/src/components/backstage/runs_list/run_list_header.tsx
@@ -49,7 +49,7 @@ const RunListHeader = ({fetchParams, setFetchParams}: Props) => {
             <div className='row'>
                 <div className='col-sm-4'>
                     <SortableColHeader
-                        name={'Run Name'}
+                        name={'Run name'}
                         direction={fetchParams.direction ? fetchParams.direction : 'desc'}
                         active={fetchParams.sort ? fetchParams.sort === 'name' : false}
                         onClick={() => colHeaderClicked('name')}


### PR DESCRIPTION
#### Summary
Fix case of `Finished runs`:
<img width="665" alt="CleanShot 2021-10-05 at 22 16 56@2x" src="https://user-images.githubusercontent.com/1023171/136125456-195560c7-f1af-4139-b22e-4057ee9549fa.png">

and `Run name`:
<img width="252" alt="CleanShot 2021-10-05 at 22 20 03@2x" src="https://user-images.githubusercontent.com/1023171/136125718-be169b66-8e97-429d-a3ca-6e95cc174460.png">

#### Ticket Link
N/A

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] ~~Unit tests updated~~
