### PR TITLE
MM-37530: Improve RHS collapse/expand experience

### DIFF
--- a/webapp/src/components/rhs/rhs_about_buttons.tsx
+++ b/webapp/src/components/rhs/rhs_about_buttons.tsx
@@ -29,6 +29,19 @@ const RHSAboutButtons = (props: Props) => {
 
     return (
         <>
+            <ExpandCollapseButton
+                title={props.collapsed ? 'Expand' : 'Collapse'}
+                className={(props.collapsed ? 'icon-chevron-down' : 'icon-chevron-up') + ' icon-16 btn-icon'}
+                tabIndex={0}
+                role={'button'}
+                onClick={props.toggleCollapsed}
+                onKeyDown={(e) => {
+                    // Handle Enter and Space as clicking on the button
+                    if (e.keyCode === 13 || e.keyCode === 32) {
+                        props.toggleCollapsed();
+                    }
+                }}
+            />
             <DotMenu
                 icon={<ThreeDotsIcon/>}
                 left={true}
@@ -52,19 +65,6 @@ const RHSAboutButtons = (props: Props) => {
                     </PlaybookInfo>
                 </StyledDropdownMenuItem>
             </DotMenu>
-            <ExpandCollapseButton
-                title={props.collapsed ? 'Expand' : 'Collapse'}
-                className={(props.collapsed ? 'icon-arrow-expand' : 'icon-arrow-collapse') + ' icon-16 btn-icon'}
-                tabIndex={0}
-                role={'button'}
-                onClick={props.toggleCollapsed}
-                onKeyDown={(e) => {
-                    // Handle Enter and Space as clicking on the button
-                    if (e.keyCode === 13 || e.keyCode === 32) {
-                        props.toggleCollapsed();
-                    }
-                }}
-            />
         </>
     );
 };


### PR DESCRIPTION
#### Summary
Replace the collapse/expand icon with chevrons, to avoid similarity with RHS expansion.

Old:
![image](https://user-images.githubusercontent.com/5236894/138330207-c0894021-0d6a-48f9-8bc1-6e81d657ed2c.png)

New:
![image](https://user-images.githubusercontent.com/5236894/138329484-93b7a315-1924-48e0-a71c-0cadf9d5aff2.png)

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/18761
JIRA: https://mattermost.atlassian.net/browse/MM-37530

#### Checklist
- [ ] ~Telemetry updated~
- [ ] ~Gated by experimental feature flag~
- [ ] ~Unit tests updated~
