### PR TITLE
[MM-38151] Lock translations to `en`, just for 1.21

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -83,7 +83,7 @@ export default class Plugin {
         registry.registerTranslations((locale: string) => {
             try {
                 // eslint-disable-next-line global-require
-                return require(`../i18n/${locale}.json`); // TODO make async, this increases bundle size exponentially
+                return require('../i18n/en.json');
             } catch {
                 return {};
             }


### PR DESCRIPTION
#### Summary
Temporarily lock to english for 1.21 release (aim to open in 1.22)

mattermost.atlassian.net/browse/MM-38151

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
