### PR TITLE
[MM-39529] Adding an item in the run's RHS dropdown menu to edit a run summary

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -85,4 +85,61 @@ describe('channels > rhs > header', () => {
             });
         });
     });
+
+    describe('edit summary', () => {
+        it('by clicking on placeholder', () => {
+            // # Run the playbook
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            const playbookRunChannelName = 'playbook-run-' + now;
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            });
+
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # click on the field
+            cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').click();
+
+            // # type text in textarea
+            cy.get('#rhsContainer').findByTestId('textarea-description').should('be.visible').type('new summary{ctrl+enter}');
+
+            // * make sure the updated summary is here
+            cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').contains('new summary');
+        });
+        it('by clicking on dot menu item', () => {
+            // # Run the playbook
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            const playbookRunChannelName = 'playbook-run-' + now;
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            });
+
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # click on the field
+            cy.get('#rhsContainer').within(() => {
+                cy.findByTestId('buttons-row').invoke('show').within(() => {
+                    cy.findAllByRole('button').eq(1).click();
+                    cy.findByText('Edit run summary').click({force: true});
+                });
+            });
+
+
+            // # type text in textarea
+            cy.get('#rhsContainer').findByTestId('textarea-description').should('be.visible').type('new summary{ctrl+enter}');
+
+            // * make sure the updated summary is here
+            cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').contains('new summary');
+        });
+    });
 });

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -61,6 +61,7 @@
   "BNB75h": "A playbook prescribes the checklists, automations, and templates for any repeatable procedures. {br} It helps teams reduce errors, earn trust with stakeholders, and become more effective with every iteration.",
   "BQtd5I": "Welcome to Playbooks!",
   "C1khRR": "Back to playbooks",
+  "C6Oghd": "Edit run summary",
   "C9NScU": "Put your team in control",
   "CBM4vh": "Timer for next update",
   "CL5OZP": "Only users who you select will be able to edit or run this playbook.",

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -68,23 +68,28 @@ const DropdownMenu = styled.div<DropdownMenuProps>`
     z-index: 1;
 `;
 
-interface ClosableDotMenuProps extends DotMenuProps {
-    isOpen: boolean;
-    setOpen: (open: boolean) => void;
+interface DotMenuProps {
+    children: JSX.Element[] | JSX.Element;
+    icon: JSX.Element;
+    top?: boolean;
+    left?: boolean;
+    wide?: boolean;
+    dotMenuButton?: StyledComponentBase<'div', any>;
 }
 
-export const ClosableDotMenu = (props: ClosableDotMenuProps) => {
+const DotMenu = (props: DotMenuProps) => {
+    const [isOpen, setOpen] = useState(false);
     const toggleOpen = () => {
-        props.setOpen(!props.isOpen);
+        setOpen(true);
     };
 
     const rootRef = useRef<HTMLDivElement>(null);
     useClickOutsideRef(rootRef, () => {
-        props.setOpen(false);
+        setOpen(false);
     });
 
     useKeyPress('Escape', () => {
-        props.setOpen(false);
+        setOpen(false);
     });
 
     const MenuButton = props.dotMenuButton ?? DotMenuButton;
@@ -109,39 +114,22 @@ export const ClosableDotMenu = (props: ClosableDotMenuProps) => {
             {props.icon}
             <DropdownMenuWrapper>
                 {
-                    props.isOpen &&
+                    isOpen &&
                     <DropdownMenu
                         data-testid='dropdownmenu'
                         top={props.top}
                         left={props.left}
                         wide={props.wide}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            setOpen(false);
+                        }}
                     >
                         {props.children}
                     </DropdownMenu>
                 }
             </DropdownMenuWrapper>
         </MenuButton>
-    );
-};
-
-interface DotMenuProps {
-    children: JSX.Element[] | JSX.Element;
-    icon: JSX.Element;
-    top?: boolean;
-    left?: boolean;
-    wide?: boolean;
-    dotMenuButton?: StyledComponentBase<'div', any>;
-}
-
-const DotMenu = (props: DotMenuProps) => {
-    const [isOpen, setOpen] = useState(false);
-
-    return (
-        <ClosableDotMenu
-            {...props}
-            isOpen={isOpen}
-            setOpen={setOpen}
-        >{props.children}</ClosableDotMenu>
     );
 };
 

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -68,8 +68,10 @@ const DropdownMenu = styled.div<DropdownMenuProps>`
     z-index: 1;
 `;
 
