### PR TITLE
MM-40305: Reorder checklists in RHS

### DIFF
--- a/client/playbook_runs.go
+++ b/client/playbook_runs.go
@@ -196,8 +196,24 @@ func (s *PlaybookRunService) AddChecklistItem(ctx context.Context, playbookRunID
 	return err
 }
 
-func (s *PlaybookRunService) MoveChecklistItem(ctx context.Context, playbookRunID string, sourceChecklistIdx, sourceItemIdx, destChecklistIdx, destItemIdx int) error {
+func (s *PlaybookRunService) MoveChecklist(ctx context.Context, playbookRunID string, sourceChecklistIdx, destChecklistIdx int) error {
 	createURL := fmt.Sprintf("runs/%s/checklists/move", playbookRunID)
+	body := struct {
+		SourceChecklistIdx int `json:"source_checklist_idx"`
+		DestChecklistIdx   int `json:"dest_checklist_idx"`
+	}{sourceChecklistIdx, destChecklistIdx}
+
+	req, err := s.client.newRequest(http.MethodPost, createURL, body)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	return err
+}
+
+func (s *PlaybookRunService) MoveChecklistItem(ctx context.Context, playbookRunID string, sourceChecklistIdx, sourceItemIdx, destChecklistIdx, destItemIdx int) error {
+	createURL := fmt.Sprintf("runs/%s/checklists/move-item", playbookRunID)
 	body := struct {
 		SourceChecklistIdx int `json:"source_checklist_idx"`
 		SourceItemIdx      int `json:"source_item_idx"`

--- a/server/app/mocks/mock_playbook_run_service.go
+++ b/server/app/mocks/mock_playbook_run_service.go
@@ -409,6 +409,20 @@ func (mr *MockPlaybookRunServiceMockRecorder) ModifyCheckedState(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCheckedState", reflect.TypeOf((*MockPlaybookRunService)(nil).ModifyCheckedState), arg0, arg1, arg2, arg3, arg4)
 }
 
+// MoveChecklist mocks base method
+func (m *MockPlaybookRunService) MoveChecklist(arg0, arg1 string, arg2, arg3 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveChecklist", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MoveChecklist indicates an expected call of MoveChecklist
+func (mr *MockPlaybookRunServiceMockRecorder) MoveChecklist(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveChecklist", reflect.TypeOf((*MockPlaybookRunService)(nil).MoveChecklist), arg0, arg1, arg2, arg3)
+}
+
 // MoveChecklistItem mocks base method
 func (m *MockPlaybookRunService) MoveChecklistItem(arg0, arg1 string, arg2, arg3, arg4, arg5 int) error {
 	m.ctrl.T.Helper()

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -476,6 +476,9 @@ type PlaybookRunService interface {
 	EditChecklistItem(playbookRunID, userID string, checklistNumber int, itemNumber int, newTitle, newCommand, newDescription string) error
 
 	// MoveChecklistItem moves a checklist item from one position to another.
+	MoveChecklist(playbookRunID, userID string, sourceChecklistIdx, destChecklistIdx int) error
+
+	// MoveChecklistItem moves a checklist item from one position to another.
 	MoveChecklistItem(playbookRunID, userID string, sourceChecklistIdx, sourceItemIdx, destChecklistIdx, destItemIdx int) error
 
 	// GetChecklistItemAutocomplete returns the list of checklist items for playbookRunID to be used in autocomplete
@@ -704,7 +707,10 @@ type PlaybookRunTelemetry interface {
 	// RenameTask tracks the update of a checklist item.
 	RenameTask(playbookRunID, userID string, task ChecklistItem)
 
-	// MoveTask tracks the unchecking of checked item.
+	// MoveChecklist tracks the movement of a checklist
+	MoveChecklist(playbookRunID, userID string, task Checklist)
+
+	// MoveTask tracks the movement of a checklist item
 	MoveTask(playbookRunID, userID string, task ChecklistItem)
 
 	// RunTaskSlashCommand tracks the execution of a slash command attached to

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1656,10 +1656,10 @@ func (s *PlaybookRunServiceImpl) MoveChecklist(playbookRunID, userID string, sou
 	checklistMoved := playbookRunToModify.Checklists[sourceChecklistIdx]
 
 	// Delete checklist to move
-	playbookRunToModify.Checklists = append(playbookRunToModify.Checklists[:sourceChecklistIdx], playbookRunToModify.Checklists[sourceChecklistIdx+1:]...)
+	copy(playbookRunToModify.Checklists[sourceChecklistIdx:], playbookRunToModify.Checklists[sourceChecklistIdx+1:])
+	playbookRunToModify.Checklists[len(playbookRunToModify.Checklists)-1] = Checklist{}
 
 	// Insert checklist in new location
-	playbookRunToModify.Checklists = append(playbookRunToModify.Checklists, Checklist{})
 	copy(playbookRunToModify.Checklists[destChecklistIdx+1:], playbookRunToModify.Checklists[destChecklistIdx:])
 	playbookRunToModify.Checklists[destChecklistIdx] = checklistMoved
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1641,6 +1641,38 @@ func (s *PlaybookRunServiceImpl) EditChecklistItem(playbookRunID, userID string,
 	return nil
 }
 
+// MoveChecklist moves a checklist to a new location
+func (s *PlaybookRunServiceImpl) MoveChecklist(playbookRunID, userID string, sourceChecklistIdx, destChecklistIdx int) error {
+	playbookRunToModify, err := s.checklistParamsVerify(playbookRunID, userID, sourceChecklistIdx)
+	if err != nil {
+		return err
+	}
+
+	if destChecklistIdx < 0 || destChecklistIdx >= len(playbookRunToModify.Checklists) {
+		return errors.New("invalid destChecklist")
+	}
+
+	// Get checklist to move
+	checklistMoved := playbookRunToModify.Checklists[sourceChecklistIdx]
+
+	// Delete checklist to move
+	playbookRunToModify.Checklists = append(playbookRunToModify.Checklists[:sourceChecklistIdx], playbookRunToModify.Checklists[sourceChecklistIdx+1:]...)
+
+	// Insert checklist in new location
+	playbookRunToModify.Checklists = append(playbookRunToModify.Checklists, Checklist{})
+	copy(playbookRunToModify.Checklists[destChecklistIdx+1:], playbookRunToModify.Checklists[destChecklistIdx:])
+	playbookRunToModify.Checklists[destChecklistIdx] = checklistMoved
+
+	if err = s.store.UpdatePlaybookRun(playbookRunToModify); err != nil {
+		return errors.Wrapf(err, "failed to update playbook run")
+	}
+
+	s.poster.PublishWebsocketEventToChannel(playbookRunUpdatedWSEvent, playbookRunToModify, playbookRunToModify.ChannelID)
+	s.telemetry.MoveChecklist(playbookRunID, userID, checklistMoved)
+
+	return nil
+}
+
 // MoveChecklistItem moves a checklist item to a new location
 func (s *PlaybookRunServiceImpl) MoveChecklistItem(playbookRunID, userID string, sourceChecklistIdx, sourceItemIdx, destChecklistIdx, destItemIdx int) error {
 	playbookRunToModify, err := s.checklistItemParamsVerify(playbookRunID, userID, sourceChecklistIdx, sourceItemIdx)

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -75,6 +75,10 @@ func (t *NoopTelemetry) ModifyCheckedState(string, string, app.ChecklistItem, bo
 func (t *NoopTelemetry) SetAssignee(string, string, app.ChecklistItem) {
 }
 
+// MoveChecklist does nothing.
+func (t *NoopTelemetry) MoveChecklist(string, string, app.Checklist) {
+}
+
 // MoveTask does nothing.
 func (t *NoopTelemetry) MoveTask(string, string, app.ChecklistItem) {
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -51,6 +51,7 @@ const (
 	actionAddChecklist    = "add_checklist"
 	actionRemoveChecklist = "remove_checklist"
 	actionRenameChecklist = "rename_checklist"
+	actionMoveChecklist   = "move_checklist"
 
 	eventPlaybook      = "playbook"
 	actionUpdate       = "update"
@@ -342,6 +343,13 @@ func (t *RudderTelemetry) RemoveChecklist(playbookRunID, userID string, checklis
 func (t *RudderTelemetry) RenameChecklist(playbookRunID, userID string, checklist app.Checklist) {
 	properties := checklistProperties(playbookRunID, userID, checklist)
 	properties["Action"] = actionRenameChecklist
+	t.track(eventChecklists, properties)
+}
+
+// MoveChecklist tracks the movement of a checklist
+func (t *RudderTelemetry) MoveChecklist(playbookRunID, userID string, checklist app.Checklist) {
+	properties := checklistProperties(playbookRunID, userID, checklist)
+	properties["Action"] = actionMoveChecklist
 	t.track(eventChecklists, properties)
 }
 

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -294,6 +294,7 @@
   "o2eHmz": "Run finished by {name}",
   "oS0w4E": "Default update timer",
   "oVHn4s": "Last update",
+  "osuP6z": "Drag to reorder checklist",
   "pKLw8O": "Are you sure you want to delete this event? Deleted events will be permanently removed from the timeline.",
   "pjt3qA": "New checklist",
   "q0cpUe": "Add checklist",

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -54,6 +54,8 @@ import {
     SET_ALL_CHECKLISTS_COLLAPSED_STATE,
     SET_CHECKLIST_ITEMS_FILTER,
     SetChecklistItemsFilter,
+    SetEachChecklistCollapsedState,
+    SET_EACH_CHECKLIST_COLLAPSED_STATE,
 } from 'src/types/actions';
 import {clientExecuteCommand} from 'src/client';
 import {GlobalSettings} from 'src/types/settings';
@@ -276,6 +278,12 @@ export const setChecklistCollapsedState = (channelId: string, checklistIndex: nu
     channelId,
     checklistIndex,
     collapsed,
+});
+
+export const setEachChecklistCollapsedState = (channelId: string, state: Record<number, boolean>): SetEachChecklistCollapsedState => ({
+    type: SET_EACH_CHECKLIST_COLLAPSED_STATE,
+    channelId,
+    state,
 });
 
 export const setAllChecklistsCollapsedState = (channelId: string, collapsed: boolean, numOfChecklists: number): SetAllChecklistsCollapsedState => ({

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -350,8 +350,19 @@ export async function clientRenameChecklist(playbookRunID: string, checklistNum:
     return data;
 }
 
-export async function clientMoveChecklistItem(playbookRunID: string, sourceChecklistIdx: number, sourceItemIdx: number, destChecklistIdx: number, destItemIdx: number) {
+export async function clientMoveChecklist(playbookRunID: string, sourceChecklistIdx: number, destChecklistIdx: number) {
     const data = await doPost(`${apiUrl}/runs/${playbookRunID}/checklists/move`,
+        JSON.stringify({
+            source_checklist_idx: sourceChecklistIdx,
+            dest_checklist_idx: destChecklistIdx,
+        }),
+    );
+
+    return data;
+}
+
+export async function clientMoveChecklistItem(playbookRunID: string, sourceChecklistIdx: number, sourceItemIdx: number, destChecklistIdx: number, destItemIdx: number) {
+    const data = await doPost(`${apiUrl}/runs/${playbookRunID}/checklists/move-item`,
         JSON.stringify({
             source_checklist_idx: sourceChecklistIdx,
             source_item_idx: sourceItemIdx,

--- a/webapp/src/components/collapsible_checklist.tsx
+++ b/webapp/src/components/collapsible_checklist.tsx
@@ -2,7 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React, {useRef, useState} from 'react';
+import ReactDOM from 'react-dom';
 import styled from 'styled-components';
+import {Draggable, DraggableProvided, DraggableStateSnapshot, DraggableProvidedDragHandleProps} from 'react-beautiful-dnd';
 
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -22,6 +24,7 @@ export interface Props {
     children: React.ReactNode;
     disabledOrRunID: true | string;
     titleHelpText?: React.ReactNode;
+    draggableProvided?: DraggableProvided;
 }
 
 const CollapsibleChecklist = ({
@@ -34,6 +37,7 @@ const CollapsibleChecklist = ({
     children,
     disabledOrRunID,
     titleHelpText,
+    draggableProvided,
 }: Props) => {
     const titleRef = useRef(null);
     const [showMenu, setShowMenu] = useState(false);
@@ -47,8 +51,15 @@ const CollapsibleChecklist = ({
     const disabled = typeof disabledOrRunID !== 'string';
     const playbookRunID = typeof disabledOrRunID === 'string' ? disabledOrRunID : '';
 
+    let borderProps = {};
+    if (draggableProvided) {
+        borderProps = {
+            ...draggableProvided.draggableProps,
+            ref: draggableProvided.innerRef,
+        };
+    }
     return (
-        <Border>
+        <Border {...borderProps}>
             <HorizontalBG
                 checklistIndex={index}
                 numChecklists={numChecklists}
@@ -83,6 +94,7 @@ const CollapsibleChecklist = ({
                             checklistTitle={title}
                             onRenameChecklist={() => setShowRenameDialog(true)}
                             onDeleteChecklist={() => setShowDeleteDialog(true)}
+                            dragHandleProps={draggableProvided?.dragHandleProps}
                         />
                     }
                 </Horizontal>

--- a/webapp/src/components/collapsible_checklist_hover_menu.tsx
+++ b/webapp/src/components/collapsible_checklist_hover_menu.tsx
@@ -7,9 +7,12 @@ import styled from 'styled-components';
 
 import {useIntl} from 'react-intl';
 
+import {DraggableProvidedDragHandleProps} from 'react-beautiful-dnd';
+
 import {addNewTask} from 'src/actions';
 import {HamburgerButton} from 'src/components/assets/icons/three_dots_icon';
 import DotMenu, {DotMenuButton, DropdownMenu, DropdownMenuItem} from 'src/components/dot_menu';
+import {HoverMenuButton} from 'src/components/rhs/rhs_shared';
 
 export interface Props {
     playbookRunID: string;
@@ -17,6 +20,7 @@ export interface Props {
     checklistTitle: string;
     onRenameChecklist: () => void;
     onDeleteChecklist: () => void;
+    dragHandleProps: DraggableProvidedDragHandleProps | undefined;
 }
 
 const CollapsibleChecklistHoverMenu = (props: Props) => {
@@ -25,6 +29,13 @@ const CollapsibleChecklistHoverMenu = (props: Props) => {
 
     return (
         <ButtonRow>
+            {props.dragHandleProps &&
+            <Handle
+                title={formatMessage({defaultMessage: 'Drag to reorder checklist'})}
+                className={'icon icon-menu'}
+                {...props.dragHandleProps}
+            />
+            }
             <AddNewTask
                 data-testid={'addNewTask'}
                 onClick={(e) => {
@@ -56,6 +67,14 @@ const CollapsibleChecklistHoverMenu = (props: Props) => {
         </ButtonRow>
     );
 };
+
+const Handle = styled(HoverMenuButton)`
+    border-radius: 4px;
+    margin-right: 8px;
+    &:hover {
+        background: rgba(var(--center-channel-color-rgb), 0.08)
+    }
+`;
 
 const ButtonRow = styled.div`
     display: flex;

--- a/webapp/src/components/rhs/rhs_checklist.tsx
+++ b/webapp/src/components/rhs/rhs_checklist.tsx
@@ -74,7 +74,7 @@ const RHSChecklist = (props: Props) => {
             <Droppable
                 droppableId={props.checklistIndex.toString()}
                 direction='vertical'
-                type='checklist'
+                type='checklist-item'
             >
                 {(droppableProvided: DroppableProvided) => (
                     <EmptyChecklistContainer
@@ -100,7 +100,7 @@ const RHSChecklist = (props: Props) => {
         <Droppable
             droppableId={props.checklistIndex.toString()}
             direction='vertical'
-            type='checklist'
+            type='checklist-item'
         >
             {(droppableProvided: DroppableProvided) => (
                 <ChecklistContainer className='checklist'>

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -28,6 +28,7 @@ import {
     setAllChecklistsCollapsedState,
     setChecklistCollapsedState,
     setChecklistItemsFilter,
+    setEachChecklistCollapsedState,
 } from 'src/actions';
 import {
     Checklist,
@@ -163,6 +164,22 @@ const RHSChecklistList = (props: Props) => {
         if (result.type === 'checklist') {
             const [moved] = newChecklists.splice(srcIdx, 1);
             newChecklists.splice(dstIdx, 0, moved);
+
+            // The collapsed state of a checklist in the store is linked to the index in the list,
+            // so we need to shift all indices between srcIdx and dstIdx to the left (or to the
+            // right, depending on whether srcIdx < dstIdx) one position
+            const newState = {...checklistsState};
+            if (srcIdx < dstIdx) {
+                for (let i = srcIdx; i < dstIdx; i++) {
+                    newState[i] = checklistsState[i + 1];
+                }
+            } else {
+                for (let i = dstIdx + 1; i <= srcIdx; i++) {
+                    newState[i] = checklistsState[i - 1];
+                }
+            }
+            newState[dstIdx] = checklistsState[srcIdx];
+            dispatch(setEachChecklistCollapsedState(channelId, newState));
 
             // Persist the new data in the server
             clientMoveChecklist(props.playbookRun.id, srcIdx, dstIdx);

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -49,6 +49,8 @@ import {
     SetAllChecklistsCollapsedState,
     SET_CHECKLIST_COLLAPSED_STATE,
     SET_ALL_CHECKLISTS_COLLAPSED_STATE,
+    SetEachChecklistCollapsedState,
+    SET_EACH_CHECKLIST_COLLAPSED_STATE,
     SetChecklistItemsFilter,
     SET_CHECKLIST_ITEMS_FILTER,
 } from 'src/types/actions';
@@ -284,7 +286,10 @@ const rhsAboutCollapsedByChannel = (state: Record<string, boolean> = {}, action:
 // checklistCollapsedState keeps a map of channelId -> checklist number -> collapsed
 const checklistCollapsedState = (
     state: Record<string, Record<number, boolean>> = {},
-    action: SetChecklistCollapsedState | SetAllChecklistsCollapsedState,
+    action:
+    | SetChecklistCollapsedState
+    | SetAllChecklistsCollapsedState
+    | SetEachChecklistCollapsedState
 ) => {
     switch (action.type) {
     case SET_CHECKLIST_COLLAPSED_STATE: {
@@ -306,6 +311,13 @@ const checklistCollapsedState = (
         return {
             ...state,
             [setAction.channelId]: newState,
+        };
+    }
+    case SET_EACH_CHECKLIST_COLLAPSED_STATE: {
+        const setAction = action as SetEachChecklistCollapsedState;
+        return {
+            ...state,
+            [setAction.channelId]: setAction.state,
         };
     }
     default:

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -27,6 +27,7 @@ export const SHOW_POST_MENU_MODAL = pluginId + '_show_post_menu_modal';
 export const HIDE_POST_MENU_MODAL = pluginId + '_hide_post_menu_modal';
 export const SET_HAS_VIEWED_CHANNEL = pluginId + '_set_has_viewed';
 export const SET_RHS_ABOUT_COLLAPSED_STATE = pluginId + '_set_rhs_about_collapsed_state';
+export const SET_EACH_CHECKLIST_COLLAPSED_STATE = pluginId + '_set_every_checklist_collapsed_state';
 export const SET_CHECKLIST_COLLAPSED_STATE = pluginId + '_set_checklist_collapsed_state';
 export const SET_ALL_CHECKLISTS_COLLAPSED_STATE = pluginId + '_set_all_checklists_collapsed_state';
 export const SET_CHECKLIST_ITEMS_FILTER = pluginId + '_set_checklist_items_filter';
@@ -133,6 +134,12 @@ export interface SetChecklistCollapsedState {
     channelId: string;
     checklistIndex: number;
     collapsed: boolean;
+}
+
+export interface SetEachChecklistCollapsedState {
+    type: typeof SET_EACH_CHECKLIST_COLLAPSED_STATE;
+    channelId: string;
+    state: Record<number, boolean>;
 }
 
 export interface SetAllChecklistsCollapsedState {


### PR DESCRIPTION
#### Summary

This PR adds the ability to reorder checklists in the RHS:
- It adds an endpoint to move a checklist (the old `/move` now moves checklists, whereas the one to move items is now called `/move-item`)
- It refactors the `DragDropContext` structure from react-beautiful-dnd:
  - it first contains a `Droppable`, where all checklists can be dropped,
  - every checklist is now a `Draggable`, with a new icon that shows on hover that acts as the handle,
  - each checklist is still a `Droppable`, with every item being a `Draggable`.
- To keep the collapsed state of every checklist in sync, I had to add a new action to the store so that we can overwrite the whole state of `Record<number, boolean>` that keeps track of it: if we move the i-th checklist to the j-th position, we need to update the state of every k-th checklist, with `i <= k <= j` (assuming `i < j`). Otherwise, the checklists would change their collapsed state depending on the position they are in. Maybe it's time to add proper IDs to checklists.

https://user-images.githubusercontent.com/3924815/146217995-a6a09321-7896-41e5-b171-02e2010493b2.mp4

This PR is based off #933, and so it should be merged after that one is merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40305

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [X] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated