### PR TITLE
MM-40656: Z-index issue between sticky headers and user profile dropdown

### DIFF
--- a/webapp/src/components/profile/dropdown_selector_style.tsx
+++ b/webapp/src/components/profile/dropdown_selector_style.tsx
@@ -11,7 +11,7 @@ export const DropdownSelectorStyle = styled.div`
 
     .profile-dropdown {
         .playbook-run-user-select__container {
-            z-index: 3;
+            z-index: 50;
             position: absolute;
         }
     }


### PR DESCRIPTION
#### Summary
- A recent change made the checklist headers change their z-index based on how many checklists there are -- so I'm changing the profile dropdown to have a z-index of 50, under the assumption that we won't ever have that many checklists -- unless you think we should go even higher?

![image](https://user-images.githubusercontent.com/1490756/146609491-ef0362a1-7e70-467f-91ae-a020d6ce34d5.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-40656

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
