### PR TITLE
[MM-39255] Make all participants followers by default

### DIFF
--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -37,6 +37,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		teamID := model.NewId()
 		playbookRun := &app.PlaybookRun{
@@ -51,7 +52,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		mattermostConfig.SetDefaults()
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		_, err := s.CreatePlaybookRun(playbookRun, nil, "testUserID", true)
 		require.Equal(t, err, app.ErrChannelDisplayNameInvalid)
@@ -67,6 +68,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		teamID := model.NewId()
 		playbookRun := &app.PlaybookRun{
@@ -81,7 +83,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.2_or_more.app_error"})
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		_, err := s.CreatePlaybookRun(playbookRun, nil, "testUserID", true)
 		require.Equal(t, err, app.ErrChannelDisplayNameInvalid)
@@ -97,6 +99,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		teamID := model.NewId()
 		playbookRun := &app.PlaybookRun{
@@ -138,7 +141,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 			Return(&model.Post{Id: "testPostId"}, nil)
 		store.EXPECT().SetBroadcastChannelIDsToRootID(playbookRunWithID.ID, map[string]string{"channel_id": "testPostId"}).Return(nil)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		_, err := s.CreatePlaybookRun(playbookRun, nil, "user_id", true)
 		require.NoError(t, err)
@@ -154,6 +157,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		teamID := model.NewId()
 		playbookRun := &app.PlaybookRun{
@@ -169,7 +173,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "store.sql_channel.save_channel.exists.app_error"})
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		_, err := s.CreatePlaybookRun(playbookRun, nil, "user_id", true)
 		require.EqualError(t, err, "failed to create channel: : , ")
@@ -185,6 +189,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		teamID := model.NewId()
 		playbookRun := &app.PlaybookRun{
@@ -219,7 +224,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 			Return(&model.Post{Id: "testPostId"}, nil)
 		store.EXPECT().SetBroadcastChannelIDsToRootID(playbookRunWithID.ID, map[string]string{"channel_id": "testPostId"}).Return(nil)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		_, err := s.CreatePlaybookRun(playbookRun, nil, "user_id", true)
 		require.NoError(t, err)
@@ -235,6 +240,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		teamID := model.NewId()
 		playbookRun := &app.PlaybookRun{
@@ -270,7 +276,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 			Return(&model.Post{Id: "testPostId"}, nil)
 		store.EXPECT().SetBroadcastChannelIDsToRootID(playbookRunWithID.ID, map[string]string{"channel_id": "testPostId"}).Return(nil)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		_, err := s.CreatePlaybookRun(playbookRun, nil, "user_id", true)
 		pluginAPI.AssertExpectations(t)
@@ -287,6 +293,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		type webhookPayload struct {
 			app.PlaybookRun
@@ -350,7 +357,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{Id: "channel_id", Name: "channel-name"}, nil)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		createdPlaybookRun, err := s.CreatePlaybookRun(playbookRun, nil, "user_id", true)
 		require.NoError(t, err)
@@ -384,6 +391,7 @@ func TestUpdateStatus(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		type webhookPayload struct {
 			app.PlaybookRun
@@ -474,7 +482,7 @@ func TestUpdateStatus(t *testing.T) {
 			},
 		})
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		err := s.UpdateStatus(playbookRun.ID, "user_id", statusUpdateOptions)
 		require.NoError(t, err)
@@ -505,6 +513,7 @@ func TestUpdateStatusWebhookFailure(t *testing.T) {
 	configService := mock_config.NewMockService(controller)
 	telemetryService := &telemetry.NoopTelemetry{}
 	scheduler := mock_app.NewMockJobOnceScheduler(controller)
+	playbookService := mock_app.NewMockPlaybookService(controller)
 
 	type webhookPayload struct {
 		app.PlaybookRun
@@ -586,7 +595,7 @@ func TestUpdateStatusWebhookFailure(t *testing.T) {
 	pluginAPI.On("LogWarn", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	poster.EXPECT().PostMessage(homeChannelID, gomock.Any()).Return(nil, nil)
 
-	s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+	s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 	err := s.UpdateStatus(playbookRun.ID, "user_id", statusUpdateOptions)
 	require.NoError(t, err)
@@ -715,7 +724,8 @@ func TestOpenCreatePlaybookRunDialog(t *testing.T) {
 			telemetryService := &telemetry.NoopTelemetry{}
 			scheduler := mock_app.NewMockJobOnceScheduler(controller)
 			tt.prepMocks(t, store, poster, api, configService)
-			service := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, api)
+			playbookService := mock_app.NewMockPlaybookService(controller)
+			service := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, api, playbookService)
 
 			err := service.OpenCreatePlaybookRunDialog(tt.args.teamID, tt.args.ownerID, tt.args.triggerID, tt.args.postID, tt.args.clientID, tt.args.playbooks, tt.args.isMobileApp)
 			if (err != nil) != tt.wantErr {
@@ -791,8 +801,9 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
-		playbookRun := &app.PlaybookRun{CategoryName: "Playbook Runs"}
+		playbookRun := &app.PlaybookRun{ID: "playbook_run_id", CategoryName: "Playbook Runs"}
 		existingSidebarCategory := &model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{Id: "sidebar_category_id", DisplayName: "Test Category Sidebar"},
 			Channels:        []string{},
@@ -814,6 +825,7 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		store.EXPECT().CreateTimelineEvent(gomock.AssignableToTypeOf(&app.TimelineEvent{})).Return(nil, nil)
 		store.EXPECT().GetPlaybookRunIDForChannel(gomock.Any()).Return("playbook_run_id", nil)
 		store.EXPECT().GetPlaybookRun("playbook_run_id").Return(playbookRun, nil).Times(2)
+		store.EXPECT().Follow("playbook_run_id", "user_id").Return(nil)
 		poster.EXPECT().PublishWebsocketEventToChannel(gomock.Any(), gomock.Any(), gomock.Any())
 		pluginAPI.On("GetUser", "user_id").Return(&model.User{}, nil)
 		pluginAPI.On("GetChannel", "channel_id").Return(&model.Channel{TeamId: "team_id"}, nil)
@@ -827,7 +839,7 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		).Return(newSidebarCategory, nil)
 		pluginAPI.On("GetConfig").Return(&model.Config{})
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		userID := "user_id"
 		channelID := "channel_id"
@@ -900,8 +912,9 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
-		playbookRun := &app.PlaybookRun{CategoryName: "Playbook Runs 2"}
+		playbookRun := &app.PlaybookRun{ID: "playbook_run_id", CategoryName: "Playbook Runs 2"}
 		existingSidebarCategory := &model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{Id: "sidebar_category_id", DisplayName: "Test Category Sidebar"},
 			Channels:        []string{},
@@ -923,6 +936,7 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		store.EXPECT().CreateTimelineEvent(gomock.AssignableToTypeOf(&app.TimelineEvent{})).Return(nil, nil)
 		store.EXPECT().GetPlaybookRunIDForChannel(gomock.Any()).Return("playbook_run_id", nil)
 		store.EXPECT().GetPlaybookRun("playbook_run_id").Return(playbookRun, nil).Times(2)
+		store.EXPECT().Follow("playbook_run_id", "user_id").Return(nil)
 		poster.EXPECT().PublishWebsocketEventToChannel(gomock.Any(), gomock.Any(), gomock.Any())
 		pluginAPI.On("GetUser", "user_id").Return(&model.User{}, nil)
 		pluginAPI.On("GetChannel", "channel_id").Return(&model.Channel{TeamId: "team_id"}, nil)
@@ -936,7 +950,7 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		).Return(newSidebarCategory, nil)
 		pluginAPI.On("GetConfig").Return(&model.Config{})
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		userID := "user_id"
 		channelID := "channel_id"
@@ -957,6 +971,7 @@ func TestMultipleWebhooks(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		type webhookPayload struct {
 			app.PlaybookRun
@@ -1023,7 +1038,7 @@ func TestMultipleWebhooks(t *testing.T) {
 		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{Id: "channel_id", Name: "channel-name"}, nil)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		createdPlaybookRun, err := s.CreatePlaybookRun(playbookRun, nil, "user_id", true)
 		require.NoError(t, err)
@@ -1057,6 +1072,7 @@ func TestMultipleWebhooks(t *testing.T) {
 		configService := mock_config.NewMockService(controller)
 		telemetryService := &telemetry.NoopTelemetry{}
 		scheduler := mock_app.NewMockJobOnceScheduler(controller)
+		playbookService := mock_app.NewMockPlaybookService(controller)
 
 		type webhookPayload struct {
 			app.PlaybookRun
@@ -1151,7 +1167,7 @@ func TestMultipleWebhooks(t *testing.T) {
 		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "team_name"}, nil)
 		pluginAPI.On("GetUser", "user_id").Return(&model.User{}, nil)
 
-		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI)
+		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService)
 
 		err := s.UpdateStatus(playbookRun.ID, "user_id", statusUpdateOptions)
 		require.NoError(t, err)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -139,6 +139,7 @@ func (p *Plugin) OnActivate() error {
 		scheduler,
 		p.telemetryClient,
 		p.API,
+		p.playbookService,
 	)
 
 	if err = scheduler.SetCallback(p.playbookRunService.HandleReminder); err != nil {


### PR DESCRIPTION

#### Summary
This PR 
1. Makes all participants followers by default
2. Sends status updates to followers  only if they have permission to access run.

#### Ticket Link
  Fixes: https://mattermost.atlassian.net/browse/MM-39255


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [X] Unit tests updated
