### PR TITLE
Migrate FormattedDuration from Moment to Luxon and remove moment dependency

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -12,7 +12,6 @@
         "debounce": "1.2.1",
         "luxon": "2.0.2",
         "mattermost-webapp": "github:mattermost/mattermost-webapp#0621a51815150aa4158bce383cc3b745cd6d8d51",
-        "moment": "2.29.1",
         "parse-duration": "1.0.0",
         "qs": "6.10.1",
         "react": "16.13.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -91,7 +91,6 @@
     "debounce": "1.2.1",
     "luxon": "2.0.2",
     "mattermost-webapp": "github:mattermost/mattermost-webapp#0621a51815150aa4158bce383cc3b745cd6d8d51",
-    "moment": "2.29.1",
     "parse-duration": "1.0.0",
     "qs": "6.10.1",
     "react": "16.13.1",

--- a/webapp/src/components/formatted_duration.test.tsx
+++ b/webapp/src/components/formatted_duration.test.tsx
@@ -1,11 +1,10 @@
-import moment from 'moment';
-import {Duration, DurationObjectUnits} from 'luxon';
+import {DateTime, Duration, DurationObjectUnits} from 'luxon';
 
 import React from 'react';
 
 import renderer from 'react-test-renderer';
 
-const mockNow = moment('2017-02-08 12:00');
+const mockNow = DateTime.fromISO('2017-02-08T12:00');
 
 jest.mock('src/hooks', () => {
     return {
@@ -40,19 +39,14 @@ describe('formatDuration', () => {
         expect(formatDuration(duration)).toEqual(expectedNarrow);
         expect(formatDuration(duration, 'long')).toEqual(expecetedLong);
     });
-
-    it('is backwards-compatible with moment durations', () => {
-        const duration = moment.duration({days: 1, hours: 2, minutes: 5});
-        expect(formatDuration(duration)).toEqual('1d 2h 5m');
-    });
 });
 
 describe('FormattedDuration', () => {
     it('renders correctly', () => {
         const duration = renderer.create(
             <FormattedDuration
-                from={moment('2013-02-08 09:30').valueOf()}
-                to={moment('2013-02-08 09:30:59').valueOf()}
+                from={DateTime.fromISO('2013-02-08T09:30').valueOf()}
+                to={DateTime.fromISO('2013-02-08T09:30:59').valueOf()}
             />,
         ).toJSON();
         expect(duration).toMatchSnapshot();
@@ -61,8 +55,8 @@ describe('FormattedDuration', () => {
     it('renders correctly with ago', () => {
         const duration = renderer.create(
             <FormattedDuration
-                from={moment('2013-02-08 09:30').valueOf()}
-                to={moment('2013-02-08 09:30:59').valueOf()}
+                from={DateTime.fromISO('2013-02-08T09:30').valueOf()}
+                to={DateTime.fromISO('2013-02-08T09:30:59').valueOf()}
                 ago={true}
             />,
         ).toJSON();
@@ -72,8 +66,8 @@ describe('FormattedDuration', () => {
     it('renders correctly slightly greater than 1 year', () => {
         const duration = renderer.create(
             <FormattedDuration
-                from={moment('2013-02-08 09:30').valueOf()}
-                to={moment('2014-02-08 09:30:59').valueOf()}
+                from={DateTime.fromISO('2013-02-08T09:30').valueOf()}
+                to={DateTime.fromISO('2014-02-08T09:30:59').valueOf()}
                 ago={true}
             />,
         ).toJSON();
@@ -83,8 +77,8 @@ describe('FormattedDuration', () => {
     it('renders correctly 1.5 years', () => {
         const duration = renderer.create(
             <FormattedDuration
-                from={moment('2013-02-08 09:30').valueOf()}
-                to={moment('2014-08-08 09:30:59').valueOf()}
+                from={DateTime.fromISO('2013-02-08T09:30').valueOf()}
+                to={DateTime.fromISO('2014-08-08T09:30:59').valueOf()}
                 ago={true}
             />,
         ).toJSON();
@@ -94,7 +88,7 @@ describe('FormattedDuration', () => {
     it('renders correctly when to is 0 or undefined', () => {
         const duration = renderer.create(
             <FormattedDuration
-                from={moment('2014-02-08 09:30:59').valueOf()}
+                from={DateTime.fromISO('2014-02-08T09:30:59').valueOf()}
                 ago={true}
             />,
         ).toJSON();

--- a/webapp/src/components/formatted_duration.tsx
+++ b/webapp/src/components/formatted_duration.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import moment from 'moment';
 import {DateTime, Duration, Interval} from 'luxon';
 import React from 'react';
 
@@ -29,9 +28,8 @@ const label = (num: number, style: FormatStyle, narrow: string, singular: string
     return num >= 2 ? plural : singular;
 };
 
-export const formatDuration = (value: Duration | moment.Duration, style: FormatStyle = 'narrow') => {
-    const duration = (Duration.isDuration(value) ? value : Duration.fromMillis(value.as('milliseconds')))
-        .shiftTo('years', 'days', 'hours', 'minutes');
+export const formatDuration = (value: Duration, style: FormatStyle = 'narrow') => {
+    const duration = value.shiftTo('years', 'days', 'hours', 'minutes');
 
     if (duration.as('seconds') < 60) {
         return style === 'narrow' ? '< 1m' : 'less than 1 minute';


### PR DESCRIPTION
#### Summary
Migrate FormattedDuration from Moment to Luxon and remove moment dependency

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/18595
JIRA: https://mattermost.atlassian.net/browse/MM-39152

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
