### PR TITLE
[MM-38725] Add warning to run status modal if reminder date is in the past

### DIFF
--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -35,6 +35,7 @@ import {formatDuration} from '../formatted_duration';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {nearest} from 'src/utils';
 import Tooltip from 'src/components/widgets/tooltip';
+import WarningIcon from '../assets/icons/warning_icon';
 
 const ID = 'playbooks_update_run_status_dialog';
 
@@ -67,6 +68,8 @@ const UpdateRunStatusModal = ({
     }
 
     const {input: reminderInput, reminder} = useReminderTimerOption(run);
+
+    const isReminderValid = !reminder || reminder > 0;
 
     const onConfirm = () => {
         if (hasPermission && message?.trim() && currentUserId && channelId && run?.team_id) {
@@ -129,6 +132,11 @@ const UpdateRunStatusModal = ({
                 {'Timer for next update'}
             </Label>
             {reminderInput}
+            {!isReminderValid &&
+            <WarningLine>
+                <WarningIcon/> {formatMessage({defaultMessage: 'Date must be in the future.'})}
+            </WarningLine>
+            }
         </FormContainer>
     );
 
@@ -147,7 +155,7 @@ const UpdateRunStatusModal = ({
             confirmButtonText={hasPermission ? 'Post' : 'Ok'}
             handleCancel={() => true}
             handleConfirm={hasPermission ? onConfirm : null}
-            isConfirmDisabled={!(hasPermission && message?.trim() && currentUserId && channelId && run?.team_id)}
+            isConfirmDisabled={!(hasPermission && message?.trim() && currentUserId && channelId && run?.team_id && isReminderValid)}
             {...modalProps}
             id={ID}
         >
@@ -258,6 +266,11 @@ const WarningBlock = styled.div`
     span {
         padding: 1.5rem;
     }
+`;
+
+const WarningLine = styled.p`
+    color: var(--error-text);
+    margin-top: 0.6rem;
 `;
 
 export default UpdateRunStatusModal;


### PR DESCRIPTION
#### Summary

Warns the user and prevents posting if they attempt to set a reminder date in the past when posting a status update.

#### Screenshots

Post prevented with past date:
<img width="604" alt="2021-10-06_00-05-17" src="https://user-images.githubusercontent.com/9410325/136139144-11161ace-fa65-463f-b638-e8a6322d3e88.png">

Post permitted with no date:
<img width="605" alt="2021-10-06_00-05-31" src="https://user-images.githubusercontent.com/9410325/136139173-e7d27363-eade-422a-a379-c32fcd76381f.png">

Post permitted with future date:
<img width="606" alt="2021-10-06_00-06-03" src="https://user-images.githubusercontent.com/9410325/136139182-e805a0cb-1b99-4fe5-84bf-a9050f5df829.png">

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/18508

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~- [ ] Telemetry updated~
~- [ ] Gated by experimental feature flag~
~- [ ] Unit tests updated~
