### PR TITLE
MM-38954: Scroll the RHS to top when the run is finished

### DIFF
--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import Scrollbars from 'react-custom-scrollbars';
 import {useSelector} from 'react-redux';
 
@@ -16,11 +16,21 @@ import RHSAbout from 'src/components/rhs/rhs_about';
 import RHSChecklists from 'src/components/rhs/rhs_checklists';
 import {browserHistory} from 'src/webapp_globals';
 import {telemetryEventForPlaybookRun} from 'src/client';
+import {usePrevious} from 'src/hooks/general';
+import {PlaybookRunStatus} from 'src/types/playbook_run';
 
 const RHSRunDetails = () => {
+    const scrollbarsRef = useRef<Scrollbars>(null);
     const playbookRun = useSelector(currentPlaybookRun);
     const url = new URL(window.location.href);
     const searchParams = new URLSearchParams(url.searchParams);
+
+    const prevStatus = usePrevious(playbookRun?.current_status);
+    useEffect(() => {
+        if ((prevStatus !== playbookRun?.current_status) && (playbookRun?.current_status === PlaybookRunStatus.Finished)) {
+            scrollbarsRef?.current?.scrollToTop();
+        }
+    }, [playbookRun?.current_status]);
 
     if (searchParams.has('telem') && playbookRun) {
         const action = searchParams.get('telem');
@@ -40,6 +50,7 @@ const RHSRunDetails = () => {
         <RHSContainer>
             <RHSContent>
                 <Scrollbars
+                    ref={scrollbarsRef}
                     autoHide={true}
                     autoHideTimeout={500}
                     autoHideDuration={500}

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -567,3 +567,16 @@ export const useStats = (playbookId: string) => {
 
     return stats;
 };
+
+/**
+ * Hook that returns the previous value of the prop passed as argument
+ */
+export const usePrevious = (value: any) => {
+    const ref = useRef();
+
+    useEffect(() => {
+        ref.current = value;
+    });
+
+    return ref.current;
+};


### PR DESCRIPTION
#### Summary

Scroll to top when the run is finished. To actually finish the run, the user needs to click on an interactive dialog, to which we don't have direct access. Thus, what this PR does is listening to any change of `run.current_status`, and fires the scrolling event when it changes to finished.

https://user-images.githubusercontent.com/3924815/142421094-957bc309-c69a-4257-a3f8-45659dd53518.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38954

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
