### PR TITLE
MM-39646 - Fix for: Build should not use circleCI caches for security

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,11 @@ jobs:
       name: default
     steps:
       - checkout
-      - npm-dependencies
+      - run:
+          name: Getting JavaScript dependencies
+          command: |
+            cd webapp
+            NODE_ENV=development npm install --ignore-scripts --no-save
       - run:
           name: Building Plugin Bundle
           command: |


### PR DESCRIPTION
#### Summary
- Don't use the CircleCI cache when preparing the build

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39646

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
