### PR TITLE
Cypress: Reduce numTestsKeptInMemory

### DIFF
--- a/tests-e2e/cypress.json
+++ b/tests-e2e/cypress.json
@@ -40,5 +40,6 @@
     "reporter": "cypress-multi-reporters",
     "reporterOptions": {
         "configFile": "reporter-config.json"
-    }
+    },
+    "numTestsKeptInMemory": 5
 }


### PR DESCRIPTION
This lowers the numbers of test debug snapshots available in the Cypress runner from the default `50` to `5` in order to avoid OOM crashes when running specs with a large number of tests (`edit_spec.js` for example).
