### PR TITLE
Allow creating runs in an existing channel via API

### DIFF
--- a/client/playbook_run.go
+++ b/client/playbook_run.go
@@ -84,6 +84,7 @@ type PlaybookRunCreateOptions struct {
 	Name        string `json:"name"`
 	OwnerUserID string `json:"owner_user_id"`
 	TeamID      string `json:"team_id"`
+	ChannelID   string `json:"channel_id"`
 	Description string `json:"description"`
 	PostID      string `json:"post_id"`
 	PlaybookID  string `json:"playbook_id"`

--- a/tests-e2e/cypress/integration/api/runs_spec.js
+++ b/tests-e2e/cypress/integration/api/runs_spec.js
@@ -1,0 +1,238 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('api > runs', () => {
+    const baseUrl = Cypress.config('baseUrl') + '/plugins/playbooks/api/v0';
+    let testTeam;
+    let testUser;
+    let testPlaybook;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Playbook',
+                memberIDs: [],
+                createPublicPlaybookRun: true,
+            }).then((playbook) => {
+                testPlaybook = playbook;
+            })
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    describe('creating a run', () => {
+        describe('in an existing, public channel', () => {
+            it('with no team_id specified', () => {
+                // # Create a test channel without a playbook run
+                cy.apiCreateChannel(testTeam.id, 'channel', 'Channel').then(({channel}) => {
+                    // # Run the testPlaybook in the previously created channel
+                    cy.request({
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                        url: `${baseUrl}/runs`,
+                        method: 'POST',
+                        body: {
+                            owner_user_id: testUser.id,
+                            channel_id: channel.id,
+                            playbook_id: testPlaybook.id,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(201);
+                        expect(response.body).to.have.property('owner_user_id', testUser.id);
+                        expect(response.body).to.have.property('reporter_user_id', testUser.id);
+                        expect(response.body).to.have.property('team_id', testTeam.id);
+                        expect(response.body).to.have.property('channel_id', channel.id);
+                        expect(response.body).to.have.property('playbook_id', testPlaybook.id);
+                    });
+                });
+            });
+
+            it('with correct team_id specified', () => {
+                // # Create a test channel without a playbook run
+                cy.apiCreateChannel(testTeam.id, 'channel', 'Channel').then(({channel}) => {
+                    // # Run the testPlaybook in the previously created channel
+                    cy.request({
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                        url: `${baseUrl}/runs`,
+                        method: 'POST',
+                        body: {
+                            owner_user_id: testUser.id,
+                            channel_id: channel.id,
+                            playbook_id: testPlaybook.id,
+                            team_id: testTeam.id,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(201);
+                        expect(response.body).to.have.property('owner_user_id', testUser.id);
+                        expect(response.body).to.have.property('reporter_user_id', testUser.id);
+                        expect(response.body).to.have.property('team_id', testTeam.id);
+                        expect(response.body).to.have.property('channel_id', channel.id);
+                        expect(response.body).to.have.property('playbook_id', testPlaybook.id);
+                    });
+                });
+            });
+
+            it('with wrong team_id specified', () => {
+                // # Create a test channel without a playbook run
+                cy.apiCreateChannel(testTeam.id, 'channel', 'Channel').then(({channel}) => {
+                    // # Run the testPlaybook in the previously created channel
+                    cy.request({
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                        url: `${baseUrl}/runs`,
+                        method: 'POST',
+                        body: {
+                            owner_user_id: testUser.id,
+                            channel_id: channel.id,
+                            playbook_id: testPlaybook.id,
+                            team_id: 'other_team_id',
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(400);
+                        expect(response.body).to.have.property('error', 'unable to create playbook run');
+                    });
+                });
+            });
+        });
+
+        describe('in an existing, private channel', () => {
+            it('with no team_id specified', () => {
+                // # Create a test channel without a playbook run
+                cy.apiCreateChannel(testTeam.id, 'channel', 'Channel', 'P').then(({channel}) => {
+                    // # Run the testPlaybook in the previously created channel
+                    cy.request({
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                        url: `${baseUrl}/runs`,
+                        method: 'POST',
+                        body: {
+                            owner_user_id: testUser.id,
+                            channel_id: channel.id,
+                            playbook_id: testPlaybook.id,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(201);
+                        expect(response.body).to.have.property('owner_user_id', testUser.id);
+                        expect(response.body).to.have.property('reporter_user_id', testUser.id);
+                        expect(response.body).to.have.property('team_id', testTeam.id);
+                        expect(response.body).to.have.property('channel_id', channel.id);
+                        expect(response.body).to.have.property('playbook_id', testPlaybook.id);
+                    });
+                });
+            });
+
+            it('with correct team_id specified', () => {
+                // # Create a test channel without a playbook run
+                cy.apiCreateChannel(testTeam.id, 'channel', 'Channel', 'P').then(({channel}) => {
+                    // # Run the testPlaybook in the previously created channel
+                    cy.request({
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                        url: `${baseUrl}/runs`,
+                        method: 'POST',
+                        body: {
+                            owner_user_id: testUser.id,
+                            channel_id: channel.id,
+                            playbook_id: testPlaybook.id,
+                            team_id: testTeam.id,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(201);
+                        expect(response.body).to.have.property('owner_user_id', testUser.id);
+                        expect(response.body).to.have.property('reporter_user_id', testUser.id);
+                        expect(response.body).to.have.property('team_id', testTeam.id);
+                        expect(response.body).to.have.property('channel_id', channel.id);
+                        expect(response.body).to.have.property('playbook_id', testPlaybook.id);
+                    });
+                });
+            });
+
+            it('with wrong team_id specified', () => {
+                // # Create a test channel without a playbook run
+                cy.apiCreateChannel(testTeam.id, 'channel', 'Channel', 'P').then(({channel}) => {
+                    // # Run the testPlaybook in the previously created channel
+                    cy.request({
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                        url: `${baseUrl}/runs`,
+                        method: 'POST',
+                        body: {
+                            owner_user_id: testUser.id,
+                            channel_id: channel.id,
+                            playbook_id: testPlaybook.id,
+                            team_id: 'other_team_id',
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(400);
+                        expect(response.body).to.have.property('error', 'unable to create playbook run');
+                    });
+                });
+            });
+        });
+
+        it('in an existing, private channel, of which the user is not a member', () => {
+            // # Create a test channel without a playbook run
+            cy.apiCreateChannel(testTeam.id, 'channel', 'Channel', 'P').then(({channel}) => {
+                // # Leave the channel
+                cy.apiRemoveUserFromChannel(channel.id, testUser.id);
+
+                // # Run the testPlaybook in the previously created channel
+                cy.request({
+                    headers: {'X-Requested-With': 'XMLHttpRequest'},
+                    url: `${baseUrl}/runs`,
+                    method: 'POST',
+                    body: {
+                        owner_user_id: testUser.id,
+                        channel_id: channel.id,
+                        playbook_id: testPlaybook.id,
+                        team_id: testTeam.id,
+                    },
+                    failOnStatusCode: false,
+                }).then((response) => {
+                    expect(response.status).to.eq(403);
+                    expect(response.body).to.have.property('error', 'unable to create playbook run');
+                });
+            });
+        });
+
+        it('in a channel with an existing playbook run', () => {
+            // # Run the playbook, creating a channel.
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName: 'Playbook',
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                // # Run the testPlaybook in the previously created channel
+                cy.request({
+                    headers: {'X-Requested-With': 'XMLHttpRequest'},
+                    url: `${baseUrl}/runs`,
+                    method: 'POST',
+                    body: {
+                        owner_user_id: testUser.id,
+                        channel_id: playbookRun.channel_id,
+                        playbook_id: testPlaybook.id,
+                    },
+                    failOnStatusCode: false,
+                }).then((response) => {
+                    expect(response.status).to.eq(400);
+                    expect(response.body).to.have.property('error', 'unable to create playbook run');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Fundamentally, we don't require a /new/ channel for a run, but currently tie the two steps together. Let's start decoupling that by allowing -- at an API level -- the ability to specify an existing channel into which to create a playbook run.

Note that I'm using Cypress E2E tests to exercise this API vs. unit tests.

#### Ticket Link
None, but the backstory here is a desire to apply a playbook retroactively to an existing channel on community.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
