### PR TITLE
temporarily drop min version to 6.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
     "icon_path": "assets/plugin_icon.svg",
-    "min_server_version": "6.1.0",
+    "min_server_version": "6.0.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
Community has the requisite code (Luxon), but didn't actually get bumped to 6.1 like we expected. Let's drop the min version for a few days until it catches up to restore Playbooks to community.

#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
