### PR TITLE
[MM-39772] Use relative URLs in the channel header

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -124,13 +124,13 @@ func (s *PlaybookRunServiceImpl) broadcastPlaybookRunCreation(playbookTitle, pla
 	announcementMsg := fmt.Sprintf(
 		"### New run started: [%s](%s)\n",
 		playbookRun.Name,
-		getRunDetailsURL(*siteURL, playbookRun.ID),
+		getRunDetailsRelativeURL(playbookRun.ID),
 	)
 	announcementMsg += fmt.Sprintf(
 		"@%s just ran the [%s](%s) playbook.",
 		owner.Username,
 		playbookTitle,
-		getPlaybookDetailsURL(*siteURL, playbookID),
+		getPlaybookDetailsRelativeURL(playbookID),
 	)
 
 	if playbookRunChannel.Type == model.ChannelTypeOpen {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -124,13 +124,13 @@ func (s *PlaybookRunServiceImpl) broadcastPlaybookRunCreation(playbookTitle, pla
 	announcementMsg := fmt.Sprintf(
 		"### New run started: [%s](%s)\n",
 		playbookRun.Name,
-		getRunDetailsURL(*siteURL, s.configService.GetManifest().Id, playbookRun.ID),
+		getRunDetailsURL(*siteURL, playbookRun.ID),
 	)
 	announcementMsg += fmt.Sprintf(
 		"@%s just ran the [%s](%s) playbook.",
 		owner.Username,
 		playbookTitle,
-		getPlaybookDetailsURL(*siteURL, s.configService.GetManifest().Id, playbookID),
+		getPlaybookDetailsURL(*siteURL, playbookID),
 	)
 
 	if playbookRunChannel.Type == model.ChannelTypeOpen {
@@ -188,7 +188,7 @@ func (s *PlaybookRunServiceImpl) sendWebhooksOnCreation(playbookRun PlaybookRun)
 
 	channelURL := getChannelURL(*siteURL, team.Name, channel.Name)
 
-	detailsURL := getRunDetailsURL(*siteURL, s.configService.GetManifest().Id, playbookRun.ID)
+	detailsURL := getRunDetailsURL(*siteURL, playbookRun.ID)
 
 	payload := PlaybookRunWebhookPayload{
 		PlaybookRun: playbookRun,
@@ -228,8 +228,8 @@ func (s *PlaybookRunServiceImpl) CreatePlaybookRun(playbookRun *PlaybookRun, pb 
 
 	header := "This channel was created as part of a playbook run. To view more information, select the shield icon then select *Tasks* or *Overview*."
 	if pb != nil {
-		overviewURL = getRelativeRunDetailsURL(playbookRun.ID)
-		playbookURL = getRelativePlaybookDetailsURL(pb.ID)
+		overviewURL = getRunDetailsRelativeURL(playbookRun.ID)
+		playbookURL = getPlaybookDetailsRelativeURL(pb.ID)
 		header = fmt.Sprintf("This channel was created as part of the [%s](%s) playbook. Visit [the overview page](%s) for more information.",
 			pb.Title, playbookURL, overviewURL)
 	}
@@ -737,7 +737,7 @@ func (s *PlaybookRunServiceImpl) sendWebhooksOnUpdateStatus(playbookRunID string
 
 	channelURL := getChannelURL(*siteURL, team.Name, channel.Name)
 
-	detailsURL := getRunDetailsURL(*siteURL, s.configService.GetManifest().Id, playbookRun.ID)
+	detailsURL := getRunDetailsURL(*siteURL, playbookRun.ID)
 
 	payload := PlaybookRunWebhookPayload{
 		PlaybookRun: *playbookRun,
@@ -942,11 +942,7 @@ func (s *PlaybookRunServiceImpl) FinishPlaybookRun(playbookRunID, userID string)
 }
 
 func (s *PlaybookRunServiceImpl) postRetrospectiveReminder(playbookRun *PlaybookRun, isInitial bool) error {
-	retrospectiveURL := getRunRetrospectiveURL(
-		"",
-		s.configService.GetManifest().Id,
-		playbookRun.ID,
-	)
+	retrospectiveURL := getRunRetrospectiveURL("", playbookRun.ID)
 
 	attachments := []*model.SlackAttachment{
 		{
@@ -1952,7 +1948,7 @@ func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, ownerID, postID, c
 	}
 	newPlaybookMarkdown := ""
 	if siteURL != "" && !isMobileApp {
-		url := getPlaybooksNewURL(siteURL, s.configService.GetManifest().Id)
+		url := getPlaybooksNewURL(siteURL)
 		newPlaybookMarkdown = fmt.Sprintf("[Click here](%s) to create your own playbook.", url)
 	}
 
@@ -2171,11 +2167,7 @@ func (s *PlaybookRunServiceImpl) PublishRetrospective(playbookRunID, text, publi
 		return errors.Wrap(err, "failed to get publisher user")
 	}
 
-	retrospectiveURL := getRunRetrospectiveURL(
-		"",
-		s.configService.GetManifest().Id,
-		playbookRunToPublish.ID,
-	)
+	retrospectiveURL := getRunRetrospectiveURL("", playbookRunToPublish.ID)
 	if _, err = s.poster.PostMessage(playbookRunToPublish.ChannelID, "@channel Retrospective has been published by @%s\n[See the full retrospective](%s)\n%s", publisherUser.Username, retrospectiveURL, text); err != nil {
 		return errors.Wrap(err, "failed to post to channel")
 	}

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -227,9 +227,9 @@ func (s *PlaybookRunServiceImpl) CreatePlaybookRun(playbookRun *PlaybookRun, pb 
 	playbookURL := ""
 
 	header := "This channel was created as part of a playbook run. To view more information, select the shield icon then select *Tasks* or *Overview*."
-	if siteURL != "" && pb != nil {
-		overviewURL = getRunDetailsURL(siteURL, s.configService.GetManifest().Id, playbookRun.ID)
-		playbookURL = getPlaybookDetailsURL(siteURL, s.configService.GetManifest().Id, pb.ID)
+	if pb != nil {
+		overviewURL = getRelativeRunDetailsURL(playbookRun.ID)
+		playbookURL = getRelativePlaybookDetailsURL(pb.ID)
 		header = fmt.Sprintf("This channel was created as part of the [%s](%s) playbook. Visit [the overview page](%s) for more information.",
 			pb.Title, playbookURL, overviewURL)
 	}

--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -151,12 +151,11 @@ func (s *playbookService) MessageHasBeenPosted(sessionID string, post *model.Pos
 		return
 	}
 
-	pluginID := s.configService.GetManifest().Id
 	siteURL := model.ServiceSettingsDefaultSiteURL
 	if s.api.Configuration.GetConfig().ServiceSettings.SiteURL != nil {
 		siteURL = *s.api.Configuration.GetConfig().ServiceSettings.SiteURL
 	}
-	playbooksURL := getPlaybooksURL(siteURL, pluginID)
+	playbooksURL := getPlaybooksURL(siteURL)
 
 	message := s.getPlaybookSuggestionsMessage(suggestedPlaybooks, triggers, playbooksURL)
 	attachment := s.getPlaybookSuggestionsSlackAttachment(suggestedPlaybooks, post.Id, playbooksURL, session.IsMobileApp())

--- a/server/app/urls.go
+++ b/server/app/urls.go
@@ -2,54 +2,35 @@ package app
 
 import "fmt"
 
-func getRunsURL(siteURL string, manifestID string) string {
-	return fmt.Sprintf(
-		"%s/playbooks/runs",
-		siteURL,
-	)
+const (
+	PlaybooksPath = "/playbooks/playbooks"
+	RunsPath      = "/playbooks/runs"
+)
+
+func getRunDetailsRelativeURL(playbookRunID string) string {
+	return fmt.Sprintf("%s/%s", RunsPath, playbookRunID)
 }
 
-func getRunDetailsURL(siteURL string, manifestID string, playbookRunID string) string {
-	return fmt.Sprintf(
-		"%s/%s",
-		getRunsURL(siteURL, manifestID),
-		playbookRunID,
-	)
+func getPlaybookDetailsRelativeURL(playbookID string) string {
+	return fmt.Sprintf("%s/%s", PlaybooksPath, playbookID)
 }
 
-func getRunRetrospectiveURL(siteURL string, manifestID string, playbookRunID string) string {
-	return fmt.Sprintf("%s/retrospective", getRunDetailsURL(siteURL, manifestID, playbookRunID))
+func getRunDetailsURL(siteURL string, playbookRunID string) string {
+	return fmt.Sprintf("%s%s", siteURL, getRunDetailsRelativeURL(playbookRunID))
 }
 
-func getPlaybooksURL(siteURL string, manifestID string) string {
-	return fmt.Sprintf(
-		"%s/playbooks/playbooks",
-		siteURL,
-	)
+func getRunRetrospectiveURL(siteURL string, playbookRunID string) string {
+	return fmt.Sprintf("%s/retrospective", getRunDetailsURL(siteURL, playbookRunID))
 }
 
-func getPlaybooksNewURL(siteURL string, manifestID string) string {
-	return fmt.Sprintf("%s/new", getPlaybooksURL(siteURL, manifestID))
+func getPlaybooksURL(siteURL string) string {
+	return fmt.Sprintf("%s%s", siteURL, PlaybooksPath)
 }
 
-func getPlaybookDetailsURL(siteURL string, manifestID string, playbookID string) string {
-	return fmt.Sprintf(
-		"%s/%s",
-		getPlaybooksURL(siteURL, manifestID),
-		playbookID,
-	)
+func getPlaybooksNewURL(siteURL string) string {
+	return fmt.Sprintf("%s/new", getPlaybooksURL(siteURL))
 }
 
-func getRelativeRunDetailsURL(playbookRunID string) string {
-	return fmt.Sprintf(
-		"/playbooks/runs/%s",
-		playbookRunID,
-	)
-}
-
-func getRelativePlaybookDetailsURL(playbookID string) string {
-	return fmt.Sprintf(
-		"/playbooks/playbooks/%s",
-		playbookID,
-	)
+func getPlaybookDetailsURL(siteURL string, playbookID string) string {
+	return fmt.Sprintf("%s%s", siteURL, getPlaybookDetailsRelativeURL(playbookID))
 }

--- a/server/app/urls.go
+++ b/server/app/urls.go
@@ -39,3 +39,17 @@ func getPlaybookDetailsURL(siteURL string, manifestID string, playbookID string)
 		playbookID,
 	)
 }
+
+func getRelativeRunDetailsURL(playbookRunID string) string {
+	return fmt.Sprintf(
+		"/playbooks/runs/%s",
+		playbookRunID,
+	)
+}
+
+func getRelativePlaybookDetailsURL(playbookID string) string {
+	return fmt.Sprintf(
+		"/playbooks/playbooks/%s",
+		playbookID,
+	)
+}

--- a/server/app/urls_test.go
+++ b/server/app/urls_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPlaybookDetailsURL(t *testing.T) {
+	require.Equal(t,
+		"http://mattermost.com/playbooks/playbooks/playbookTestId",
+		getPlaybookDetailsURL("http://mattermost.com", "playbookTestId"),
+	)
+}
+
+func TestGetPlaybooksNewURL(t *testing.T) {
+	require.Equal(t,
+		"http://mattermost.com/playbooks/playbooks/new",
+		getPlaybooksNewURL("http://mattermost.com"),
+	)
+}
+
+func TestGetPlaybooksURL(t *testing.T) {
+	require.Equal(t,
+		"http://mattermost.com/playbooks/playbooks",
+		getPlaybooksURL("http://mattermost.com"),
+	)
+}
+
+func TestGetPlaybookDetailsRelativeURL(t *testing.T) {
+	require.Equal(t,
+		"/playbooks/playbooks/testPlaybookId",
+		getPlaybookDetailsRelativeURL("testPlaybookId"),
+	)
+}
+
+func TestGetRunDetailsRelativeURL(t *testing.T) {
+	require.Equal(t,
+		"/playbooks/runs/testPlaybookRunId",
+		getRunDetailsRelativeURL("testPlaybookRunId"),
+	)
+}
+
+func TestGetRunDetailsURL(t *testing.T) {
+	require.Equal(t,
+		"http://mattermost.com/playbooks/runs/testPlaybookRunId",
+		getRunDetailsURL("http://mattermost.com", "testPlaybookRunId"),
+	)
+}
+
+func TestGetRunRetrospectiveURL(t *testing.T) {
+	require.Equal(t,
+		"http://mattermost.com/playbooks/runs/testPlaybookRunId/retrospective",
+		getRunRetrospectiveURL("http://mattermost.com", "testPlaybookRunId"),
+	)
+}

--- a/tests-e2e/cypress/integration/channels/channel_header_spec.js
+++ b/tests-e2e/cypress/integration/channels/channel_header_spec.js
@@ -10,6 +10,7 @@ describe('channels > channel header', () => {
     let testTeam;
     let testUser;
     let testPlaybook;
+    let testPlaybookRun;
 
     before(() => {
         cy.apiInitSetup().then(({team, user}) => {
@@ -33,6 +34,8 @@ describe('channels > channel header', () => {
                     playbookId: testPlaybook.id,
                     playbookRunName: 'Playbook Run',
                     ownerUserId: testUser.id,
+                }).then((run) => {
+                    testPlaybookRun = run;
                 });
             });
         });
@@ -71,6 +74,27 @@ describe('channels > channel header', () => {
 
             // # Verify tooltip text
             cy.get('#pluginTooltip').contains('Toggle Run Details');
+        });
+    });
+
+    describe('description text', () => {
+        it('should contain a link to the playbook', () => {
+            // # Navigate directly to a playbook run channel
+            cy.visit(`/${testTeam.name}/channels/playbook-run`);
+
+            // * Verify link to playbook
+            cy.get('.header-description__text').findByText('Playbook').should('have.attr', 'href').then((href) => {
+                expect(href).to.equals(`/playbooks/playbooks/${testPlaybook.id}`);
+            });
+        });
+        it('should contain a link to the overview page', () => {
+            // # Navigate directly to a playbook run channel
+            cy.visit(`/${testTeam.name}/channels/playbook-run`);
+
+            // * Verify link to overview page
+            cy.get('.header-description__text').findByText('the overview page').should('have.attr', 'href').then((href) => {
+                expect(href).to.equals(`/playbooks/runs/${testPlaybookRun.id}`);
+            });
         });
     });
 });


### PR DESCRIPTION
#### Summary
This PR goal is to use relative URLs instead of absolute in the header of the channel created by a new playbook run.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/18905

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