-interface DotMenuProps {
+interface ClosableDotMenuProps {
     children: JSX.Element[] | JSX.Element;
+    isOpen: boolean;
+    setOpen: (open: boolean) => void;
     icon: JSX.Element;
     top?: boolean;
     left?: boolean;
@@ -77,19 +79,18 @@ interface DotMenuProps {
     dotMenuButton?: StyledComponentBase<'div', any>;
 }
 
-const DotMenu = (props: DotMenuProps) => {
-    const [isOpen, setOpen] = useState(false);
+export const ClosableDotMenu = (props: ClosableDotMenuProps) => {
     const toggleOpen = () => {
-        setOpen(true);
+        props.setOpen(!props.isOpen);
     };
 
     const rootRef = useRef<HTMLDivElement>(null);
     useClickOutsideRef(rootRef, () => {
-        setOpen(false);
+        props.setOpen(false);
     });
 
     useKeyPress('Escape', () => {
-        setOpen(false);
+        props.setOpen(false);
     });
 
     const MenuButton = props.dotMenuButton ?? DotMenuButton;
@@ -114,7 +115,7 @@ const DotMenu = (props: DotMenuProps) => {
             {props.icon}
             <DropdownMenuWrapper>
                 {
-                    isOpen &&
+                    props.isOpen &&
                     <DropdownMenu
                         data-testid='dropdownmenu'
                         top={props.top}
@@ -126,6 +127,27 @@ const DotMenu = (props: DotMenuProps) => {
                 }
             </DropdownMenuWrapper>
         </MenuButton>
+    );
+};
+
+interface DotMenuProps {
+    children: JSX.Element[] | JSX.Element;
+    icon: JSX.Element;
+    top?: boolean;
+    left?: boolean;
+    wide?: boolean;
+    dotMenuButton?: StyledComponentBase<'div', any>;
+}
+
+const DotMenu = (props: DotMenuProps) => {
+    const [isOpen, setOpen] = useState(false);
+
+    return (
+        <ClosableDotMenu
+            {...props}
+            isOpen={isOpen}
+            setOpen={setOpen}
+        >{props.children}</ClosableDotMenu>
     );
 };
 

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -68,15 +68,9 @@ const DropdownMenu = styled.div<DropdownMenuProps>`
     z-index: 1;
 `;
 
-interface ClosableDotMenuProps {
-    children: JSX.Element[] | JSX.Element;
+interface ClosableDotMenuProps extends DotMenuProps {
     isOpen: boolean;
     setOpen: (open: boolean) => void;
-    icon: JSX.Element;
-    top?: boolean;
-    left?: boolean;
-    wide?: boolean;
-    dotMenuButton?: StyledComponentBase<'div', any>;
 }
 
 export const ClosableDotMenu = (props: ClosableDotMenuProps) => {

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useIntl} from 'react-intl';
 import styled from 'styled-components';
@@ -61,15 +61,21 @@ const RHSAbout = (props: Props) => {
         updatePlaybookRunDescription(props.playbookRun.id, value);
     };
 
+    const [editingSummary, setEditingSummary] = useState(false);
+    const editSummary = () => {
+        setEditingSummary(true);
+    };
+
     const isFinished = props.playbookRun.current_status === PlaybookRunStatus.Finished;
 
     return (
         <Container tabIndex={0}>
-            <ButtonsRow>
+            <ButtonsRow data-testid='buttons-row'>
                 <RHSAboutButtons
                     playbookRun={props.playbookRun}
                     collapsed={collapsed}
                     toggleCollapsed={toggleCollapsed}
+                    editSummary={editSummary}
                 />
             </ButtonsRow>
             <RHSAboutTitle
@@ -83,6 +89,8 @@ const RHSAbout = (props: Props) => {
                 <RHSAboutDescription
                     value={props.playbookRun.summary}
                     onEdit={onDescriptionEdit}
+                    editing={editingSummary}
+                    setEditing={setEditingSummary}
                 />
                 <Row>
                     <OwnerSection>

--- a/webapp/src/components/rhs/rhs_about_buttons.tsx
+++ b/webapp/src/components/rhs/rhs_about_buttons.tsx
@@ -6,13 +6,13 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import styled from 'styled-components';
 
 import Icon from '@mdi/react';
-import {mdiClipboardPlayOutline, mdiNotebookOutline} from '@mdi/js';
+import {mdiClipboardPlayOutline, mdiNotebookOutline, mdiPencil} from '@mdi/js';
 
 import {PlaybookRun} from 'src/types/playbook_run';
 
 import {navigateToPluginUrl} from 'src/browser_routing';
 import {HoverMenuButton} from 'src/components/rhs/rhs_shared';
-import DotMenu, {DotMenuButton, DropdownMenuItem} from 'src/components/dot_menu';
+import {ClosableDotMenu, DotMenuButton, DropdownMenuItem} from 'src/components/dot_menu';
 import {HamburgerButton} from 'src/components/assets/icons/three_dots_icon';
 import {usePlaybookName} from 'src/hooks';
 
@@ -20,6 +20,7 @@ interface Props {
     playbookRun: PlaybookRun;
     collapsed: boolean;
     toggleCollapsed: () => void;
+    editSummary: () => void;
 }
 
 const RHSAboutButtons = (props: Props) => {
@@ -28,6 +29,8 @@ const RHSAboutButtons = (props: Props) => {
 
     const overviewURL = `/runs/${props.playbookRun.id}`;
     const playbookURL = `/playbooks/${props.playbookRun.playbook_id}`;
+
+    const [isDotMenuOpen, setDotMenuOpen] = useState(false);
 
     return (
         <>
@@ -44,11 +47,27 @@ const RHSAboutButtons = (props: Props) => {
                     }
                 }}
             />
-            <DotMenu
+            <ClosableDotMenu
                 icon={<ThreeDotsIcon/>}
+                isOpen={isDotMenuOpen}
+                setOpen={setDotMenuOpen}
                 left={true}
                 dotMenuButton={StyledDotMenuButton}
+                data-testid='run-dot-menu'
             >
+                <StyledDropdownMenuItem
+                    onClick={() => {
+                        setDotMenuOpen(false);
+                        props.editSummary();
+                    }}
+                >
+                    <DropdownIcon
+                        path={mdiPencil}
+                        size={1.25}
+                    />
+                    <FormattedMessage defaultMessage='Edit run summary'/>
+                </StyledDropdownMenuItem>
+                <Separator/>
                 <StyledDropdownMenuItem onClick={() => navigateToPluginUrl(overviewURL)}>
                     <DropdownIcon
                         path={mdiClipboardPlayOutline}
@@ -66,7 +85,7 @@ const RHSAboutButtons = (props: Props) => {
                         {(playbookName !== '') && <PlaybookName>{playbookName}</PlaybookName>}
                     </PlaybookInfo>
                 </StyledDropdownMenuItem>
-            </DotMenu>
+            </ClosableDotMenu>
         </>
     );
 };
@@ -98,6 +117,14 @@ const DropdownIcon = styled(Icon)`
 const StyledDropdownMenuItem = styled(DropdownMenuItem)`
     display: flex;
     align-content: center;
+`;
+
+const Separator = styled.hr`
+    display: flex;
+    align-content: center;
+    border-top: 1px solid var(--center-channel-color-08);
+    margin: 5px auto;
+    width: 100%;
 `;
 
 const PlaybookInfo = styled.div`

--- a/webapp/src/components/rhs/rhs_about_buttons.tsx
+++ b/webapp/src/components/rhs/rhs_about_buttons.tsx
@@ -12,7 +12,7 @@ import {PlaybookRun} from 'src/types/playbook_run';
 
 import {navigateToPluginUrl} from 'src/browser_routing';
 import {HoverMenuButton} from 'src/components/rhs/rhs_shared';
-import {ClosableDotMenu, DotMenuButton, DropdownMenuItem} from 'src/components/dot_menu';
+import DotMenu, {DotMenuButton, DropdownMenuItem} from 'src/components/dot_menu';
 import {HamburgerButton} from 'src/components/assets/icons/three_dots_icon';
 import {usePlaybookName} from 'src/hooks';
 
@@ -30,8 +30,6 @@ const RHSAboutButtons = (props: Props) => {
     const overviewURL = `/runs/${props.playbookRun.id}`;
     const playbookURL = `/playbooks/${props.playbookRun.playbook_id}`;
 
-    const [isDotMenuOpen, setDotMenuOpen] = useState(false);
-
     return (
         <>
             <ExpandCollapseButton
@@ -47,17 +45,14 @@ const RHSAboutButtons = (props: Props) => {
                     }
                 }}
             />
-            <ClosableDotMenu
+            <DotMenu
                 icon={<ThreeDotsIcon/>}
-                isOpen={isDotMenuOpen}
-                setOpen={setDotMenuOpen}
                 left={true}
                 dotMenuButton={StyledDotMenuButton}
                 data-testid='run-dot-menu'
             >
                 <StyledDropdownMenuItem
                     onClick={() => {
-                        setDotMenuOpen(false);
                         props.editSummary();
                     }}
                 >
@@ -85,7 +80,7 @@ const RHSAboutButtons = (props: Props) => {
                         {(playbookName !== '') && <PlaybookName>{playbookName}</PlaybookName>}
                     </PlaybookInfo>
                 </StyledDropdownMenuItem>
-            </ClosableDotMenu>
+            </DotMenu>
         </>
     );
 };

--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useRef, useEffect} from 'react';
+import React, {useState, useRef, useEffect, Dispatch, SetStateAction} from 'react';
 import styled, {css} from 'styled-components';
 
 import {useSelector} from 'react-redux';
@@ -17,13 +17,14 @@ import {useClickOutsideRef, useKeyPress} from 'src/hooks/general';
 interface DescriptionProps {
     value: string;
     onEdit: (value: string) => void;
+    editing: boolean;
+    setEditing: (editing: boolean) => void;
 }
 
 const RHSAboutDescription = (props: DescriptionProps) => {
     const {formatMessage} = useIntl();
     const placeholder = formatMessage({defaultMessage: 'Add a run summary…'});
 
-    const [editing, setEditing] = useState(false);
     const [editedValue, setEditedValue] = useState(props.value);
 
     const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
@@ -34,7 +35,7 @@ const RHSAboutDescription = (props: DescriptionProps) => {
         const newValue = editedValue.trim();
         setEditedValue(newValue);
         props.onEdit(newValue);
-        setEditing(false);
+        props.setEditing(false);
     };
 
     useClickOutsideRef(textareaRef, saveAndClose);
@@ -44,15 +45,16 @@ const RHSAboutDescription = (props: DescriptionProps) => {
         setEditedValue(props.value);
     }, [props.value]);
 
-    if (!editing) {
+    if (!props.editing) {
         return (
 
             <RenderedDescription
+                data-testid='rendered-description'
                 onClick={(event) => {
                     // Enter edit mode only if the user is not clicking a link
                     const targetNode = event.target as Node;
                     if (targetNode.nodeName !== 'A') {
-                        setEditing(true);
+                        props.setEditing(true);
                     }
                 }}
             >
@@ -75,6 +77,7 @@ const RHSAboutDescription = (props: DescriptionProps) => {
 
     return (
         <DescriptionTextArea
+            data-testid='textarea-description'
             value={editedValue}
             placeholder={placeholder}
             ref={textareaRef}


### PR DESCRIPTION
#### Summary
This PR is modifying the hamburger menu of a run in the RHS to add an explicit "Edit run summary" item.

![image](https://user-images.githubusercontent.com/785518/141498100-eee17478-0329-457c-ad4e-5695106f2927.png)

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/18972

#### Checklist
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated

#### Dev note
1) My ReactJS skills are not perfect, so I'm not quite sure that the way I implemented the communication between components is the "state of the art" way to do it. I'm happy to change that to whatever is best!
2) I had to use a bit of trickery to have the hamburger menu open in the e2e tests because it appears only when the mouse goes over the container. I tried using `trigger('mouseover')` on the container but it did not work and [cypress has no implementation of `hover` yet](https://docs.cypress.io/api/commands/hover#Workarounds) was not enough. To remedy that during the test I force the buttons the show.