### PR TITLE
MM-37227: move profile selector to styled components

### DIFF
--- a/tests-e2e/cypress/support/api/role.js
+++ b/tests-e2e/cypress/support/api/role.js
@@ -625,6 +625,10 @@ Cypress.Commands.add('apiResetRoles', () => {
             const diff = xor(role.permissions, defaultPermissions);
 
             if (diff.length > 0) {
+                cy.log({
+                    name: 'patchRole',
+                    message: `name: ${role.name}, diff: ${diff}`,
+                });
                 cy.apiPatchRole(role.id, {permissions: defaultPermissions});
             }
         });

--- a/webapp/src/components/backstage/runs_list/playbook_selector.tsx
+++ b/webapp/src/components/backstage/runs_list/playbook_selector.tsx
@@ -10,6 +10,7 @@ import {useClientRect} from 'src/hooks';
 import {PlaybookRunFilterButton} from '../../backstage/styles';
 import {Playbook} from '../../../types/playbook';
 import {SelectedButton} from 'src/components/team/team_selector';
+import {DropdownSelectorStyle} from 'src/components/profile/dropdown_selector_style';
 
 export interface Option {
     value: string;
@@ -263,16 +264,18 @@ const Dropdown = ({children, isOpen, showOnRight, moveUp, target, onClose}: Drop
         'PlaybookRunFilter--active', 'profile-dropdown--active');
 
     return (
-        <ProfileDropdown className={classes}>
-            {target}
-            <ChildContainer
-                className='playbook-run-user-select__container'
-                moveUp={moveUp}
-                showOnRight={showOnRight}
-            >
-                {children}
-            </ChildContainer>
-            <Blanket onClick={onClose}/>
-        </ProfileDropdown>
+        <DropdownSelectorStyle>
+            <ProfileDropdown className={classes}>
+                {target}
+                <ChildContainer
+                    className='playbook-run-user-select__container'
+                    moveUp={moveUp}
+                    showOnRight={showOnRight}
+                >
+                    {children}
+                </ChildContainer>
+                <Blanket onClick={onClose}/>
+            </ProfileDropdown>
+        </DropdownSelectorStyle>
     );
 };

--- a/webapp/src/components/profile/dropdown_selector_style.tsx
+++ b/webapp/src/components/profile/dropdown_selector_style.tsx
@@ -1,4 +1,6 @@
-.app__body {
+import styled from 'styled-components';
+
+export const DropdownSelectorStyle = styled.div`
     .profile-dropdown--active {
         .PlaybookRunProfileButton {
             .Profile {
@@ -98,4 +100,4 @@
             top: 3px;
         }
     }
-}
+`;

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -11,11 +11,11 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {UserProfile} from 'mattermost-redux/types/users';
 
-import './profile_selector.scss';
 import Profile from 'src/components/profile/profile';
 import ProfileButton from 'src/components/profile/profile_button';
 import {useClientRect} from 'src/hooks';
 import {PlaybookRunFilterButton} from '../backstage/styles';
+import {DropdownSelectorStyle} from 'src/components/profile/dropdown_selector_style';
 
 export interface Option {
     value: string;
@@ -330,17 +330,19 @@ const Dropdown = ({children, isOpen, showOnRight, moveUp, target, onClose}: Drop
         'PlaybookRunFilter--active', 'profile-dropdown--active');
 
     return (
-        <ProfileDropdown className={classes}>
-            {target}
-            <ChildContainer
-                className='playbook-run-user-select__container'
-                moveUp={moveUp}
-                showOnRight={showOnRight}
-            >
-                {children}
-            </ChildContainer>
-            <Blanket onClick={onClose}/>
-        </ProfileDropdown>
+        <DropdownSelectorStyle>
+            <ProfileDropdown className={classes}>
+                {target}
+                <ChildContainer
+                    className='playbook-run-user-select__container'
+                    moveUp={moveUp}
+                    showOnRight={showOnRight}
+                >
+                    {children}
+                </ChildContainer>
+                <Blanket onClick={onClose}/>
+            </ProfileDropdown>
+        </DropdownSelectorStyle>
     );
 };
 

--- a/webapp/src/components/team/create_playbook_team_selector.tsx
+++ b/webapp/src/components/team/create_playbook_team_selector.tsx
@@ -10,6 +10,7 @@ import {Team} from 'mattermost-redux/types/teams';
 import {useIntl} from 'react-intl';
 
 import {useDropdownPosition} from 'src/hooks';
+import {DropdownSelectorStyle} from 'src/components/profile/dropdown_selector_style';
 
 import TeamWithIcon from './team_with_icon';
 
@@ -183,16 +184,18 @@ const Dropdown = ({children, showOnRight, moveUp, target, onClose, dependsOnMous
         'PlaybookRunFilter--active', 'profile-dropdown--active', {'show-on-right': showOnRight});
 
     return (
-        <ProfileDropdown className={classes}>
-            {target}
-            <ChildContainer
-                moveUp={moveUp}
-                position={position}
-                dependsOnPosition={dependsOnMousePosition}
-            >
-                {children}
-            </ChildContainer>
-            <Blanket onClick={onClose}/>
-        </ProfileDropdown>
+        <DropdownSelectorStyle>
+            <ProfileDropdown className={classes}>
+                {target}
+                <ChildContainer
+                    moveUp={moveUp}
+                    position={position}
+                    dependsOnPosition={dependsOnMousePosition}
+                >
+                    {children}
+                </ChildContainer>
+                <Blanket onClick={onClose}/>
+            </ProfileDropdown>
+        </DropdownSelectorStyle>
     );
 };


### PR DESCRIPTION
#### Summary
Instead of importing a SCSS stylesheet with global definitions, rewrite as a styled components and wrap the affected components.

Note that the profile selector, as a widget, deserves some general refactoring. This PR doesn't attempt to address that.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-37227

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
