### PR TITLE
[GH-18760] - Changed Finished runs filter text to Include finished

### DIFF
--- a/webapp/src/components/backstage/runs_list/filters.tsx
+++ b/webapp/src/components/backstage/runs_list/filters.tsx
@@ -144,7 +144,7 @@ const Filters = ({fetchParams, setFetchParams, fixedTeam}: Props) => {
             />
             <CheckboxInput
                 testId={'finished-runs'}
-                text={'Finished runs'}
+                text={'Include finished'}
                 checked={(fetchParams.statuses?.length ?? 0) > 1}
                 onChange={setFinishedRuns}
             />


### PR DESCRIPTION
#### Summary
Changed "Finished runs" filter text to "Include Finished" to clarify its meaning.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/18760
