### PR TITLE
Reorganize E2E Tests

### DIFF
--- a/tests-e2e/cypress/integration/channels/actions_spec.js
+++ b/tests-e2e/cypress/integration/channels/actions_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook run automation', () => {
+describe('channels > actions', () => {
     let testTeam;
     let testUser;
     let testPublicChannel;

--- a/tests-e2e/cypress/integration/channels/broadcast_spec.js
+++ b/tests-e2e/cypress/integration/channels/broadcast_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook run broadcast', () => {
+describe('channels > broadcast', () => {
     let testTeam;
     let testUser;
     let testAdmin;

--- a/tests-e2e/cypress/integration/channels/channel_header_spec.js
+++ b/tests-e2e/cypress/integration/channels/channel_header_spec.js
@@ -1,7 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-describe('channel header', () => {
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('channels > channel header', () => {
     let testTeam;
     let testUser;
     let testPlaybook;

--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -8,7 +8,7 @@
 
 import {HALF_SEC} from '../../fixtures/timeouts';
 
-describe('playbook run rhs checklist', () => {
+describe('channels > rhs > checklist', () => {
     let testTeam;
     let testUser;
     const testUsers = [];

--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-import {HALF_SEC} from '../../fixtures/timeouts';
+import {HALF_SEC} from '../../../fixtures/timeouts';
 
 describe('channels > rhs > checklist', () => {
     let testTeam;

--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook run rhs > header', () => {
+describe('channels > rhs > header', () => {
     let testTeam;
     let testUser;
     let testPlaybook;

--- a/tests-e2e/cypress/integration/channels/rhs/home_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/home_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook run rhs > home', () => {
+describe('channels > rhs > home', () => {
     let testTeam;
     let testUser;
 

--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook run rhs > latest update', () => {
+describe('channels > rhs > status update', () => {
     const defaultReminderMessage = '# Default reminder message';
     let testTeam;
     let testChannel;

--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('channels > rhs', () => {
     let testTeam;

--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -8,7 +8,7 @@
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
-describe('playbook run rhs', () => {
+describe('channels > rhs', () => {
     let testTeam;
     let testUser;
     let testPlaybook;

--- a/tests-e2e/cypress/integration/channels/run_dialog_spec.js
+++ b/tests-e2e/cypress/integration/channels/run_dialog_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook run creation dialog', () => {
+describe('channels > run dialog', () => {
     let testTeam;
     let testUser;
 

--- a/tests-e2e/cypress/integration/channels/run_spec.js
+++ b/tests-e2e/cypress/integration/channels/run_spec.js
@@ -6,21 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-/*
- * This test spec includes tests for the playbook run creation using all 3 methods:
- * - Slash command
- * - RHS
- * - Post action menu
- *
- * This spec also includes tests for starting a playbook run in all types of channels:
- * - Public
- * - Private
- * - Group message
- * - Direct message
- * - Direct message with self
- */
-
-describe('playbook runs can be started', () => {
+describe('channels > run', () => {
     let testTeam;
     let testUser;
     let testPrivateChannel;

--- a/tests-e2e/cypress/integration/channels/slash_command/info_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/info_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('slash command > info', () => {
+describe('channels > slash command > info', () => {
     let testTeam;
     let testUser;
     let testUser2;

--- a/tests-e2e/cypress/integration/channels/slash_command/owner_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/owner_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('slash command > owner', () => {
+describe('channels > slash command > owner', () => {
     let testTeam;
     let testUser;
     let testUser2;

--- a/tests-e2e/cypress/integration/channels/slash_command/test_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/test_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('slash command > test', () => {
+describe('channels > slash command > test', () => {
     let testTeam;
     let testUser;
     let testUser2;

--- a/tests-e2e/cypress/integration/channels/slash_command/todo_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/todo_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('slash command > todo', () => {
+describe('channels > slash command > todo', () => {
     let team1;
     let team2;
     let testUser;

--- a/tests-e2e/cypress/integration/navigation_spec.js
+++ b/tests-e2e/cypress/integration/navigation_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('backstage', () => {
+describe('navigation', () => {
     let testTeam;
     let testUser;
 

--- a/tests-e2e/cypress/integration/navigation_spec.js
+++ b/tests-e2e/cypress/integration/navigation_spec.js
@@ -43,10 +43,10 @@ describe('navigation', () => {
     });
 
     it('switches to playbooks list view via header button', () => {
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbooks backstage
+        // # Switch to playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
         // * Verify that playbooks are shown
@@ -54,13 +54,13 @@ describe('navigation', () => {
     });
 
     it('switches to playbook runs list view via header button', () => {
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbooks backstage
+        // # Switch to playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
-        // # Switch to playbook runs backstage
+        // # Switch to playbook runs
         cy.findByTestId('playbookRunsLHSButton').click();
 
         // * Verify that playbook runs are shown

--- a/tests-e2e/cypress/integration/playbooks/creation_button_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/creation_button_spec.js
@@ -45,10 +45,10 @@ describe('playbooks > creation button', () => {
         const url = 'playbooks/new';
         const playbookName = 'Untitled playbook';
 
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbooks backstage
+        // # Switch to playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
         // # Click 'New Playbook' button
@@ -62,10 +62,10 @@ describe('playbooks > creation button', () => {
         const url = 'playbooks/new';
         const playbookName = 'Untitled playbook';
 
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbooks backstage
+        // # Switch to playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
         // # Click 'Blank'
@@ -80,10 +80,10 @@ describe('playbooks > creation button', () => {
         const url2 = '&template_title=Service%20Reliability%20Incident';
         const playbookName = 'Service Reliability Incident';
 
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbooks backstage
+        // # Switch to playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
         // # Click 'Service Reliability Incident'
@@ -95,10 +95,10 @@ describe('playbooks > creation button', () => {
     });
 
     it('shows remove beside members when > 1 member', () => {
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbooks backstage
+        // # Switch to playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
         // # Click 'Create playbook' button

--- a/tests-e2e/cypress/integration/playbooks/creation_button_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/creation_button_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('playbook creation button', () => {
+describe('playbooks > creation button', () => {
     let testTeam;
     let testUser;
     let testUser2;

--- a/tests-e2e/cypress/integration/playbooks/edit_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_spec.js
@@ -42,7 +42,7 @@ describe('playooks > edit', () => {
     describe('checklists', () => {
         describe('slash command', () => {
             it('autocompletes after clicking Add a slash command', () => {
-                // # Visit the playbook backstage
+                // # Open Playbooks
                 cy.visit('/playbooks/playbooks');
 
                 // # Start a blank playbook
@@ -66,7 +66,7 @@ describe('playooks > edit', () => {
             });
 
             it('removes the input prompt when blurring with an empty slash command', () => {
-                // # Visit the playbook backstage
+                // # Open playbook
                 cy.visit('/playbooks/playbooks');
 
                 // # Start a blank playbook
@@ -95,7 +95,7 @@ describe('playooks > edit', () => {
             });
 
             it('removes the input prompt when blurring with an invalid slash command', () => {
-                // # Visit the playbook backstage
+                // # Open Playbooks
                 cy.visit('/playbooks/playbooks');
 
                 // # Start a blank playbook

--- a/tests-e2e/cypress/integration/playbooks/edit_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('backstage playbook details', () => {
+describe('playooks > edit', () => {
     let testTeam;
     let testUser;
     let testUser2;
@@ -37,14 +37,6 @@ describe('backstage playbook details', () => {
     beforeEach(() => {
         // # Login as testUser
         cy.apiLogin(testUser);
-    });
-
-    it('redirects to not found error if the playbook is unknown', () => {
-        // # Visit the URL of a non-existing playbook
-        cy.visit('/playbooks/playbooks/an_unknown_id');
-
-        // * Verify that the user has been redirected to the playbooks not found error page
-        cy.url().should('include', '/playbooks/error?type=playbooks');
     });
 
     describe('checklists', () => {

--- a/tests-e2e/cypress/integration/playbooks/list_permissions_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/list_permissions_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('backstage playbook list permissions', () => {
+describe('playbooks > list permissions', () => {
     let testTeam;
     let testTeam2;
     let testUser;
@@ -240,7 +240,7 @@ describe('backstage playbook list permissions', () => {
         cy.viewport('macbook-13');
     });
 
-    it('all runs are visible to testUser', () => {
+    it('shows all runs to testUser', () => {
         // # Login as testUser
         cy.apiLogin(testUser);
 
@@ -255,7 +255,7 @@ describe('backstage playbook list permissions', () => {
         verifyRunIsVisible(runCond9);
     });
 
-    it('only runs testUser2 has permissions to are visible to testUser2', () => {
+    it('restricts some runs frm testUser2', () => {
         // # Login as testUser2
         cy.apiLogin(testUser2);
 
@@ -270,8 +270,8 @@ describe('backstage playbook list permissions', () => {
         verifyRunIsNotVisible(runCond9);
     });
 
-    it('sysadmin has permissions to see all runs', () => {
-        // # Login as testUser2
+    it('shows all runs to sysadmin', () => {
+        // # Login as sysadmin
         cy.apiAdminLogin();
 
         verifyRunIsVisible(runCond1);

--- a/tests-e2e/cypress/integration/playbooks/list_permissions_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/list_permissions_spec.js
@@ -236,7 +236,7 @@ describe('playbooks > list permissions', () => {
     });
 
     beforeEach(() => {
-        // # Size the viewport to show all of the backstage.
+        // # Size the viewport to show all
         cy.viewport('macbook-13');
     });
 
@@ -287,7 +287,7 @@ describe('playbooks > list permissions', () => {
 });
 
 const verifyRunIsVisible = (run) => {
-    // # Open the Runs backstage
+    // # Open Runs
     cy.visit('/playbooks/runs');
 
     // # Find the playbook run and click to open details view
@@ -300,7 +300,7 @@ const verifyRunIsVisible = (run) => {
 };
 
 const verifyRunIsNotVisible = (run) => {
-    // # Open the Runs backstage
+    // # Open Runs
     cy.visit('/playbooks/runs');
 
     // * Verify the playbook run is not visible

--- a/tests-e2e/cypress/integration/playbooks/list_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/list_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('backstage playbook list', () => {
+describe('playbooks > list', () => {
     let testTeam;
     let testUser;
 
@@ -30,9 +30,6 @@ describe('backstage playbook list', () => {
     beforeEach(() => {
         // # Login as testUser
         cy.apiLogin(testUser);
-
-        // # Navigate to the application
-        cy.visit('/ad-1/');
     });
 
     it('has "Playbooks" in heading', () => {

--- a/tests-e2e/cypress/integration/playbooks/list_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/list_spec.js
@@ -33,10 +33,10 @@ describe('playbooks > list', () => {
     });
 
     it('has "Playbooks" in heading', () => {
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to Playbooks backstage
+        // # Switch to Playbooks
         cy.findByTestId('playbooksLHSButton').click();
 
         // * Assert contents of heading.

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -1,7 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-describe('playbook overview', () => {
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('playbooks > overview', () => {
     let testTeam;
     let testUser;
     let testPublicPlaybook;
@@ -54,6 +59,14 @@ describe('playbook overview', () => {
 
         // # Login as testUser
         cy.apiLogin(testUser);
+    });
+
+    it('redirects to not found error if the playbook is unknown', () => {
+        // # Visit the URL of a non-existing playbook
+        cy.visit('/playbooks/playbooks/an_unknown_id');
+
+        // * Verify that the user has been redirected to the playbooks not found error page
+        cy.url().should('include', '/playbooks/error?type=playbooks');
     });
 
     describe('permissions text', () => {

--- a/tests-e2e/cypress/integration/runs/details_spec.js
+++ b/tests-e2e/cypress/integration/runs/details_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-describe('backstage playbook run details', () => {
+describe('runs > details', () => {
     let testTeam;
     let testUser;
     let testPublicPlaybook;

--- a/tests-e2e/cypress/integration/runs/list_spec.js
+++ b/tests-e2e/cypress/integration/runs/list_spec.js
@@ -8,7 +8,7 @@
 
 const BACKSTAGE_LIST_PER_PAGE = 15;
 
-describe('backstage playbook run list', () => {
+describe('runs > list', () => {
     let testTeam;
     let testUser;
     let testAnotherUser;

--- a/tests-e2e/cypress/integration/runs/list_spec.js
+++ b/tests-e2e/cypress/integration/runs/list_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-const BACKSTAGE_LIST_PER_PAGE = 15;
+const LIST_PER_PAGE = 15;
 
 describe('runs > list', () => {
     let testTeam;
@@ -42,7 +42,7 @@ describe('runs > list', () => {
     });
 
     beforeEach(() => {
-        // # Size the viewport to show all of the backstage.
+        // # Size the viewport to show all
         cy.viewport('macbook-13');
 
         // # Login as testUser
@@ -60,10 +60,10 @@ describe('runs > list', () => {
             ownerUserId: testUser.id,
         });
 
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbook runs backstage
+        // # Switch to playbook runs
         cy.findByTestId('playbookRunsLHSButton').click();
 
         // * Assert contents of heading.
@@ -81,10 +81,10 @@ describe('runs > list', () => {
             ownerUserId: testUser.id,
         });
 
-        // # Open backstage
+        // # Open the product
         cy.visit('/playbooks');
 
-        // # Switch to playbook runs backstage
+        // # Switch to runs
         cy.findByTestId('playbookRunsLHSButton').click();
 
         // # Find the playbook run and click to open details view
@@ -127,7 +127,7 @@ describe('runs > list', () => {
             // # Login as testUser
             cy.apiLogin(testUser);
 
-            // # Open backstage
+            // # Open the product
             cy.visit('/playbooks');
 
             // # Make sure both runs are visible by default
@@ -148,7 +148,7 @@ describe('runs > list', () => {
             // # Login as testAnotherUser
             cy.apiLogin(testAnotherUser);
 
-            // # Open backstage
+            // # Open the product
             cy.visit('/playbooks');
 
             // Make sure both runs are visible by default
@@ -186,7 +186,7 @@ describe('runs > list', () => {
             // # Login as testUser
             cy.apiLogin(testUser);
 
-            // # Open backstage
+            // # Open the product
             cy.visit('/playbooks');
 
             // # Make sure runs are visible by default, and finished is not
@@ -214,7 +214,7 @@ describe('runs > list', () => {
             cy.apiLogin(testUser);
 
             // # Start sufficient playbook runs to ensure pagination is possible.
-            for (let i = 0; i < BACKSTAGE_LIST_PER_PAGE + 1; i++) {
+            for (let i = 0; i < LIST_PER_PAGE + 1; i++) {
                 const now = Date.now();
                 cy.apiRunPlaybook({
                     teamId: testTeam.id,
@@ -230,10 +230,10 @@ describe('runs > list', () => {
             // # Login as testUser
             cy.apiLogin(testUser);
 
-            // # Open backstage
+            // # Open the product
             cy.visit('/playbooks');
 
-            // # Switch to playbook runs backstage
+            // # Switch to runs
             cy.findByTestId('playbookRunsLHSButton').click();
 
             // # Switch to page 2

--- a/tests-e2e/cypress/integration/runs/timeline_spec.js
+++ b/tests-e2e/cypress/integration/runs/timeline_spec.js
@@ -1,7 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-describe('timeline', () => {
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('runs > timeline', () => {
     const playbookName = 'Playbook (' + Date.now() + ')';
     let testTeam;
     let testUser;

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -85,23 +85,6 @@ Cypress.Commands.add('startPlaybookRunFromPostMenu', (playbookName, playbookRunN
     cy.startPlaybookRun(playbookName, playbookRunName);
 });
 
-Cypress.Commands.add('openBackstage', () => {
-    cy.get('#lhsHeader', {timeout: 120000}).should('exist').within(() => {
-        // # Wait until the channel loads enough to show the post textbox.
-        cy.get('#post-create').should('exist');
-        cy.wait(2000);
-
-        // # Click hamburger main menu
-        cy.get('#sidebarHeaderDropdownButton').click();
-
-        // * Dropdown menu should be visible
-        cy.get('.dropdown-menu').should('exist').within(() => {
-            // Click main menu option
-            cy.findByText('Playbooks').should('exist').click();
-        });
-    });
-});
-
 // Create playbook
 Cypress.Commands.add('createPlaybook', (teamName, playbookName) => {
     cy.visit('/playbooks/playbooks/new');


### PR DESCRIPTION
#### Summary
Organize into the following directory structure, rendering the term `backstage` obsolete in this context and treating `channels` as an integration and not the `frontstage`.
  - cypress/integration (all specs live here)
    - playbooks/
    - runs/
    - channels/
      - rhs/
      - slash_command/
    - (other global tests)

The top level `describe` of each spec now contains the path (e.g.  `channels > rhs > spec_name`). There's probably still room for improvement here, both in the organization and naming, but this gets us past the hump as it were.

I'm proposing we do something similar for the `webapp` component. Open for discussion -- hoping this makes the code easier to navigate.

#### Ticket Link
N/A

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated?
