### PR TITLE
Cypress default config & README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To quickly test Mattermost Playbooks, use the following test commands to create 
 
   * An example command looks like: `/playbook test bulk-data 10 3 342 2`
 
-## Running E2E Tests
+## Running E2E tests
 
 When running E2E tests, local `mattermost-server` configuration may be unexpectedly modified if values are different than a corresponding key default in either `on_prem_default_config.json` or `cloud_default_default_config.json`. This can be avoided by setting `CYPRESS_developerMode=true` when calling Cypress scripts. For example: `CYPRESS_developerMode=true npm run cypress:open`.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ To quickly test Mattermost Playbooks, use the following test commands to create 
 
   * An example command looks like: `/playbook test bulk-data 10 3 342 2`
 
+## Running E2E Tests
+
+When running E2E tests, local `mattermost-server` configuration may be unexpectedly modified if values are different than a corresponding key default in either `on_prem_default_config.json` or `cloud_default_default_config.json`. This can be avoided by setting `CYPRESS_developerMode=true` when calling Cypress scripts. For example: `CYPRESS_developerMode=true npm run cypress:open`.
+
 ## Contributing
 
 This plugin contains both a server and web app portion. Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To quickly test Mattermost Playbooks, use the following test commands to create 
 
 ## Running E2E tests
 
-When running E2E tests, the local `mattermost-server` configuration may be unexpectedly modified if either `on_prem_default_config.json` or `cloud_default_default_config.json` (depending on the server edition) has conflicting values for the the same keys. This can be avoided by setting `CYPRESS_developerMode=true` when calling Cypress scripts. For example: `CYPRESS_developerMode=true npm run cypress:open`.
+When running E2E tests, the local `mattermost-server` configuration may be unexpectedly modified if either `on_prem_default_config.json` or `cloud_default_default_config.json` (depending on the server edition) has conflicting values for the same keys. This can be avoided by setting `CYPRESS_developerMode=true` when calling Cypress scripts. For example: `CYPRESS_developerMode=true npm run cypress:open`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To quickly test Mattermost Playbooks, use the following test commands to create 
 
 ## Running E2E tests
 
-When running E2E tests, local `mattermost-server` configuration may be unexpectedly modified if values are different than a corresponding key default in either `on_prem_default_config.json` or `cloud_default_default_config.json`. This can be avoided by setting `CYPRESS_developerMode=true` when calling Cypress scripts. For example: `CYPRESS_developerMode=true npm run cypress:open`.
+When running E2E tests, the local `mattermost-server` configuration may be unexpectedly modified if either `on_prem_default_config.json` or `cloud_default_default_config.json` (depending on the server edition) has conflicting values for the the same keys. This can be avoided by setting `CYPRESS_developerMode=true` when calling Cypress scripts. For example: `CYPRESS_developerMode=true npm run cypress:open`.
 
 ## Contributing
 

--- a/tests-e2e/cypress/support/api/on_prem_default_config.json
+++ b/tests-e2e/cypress/support/api/on_prem_default_config.json
@@ -186,7 +186,7 @@
         "EnableFileAttachments": true,
         "EnableMobileUpload": true,
         "EnableMobileDownload": true,
-        "MaxFileSize": 52428800,
+        "MaxFileSize": 104857600,
         "DriverName": "local",
         "Directory": "./data/",
         "EnablePublicLink": false,


### PR DESCRIPTION
#### Summary
update `on_prem` `MaxFileSize`  default config and add a README note about `CYPRESS_developerMode`. I'll keep thinking about whether there's a better way to account for config stuff but it's probably worth documenting while we're using it.

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
