### PR TITLE
[MM-35201] Set `disabled` attribute on settings inputs

### DIFF
--- a/webapp/src/components/backstage/automation/patterned_input.tsx
+++ b/webapp/src/components/backstage/automation/patterned_input.tsx
@@ -32,7 +32,6 @@ export const PatternedInput = (props: Props) => (
         </AutomationTitle>
         <SelectorWrapper>
             <TextBox
-                enabled={props.enabled}
                 disabled={!props.enabled}
                 type={props.type}
                 required={true}
@@ -56,7 +55,7 @@ const ErrorMessage = styled.div`
 `;
 
 interface TextBoxProps {
-    enabled: boolean;
+    disabled: boolean;
 }
 
 const TextBox = styled.input<TextBoxProps>`
@@ -68,7 +67,7 @@ const TextBox = styled.input<TextBoxProps>`
     height: 40px;
     width: 100%;
 
-    background-color: ${(props) => (props.enabled ? 'var(--center-channel-bg)' : 'rgba(var(--center-channel-bg-rgb), 0.16)')};
+    background-color: ${(props) => (props.disabled ? 'rgba(var(--center-channel-bg-rgb), 0.16)' : 'var(--center-channel-bg)')};
     color: var(--center-channel-color);
     border-radius: 4px;
     border: none;
@@ -77,7 +76,7 @@ const TextBox = styled.input<TextBoxProps>`
     padding-left: 16px;
     padding-right: 16px;
 
-    ${(props) => props.enabled && props.value && css`
+    ${(props) => !props.disabled && props.value && css`
         :invalid:not(:focus) {
             box-shadow: inset 0 0 0 1px var(--error-text);
 

--- a/webapp/src/components/backstage/automation/patterned_input.tsx
+++ b/webapp/src/components/backstage/automation/patterned_input.tsx
@@ -33,6 +33,7 @@ export const PatternedInput = (props: Props) => (
         <SelectorWrapper>
             <TextBox
                 enabled={props.enabled}
+                disabled={!props.enabled}
                 type={props.type}
                 required={true}
                 value={props.enabled ? props.input : ''}

--- a/webapp/src/components/backstage/automation/patterned_text_area.tsx
+++ b/webapp/src/components/backstage/automation/patterned_text_area.tsx
@@ -62,6 +62,7 @@ export const PatternedTextArea = (props: Props) => {
             <SelectorWrapper>
                 <TextArea
                     enabled={props.enabled}
+                    disabled={!props.enabled}
                     required={true}
                     rows={props.rows}
                     value={props.enabled ? props.input : ''}

--- a/webapp/src/components/backstage/automation/patterned_text_area.tsx
+++ b/webapp/src/components/backstage/automation/patterned_text_area.tsx
@@ -61,7 +61,6 @@ export const PatternedTextArea = (props: Props) => {
             </AutomationTitle>
             <SelectorWrapper>
                 <TextArea
-                    enabled={props.enabled}
                     disabled={!props.enabled}
                     required={true}
                     rows={props.rows}
@@ -94,7 +93,7 @@ const ErrorMessage = styled.div`
 `;
 
 interface TextAreaProps {
-    enabled: boolean;
+    disabled: boolean;
     invalid: boolean;
 }
 
@@ -107,7 +106,7 @@ const TextArea = styled.textarea<TextAreaProps>`
     height: auto;
     width: 100%;
 
-    background-color: ${(props) => (props.enabled ? 'var(--center-channel-bg)' : 'rgba(var(--center-channel-bg-rgb), 0.16)')};
+    background-color: ${(props) => (props.disabled ? 'rgba(var(--center-channel-bg-rgb), 0.16)' : 'var(--center-channel-bg)')};
     color: var(--center-channel-color);
     border-radius: 4px;
     border: none;
@@ -115,9 +114,9 @@ const TextArea = styled.textarea<TextAreaProps>`
     font-size: 14px;
     padding-left: 16px;
     padding-right: 16px;
-    resize: ${(props) => !props.enabled && 'none'};
+    resize: ${(props) => props.disabled && 'none'};
 
-    ${(props) => props.invalid && props.enabled && props.value && css`
+    ${(props) => props.invalid && !props.disabled && props.value && css`
         :not(:focus) {
             box-shadow: inset 0 0 0 1px var(--error-text);
             & + ${ErrorMessage} {


### PR DESCRIPTION
#### Summary

a couple `<textarea>`s and an `<input>` on the action settings page were not fully disabled when their corresponding toggles were off because they lacked the `disabled` attribute. this PR flips the relevant logic and prop naming so that attribute does actually get set.

#### Ticket Link
fixes https://mattermost.atlassian.net/browse/MM-35201

#### Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
