### PR TITLE
MM-40048: Fix ordered lists rendering in playbook preview

### DIFF
--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -213,9 +213,6 @@ const ChecklistItemDescription = styled.div`
     font-size: 12px;
     color: rgba(var(--center-channel-color-rgb), 0.72);
 
-    display: flex;
-    flex-direction: column;
-
     max-width: 630px;
     margin: 4px 0 0 2px;
 


### PR DESCRIPTION
#### Summary

This PR removes the `display: flex` style of the description container, fixing the weirdly centered ordered lists in the tasks description.

Before:
![image](https://user-images.githubusercontent.com/3924815/141353086-0e2bfcc3-1adf-4e8b-8961-21e17aec0b83.png)

After:
![image](https://user-images.githubusercontent.com/3924815/141353100-a1952fd5-83b9-4cff-8606-0d65520f28f2.png)

For context, this is how lists are rendered in posts (it looked weird to me in the first place in the description, but it's the same in channels)

![image](https://user-images.githubusercontent.com/3924815/141353565-b60c6c82-cad8-433e-b708-93b80139494f.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
