### PR TITLE
Reduce Cypress waits

### DIFF
--- a/tests-e2e/cypress/support/extended_commands.js
+++ b/tests-e2e/cypress/support/extended_commands.js
@@ -3,12 +3,12 @@
 
 import * as TIMEOUTS from '../fixtures/timeouts';
 
-Cypress.Commands.overwrite('reload', (originalFn, forceReload, options, duration = TIMEOUTS.THREE_SEC) => {
+Cypress.Commands.overwrite('reload', (originalFn, forceReload, options, duration = TIMEOUTS.ONE_SEC) => {
     originalFn(forceReload, options);
     cy.wait(duration);
 });
 
-Cypress.Commands.overwrite('visit', (originalFn, url, options, duration = TIMEOUTS.THREE_SEC) => {
+Cypress.Commands.overwrite('visit', (originalFn, url, options, duration = TIMEOUTS.ONE_SEC) => {
     originalFn(url, options);
     cy.wait(duration);
 });

--- a/tests-e2e/cypress/support/extended_commands.js
+++ b/tests-e2e/cypress/support/extended_commands.js
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as TIMEOUTS from '../fixtures/timeouts';
+// import * as TIMEOUTS from '../fixtures/timeouts';
 
-Cypress.Commands.overwrite('reload', (originalFn, forceReload, options, duration = TIMEOUTS.ONE_SEC) => {
-    originalFn(forceReload, options);
-    cy.wait(duration);
-});
+// Cypress.Commands.overwrite('reload', (originalFn, forceReload, options, duration = TIMEOUTS.ONE_SEC) => {
+//     originalFn(forceReload, options);
+//     cy.wait(duration);
+// });
 
-Cypress.Commands.overwrite('visit', (originalFn, url, options, duration = TIMEOUTS.ONE_SEC) => {
-    originalFn(url, options);
-    cy.wait(duration);
-});
+// Cypress.Commands.overwrite('visit', (originalFn, url, options, duration = TIMEOUTS.ONE_SEC) => {
+//     originalFn(url, options);
+//     cy.wait(duration);
+// });


### PR DESCRIPTION
Every `cy.visit` and `cy.reload` has some additional waiting applied to it, but it would be nice to reduce that if it doesn't increase test flake significantly. Several local runs seemed ok with these changes, this is to test CI. If that has problems, I'll change this to be included only with `CYPRESS_developerMode` so at least test development will be faster. 