### PR TITLE
MM-39090: Telemetry on preview page (and tiny refactor)

### DIFF
--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -156,12 +156,14 @@ const Playbook = () => {
                         <NavItem
                             activeStyle={activeNavItemStyle}
                             to={`${match.url}/preview`}
+                            onClick={() => telemetryEventForPlaybook(playbook.id, 'playbook_preview_tab_clicked')}
                         >
                             {formatMessage({defaultMessage: 'Preview'})}
                         </NavItem>
                         <NavItem
                             activeStyle={activeNavItemStyle}
                             to={`${match.url}/usage`}
+                            onClick={() => telemetryEventForPlaybook(playbook.id, 'playbook_usage_tab_clicked')}
                         >
                             {formatMessage({defaultMessage: 'Usage'})}
                         </NavItem>
@@ -253,13 +255,6 @@ const Title = styled.div`
 const SubTitle = styled.div`
     font-size: 11px;
     line-height: 16px;
-`;
-
-const ClipboardsPlaySmall = styled(ClipboardsPlay)`
-    height: 18px;
-    width: auto;
-    margin-right: 7px;
-    color: var(--button-color);
 `;
 
 const PrimaryButtonLarger = styled(PrimaryButton)`

--- a/webapp/src/components/backstage/playbooks/playbook_preview.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview.tsx
@@ -38,7 +38,10 @@ const PlaybookPreview = (props: Props) => {
                     playbook={props.playbook}
                 />
             </Content>
-            <Navbar runsInProgress={props.runsInProgress}/>
+            <Navbar
+                playbookId={props.playbook.id}
+                runsInProgress={props.runsInProgress}
+            />
         </Container>
     );
 };

--- a/webapp/src/components/backstage/playbooks/playbook_preview_navbar.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_navbar.tsx
@@ -10,8 +10,11 @@ import Icon from '@mdi/react';
 import {mdiClipboardPlayMultipleOutline} from '@mdi/js';
 
 import {navigateToUrl} from 'src/browser_routing';
+import {telemetryEventForPlaybook} from 'src/client';
 import {SecondaryButtonLargerRight} from 'src/components/backstage/playbook_runs/shared';
 import {BackstageID} from 'src/components/backstage/backstage';
+
+const prefix = 'playbooks-playbookPreview-';
 
 export enum SectionID {
     Checklists = 'playbooks-playbookPreview-checklists',
@@ -21,13 +24,14 @@ export enum SectionID {
 }
 
 interface Props {
+    playbookId: string;
     runsInProgress: number;
 }
 
 // Height of the headers in pixels
 const headersOffset = 140;
 
-const PlaybookPreviewNavbar = ({runsInProgress}: Props) => {
+const PlaybookPreviewNavbar = ({playbookId, runsInProgress}: Props) => {
     const {formatMessage} = useIntl();
     const match = useRouteMatch();
     const [activeId, setActiveId] = useState(SectionID.Checklists);
@@ -69,6 +73,8 @@ const PlaybookPreviewNavbar = ({runsInProgress}: Props) => {
     }, [updateActiveSection]);
 
     const scrollToSection = (id: SectionID) => {
+        const idWithoutPrefix = String(id).replace(prefix, '');
+        telemetryEventForPlaybook(playbookId, `playbook_preview_navbar_section_${idWithoutPrefix}_clicked`);
 
         if (isSectionActive(id)) {
             return;

--- a/webapp/src/components/backstage/playbooks/playbook_preview_navbar.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_navbar.tsx
@@ -125,7 +125,6 @@ const PlaybookPreviewNavbar = ({playbookId, runsInProgress}: Props) => {
         return activeId === id;
     };
 
-
     const Item = generateItemComponent(isSectionActive, scrollToSection);
 
     return (
@@ -159,7 +158,10 @@ const PlaybookPreviewNavbar = ({playbookId, runsInProgress}: Props) => {
                     title={formatMessage({defaultMessage: 'Retrospective'})}
                 />
             </Items>
-            <UsageButton activeRuns={runsInProgress}/>
+            <UsageButton
+                playbookId={playbookId}
+                activeRuns={runsInProgress}
+            />
         </Wrapper>
     );
 };
@@ -251,12 +253,17 @@ const ItemWrapper = styled.div<{active: boolean}>`
     }
 `;
 
-const UsageButton = ({activeRuns}: {activeRuns: number}) => {
+const UsageButton = ({playbookId, activeRuns}: {playbookId: string, activeRuns: number}) => {
     const match = useRouteMatch();
     const {formatMessage} = useIntl();
 
+    const onClick = () => {
+        telemetryEventForPlaybook(playbookId, 'playbook_preview_navbar_runs_in_progress_button_clicked');
+        navigateToUrl(match.url.replace('/preview', '/usage'));
+    };
+
     return (
-        <UsageButtonWrapper onClick={() => navigateToUrl(match.url.replace('/preview', '/usage'))}>
+        <UsageButtonWrapper onClick={onClick}>
             <Icon
                 path={mdiClipboardPlayMultipleOutline}
                 size={1.2}


### PR DESCRIPTION
#### Summary

Add telemetry events for clicks on
- each of the sections in the preview navigation widget,
- the Preview and Usage tabs, and
- the button below the navigation widget, the one that reads "X active runs".

And although it's completely unrelated to telemetry, I also refactored the `Item` component to make the JSX in the `Navbar` component a bit easier to read. That change is isolated in the first commit.

#### Plan
- [X] Add a navigation bar with Preview and Usage tabs 
- [X] Implement Actions, Status Updates and Retrospective sections of the Preview page
- [X] Implement Checklists section of the Preview page
- [X] Add the sticky navigation widget 
- [X] Add telemetry  <-- we're here
- [ ] E2E tests
- [ ] Remove the Experimental Feature flag and make /preview the default view

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39090

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [X] Telemetry updated
- [X] Gated by experimental feature 
- [ ] ~~Unit tests updated~~
