### PR TITLE
remove use of React.FC

### DIFF
--- a/webapp/src/components/backstage/automation/patterned_input.tsx
+++ b/webapp/src/components/backstage/automation/patterned_input.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {FC} from 'react';
+import React from 'react';
 
 import styled, {css} from 'styled-components';
 
@@ -21,7 +21,7 @@ interface Props {
     maxLength?: number;
 }
 
-export const PatternedInput: FC<Props> = (props: Props) => (
+export const PatternedInput = (props: Props) => (
     <AutomationHeader>
         <AutomationTitle>
             <Toggle

--- a/webapp/src/components/backstage/automation/patterned_text_area.tsx
+++ b/webapp/src/components/backstage/automation/patterned_text_area.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {FC, useState} from 'react';
+import React, {useState} from 'react';
 
 import styled, {css} from 'styled-components';
 
@@ -24,7 +24,7 @@ interface Props {
     maxErrorText?: string;
 }
 
-export const PatternedTextArea: FC<Props> = (props: Props) => {
+export const PatternedTextArea = (props: Props) => {
     const [invalid, setInvalid] = useState<boolean>(false);
     const [errorText, setErrorText] = useState<string>(props.errorText);
     const handleOnBlur = (urls: string) => {


### PR DESCRIPTION
#### Summary
Minor stylistic tweak to remove the last instance of `React.FC` in favour of implicit typing.

#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
