### PR TITLE
MM-39939: Hide enabled actions that have no actual content

### DIFF
--- a/webapp/src/components/backstage/playbooks/playbook_preview_actions.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_actions.tsx
@@ -29,26 +29,34 @@ const PlaybookPreviewActions = (props: Props) => {
     // hiding them if they don't have any visible subentries.
     // If a new CardSubEntry is added or the conditions are changed, these booleans need to be updated.
 
-    const emptyPromptEntry =
-        !props.playbook.signal_any_keywords_enabled;
+    const showPromptCardEntry = props.playbook.signal_any_keywords_enabled && props.playbook.signal_any_keywords.length !== 0;
 
-    const emptyRunStartEntry =
-        !props.playbook.invite_users_enabled &&
-        !props.playbook.default_owner_enabled &&
-        !props.playbook.broadcast_enabled &&
-        !props.playbook.webhook_on_status_update_enabled &&
-        !props.playbook.webhook_on_creation_enabled;
+    const inviteUsersEnabled = props.playbook.invite_users_enabled && props.playbook.invited_user_ids.length !== 0;
+    const defaultOwnerEnabled = props.playbook.default_owner_enabled && props.playbook.default_owner_id !== '';
+    const broadcastEnabled = props.playbook.broadcast_enabled && props.playbook.broadcast_channel_ids.length !== 0;
+    const runSummaryEnabled = props.playbook.run_summary_template !== '';
+    const webhookOnCreationEnabled = props.playbook.webhook_on_creation_enabled && props.playbook.webhook_on_creation_urls.length !== 0;
 
-    const emptyNewMemberEntry =
-        !props.playbook.message_on_join_enabled &&
-        !props.playbook.categorize_channel_enabled;
+    const showRunStartCardEntry =
+        inviteUsersEnabled ||
+        broadcastEnabled ||
+        defaultOwnerEnabled ||
+        runSummaryEnabled ||
+        webhookOnCreationEnabled;
 
-    const allEmpty =
-        emptyPromptEntry &&
-        emptyRunStartEntry &&
-        emptyNewMemberEntry;
+    const messageOnJoinEnabled = props.playbook.message_on_join_enabled && props.playbook.message_on_join !== '';
+    const categorizeChannelEnabled = props.playbook.categorize_channel_enabled && props.playbook.category_name !== '';
 
-    if (allEmpty) {
+    const showNewMemberCardEntry =
+        messageOnJoinEnabled ||
+        categorizeChannelEnabled;
+
+    const allCardEntriesEmpty =
+        !showPromptCardEntry &&
+        !showRunStartCardEntry &&
+        !showNewMemberCardEntry;
+
+    if (allCardEntriesEmpty) {
         return null;
     }
 
@@ -66,14 +74,14 @@ const PlaybookPreviewActions = (props: Props) => {
                     extraInfo={props.playbook.signal_any_keywords.map((keyword) => (
                         <TextBadge key={keyword}>{keyword}</TextBadge>
                     ))}
-                    enabled={!emptyPromptEntry}
+                    enabled={showPromptCardEntry}
                 />
                 <CardEntry
                     title={formatMessage({
                         defaultMessage: 'When a run starts',
                     })}
                     iconName={'play'}
-                    enabled={!emptyRunStartEntry}
+                    enabled={showRunStartCardEntry}
                 >
                     <CardSubEntry
                         title={formatMessage(
@@ -95,13 +103,13 @@ const PlaybookPreviewActions = (props: Props) => {
                                 />
                             </UserRow>
                         )}
-                        enabled={props.playbook.invite_users_enabled}
+                        enabled={inviteUsersEnabled}
                     />
                     <CardSubEntry
                         title={formatMessage({
                             defaultMessage: 'Assign the owner role to',
                         })}
-                        enabled={props.playbook.default_owner_enabled}
+                        enabled={defaultOwnerEnabled}
                         extraInfo={(
                             <StyledProfileSelector
                                 selectedUserId={props.playbook.default_owner_id}
@@ -118,7 +126,7 @@ const PlaybookPreviewActions = (props: Props) => {
                             {defaultMessage: 'Announce in the {oneChannel, plural, one {channel} other {channels}}'},
                             {oneChannel: props.playbook.broadcast_channel_ids.length}
                         )}
-                        enabled={props.playbook.broadcast_enabled}
+                        enabled={broadcastEnabled}
                         extraInfo={props.playbook.broadcast_channel_ids.map((id) => (
                             <ChannelBadge
                                 key={id}
@@ -130,15 +138,15 @@ const PlaybookPreviewActions = (props: Props) => {
                         title={formatMessage({
                             defaultMessage: 'Update run summary',
                         })}
-                        enabled={props.playbook.webhook_on_status_update_enabled}
+                        enabled={runSummaryEnabled}
                     >
-                        {renderMarkdown(props.playbook.reminder_message_template)}
+                        {renderMarkdown(props.playbook.run_summary_template)}
                     </CardSubEntry>
                     <CardSubEntry
                         title={formatMessage({
                             defaultMessage: 'Send an outgoing webhook',
                         })}
-                        enabled={props.playbook.webhook_on_creation_enabled}
+                        enabled={webhookOnCreationEnabled}
                     >
                         {props.playbook.webhook_on_creation_urls.map((url) => (<p key={url}>{url}</p>))}
                     </CardSubEntry>
@@ -146,19 +154,19 @@ const PlaybookPreviewActions = (props: Props) => {
                 <CardEntry
                     title={formatMessage({defaultMessage: 'When a new member joins the channel'})}
                     iconName={'account-outline'}
-                    enabled={!emptyNewMemberEntry}
+                    enabled={showNewMemberCardEntry}
                 >
                     <CardSubEntry
                         title={formatMessage({
                             defaultMessage: 'Send a welcome message',
                         })}
-                        enabled={props.playbook.message_on_join_enabled}
+                        enabled={messageOnJoinEnabled}
                     >
                         {renderMarkdown(props.playbook.message_on_join)}
                     </CardSubEntry>
                     <CardSubEntry
                         title={formatMessage({defaultMessage: 'Add the channel to the sidebar category'})}
-                        enabled={props.playbook.categorize_channel_enabled}
+                        enabled={categorizeChannelEnabled}
                         extraInfo={(
                             <TextBadge>
                                 {props.playbook.category_name}

--- a/webapp/src/components/backstage/playbooks/playbook_preview_checklists.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_checklists.tsx
@@ -22,6 +22,10 @@ const PlaybookPreviewChecklists = (props: Props) => {
     const initialArray = Array(props.playbook.checklists.length).fill(false);
     const [checklistsCollapsed, setChecklistsCollapsed] = useState(initialArray);
 
+    if (props.playbook.checklists.length === 0) {
+        return null;
+    }
+
     return (
         <Section
             id={props.id}

--- a/webapp/src/components/backstage/playbooks/playbook_preview_status_updates.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_status_updates.tsx
@@ -29,17 +29,23 @@ const PlaybookPreviewStatusUpdates = (props: Props) => {
     // hiding them if they don't have any visible subentries.
     // If a new CardSubEntry is added or the conditions are changed, these booleans need to be updated.
 
-    const emptyReminderEntry =
-        props.playbook.reminder_timer_default_seconds === 0 &&
-        props.playbook.reminder_message_template === '';
+    const updateReminderEnabled = props.playbook.reminder_timer_default_seconds !== 0;
+    const updateTemplateEnabled = props.playbook.reminder_message_template !== '';
 
-    const emptyUpdatePostedEntry =
-        !props.playbook.broadcast_enabled &&
-        !props.playbook.webhook_on_status_update_enabled;
+    const showReminderCardEntry =
+        updateReminderEnabled ||
+        updateTemplateEnabled;
+
+    const broadcastEnabled = props.playbook.broadcast_enabled && props.playbook.broadcast_channel_ids.length !== 0;
+    const webhookOnStatusUpdateEnabled = props.playbook.webhook_on_status_update_enabled && props.playbook.webhook_on_status_update_urls.length !== 0;
+
+    const showUpdatePostCardEntryemptyUpdatePostedEntry =
+        broadcastEnabled ||
+        webhookOnStatusUpdateEnabled;
 
     const allEmpty =
-        emptyReminderEntry &&
-        emptyUpdatePostedEntry;
+        !showReminderCardEntry &&
+        !showUpdatePostCardEntryemptyUpdatePostedEntry;
 
     if (allEmpty) {
         return null;
@@ -57,18 +63,18 @@ const PlaybookPreviewStatusUpdates = (props: Props) => {
                         {reminderEnabled: props.playbook.reminder_timer_default_seconds !== 0},
                     )}
                     iconName={'clock-outline'}
-                    extraInfo={props.playbook.reminder_timer_default_seconds !== 0 && (
+                    extraInfo={updateReminderEnabled && (
                         <TextBadge>
                             {formatDuration(Duration.fromObject({seconds: props.playbook.reminder_timer_default_seconds}), 'long')}
                         </TextBadge>
                     )}
-                    enabled={!emptyReminderEntry}
+                    enabled={showReminderCardEntry}
                 >
                     <CardSubEntry
                         title={formatMessage({
                             defaultMessage: 'Update template',
                         })}
-                        enabled={props.playbook.reminder_message_template !== ''}
+                        enabled={updateTemplateEnabled}
                     >
                         {renderMarkdown(props.playbook.reminder_message_template)}
                     </CardSubEntry>
@@ -78,14 +84,14 @@ const PlaybookPreviewStatusUpdates = (props: Props) => {
                         defaultMessage: 'When an update is posted',
                     })}
                     iconName={'message-check-outline'}
-                    enabled={!emptyUpdatePostedEntry}
+                    enabled={showUpdatePostCardEntryemptyUpdatePostedEntry}
                 >
                     <CardSubEntry
                         title={formatMessage(
                             {defaultMessage: 'Broadcast updates in the {oneChannel, plural, one {channel} other {channels}}'},
                             {oneChannel: props.playbook.broadcast_channel_ids.length}
                         )}
-                        enabled={props.playbook.broadcast_enabled}
+                        enabled={broadcastEnabled}
                         extraInfo={props.playbook.broadcast_channel_ids.map((id) => (
                             <ChannelBadge
                                 key={id}
@@ -97,7 +103,7 @@ const PlaybookPreviewStatusUpdates = (props: Props) => {
                         title={formatMessage({
                             defaultMessage: 'Send an outgoing webhook',
                         })}
-                        enabled={props.playbook.webhook_on_status_update_enabled}
+                        enabled={webhookOnStatusUpdateEnabled}
                     >
                         {props.playbook.webhook_on_status_update_urls.map((url) => (<p key={url}>{url}</p>))}
                     </CardSubEntry>


### PR DESCRIPTION
#### Summary
The original ticket focused on the action that automatically selects a default owner when the run starts: when said action was enabled but no actual user was added (which is actually possible, and hopefully something we'll fix when the edit screen is revamped), then its preview rendered in a weird state.

But this happens with most actions: we need to check both that they are enabled and that they have actual content (the owner is selected, there is at least one webhook, there is at least one user invited...).

This PR addresses all these cases, also changing the negative boolean conditions into positive ones, which are way easier to read.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39939

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
