### PR TITLE
MM-35035: Cypress parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,10 +140,8 @@ commands:
           name: Run Cypress Tests
           no_output_timeout: 30m
           command: |
-            export FAILURE_MESSAGE="At least one test has failed."
-            export RESULTS_OUTPUT="results-output.txt"
             cd tests-e2e
-            circleci tests glob "cypress/integration/**/*.js" | circleci tests split > ./tests-to-run
+            circleci tests glob "cypress/integration/**/*.js" | circleci tests split --split-by=timings > ./tests-to-run
             npm run test -- --spec "$(cat ./tests-to-run | tr '\n' ',')"
 
       - *save_cypress_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ commands:
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
             cd tests-e2e
-            circleci tests glob "cypress/integration/*.js" | circleci tests split > ./tests-to-run
+            circleci tests glob "cypress/integration/**/*.js" | circleci tests split > ./tests-to-run
             npm run test -- --spec "$(cat ./tests-to-run | tr '\n' ',')"
 
       - *save_cypress_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,10 @@ commands:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
-            cd tests-e2e && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
+            cd tests-e2e
+            circleci tests glob "cypress/integration/*.js" | circleci tests split > ./tests-to-run
+            npm run test -- --spec "$(cat ./tests-to-run | tr '\n' ',')"
+
       - *save_cypress_cache
       - store_test_results:
           path: tests-e2e/cypress/results
@@ -390,6 +393,7 @@ jobs:
       MM_SERVICESETTINGS_SITEURL: http://localhost:8065
       MM_ADMIN_USERNAME: sysadmin
       MM_ADMIN_PASSWORD: Sys@dmin-sample1
+    parallelism: 4
     steps:
       - run-e2e-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,7 @@ jobs:
       MM_SERVICESETTINGS_SITEURL: http://localhost:8065
       MM_ADMIN_USERNAME: sysadmin
       MM_ADMIN_PASSWORD: Sys@dmin-sample1
+    parallelism: 4
     steps:
       - run-e2e-tests
 


### PR DESCRIPTION
#### Summary
This enables parallel test runs in CircleCI. Based on some test runs it cuts the Cypress jobs to ~9 minutes, which means the whole workflow will also be ~9 min since those are the longest running jobs.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35035

