### PR TITLE
[MM-39162]:Remove collapsible from long status update in run overview

### DIFF
--- a/webapp/src/components/rhs/post_card.tsx
+++ b/webapp/src/components/rhs/post_card.tsx
@@ -130,14 +130,12 @@ const PostCard = (props: Props) => {
                         }
                     </UpdateTimeLink>
                 </UpdateHeader>
-
-                    <PostText
-                        text={props.post.message}
-                        team={props.team}
-                    >
-                        {props.post.edit_at !== 0 && <EditedIndicator>{formatMessage({defaultMessage: '(edited)'})}</EditedIndicator>}
-                    </PostText>
-                
+                <PostText
+                    text={props.post.message}
+                    team={props.team}
+                >
+                    {props.post.edit_at !== 0 && <EditedIndicator>{formatMessage({defaultMessage: '(edited)'})}</EditedIndicator>}
+                </PostText>
             </UpdateContainer>
         </UpdateSection>
     );


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
<!--
A description of what this pull request does
-->
The post component we use in the run overview for status updates supports automatically collapsing long content, but this is undesirable on a page dedicated to viewing those status updates. Let's disable this functionality in this context:

- JIRA: https://mattermost.atlassian.net/browse/MM-39162
- Github: fixes https://github.com/mattermost/mattermost-server/issues/18597
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [x] Telemetry updated
- [x] Gated by experimental feature flag
- [x] Unit tests updated
