### PR TITLE
MM-36942: Set focus on textarea when `Edit` is clicked

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/report.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/report.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useRef, useEffect} from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 
 import {useSelector} from 'react-redux';
@@ -74,7 +74,6 @@ const Report = (props: ReportProps) => {
     const [editing, setEditing] = useState(false);
     const [publishedThisSession, setPublishedThisSession] = useState(false);
     const team = useSelector<GlobalState, Team>((state) => getTeam(state, props.playbookRun.team_id));
-    const reportTextareaRef = useRef<HTMLTextAreaElement>(null);
 
     const savePressed = () => {
         updateRetrospective(props.playbookRun.id, report);
@@ -86,12 +85,6 @@ const Report = (props: ReportProps) => {
         setEditing(false);
         setPublishedThisSession(true);
     };
-
-    useEffect(() => {
-        if (editing && reportTextareaRef.current) {
-            reportTextareaRef.current.focus();
-        }
-    }, [editing, reportTextareaRef]);
 
     let publishButtonText: React.ReactNode = 'Publish';
     if (publishedThisSession) {
@@ -124,7 +117,7 @@ const Report = (props: ReportProps) => {
             </Header>
             {editing &&
                 <ReportTextarea
-                    ref={reportTextareaRef}
+                    autoFocus={true}
                     value={report}
                     onChange={(e) => {
                         setReport(e.target.value);


### PR DESCRIPTION
#### Summary
When the `Edit` button is clicked in the `Retrospective` tab of a playbook, the respective textarea will be focused

#### Ticket Link
Fixes [#18510](https://github.com/mattermost/mattermost-server/issues/18510)

#### Checklist

- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
