### PR TITLE
Fix flaky TestDeletePlaybook/mysql_-_create_and_delete_playbook

### DIFF
--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -268,6 +268,7 @@ type PlaybookStore interface {
 
 	// Create creates a new playbook
 	Create(playbook Playbook) (string, error)
+
 	// GetPlaybooks retrieves all playbooks
 	GetPlaybooks() ([]Playbook, error)
 

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -1076,7 +1076,7 @@ func TestDeletePlaybook(t *testing.T) {
 		})
 
 		t.Run(driverName+" - create and delete playbook", func(t *testing.T) {
-			before := model.GetMillis()
+			now := model.GetMillis()
 
 			id, err := playbookStore.Create(pb02)
 			require.NoError(t, err)
@@ -1088,7 +1088,7 @@ func TestDeletePlaybook(t *testing.T) {
 
 			actual, err := playbookStore.Get(id)
 			require.NoError(t, err)
-			require.Greater(t, actual.DeleteAt, before)
+			require.GreaterOrEqual(t, actual.DeleteAt, now)
 
 			expected.DeleteAt = actual.DeleteAt
 			require.Equal(t, expected, actual)


### PR DESCRIPTION
#### Summary
Fix [this](https://app.circleci.com/pipelines/github/mattermost/mattermost-plugin-playbooks/5263/workflows/2a5e9589-2a42-4568-9a20-eb5c428a40e0/jobs/34434/tests#failed-test-0):

```
Failed
=== RUN   TestDeletePlaybook/mysql_-_create_and_delete_playbook
    assertion_compare.go:313:
        	Error Trace:	playbook_test.go:1091
        	Error:      	"1642446666733" is not greater than "1642446666733"
        	Test:       	TestDeletePlaybook/mysql_-_create_and_delete_playbook
        	Messages:   	[]
Dropped temporary database dbn9u6tgjuu3g79rgs3hxacubzto
Dropped temporary database dbzfmfwfk77bdfifk4f1ocnrsewa
    --- FAIL: TestDeletePlaybook/mysql_-_create_and_delete_playbook (0.00s)
```

#### Ticket Link
N/A

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
