### PR TITLE
MM-40263: Stats are erroring when there are no runs for a playbook

### DIFF
--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -145,26 +145,26 @@ func (s *StatsStore) RunsStartedPerWeekLastXWeeks(x int, filters *StatsFilters) 
 	for i := 0; i < x; i++ {
 		if s.store.db.DriverName() == model.DatabaseDriverMysql {
 			q = q.Column(`
-                CAST(
-					COALESCE(
-						 SUM(
-							 CASE
-								 WHEN i.CreateAt >= ? AND i.CreateAt < ?
-									 THEN 1
-								 ELSE 0
-							 END)
-					, 0)
-                     AS UNSIGNED)
-                 `, startOfWeek, endOfWeek)
+			CAST(
+				COALESCE(
+					 SUM(
+						 CASE
+							 WHEN i.CreateAt >= ? AND i.CreateAt < ?
+								 THEN 1
+							 ELSE 0
+						 END)
+				, 0)
+				 AS UNSIGNED)
+				 `, startOfWeek, endOfWeek)
 		} else {
 			q = q.Column(`
-                COALESCE(
-                     SUM(CASE
-                        WHEN i.CreateAt >= ? AND i.CreateAt < ?
-                            THEN 1
-                        ELSE 0
-                    END)
-                , 0)
+			COALESCE(
+				 SUM(CASE
+					WHEN i.CreateAt >= ? AND i.CreateAt < ?
+						THEN 1
+					ELSE 0
+				END)
+			, 0)
                  `, startOfWeek, endOfWeek)
 		}
 
@@ -203,26 +203,26 @@ func (s *StatsStore) ActiveRunsPerDayLastXDays(x int, filters *StatsFilters) ([]
 		// start of the day (or still active)
 		if s.store.db.DriverName() == model.DatabaseDriverMysql {
 			q = q.Column(`
-                CAST(
-					COALESCE(
-						 SUM(
-							 CASE
-								 WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
-									 THEN 1
-								 ELSE 0
-							 END)
-					, 0)
-                     AS UNSIGNED)
+			CAST(
+				COALESCE(
+					 SUM(
+						 CASE
+							 WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
+								 THEN 1
+							 ELSE 0
+						 END)
+				, 0)
+				 AS UNSIGNED)
                 `, startOfDay, endOfDay)
 		} else {
 			q = q.Column(`
-                COALESCE(
-                    SUM(CASE
-                        WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
-                            THEN 1
-                        ELSE 0
-                    END)
-                , 0)
+			COALESCE(
+				SUM(CASE
+					WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
+						THEN 1
+					ELSE 0
+				END)
+			, 0)
                 `, startOfDay, endOfDay)
 		}
 
@@ -266,7 +266,7 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 		// second two lines: a user was active in the same way--if they left after the start of
 		// the day (or are still in the channel) and joined before the end of the day
 		q = q.Column(`
-                COALESCE(
+				COALESCE(
 					COUNT(DISTINCT
 						  (CASE
 							   WHEN (i.EndAt >= ? OR i.EndAt = 0) AND
@@ -275,7 +275,7 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 									cmh.JoinTime < ?
 								   THEN cmh.UserId
 						  END))
-                , 0)
+				, 0)
                 `, startOfDay, endOfDay, startOfDay, endOfDay)
 
 		daysAsTimes = append(daysAsTimes, []int64{startOfDay, endOfDay})

--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -146,21 +146,25 @@ func (s *StatsStore) RunsStartedPerWeekLastXWeeks(x int, filters *StatsFilters) 
 		if s.store.db.DriverName() == model.DatabaseDriverMysql {
 			q = q.Column(`
                 CAST(
-                     SUM(
-                         CASE
-                             WHEN i.CreateAt >= ? AND i.CreateAt < ?
-                                 THEN 1
-                             ELSE 0
-                         END)
+					COALESCE(
+						 SUM(
+							 CASE
+								 WHEN i.CreateAt >= ? AND i.CreateAt < ?
+									 THEN 1
+								 ELSE 0
+							 END)
+					, 0)
                      AS UNSIGNED)
                  `, startOfWeek, endOfWeek)
 		} else {
 			q = q.Column(`
-                SUM(CASE
+                COALESCE(
+                     SUM(CASE
                         WHEN i.CreateAt >= ? AND i.CreateAt < ?
                             THEN 1
                         ELSE 0
                     END)
+                , 0)
                  `, startOfWeek, endOfWeek)
 		}
 
@@ -200,21 +204,25 @@ func (s *StatsStore) ActiveRunsPerDayLastXDays(x int, filters *StatsFilters) ([]
 		if s.store.db.DriverName() == model.DatabaseDriverMysql {
 			q = q.Column(`
                 CAST(
-                     SUM(
-                         CASE
-                             WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
-                                 THEN 1
-                             ELSE 0
-                         END)
+					COALESCE(
+						 SUM(
+							 CASE
+								 WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
+									 THEN 1
+								 ELSE 0
+							 END)
+					, 0)
                      AS UNSIGNED)
                 `, startOfDay, endOfDay)
 		} else {
 			q = q.Column(`
-                SUM(CASE
+                COALESCE(
+                    SUM(CASE
                         WHEN (i.EndAt >= ? OR i.EndAt = 0) AND i.CreateAt < ?
                             THEN 1
                         ELSE 0
                     END)
+                , 0)
                 `, startOfDay, endOfDay)
 		}
 
@@ -258,14 +266,16 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 		// second two lines: a user was active in the same way--if they left after the start of
 		// the day (or are still in the channel) and joined before the end of the day
 		q = q.Column(`
-                COUNT(DISTINCT
-                      (CASE
-                           WHEN (i.EndAt >= ? OR i.EndAt = 0) AND
-                                i.CreateAt < ? AND
-                                (cmh.LeaveTime >= ? OR cmh.LeaveTime is NULL) AND
-                                cmh.JoinTime < ?
-                               THEN cmh.UserId
-                      END))
+                COALESCE(
+					COUNT(DISTINCT
+						  (CASE
+							   WHEN (i.EndAt >= ? OR i.EndAt = 0) AND
+									i.CreateAt < ? AND
+									(cmh.LeaveTime >= ? OR cmh.LeaveTime is NULL) AND
+									cmh.JoinTime < ?
+								   THEN cmh.UserId
+						  END))
+                , 0)
                 `, startOfDay, endOfDay, startOfDay, endOfDay)
 
 		daysAsTimes = append(daysAsTimes, []int64{startOfDay, endOfDay})

--- a/server/sqlstore/stats_test.go
+++ b/server/sqlstore/stats_test.go
@@ -94,6 +94,7 @@ func TestTotalInProgressPlaybookRuns(t *testing.T) {
 		_, store := setupSQLStore(t, db)
 		setupTeamMembersTable(t, db)
 		setupChannelMembersTable(t, db)
+		setupChannelMemberHistoryTable(t, db)
 		setupChannelsTable(t, db)
 
 		addUsers(t, store, []userInfo{lucy, bob, john, jane, notInvolved, phil, quincy, bot1, bot2})
@@ -266,5 +267,26 @@ func TestTotalInProgressPlaybookRuns(t *testing.T) {
 			result := statsStore.AverageDurationActivePlaybookRunsMinutes()
 			assert.Equal(t, 26912080, result)
 		})*/
+
+		t.Run(driverName+" RunsStartedPerWeekLastXWeeks for a playbook with no runs", func(t *testing.T) {
+			runsStartedPerWeek, _ := statsStore.RunsStartedPerWeekLastXWeeks(4, &StatsFilters{
+				PlaybookID: "playbook101test123123",
+			})
+			assert.Equal(t, []int{0, 0, 0, 0}, runsStartedPerWeek)
+		})
+
+		t.Run(driverName+" ActiveRunsPerDayLastXDays for a playbook with no runs", func(t *testing.T) {
+			activeRunsPerDay, _ := statsStore.ActiveRunsPerDayLastXDays(4, &StatsFilters{
+				PlaybookID: "playbook101test1234",
+			})
+			assert.Equal(t, []int{0, 0, 0, 0}, activeRunsPerDay)
+		})
+
+		t.Run(driverName+" ActiveParticipantsPerDayLastXDays for a playbook with no runs", func(t *testing.T) {
+			activeParticipantsPerDay, _ := statsStore.ActiveParticipantsPerDayLastXDays(4, &StatsFilters{
+				PlaybookID: "playbook101test32412",
+			})
+			assert.Equal(t, []int{0, 0, 0, 0}, activeParticipantsPerDay)
+		})
 	}
 }


### PR DESCRIPTION
#### Summary
- If there are no incidents for a playbook, the select statement wasn't able to generate the columns that we expect later. There are a couple ways to solve it, this seemed cleanest.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-40263

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
