### PR TITLE
MM-39124: Run Overview timestamp format

### DIFF
--- a/webapp/src/components/rhs/post_card.tsx
+++ b/webapp/src/components/rhs/post_card.tsx
@@ -92,6 +92,11 @@ interface Props {
     channelId: string;
 }
 
+const REL_UNITS = [
+    'Today',
+    'Yesterday',
+];
+
 const PostCard = (props: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
@@ -119,7 +124,7 @@ const PostCard = (props: Props) => {
                     >
                         <Timestamp
                             value={props.post.create_at}
-                            useRelative={true}
+                            units={REL_UNITS}
                         />
                     </UpdateTimeLink>
                 </UpdateHeader>


### PR DESCRIPTION
#### Summary
Update time spec in Run Overview by adding `Today`, `Yesterday`, `<weekday>`, `month day[, year]`. This is the same format used in Channels post tooltips and date separators.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/11724372/148106576-aeffd4e0-35dd-4e81-bb00-3f03676abc27.png">



#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39124

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | N
Gated by experimental feature flag? | N
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.