### PR TITLE
[MM-39116] Moved null check for post to happen before reference to channel_id

### DIFF
--- a/webapp/src/components/post_menu.tsx
+++ b/webapp/src/components/post_menu.tsx
@@ -27,11 +27,16 @@ interface Props {
 
 export const StartPlaybookRunPostMenu = (props: Props) => {
     const dispatch = useDispatch();
-    const post = useSelector<GlobalState, Post>((state) => getPost(state, props.postId));
-    if (!post || isSystemMessage(post)) {
+    const channel = useSelector<GlobalState, Channel | null>((state) => {
+        const post = getPost(state, props.postId);
+        if (!post || isSystemMessage(post)) {
+            return null;
+        }
+        return getChannel(state, post.channel_id);
+    });
+    if (!channel) {
         return null;
     }
-    const channel = useSelector<GlobalState, Channel>((state) => getChannel(state, post.channel_id));
 
     const handleClick = () => {
         dispatch(startPlaybookRun(channel.team_id, props.postId));


### PR DESCRIPTION
#### Summary
There was a null reference happening when opening the post menu if the message was a system message. We were trying to reference the `channel_id` before we did the null check, so I've moved the null check up.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39116
