### PR TITLE
MM-40659: Skipped tasks incorrectly marked as unfinished

### DIFF
--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -328,14 +328,14 @@ const (
 	ChecklistItemStateOpen       = ""
 	ChecklistItemStateInProgress = "in_progress"
 	ChecklistItemStateClosed     = "closed"
-	CheckListItemStateSkipped    = "skipped"
+	ChecklistItemStateSkipped    = "skipped"
 )
 
 func IsValidChecklistItemState(state string) bool {
 	return state == ChecklistItemStateClosed ||
 		state == ChecklistItemStateInProgress ||
 		state == ChecklistItemStateOpen ||
-		state == CheckListItemStateSkipped
+		state == ChecklistItemStateSkipped
 }
 
 func IsValidChecklistItemIndex(checklists []Checklist, checklistNum, itemNum int) bool {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -780,7 +780,7 @@ func (s *PlaybookRunServiceImpl) OpenFinishPlaybookRunDialog(playbookRunID, trig
 	numOutstanding := 0
 	for _, c := range currentPlaybookRun.Checklists {
 		for _, item := range c.Items {
-			if item.State == "" {
+			if item.State == ChecklistItemStateOpen || item.State == ChecklistItemStateInProgress {
 				numOutstanding++
 			}
 		}
@@ -1143,10 +1143,10 @@ func (s *PlaybookRunServiceImpl) ModifyCheckedState(playbookRunID, userID, newSt
 	if newState == ChecklistItemStateOpen {
 		modifyMessage = fmt.Sprintf("unchecked checklist item **%v**", stripmd.Strip(itemToCheck.Title))
 	}
-	if newState == CheckListItemStateSkipped {
+	if newState == ChecklistItemStateSkipped {
 		modifyMessage = fmt.Sprintf("skipped checklist item **%v**", stripmd.Strip(itemToCheck.Title))
 	}
-	if itemToCheck.State == CheckListItemStateSkipped && newState == ChecklistItemStateOpen {
+	if itemToCheck.State == ChecklistItemStateSkipped && newState == ChecklistItemStateOpen {
 		modifyMessage = fmt.Sprintf("restored checklist item **%v**", stripmd.Strip(itemToCheck.Title))
 	}
 
@@ -1481,7 +1481,7 @@ func (s *PlaybookRunServiceImpl) SkipChecklistItem(playbookRunID, userID string,
 	}
 
 	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].LastSkipped = model.GetMillis()
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].State = CheckListItemStateSkipped
+	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].State = ChecklistItemStateSkipped
 
 	checklistItem := playbookRunToModify.Checklists[checklistNumber].Items[itemNumber]
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -780,7 +780,7 @@ func (s *PlaybookRunServiceImpl) OpenFinishPlaybookRunDialog(playbookRunID, trig
 	numOutstanding := 0
 	for _, c := range currentPlaybookRun.Checklists {
 		for _, item := range c.Items {
-			if item.State != ChecklistItemStateClosed {
+			if item.State == "" {
 				numOutstanding++
 			}
 		}

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -310,7 +310,7 @@ const outstandingTasks = (checklists: Checklist[]) => {
     let count = 0;
     for (const list of checklists) {
         for (const item of list.items) {
-            if (item.state !== ChecklistItemState.Closed) {
+            if (item.state === ChecklistItemState.Open || item.state === ChecklistItemState.InProgress) {
                 count++;
             }
         }

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -373,7 +373,7 @@ const outstandingTasks = (checklists: Checklist[]) => {
     let count = 0;
     for (const list of checklists) {
         for (const item of list.items) {
-            if (item.state !== ChecklistItemState.Closed) {
+            if (item.state === ChecklistItemState.Open || item.state === ChecklistItemState.InProgress) {
                 count++;
             }
         }


### PR DESCRIPTION
#### Summary
When the confirmation for a run finish is shown, skipped tasks are no longer considered "outstanding".

![Screenshot from 2022-01-04 16-59-55](https://user-images.githubusercontent.com/3723666/148129577-c5a16a91-b272-42f9-b707-cbef140d342f.png)

![Screenshot from 2022-01-04 17-00-03](https://user-images.githubusercontent.com/3723666/148129584-ab600d33-1b10-47ac-9a81-ae9823aa1ac2.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40659

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~Telemetry updated~~
-  ~~Gated by experimental feature flag~~
- ~~Unit tests updated~~
