### PR TITLE
[MM-39933]:On click sort numeric playbook columns in descending order

### DIFF
--- a/webapp/src/hooks/crud.ts
+++ b/webapp/src/hooks/crud.ts
@@ -102,7 +102,7 @@ export function usePlaybooksCrud(
             return;
         }
 
-        setParams({sort: colName, direction: 'asc'});
+        setParams({sort: colName, direction: 'desc'});
     };
 
     return [


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

# Summary
Change the checklists, tasks and run columns on the /playbooks/playbooks to sort descending on the first click, bringing to the top the playbooks with the most checklists, tasks or runs respectively. Subsequent clicks on the same column should continue to toggle the direction.

# Fixes
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:
-->
  * https://github.com/mattermost/mattermost-server/issues/18960

## Jira ticket.
https://mattermost.atlassian.net/browse/MM-39933

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [x] Telemetry updated
- [x] Gated by experimental feature flag
- [x] Unit tests updated
