### PR TITLE
MM-38732: retrospective tests

### DIFF
--- a/tests-e2e/cypress/integration/runs/retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/retrospective_spec.js
@@ -44,33 +44,8 @@ describe('runs > retrospective', () => {
         });
     });
 
-    it('can be edited and published to run channel', () => {
-        // # Navigate directly to the retro tab
-        cy.visit(`/playbooks/runs/${runId}/retrospective`);
-
-        // # Start editing
-        cy.findByTestId('retro-report-text').click();
-
-        // * Verify the provided template text is pre-filled
-        cy.focused().should('include.text', 'This is a retrospective template.');
-
-        // # Change the retro text
-        cy.focused().clear().type('Edited retrospective.');
-
-        // # Save it by clicking outside the text area
-        cy.findByText('Report').click();
-
-        // # Publish
-        cy.findByText('Publish').click({force: true});
-
-        // * Verify we're showing the publish retro confirmation modal
-        cy.get('#confirm-modal-light').contains('Are you sure you want to publish');
-
-        // # Publish
-        cy.get('#confirm-modal-light-button').click({force: true});
-
-        // * Verify that retro got published
-        cy.get('.icon-check-all').should('be.visible');
+    it('publishing posts to run channel', () => {
+        editAndPublishRetro(runId);
 
         // # Switch to the run channel
         cy.findByText('Go to channel').click();
@@ -78,4 +53,38 @@ describe('runs > retrospective', () => {
         // * Verify the modified retro text is posted
         cy.verifyPostedMessage('Edited retrospective.');
     });
+
+    it('prevents repeated publishing', () => {
+        editAndPublishRetro(runId);
+        cy.findByText('Publish').should('not.be.enabled');
+    });
 });
+
+const editAndPublishRetro = (runId) => {
+    // # Navigate directly to the retro tab
+    cy.visit(`/playbooks/runs/${runId}/retrospective`);
+
+    // # Start editing
+    cy.findByTestId('retro-report-text').click();
+
+    // * Verify the provided template text is pre-filled
+    cy.focused().should('include.text', 'This is a retrospective template.');
+
+    // # Change the retro text
+    cy.focused().clear().type('Edited retrospective.');
+
+    // # Save it by clicking outside the text area
+    cy.findByText('Report').click();
+
+    // # Publish
+    cy.findByRole('button', {name: 'Publish'}).click();
+
+    // * Verify we're showing the publish retro confirmation modal
+    cy.get('#confirm-modal-light').contains('Are you sure you want to publish');
+
+    // # Publish
+    cy.findByRole('button', {name: 'Publish'}).click();
+
+    // * Verify that retro got published
+    cy.get('.icon-check-all').should('be.visible');
+};


### PR DESCRIPTION
#954 additions:

- adds a test around the new behavior
- change a couple `click({force: true})` calls to `click()` thanks to `findByRole`