### PR TITLE
MM-39938: react-select theming, support portaling

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/edit_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_spec.js
@@ -817,7 +817,7 @@ describe('playooks > edit', () => {
                     cy.get('#broadcast-channels').within(() => {
                         cy.getStyledComponent('StyledSelect').should(
                             'have.class',
-                            'channel-selector--is-disabled'
+                            'playbooks-select--is-disabled'
                         );
                     });
                 });
@@ -846,7 +846,7 @@ describe('playooks > edit', () => {
                         cy.selectChannel('Town Square');
 
                         // * Verify that the control shows the selected owner
-                        cy.get('.channel-selector__control').contains(
+                        cy.get('.playbooks-select__control').contains(
                             'Town Square'
                         );
                     });
@@ -876,12 +876,12 @@ describe('playooks > edit', () => {
                         cy.selectChannel('Town Square');
 
                         // * Verify that the control shows the selected channel
-                        cy.get('.channel-selector__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
                             'Town Square'
                         );
 
                         // # Open the channel selector
-                        cy.get('.channel-selector__control').click({
+                        cy.get('#playbook-automation-broadcast .playbooks-select__control').click({
                             force: true,
                         });
 
@@ -889,7 +889,7 @@ describe('playooks > edit', () => {
                         cy.selectChannel(testPublicChannel.display_name);
 
                         // * Verify that the control shows the selected channel
-                        cy.get('.channel-selector__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
                             testPublicChannel.display_name,
                         );
                     });
@@ -919,7 +919,7 @@ describe('playooks > edit', () => {
                         cy.selectChannel('Town Square');
 
                         // * Verify that the control shows the selected channel
-                        cy.get('.channel-selector__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
                             'Town Square'
                         );
 
@@ -950,7 +950,7 @@ describe('playooks > edit', () => {
                         cy.get('label input').should('be.checked');
 
                         // * Verify that the control still shows the selected channel
-                        cy.get('.channel-selector__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
                             'Town Square'
                         );
                     });
@@ -1021,7 +1021,7 @@ describe('playooks > edit', () => {
                                 cy.get('label input').click({force: true});
 
                                 // * Verify that the control shows no selected channel
-                                cy.get('.channel-selector__control').within(
+                                cy.get('#playbook-automation-broadcast .playbooks-select__control').within(
                                     () => {
                                         cy.findByText('Select a channel');
                                     }

--- a/tests-e2e/cypress/integration/playbooks/edit_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_spec.js
@@ -817,7 +817,7 @@ describe('playooks > edit', () => {
                     cy.get('#broadcast-channels').within(() => {
                         cy.getStyledComponent('StyledSelect').should(
                             'have.class',
-                            'playbooks-select--is-disabled'
+                            'playbooks-rselect--is-disabled'
                         );
                     });
                 });
@@ -846,7 +846,7 @@ describe('playooks > edit', () => {
                         cy.selectChannel('Town Square');
 
                         // * Verify that the control shows the selected owner
-                        cy.get('.playbooks-select__control').contains(
+                        cy.get('.playbooks-rselect__control').contains(
                             'Town Square'
                         );
                     });
@@ -876,12 +876,12 @@ describe('playooks > edit', () => {
                         cy.selectChannel('Town Square');
 
                         // * Verify that the control shows the selected channel
-                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-rselect__control').contains(
                             'Town Square'
                         );
 
                         // # Open the channel selector
-                        cy.get('#playbook-automation-broadcast .playbooks-select__control').click({
+                        cy.get('#playbook-automation-broadcast .playbooks-rselect__control').click({
                             force: true,
                         });
 
@@ -889,7 +889,7 @@ describe('playooks > edit', () => {
                         cy.selectChannel(testPublicChannel.display_name);
 
                         // * Verify that the control shows the selected channel
-                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-rselect__control').contains(
                             testPublicChannel.display_name,
                         );
                     });
@@ -919,7 +919,7 @@ describe('playooks > edit', () => {
                         cy.selectChannel('Town Square');
 
                         // * Verify that the control shows the selected channel
-                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-rselect__control').contains(
                             'Town Square'
                         );
 
@@ -950,7 +950,7 @@ describe('playooks > edit', () => {
                         cy.get('label input').should('be.checked');
 
                         // * Verify that the control still shows the selected channel
-                        cy.get('#playbook-automation-broadcast .playbooks-select__control').contains(
+                        cy.get('#playbook-automation-broadcast .playbooks-rselect__control').contains(
                             'Town Square'
                         );
                     });
@@ -1021,7 +1021,7 @@ describe('playooks > edit', () => {
                                 cy.get('label input').click({force: true});
 
                                 // * Verify that the control shows no selected channel
-                                cy.get('#playbook-automation-broadcast .playbooks-select__control').within(
+                                cy.get('#playbook-automation-broadcast .playbooks-rselect__control').within(
                                     () => {
                                         cy.findByText('Select a channel');
                                     }

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -157,7 +157,7 @@ Cypress.Commands.add('selectOwner', (userName) => {
 });
 
 Cypress.Commands.add('selectChannel', (channelName) => {
-    cy.get('#playbook-automation-broadcast .playbooks-select__menu').within(() => {
+    cy.get('#playbook-automation-broadcast .playbooks-rselect__menu').within(() => {
         cy.findByText(channelName).click({force: true});
     });
 });

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -157,7 +157,7 @@ Cypress.Commands.add('selectOwner', (userName) => {
 });
 
 Cypress.Commands.add('selectChannel', (channelName) => {
-    cy.get('.channel-selector__menu').within(() => {
+    cy.get('#playbook-automation-broadcast .playbooks-select__menu').within(() => {
         cy.findByText(channelName).click({force: true});
     });
 });

--- a/webapp/src/components/backstage/automation/broadcast.tsx
+++ b/webapp/src/components/backstage/automation/broadcast.tsx
@@ -53,7 +53,7 @@ export const Broadcast = (props: Props) => {
 const StyledChannelSelector = styled(ChannelSelector)`
     background-color: ${(props) => (props.isDisabled ? 'rgba(var(--center-channel-bg-rgb), 0.16)' : 'var(--center-channel-bg)')};
 
-    .channel-selector__control {
+    .playbooks-select__control {
         padding: 4px 16px 4px 3.2rem;
 
         &:before {

--- a/webapp/src/components/backstage/automation/broadcast.tsx
+++ b/webapp/src/components/backstage/automation/broadcast.tsx
@@ -53,7 +53,7 @@ export const Broadcast = (props: Props) => {
 const StyledChannelSelector = styled(ChannelSelector)`
     background-color: ${(props) => (props.isDisabled ? 'rgba(var(--center-channel-bg-rgb), 0.16)' : 'var(--center-channel-bg)')};
 
-    .playbooks-select__control {
+    .playbooks-rselect__control {
         padding: 4px 16px 4px 3.2rem;
 
         &:before {

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -87,7 +87,6 @@ const ChannelSelector = (props: Props & { className?: string }) => {
             isClearable={props.isClearable}
             value={values}
             placeholder={props.placeholder || formatMessage({defaultMessage: 'Select a channel'})}
-            classNamePrefix='channel-selector'
             components={components}
             isDisabled={props.isDisabled}
             captureMenuScroll={props.captureMenuScroll}

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -636,7 +636,6 @@ const PlaybookEdit = (props: Props) => {
                                                 });
                                                 setChangesMade(true);
                                             }}
-                                            classNamePrefix='channel-selector'
                                             options={retrospectiveReminderOptions}
                                             isClearable={false}
                                         />

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import styled, {css} from 'styled-components';
+import styled, {css, createGlobalStyle} from 'styled-components';
 import AsyncSelect from 'react-select/async';
 import Select from 'react-select';
 
 import {RegularHeading} from 'src/styles/headings';
 import MarkdownTextbox from 'src/components/markdown_textbox';
+import {pluginId} from 'src/manifest';
 
 export const Banner = styled.div`
     color: var(--button-color);
@@ -87,29 +88,8 @@ export const StyledMarkdownTextbox = styled(MarkdownTextbox)`
     }
 `;
 
-const commonSelectStyle = css`
-    flex-grow: 1;
-    background-color: var(--center-channel-bg);
-
-    .channel-selector__menu-list {
-        background-color: var(--center-channel-bg);
-        border: none;
-    }
-
-    .channel-selector__input {
-        color: var(--center-channel-color);
-    }
-
-    .channel-selector__option--is-selected {
-        background-color: var(--center-channel-color-08);
-        color: inherit;
-    }
-
-    .channel-selector__option--is-focused {
-        background-color: var(--center-channel-color-16);
-    }
-
-    .channel-selector__control {
+export const GlobalSelectStyle = createGlobalStyle`
+    .playbooks-select__control.playbooks-select__control {
         transition: all 0.15s ease;
         transition-delay: 0s;
         background-color: transparent;
@@ -124,38 +104,74 @@ const commonSelectStyle = css`
         }
     }
 
-    .channel-selector__option {
-        &:active {
-            background-color: var(--center-channel-color-08);
+    .playbooks-select__control,
+    .playbooks-select__menu {
+        .playbooks-select__menu-list {
+            background-color: var(--center-channel-bg);
+            border: none;
         }
-    }
 
-    .channel-selector__single-value {
-        color: var(--center-channel-color);
-    }
-
-    .channel-selector__multi-value {
-        height: 20px;
-        line-height: 19px;
-        background-color: var(--center-channel-color-08);
-        border-radius: 10px;
-        padding-left: 8px;
-
-        .channel-selector__multi-value__label {
-            padding: 0;
+        .playbooks-select__input {
             color: var(--center-channel-color);
         }
-        .channel-selector__multi-value__remove {
-            color: var(--center-channel-bg-80);
+
+        .playbooks-select__option--is-selected {
+            background-color: var(--center-channel-color-08);
+            color: inherit;
+        }
+
+        .playbooks-select__option--is-focused {
+            background-color: var(--center-channel-color-16);
+        }
+
+        .playbooks-select__option {
+            &:active {
+                background-color: var(--center-channel-color-08);
+            }
+        }
+
+        .playbooks-select__single-value {
+            color: var(--center-channel-color);
+        }
+
+        .playbooks-select__multi-value {
+            height: 20px;
+            line-height: 19px;
+            background-color: var(--center-channel-color-08);
+            border-radius: 10px;
+            padding-left: 8px;
+
+            .playbooks-select__multi-value__label {
+                padding: 0;
+                color: var(--center-channel-color);
+            }
+            .playbooks-select__multi-value__remove {
+                color: var(--center-channel-bg-80);
+            }
         }
     }
 `;
 
-export const StyledAsyncSelect = styled(AsyncSelect)`
+const commonSelectStyle = css`
+    flex-grow: 1;
+    background-color: var(--center-channel-bg);
+`;
+
+export const StyledAsyncSelect = styled(AsyncSelect).attrs((props) => {
+    return {
+        classNamePrefix: 'playbooks-select',
+        ...props,
+    };
+})`
     ${commonSelectStyle}
 `;
 
-export const StyledSelect = styled(Select)`
+export const StyledSelect = styled(Select).attrs((props) => {
+    return {
+        classNamePrefix: 'playbooks-select',
+        ...props,
+    };
+})`
     ${commonSelectStyle}
 `;
 

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -89,7 +89,7 @@ export const StyledMarkdownTextbox = styled(MarkdownTextbox)`
 `;
 
 export const GlobalSelectStyle = createGlobalStyle`
-    .playbooks-select__control.playbooks-select__control {
+    .playbooks-rselect__control.playbooks-rselect__control {
         transition: all 0.15s ease;
         transition-delay: 0s;
         background-color: transparent;
@@ -104,48 +104,48 @@ export const GlobalSelectStyle = createGlobalStyle`
         }
     }
 
-    .playbooks-select__control,
-    .playbooks-select__menu {
-        .playbooks-select__menu-list {
+    .playbooks-rselect__control,
+    .playbooks-rselect__menu {
+        .playbooks-rselect__menu-list {
             background-color: var(--center-channel-bg);
             border: none;
         }
 
-        .playbooks-select__input {
+        .playbooks-rselect__input {
             color: var(--center-channel-color);
         }
 
-        .playbooks-select__option--is-selected {
+        .playbooks-rselect__option--is-selected {
             background-color: var(--center-channel-color-08);
             color: inherit;
         }
 
-        .playbooks-select__option--is-focused {
+        .playbooks-rselect__option--is-focused {
             background-color: var(--center-channel-color-16);
         }
 
-        .playbooks-select__option {
+        .playbooks-rselect__option {
             &:active {
                 background-color: var(--center-channel-color-08);
             }
         }
 
-        .playbooks-select__single-value {
+        .playbooks-rselect__single-value {
             color: var(--center-channel-color);
         }
 
-        .playbooks-select__multi-value {
+        .playbooks-rselect__multi-value {
             height: 20px;
             line-height: 19px;
             background-color: var(--center-channel-color-08);
             border-radius: 10px;
             padding-left: 8px;
 
-            .playbooks-select__multi-value__label {
+            .playbooks-rselect__multi-value__label {
                 padding: 0;
                 color: var(--center-channel-color);
             }
-            .playbooks-select__multi-value__remove {
+            .playbooks-rselect__multi-value__remove {
                 color: var(--center-channel-bg-80);
             }
         }
@@ -159,7 +159,7 @@ const commonSelectStyle = css`
 
 export const StyledAsyncSelect = styled(AsyncSelect).attrs((props) => {
     return {
-        classNamePrefix: 'playbooks-select',
+        classNamePrefix: 'playbooks-rselect',
         ...props,
     };
 })`
@@ -168,7 +168,7 @@ export const StyledAsyncSelect = styled(AsyncSelect).attrs((props) => {
 
 export const StyledSelect = styled(Select).attrs((props) => {
     return {
-        classNamePrefix: 'playbooks-select',
+        classNamePrefix: 'playbooks-rselect',
         ...props,
     };
 })`

--- a/webapp/src/components/datetime_input.tsx
+++ b/webapp/src/components/datetime_input.tsx
@@ -131,7 +131,6 @@ const DateTimeInput = ({
     return (
         <StyledSelect
             {...selectProps}
-            classNamePrefix='channel-selector'
             filterOption={null}
             isMulti={false}
 

--- a/webapp/src/components/update_request_post.tsx
+++ b/webapp/src/components/update_request_post.tsx
@@ -105,7 +105,6 @@ export const UpdateRequestPost = (props: Props) => {
                 </PostUpdateTertiaryButton>
                 <Spacer/>
                 <StyledSelect
-                    classNamePrefix='channel-selector'
                     filterOption={null}
                     isMulti={false}
                     menuPlacement={'top'}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {render, unmountComponentAtNode} from 'react-dom';
 import {Store, Unsubscribe} from 'redux';
 import {Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 
@@ -11,6 +12,8 @@ import {GlobalState} from 'mattermost-redux/types/store';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Client4} from 'mattermost-redux/client';
 import WebsocketEvents from 'mattermost-redux/constants/websocket';
+
+import {GlobalSelectStyle} from 'src/components/backstage/styles';
 
 import {makeRHSOpener} from 'src/rhs_opener';
 import {makeSlashCommandHook} from 'src/slash_command';
@@ -76,6 +79,8 @@ const OldRoutesRedirect = () => {
 export default class Plugin {
     removeRHSListener?: Unsubscribe;
     activityFunc?: () => void;
+
+    stylesContainer?: Element;
 
     doRegistrations(registry: PluginRegistry, store: Store<GlobalState>): void {
         registry.registerReducer(reducer);
@@ -162,6 +167,9 @@ export default class Plugin {
 
     public initialize(registry: PluginRegistry, store: Store<GlobalState>): void {
         this.doRegistrations(registry, store);
+        this.stylesContainer = document.createElement('div');
+        document.body.appendChild(this.stylesContainer);
+        render(<><GlobalSelectStyle/></>, this.stylesContainer);
 
         // Consume the SiteURL so that the client is subpath aware. We also do this for Client4
         // in our version of the mattermost-redux, since webapp only does it in its copy.
@@ -189,6 +197,9 @@ export default class Plugin {
         if (this.activityFunc) {
             document.removeEventListener('click', this.activityFunc);
             delete this.activityFunc;
+        }
+        if (this.stylesContainer) {
+            unmountComponentAtNode(this.stylesContainer);
         }
     }
 }


### PR DESCRIPTION
#### Summary
- Refactor and globalize `react-select` theming overrides to support portaling.
- Mount/unmount global style in index-init., as we don't have an always-active, central mounting point.
- Replaces classNamePrefix `channel-selector` with `playbooks-rselect` as the shared select is used for multiple things.

<img width="717" alt="CleanShot 2021-11-09 at 09 18 32@2x" src="https://user-images.githubusercontent.com/11724372/140952304-92c9fcaa-0535-4397-bb28-ff7af15f852e.png">


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39938


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [x] Unit tests updated
