### PR TITLE
e2e: fix config plumbing for EnableOnboardingFlow

### DIFF
--- a/tests-e2e/cypress.json
+++ b/tests-e2e/cypress.json
@@ -15,7 +15,6 @@
         "dbClient": "postgres",
         "dbConnection": "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10",
         "elasticsearchConnectionUrl": "http://localhost:9200",
-        "enableOnboardingFlow": false,
         "firstTest": false,
         "keycloakAppName": "mattermost",
         "keycloakBaseUrl": "http://localhost:8484",

--- a/tests-e2e/cypress/support/api/cloud_default_config.json
+++ b/tests-e2e/cypress/support/api/cloud_default_config.json
@@ -28,7 +28,8 @@
         "EnableBotAccountCreation": true,
         "EnableSVGs": true,
         "EnableLatex": false,
-        "EnableLegacySidebar": false
+        "EnableLegacySidebar": false,
+        "EnableOnboardingFlow": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/tests-e2e/cypress/support/api/on_prem_default_config.json
+++ b/tests-e2e/cypress/support/api/on_prem_default_config.json
@@ -82,7 +82,8 @@
         "EnableBotAccountCreation": true,
         "EnableSVGs": true,
         "EnableLatex": false,
-        "EnableLegacySidebar": false
+        "EnableLegacySidebar": false,
+        "EnableOnboardingFlow": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/tests-e2e/cypress/support/api/system.js
+++ b/tests-e2e/cypress/support/api/system.js
@@ -117,7 +117,6 @@ export const getDefaultConfig = () => {
         ServiceSettings: {
             AllowedUntrustedInternalConnections: cypressEnv.allowedUntrustedInternalConnections,
             SiteURL: siteUrl,
-            EnableOnboardingFlow: cypressEnv.enableOnboardingFlow,
         },
     };
 

--- a/tests-e2e/cypress/support/api/system.js
+++ b/tests-e2e/cypress/support/api/system.js
@@ -103,6 +103,7 @@ Cypress.Commands.add('apiDeleteLicense', () => {
 });
 
 export const getDefaultConfig = () => {
+    const siteUrl = Cypress.config('baseUrl');
     const cypressEnv = Cypress.env();
 
     const fromCypressEnv = {
@@ -115,8 +116,8 @@ export const getDefaultConfig = () => {
         },
         ServiceSettings: {
             AllowedUntrustedInternalConnections: cypressEnv.allowedUntrustedInternalConnections,
-            SiteURL: Cypress.config('baseUrl'),
-            EnableOnboardingFlow: Cypress.config('enableOnboardingFlow'),
+            SiteURL: siteUrl,
+            EnableOnboardingFlow: cypressEnv.enableOnboardingFlow,
         },
     };
 


### PR DESCRIPTION
`getDefaultConfig()` was trying to fetch `config.enableOnboardingFlow` from `tests-e2e/cypress.json` but that key is actually present under `config.env.enableOnboardingFlow`. This should prevent the view from appearing and failing tests both in CI (which @cpoile already fixed, so should be double good now) and locally.