### PR TITLE
MM-39650: Fix markdown rendering

### DIFF
--- a/webapp/src/components/backstage/playbooks/playbook_preview_cards.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_cards.tsx
@@ -177,6 +177,8 @@ const CardSubEntryContent = styled.div`
         :not(:last-child) {
             margin-bottom: 6px;
         }
+
+        white-space: pre-wrap;
     }
 
     margin-left: 32px;

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -219,14 +219,11 @@ const ChecklistItemDescription = styled.div`
     margin: 4px 0 0 2px;
 
     // Fix default markdown styling in the paragraphs
-    .markdown__paragraph-inline {
+    p {
         :last-child {
             margin-bottom: 0;
         }
 
-        + .markdown__paragraph-inline {
-            margin-left: 0;
-        }
     }
 `;
 
@@ -490,7 +487,7 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                         </label>
                         {props.inlineDescription && (
                             <ChecklistItemDescription>
-                                {messageHtmlToComponent(formatText(props.checklistItem.description, markdownOptions), true, {})}
+                                {messageHtmlToComponent(formatText(props.checklistItem.description, {...markdownOptions, singleline: false}), true, {})}
                             </ChecklistItemDescription>
                         )}
                     </ChecklistItemLabel>

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -224,6 +224,7 @@ const ChecklistItemDescription = styled.div`
             margin-bottom: 0;
         }
 
+        white-space: pre-wrap;
     }
 `;
 

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -214,7 +214,6 @@ const ChecklistItemDescription = styled.div`
 
     display: flex;
     flex-direction: column;
-    align-items: center;
 
     max-width: 630px;
     margin: 4px 0 0 2px;


### PR DESCRIPTION
#### Summary

Fix the CSS by:
- Removing `align-items: center`, which made the single lines in the description be centered.
- Setting the `singleline` mardown option to `false` (as it should have been from the beggining), so that we render simple `p` elements without the `markdown__paragraph-inline` class, which made the CSS a bit more complex.
- Adding `whitespace: pre-wrap`, so new lines in the original text are rendered as line breaks.

All this converts these

| Item description | Template |
|-----|-----|
| ![image](https://user-images.githubusercontent.com/3924815/139547514-a68e35a7-b60c-4843-bcd3-92a689acc6df.png) | ![image](https://user-images.githubusercontent.com/3924815/139547671-b17c6a5e-483a-4b18-afd8-7e3a8a0708c1.png) |

to these:

| Item description | Template |
|-----|-----|
| ![image](https://user-images.githubusercontent.com/3924815/139543808-c065d3d9-7cd0-4022-8486-128f6f93b409.png) | ![image](https://user-images.githubusercontent.com/3924815/139544048-7235b0bf-920e-4edf-a70d-5772cde336c0.png) |


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39650

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
