### PR TITLE
[MM-40500] Fix copy link

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -41,21 +41,24 @@ import {EmptyPlaybookStats, PlaybookStats, Stats} from 'src/types/stats';
 import {pluginId} from './manifest';
 import {GlobalSettings, globalSettingsSetDefaults} from './types/settings';
 
+let siteURL = '';
 let basePath = '';
 let apiUrl = `${basePath}/plugins/${pluginId}/api/v0`;
 
-export const setSiteUrl = (siteUrl?: string): void => {
-    if (siteUrl) {
-        basePath = new URL(siteUrl).pathname.replace(/\/+$/, '');
+export const setSiteUrl = (url?: string): void => {
+    if (url) {
+        basePath = new URL(url).pathname.replace(/\/+$/, '');
+        siteURL = url;
     } else {
         basePath = '';
+        siteURL = '';
     }
 
     apiUrl = `${basePath}/plugins/${pluginId}/api/v0`;
 };
 
 export const getSiteUrl = (): string => {
-    return basePath;
+    return siteURL;
 };
 
 export async function fetchPlaybookRuns(params: FetchPlaybookRunsParams) {


### PR DESCRIPTION

#### Summary
This PR fixes the copy link bug. 
Turns out `basePath` stored in the `clients.ts` file contains just the path name - not the entire site URL. What a surprise, amrite? :D

#### Ticket Link
  Fixes: https://mattermost.atlassian.net/browse/MM-40500


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
