### PR TITLE
MM-39154 migrate retrospective_reminder_posts from moment to Luxon

### DIFF
--- a/webapp/src/components/retrospective_reminder_posts.tsx
+++ b/webapp/src/components/retrospective_reminder_posts.tsx
@@ -3,13 +3,13 @@ import {useSelector} from 'react-redux';
 
 import styled from 'styled-components';
 
-import moment from 'moment';
-
 import {Post} from 'mattermost-redux/types/posts';
 
 import {getPostIdsInCurrentChannel, getPostsInCurrentChannel} from 'mattermost-redux/selectors/entities/posts';
 
 import {GlobalState} from 'mattermost-redux/types/store';
+
+import {Duration} from 'luxon';
 
 import {currentPlaybookRun} from 'src/selectors';
 
@@ -62,7 +62,7 @@ const ReminderCommon = (props: ReminderCommonProps) => {
         reminderText = (
             <>
                 {'A reminder will be sent in '}
-                <b>{formatDuration(moment.duration(reminderDuration, 'seconds'))}</b>
+                <b>{formatDuration(Duration.fromObject({seconds: reminderDuration}))}</b>
             </>
         );
     }


### PR DESCRIPTION
#### Summary
Updates retrospective reminder post interval timer to use Luxon instead of moment.

**Before:**
<img width="653" alt="2021-10-14_00-24-13" src="https://user-images.githubusercontent.com/9410325/137251742-1e1da677-7fa3-4ae8-9af2-749b8e956bce.png">

**After (looks the same; no regressions):**
<img width="656" alt="2021-10-14_00-17-39" src="https://user-images.githubusercontent.com/9410325/137251614-3b0b6bd5-5002-48d6-8878-c3484d5c9112.png">

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/18593

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~[ ] Telemetry updated~
- ~[ ] Gated by experimental feature flag~
- ~[ ] Unit tests updated~
