### PR TITLE
MM-39896: Add more preview tests

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -90,8 +90,7 @@ describe('playbooks > overview', () => {
         cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
 
         // # trigger the tooltip
-        cy.scrollTo('top', {ensureScrollable: false});
-        cy.get('.icon-link-variant').trigger('mouseover');
+        cy.get('.icon-link-variant').trigger('mouseover', {force: true});
 
         // * Verify tooltip text
         cy.get('#copy-playbook-link-tooltip').should('contain', 'Copy link to playbook');
@@ -99,7 +98,7 @@ describe('playbooks > overview', () => {
         stubClipboard().as('clipboard');
 
         // # click on copy button
-        cy.get('.icon-link-variant').click().then(() => {
+        cy.get('.icon-link-variant').click({force: true}).then(() => {
             // * Verify that tooltip text changed
             cy.get('#copy-playbook-link-tooltip').should('contain', 'Copied!');
 

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -29,6 +29,8 @@ describe('playbooks > overview', () => {
                     teamId: testTeam.id,
                     title: 'Public Playbook',
                     memberIDs: [],
+                    retrospectiveTemplate: 'Retro template text',
+                    retrospectiveReminderIntervalSeconds: 60 * 60 * 24 * 7 // 7 days
                 }).then((playbook) => {
                     testPublicPlaybook = playbook;
                 });
@@ -68,6 +70,122 @@ describe('playbooks > overview', () => {
 
         // * Verify that the user has been redirected to the playbooks not found error page
         cy.url().should('include', '/playbooks/error?type=playbooks');
+    });
+
+    it('should switch to channels and prompt to run when clicking run', () => {
+        // # Navigate directly to the playbook
+        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
+
+        // # Click Run Playbook
+        cy.findByTestId('run-playbook').click({force: true});
+
+        // * Verify the playbook run creation dialog has opened
+        cy.get('#interactiveDialogModal').should('exist').within(() => {
+            cy.findByText('Start run').should('exist');
+        });
+    });
+
+    it('should copy playbook link', () => {
+        // # Navigate directly to the playbook
+        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
+
+        // # trigger the tooltip
+        cy.get('.icon-link-variant').trigger('mouseover');
+
+        // * Verify tooltip text
+        cy.get('#copy-playbook-link-tooltip').should('contain', 'Copy link to playbook');
+
+        stubClipboard().as('clipboard');
+
+        // # click on copy button
+        cy.get('.icon-link-variant').click().then(() => {
+            // * Verify that tooltip text changed
+            cy.get('#copy-playbook-link-tooltip').should('contain', 'Copied!');
+
+            // * Verify clipboard content
+            cy.get('@clipboard').its('contents').should('contain', `/playbooks/playbooks/${testPublicPlaybook.id}`);
+        });
+    });
+
+    it('shows checklists', () => {
+        cy.apiCreatePlaybook({
+            teamId: testTeam.id,
+            title: 'Playbook',
+            description: 'Cypress Playbook',
+            memberIDs: [],
+            checklists: [
+                {
+                    title: 'Stage 1',
+                    items: [
+                        {title: 'Step 1'},
+                        {title: 'Step 2'},
+                    ],
+                },
+            ],
+            retrospectiveTemplate: 'Cypress test template'
+        }).then((playbook) => {
+            cy.visit(`/playbooks/playbooks/${playbook.id}`);
+        });
+
+        cy.findByTestId('preview-content').within(() => {
+            // * Verify checklist and associated steps
+            cy.findByText('Checklists').next().within(() => {
+                cy.findByText('Stage 1').should('exist');
+                cy.findByText('Step 1').should('exist');
+                cy.findByText('Step 2').should('exist');
+            });
+        });
+    });
+
+    it('shows status update timer', () => {
+        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
+        cy.findByTestId('preview-content').within(() => {
+            cy.findByText('Status updates').next().within(() => {
+                cy.findByText('1 day').should('exist');
+            });
+        });
+    });
+
+    it('shows correct retrospective timer and template text', () => {
+        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
+
+        cy.findByTestId('preview-content').within(() => {
+            cy.findByText('Retrospective').next().within(() => {
+                cy.findByText('7 days').should('exist');
+                cy.findByText('Retrospective report template').click();
+                cy.findByText('Retro template text').should('exist');
+            });
+        });
+    });
+
+    it('shows statistics in usage tab', () => {
+        // # Start playbook run.
+        const now = Date.now();
+        const playbookRunName = `Run (${now})`;
+        cy.apiRunPlaybook({
+            teamId: testTeam.id,
+            playbookId: testPublicPlaybook.id,
+            playbookRunName,
+            ownerUserId: testUser.id,
+        }).then((playbookRun) => {
+            // # Go to usage view
+            cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}/usage`);
+
+            // * Verify basic information.
+            cy.findByText('Runs currently in progress').next().should('contain', '1');
+            cy.findByText('Participants currently active').next().should('contain', '1');
+            cy.findByText('Runs finished in the last 30 days').next().should('contain', '0');
+
+            // # End the run so those metrics change.
+            cy.apiFinishRun(playbookRun.id).then(() => {
+                cy.reload();
+
+                // * Verify changes.
+                cy.findByText('Runs currently in progress').next().should('contain', '0');
+                cy.findByText('Participants currently active').next().should('contain', '0');
+                cy.findByText('Runs finished in the last 30 days').next().should('contain', '1');
+            });
+        });
     });
 
     describe('permissions text', () => {
@@ -111,41 +229,6 @@ describe('playbooks > overview', () => {
             // # Verify permissions text
             cy.findByTestId('playbookPermissionsDescription')
                 .contains('2 people can access this playbook');
-        });
-    });
-
-    it('should switch to channels and prompt to run when clicking run', () => {
-        // # Navigate directly to the playbook
-        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
-
-        // # Click Run Playbook
-        cy.findByTestId('run-playbook').click({force: true});
-
-        // * Verify the playbook run creation dialog has opened
-        cy.get('#interactiveDialogModal').should('exist').within(() => {
-            cy.findByText('Start run').should('exist');
-        });
-    });
-
-    it('should copy playbook link', () => {
-        // # Navigate directly to the playbook
-        cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
-
-        // # trigger the tooltip
-        cy.get('.icon-link-variant').trigger('mouseover');
-
-        // * Verify tooltip text
-        cy.get('#copy-playbook-link-tooltip').should('contain', 'Copy link to playbook');
-
-        stubClipboard().as('clipboard');
-
-        // # click on copy button
-        cy.get('.icon-link-variant').click().then(() => {
-            // * Verify that tooltip text changed
-            cy.get('#copy-playbook-link-tooltip').should('contain', 'Copied!');
-
-            // * Verify clipboard content
-            cy.get('@clipboard').its('contents').should('contain', `/playbooks/playbooks/${testPublicPlaybook.id}`);
         });
     });
 

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -90,7 +90,7 @@ describe('playbooks > overview', () => {
         cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
 
         // # trigger the tooltip
-        cy.scrollTo('top');
+        cy.scrollTo('top', {ensureScrollable: false});
         cy.get('.icon-link-variant').trigger('mouseover');
 
         // * Verify tooltip text

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -91,7 +91,7 @@ describe('playbooks > overview', () => {
 
         // # trigger the tooltip
         cy.scrollTo(0, 0);
-        cy.get('.icon-link-variant').scroll().trigger('mouseover');
+        cy.get('.icon-link-variant').trigger('mouseover');
 
         // * Verify tooltip text
         cy.get('#copy-playbook-link-tooltip').should('contain', 'Copy link to playbook');

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -90,7 +90,8 @@ describe('playbooks > overview', () => {
         cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
 
         // # trigger the tooltip
-        cy.get('.icon-link-variant').scrollIntoView().trigger('mouseover');
+        cy.scrollTo(0, 0);
+        cy.get('.icon-link-variant').scroll().trigger('mouseover');
 
         // * Verify tooltip text
         cy.get('#copy-playbook-link-tooltip').should('contain', 'Copy link to playbook');

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -90,7 +90,7 @@ describe('playbooks > overview', () => {
         cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
 
         // # trigger the tooltip
-        cy.get('.icon-link-variant').trigger('mouseover');
+        cy.get('.icon-link-variant').scrollIntoView().trigger('mouseover');
 
         // * Verify tooltip text
         cy.get('#copy-playbook-link-tooltip').should('contain', 'Copy link to playbook');

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -90,7 +90,7 @@ describe('playbooks > overview', () => {
         cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
 
         // # trigger the tooltip
-        cy.scrollTo(0, 0);
+        cy.scrollTo('top');
         cy.get('.icon-link-variant').trigger('mouseover');
 
         // * Verify tooltip text

--- a/tests-e2e/cypress/support/plugin/api_commands.js
+++ b/tests-e2e/cypress/support/plugin/api_commands.js
@@ -225,6 +225,7 @@ Cypress.Commands.add('apiCreatePlaybook', (
     {
         teamId,
         title,
+        description,
         createPublicPlaybookRun,
         checklists,
         memberIDs,
@@ -233,6 +234,7 @@ Cypress.Commands.add('apiCreatePlaybook', (
         reminderMessageTemplate,
         reminderTimerDefaultSeconds = 24 * 60 * 60, // 24 hours
         statusUpdateEnabled = true,
+        retrospectiveReminderIntervalSeconds,
         retrospectiveTemplate,
         retrospectiveEnabled = true,
         invitedUserIds,
@@ -257,6 +259,7 @@ Cypress.Commands.add('apiCreatePlaybook', (
         method: 'POST',
         body: {
             title,
+            description,
             team_id: teamId,
             create_public_playbook_run: createPublicPlaybookRun,
             checklists,
@@ -266,6 +269,7 @@ Cypress.Commands.add('apiCreatePlaybook', (
             reminder_message_template: reminderMessageTemplate,
             reminder_timer_default_seconds: reminderTimerDefaultSeconds,
             status_update_enabled: statusUpdateEnabled,
+            retrospective_reminder_interval_seconds: retrospectiveReminderIntervalSeconds,
             retrospective_template: retrospectiveTemplate,
             retrospective_enabled: retrospectiveEnabled,
             invited_user_ids: invitedUserIds,

--- a/webapp/src/components/backstage/playbooks/playbook_preview.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview.tsx
@@ -46,7 +46,7 @@ const PlaybookPreview = (props: Props) => {
 
     return (
         <Container>
-            <Content>
+            <Content data-testid='preview-content'>
                 {description}
                 {checklists}
                 {actions}


### PR DESCRIPTION
#### Summary
Adds a few more tests on the main Playbook preview as well as one for the usage tab. Also slight reorder of the file so all of the single `it` blocks come before the nested `describe` blocks. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39896

#### Checklist
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
