### PR TITLE
MM-40833: fix /playbooks height

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -34,11 +34,10 @@ import {applyTheme} from 'src/components/backstage/css_utils';
 
 const BackstageContainer = styled.div`
     background: var(--center-channel-bg);
-    // The container should take up all vertical real estate, less the height of the global header.
-    height: calc(100% - 40px);
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    height: 100%;
 `;
 
 const BackstageTitlebarItem = styled(NavLink)`


### PR DESCRIPTION
#### Summary
The `-40px` calc was [introduced in mattermost-webapp](https://github.com/mattermost/mattermost-webapp/blob/56d0522/sass/layout/_team-sidebar.scss#L171-L179), now ours can be removed.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/11724372/148295703-857d8450-75ff-40d4-a566-d67c3554953e.png">

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-40833

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | NA
Gated by experimental feature flag? | NA
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.
