### PR TITLE
MM-38841: fix retro timeline dates

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -72,7 +72,6 @@
   "UbTsGY": "Runs started between {start} and {end}",
   "Ui6GK/": "When a new member joins the channel",
   "VmpFFw": "There is no description available.",
-  "W9j0FJ": "{date}",
   "X3DLGJ": "Everyone in this workspace can create playbooks.",
   "XmUdvV": "All the statistics you need",
   "YDuW/T": "{num_runs, plural, =0 {Not run yet} one {# run} other {# total runs}}",

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item.tsx
@@ -220,7 +220,12 @@ const TimelineEventItem = (props: Props) => {
             </HoverMenu>
             }
             <TimeContainer>
-                <TimeHours>{formatMessage({defaultMessage: '{date}'}, {date: <Timestamp value={DateTime.fromMillis(props.event.event_at).toFormat('LLL dd T')}/>})}</TimeHours>
+                <TimeHours>
+                    <Timestamp
+                        value={props.event.event_at}
+                        month='short'
+                    />
+                </TimeHours>
                 {timeSince}
             </TimeContainer>
             <Circle>


### PR DESCRIPTION
#### Summary
Re: https://github.com/mattermost/mattermost-plugin-playbooks/pull/830 / [MM-38841](mattermost.atlassian.net/browse/MM-38841), retro timeline dates off, can potentially result in white-screen errors with `Invalid date` console errors.

<img width="186" alt="CleanShot 2021-11-02 at 09 44 02@2x" src="https://user-images.githubusercontent.com/11724372/139878123-3de5a8d6-efb8-4ae2-adef-016fe68ab1b7.png">

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
