### PR TITLE
Revert "temporarily drop min version to 6.0 (#905)"

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
     "icon_path": "assets/plugin_icon.svg",
-    "min_server_version": "6.0.0",
+    "min_server_version": "6.1.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
This reverts commit abb1f129d7ea5eefb16a4f865082251b45762726, requiring v6.1 again in anticipation of the upcoming v1.22.

#### Ticket Link
N/A

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
