### PR TITLE
MM-39456 - Send 'Overdue status updates' to all users; add at-mention of owner

### DIFF
--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -366,6 +366,7 @@ type RunLink struct {
 	TeamName           string
 	ChannelName        string
 	ChannelDisplayName string
+	OwnerUserName      string
 }
 
 // AssignedRun represents all the info needed to display a Run & ChecklistItem to a user
@@ -599,7 +600,7 @@ type PlaybookRunStore interface {
 	// GetParticipatingRuns returns the list of active runs with userID as a participant
 	GetParticipatingRuns(userID string) ([]RunLink, error)
 
-	// GetOverdueUpdateRuns returns the list of userID's runs that have overdue updates
+	// GetOverdueUpdateRuns returns the list of runs that userID is participating in that have overdue updates
 	GetOverdueUpdateRuns(userID string) ([]RunLink, error)
 }
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2466,8 +2466,8 @@ func buildRunsOverdueMessage(runs []RunLink, siteURL string) string {
 	message := fmt.Sprintf("\n##### Overdue Status Updates\nYou have %d %s overdue for a status update:\n", total, runPlural)
 
 	for _, run := range runs {
-		message += fmt.Sprintf("- [%s](%s/%s/channels/%s?telem=todo_overduestatus_clicked)\n",
-			run.ChannelDisplayName, siteURL, run.TeamName, run.ChannelName)
+		message += fmt.Sprintf("- [%s](%s/%s/channels/%s?telem=todo_overduestatus_clicked) (Owner: @%s)\n",
+			run.ChannelDisplayName, siteURL, run.TeamName, run.ChannelName, run.OwnerUserName)
 	}
 
 	return message

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -950,7 +950,6 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 		})
 
 		_, store := setupSQLStore(t, db)
-		setupUsersTable(t, db)
 		setupTeamMembersTable(t, db)
 		addUsers(t, store, users)
 		addUsersToTeam(t, store, users, team1id)
@@ -1529,7 +1528,6 @@ func TestGetPlaybookIDsForUser(t *testing.T) {
 		})
 
 		_, store := setupSQLStore(t, db)
-		setupUsersTable(t, db)
 		setupTeamMembersTable(t, db)
 		addUsers(t, store, users)
 

--- a/server/sqlstore/stats_test.go
+++ b/server/sqlstore/stats_test.go
@@ -92,7 +92,6 @@ func TestTotalInProgressPlaybookRuns(t *testing.T) {
 		statsStore := setupStatsStore(t, db)
 
 		_, store := setupSQLStore(t, db)
-		setupUsersTable(t, db)
 		setupTeamMembersTable(t, db)
 		setupChannelMembersTable(t, db)
 		setupChannelsTable(t, db)

--- a/server/sqlstore/support_for_test.go
+++ b/server/sqlstore/support_for_test.go
@@ -68,6 +68,7 @@ func setupSQLStore(t *testing.T, db *sqlx.DB) (bot.Logger, *SQLStore) {
 	setupBotsTable(t, db)
 	setupChannelMembersTable(t, db)
 	setupKVStoreTable(t, db)
+	setupUsersTable(t, db)
 
 	if currentSchemaVersion.LT(LatestVersion()) {
 		err = sqlStore.Migrate(currentSchemaVersion)
@@ -111,7 +112,8 @@ func setupUsersTable(t *testing.T, db *sqlx.DB) {
 				locale character varying(5),
 				timezone character varying(256),
 				mfaactive boolean,
-				mfasecret character varying(128)
+				mfasecret character varying(128),
+				PRIMARY KEY (Id)
 			);
 		`)
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
- Send 'Overdue status updates' to all participating users
- Add at-mention of owner in the summary
- Add unit tests

Pending: 
- Not sure if we're going to be able to add telemetry to the `@mention` click. Not likely; that's in the profile popover, which we don't control, and the link goes to a DM channel which we also don't have components in. @stephenvanhemmen 

Looks like: (a digest from `/playbook todo` so all sections are forced)

![image](https://user-images.githubusercontent.com/1490756/138950419-d1f70741-d9e4-4c15-b7ab-d8626d54eaba.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39456

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
