### PR TITLE
Stop notifying others' overdue runs

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -8,10 +8,6 @@
     "translation": "Overdue Status Updates"
   },
   {
-    "id": "app.user.digest.overdue_status_updates.md_link_item_appended",
-    "translation": "(Owner: @{{.Username}})"
-  },
-  {
     "id": "app.user.digest.overdue_status_updates.num_overdue",
     "translation": {
       "one": "You have {{.Count}} run overdue for a status update:",

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -376,7 +376,6 @@ type RunLink struct {
 	TeamName           string
 	ChannelName        string
 	ChannelDisplayName string
-	OwnerUserName      string
 }
 
 // AssignedRun represents all the info needed to display a Run & ChecklistItem to a user

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2676,8 +2676,8 @@ func buildRunsOverdueMessage(runs []RunLink, locale string) string {
 	msg += T("app.user.digest.overdue_status_updates.num_overdue", total) + "\n"
 
 	for _, run := range runs {
-		msg += fmt.Sprintf("- [%s](/%s/channels/%s?telem_action=todo_overduestatus_clicked&telem_run_id=%s&forceRHSOpen)",
-			run.ChannelDisplayName, run.TeamName, run.ChannelName, run.PlaybookRunID) + "\n"
+		msg += fmt.Sprintf("- [%s](/%s/channels/%s?telem_action=todo_overduestatus_clicked&telem_run_id=%s&forceRHSOpen)\n",
+			run.ChannelDisplayName, run.TeamName, run.ChannelName, run.PlaybookRunID)
 	}
 
 	return msg

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2676,12 +2676,8 @@ func buildRunsOverdueMessage(runs []RunLink, locale string) string {
 	msg += T("app.user.digest.overdue_status_updates.num_overdue", total) + "\n"
 
 	for _, run := range runs {
-		values := map[string]interface{}{
-			"Username": run.OwnerUserName,
-		}
-		appended := " " + T("app.user.digest.overdue_status_updates.md_link_item_appended", values)
 		msg += fmt.Sprintf("- [%s](/%s/channels/%s?telem_action=todo_overduestatus_clicked&telem_run_id=%s&forceRHSOpen)",
-			run.ChannelDisplayName, run.TeamName, run.ChannelName, run.PlaybookRunID) + appended + "\n"
+			run.ChannelDisplayName, run.TeamName, run.ChannelName, run.PlaybookRunID) + "\n"
 	}
 
 	return msg

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -967,12 +967,11 @@ func (s *playbookRunStore) GetRunsWithAssignedTasks(userID string) ([]app.Assign
 	}
 
 	query := s.store.builder.Select("i.ID AS PlaybookRunID", "t.Name AS TeamName",
-		"c.Name AS ChannelName", "c.DisplayName AS ChannelDisplayName", "u.UserName AS OwnerUserName",
+		"c.Name AS ChannelName", "c.DisplayName AS ChannelDisplayName",
 		"i.ChecklistsJSON AS ChecklistsJSON").
 		From("IR_Incident AS i").
 		Join("Teams AS t ON (i.TeamID = t.Id)").
 		Join("Channels AS c ON (i.ChannelID = c.Id)").
-		Join("Users AS u ON i.CommanderUserID = u.Id").
 		Where(sq.Eq{"i.CurrentStatus": app.StatusInProgress}).
 		OrderBy("ChannelDisplayName")
 
@@ -1030,12 +1029,12 @@ func (s *playbookRunStore) GetParticipatingRuns(userID string) ([]app.RunLink, e
 
 	query := s.store.builder.
 		Select("i.ID AS PlaybookRunID", "t.Name AS TeamName",
-			"c.Name AS ChannelName", "c.DisplayName AS ChannelDisplayName", "u.UserName AS OwnerUserName").
+			"c.Name AS ChannelName", "c.DisplayName AS ChannelDisplayName").
 		From("IR_Incident AS i").
 		Join("Teams AS t ON (i.TeamID = t.Id)").
 		Join("Channels AS c ON (i.ChannelId = c.Id)").
-		Join("Users AS u ON i.CommanderUserID = u.Id").
 		Where(sq.Eq{"i.CurrentStatus": app.StatusInProgress}).
+		Where(sq.Eq{"i.CommanderUserID": userID}).
 		Where(membershipClause).
 		OrderBy("ChannelDisplayName")
 
@@ -1051,11 +1050,10 @@ func (s *playbookRunStore) GetParticipatingRuns(userID string) ([]app.RunLink, e
 func (s *playbookRunStore) GetOverdueUpdateRuns(userID string) ([]app.RunLink, error) {
 	query := s.store.builder.
 		Select("i.ID AS PlaybookRunID", "t.Name AS TeamName",
-			"c.Name AS ChannelName", "c.DisplayName AS ChannelDisplayName", "u.UserName AS OwnerUserName").
+			"c.Name AS ChannelName", "c.DisplayName AS ChannelDisplayName").
 		From("IR_Incident AS i").
 		Join("Teams AS t ON (i.TeamID = t.Id)").
 		Join("Channels AS c ON (i.ChannelId = c.Id)").
-		Join("Users AS u ON i.CommanderUserID = u.Id").
 		Where(sq.Eq{"i.CurrentStatus": app.StatusInProgress}).
 		Where(sq.NotEq{"i.PreviousReminder": 0}).
 		Where(sq.Eq{"i.CommanderUserId": userID}).

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -1034,7 +1034,6 @@ func (s *playbookRunStore) GetParticipatingRuns(userID string) ([]app.RunLink, e
 		Join("Teams AS t ON (i.TeamID = t.Id)").
 		Join("Channels AS c ON (i.ChannelId = c.Id)").
 		Where(sq.Eq{"i.CurrentStatus": app.StatusInProgress}).
-		Where(sq.Eq{"i.CommanderUserID": userID}).
 		Where(membershipClause).
 		OrderBy("ChannelDisplayName")
 

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -751,19 +751,20 @@ func TestTasksAndRunsDigest(t *testing.T) {
 			}
 		})
 
-		t.Run("gets owned runs only", func(t *testing.T) {
+		t.Run("gets participating runs only", func(t *testing.T) {
 			runs, err := playbookRunStore.GetParticipatingRuns(userID)
 			require.NoError(t, err)
 
 			total := len(runs)
 
-			require.Equal(t, 3, total)
+			require.Equal(t, 4, total)
 
 			// don't make assumptions about ordering until we figure that out PM-side
 			expected := map[string]int{
 				channel01.Name: 1,
 				channel02.Name: 1,
 				channel03.Name: 1,
+				channel06.Name: 1,
 			}
 
 			actual := make(map[string]int)

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -751,20 +751,19 @@ func TestTasksAndRunsDigest(t *testing.T) {
 			}
 		})
 
-		t.Run("gets participating runs only", func(t *testing.T) {
+		t.Run("gets owned runs only", func(t *testing.T) {
 			runs, err := playbookRunStore.GetParticipatingRuns(userID)
 			require.NoError(t, err)
 
 			total := len(runs)
 
-			require.Equal(t, 4, total)
+			require.Equal(t, 3, total)
 
 			// don't make assumptions about ordering until we figure that out PM-side
 			expected := map[string]int{
 				channel01.Name: 1,
 				channel02.Name: 1,
 				channel03.Name: 1,
-				channel06.Name: 1,
 			}
 
 			actual := make(map[string]int)
@@ -782,13 +781,12 @@ func TestTasksAndRunsDigest(t *testing.T) {
 
 			total := len(runs)
 
-			require.Equal(t, 3, total)
+			require.Equal(t, 2, total)
 
 			// don't make assumptions about ordering until we figure that out PM-side
 			expected := map[string]int{
 				channel01.Name: 1,
 				channel02.Name: 1,
-				channel06.Name: 1,
 			}
 
 			actual := make(map[string]int)

--- a/tests-e2e/cypress/integration/channels/slash_command/todo_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/todo_spec.js
@@ -157,6 +157,13 @@ describe('channels > slash command > todo', () => {
 
                         // # Invite testUser to the channel
                         cy.apiAddUserToChannel(run.channel_id, testUser.id);
+
+                        // # Force this run to be overdue
+                        cy.apiUpdateStatus({
+                            playbookRunId: run4.id,
+                            message: 'no message 4',
+                            reminder: 1,
+                        });
                     });
 
                     // # Create a run in team 1, with testOtherUser as owner but not inviting testUser
@@ -166,6 +173,13 @@ describe('channels > slash command > todo', () => {
                         playbookId,
                         playbookRunName: 'Other Playbook Run (' + now2 + ')',
                         ownerUserId: testOtherUser.id,
+                    }).then((run) => {
+                        // # Force this run to be overdue
+                        cy.apiUpdateStatus({
+                            playbookRunId: run.id,
+                            message: 'no message 5',
+                            reminder: 1,
+                        });
                     });
                 });
             });

--- a/tests-e2e/cypress/support/api/user.js
+++ b/tests-e2e/cypress/support/api/user.js
@@ -246,6 +246,7 @@ Cypress.Commands.add('apiCreateUser', ({
 
         if (hideOnboarding) {
             cy.apiSaveOnboardingPreference(createdUser.id, 'hide', 'true');
+            cy.apiSaveOnboardingPreference(createdUser.id, 'skip', 'true');
         }
 
         if (bypassWhatsNewModal) {

--- a/tests-e2e/cypress/support/index.js
+++ b/tests-e2e/cypress/support/index.js
@@ -189,6 +189,7 @@ function sysadminSetup(user) {
     cy.apiSaveClockDisplayModeTo24HourPreference(false);
     cy.apiSaveTutorialStep(user.id, '999');
     cy.apiSaveOnboardingPreference(user.id, 'hide', 'true');
+    cy.apiSaveOnboardingPreference(user.id, 'skip', 'true');
     cy.apiUpdateUserStatus('online');
     cy.apiPatchMe({
         locale: 'en',


### PR DESCRIPTION
#### Summary
Following up on [this thread](https://community-daily.mattermost.com/core/pl/gza8jybbrtn5ifeqq9r5bbmwhr), let's stop notifying participants about runs with overdue status updates of which they are not the owner. We're not finding this to be an actionable event at this time, and want to "stop the spam" while we revisit the overall approach.

#### Ticket Link
N/A

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
