### PR TITLE
Build just one binary on a developer environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ GO_TEST_FLAGS ?= -race
 GO_BUILD_FLAGS ?=
 MM_UTILITIES_DIR ?= ../mattermost-utilities
 DLV_DEBUG_PORT := 2346
+DEFAULT_GOOS := $(shell go env GOOS)
+DEFAULT_GOARCH := $(shell go env GOARCH)
 
 export GO111MODULE=on
 
@@ -62,23 +64,30 @@ ifneq ($(HAS_SERVER),)
 	golangci-lint run ./...
 endif
 
-## Builds the server, if it exists, for all supported architectures.
+## Builds the server, if it exists, for all supported architectures, unless MM_SERVICESETTINGS_ENABLEDEVELOPER is set
 .PHONY: server
 server:
 ifneq ($(HAS_SERVER),)
 	mkdir -p server/dist;
 ifeq ($(MM_DEBUG),)
+ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
+	cd server && $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-$(DEFAULT_GOOS)-$(DEFAULT_GOARCH);
+else
 	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-linux-amd64;
 	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-darwin-amd64;
 	cd server && env GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-darwin-arm64;
 	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-windows-amd64.exe;
+endif
 else
 	$(info DEBUG mode is on; to disable, unset MM_DEBUG)
-
+ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
+	cd server && $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-$(DEFAULT_GOOS)-$(DEFAULT_GOARCH);
+else
 	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-darwin-amd64;
 	cd server && env GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-darwin-arm64;
 	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-linux-amd64;
 	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -gcflags "all=-N -l" -o dist/plugin-windows-amd64.exe;
+endif
 endif
 endif
 


### PR DESCRIPTION
#### Summary
After [this conversation](https://community-daily.mattermost.com/core/pl/bf4kq4i77fnr5qzqrpwqz3befa) in Mattermost, I decided to set up this simple proof of concept to build only one binary when developing locally.

Right now I'm using the environment variable `MM_SERVICESETTINGS_ENABLEDEVELOPER`, but we could also use any ad-hoc variable. This PR is just intended to continue the conversation so it does not die in a poor abandoned thread.

Let me know what you think!

#### Ticket Link
--
