### PR TITLE
fix mmjstool integrity check

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,7 +11,7 @@
         "core-js": "3.20.2",
         "debounce": "1.2.1",
         "luxon": "2.0.2",
-        "mattermost-webapp": "github:mattermost/mattermost-webapp#fc13e7e224a8b05e660e585f78febcc975921efd",
+        "mattermost-webapp": "github:mattermost/mattermost-webapp#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
         "parse-duration": "1.0.2",
         "qs": "6.10.2",
         "react": "16.13.1",
@@ -14287,7 +14287,7 @@
     "node_modules/mattermost-webapp": {
       "name": "@mattermost/webapp",
       "version": "5.36.0-0",
-      "resolved": "git+ssh://git@github.com/mattermost/mattermost-webapp.git#fc13e7e224a8b05e660e585f78febcc975921efd",
+      "resolved": "git+ssh://git@github.com/mattermost/mattermost-webapp.git#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
       "dependencies": {
         "@mattermost/compass-components": "^0.2.12",
         "@mattermost/compass-icons": "^0.1.10",
@@ -31515,8 +31515,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-webapp": {
-      "version": "git+ssh://git@github.com/mattermost/mattermost-webapp.git#fc13e7e224a8b05e660e585f78febcc975921efd",
-      "from": "mattermost-webapp@github:mattermost/mattermost-webapp#fc13e7e224a8b05e660e585f78febcc975921efd",
+      "version": "git+ssh://git@github.com/mattermost/mattermost-webapp.git#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
+      "from": "mattermost-webapp@github:mattermost/mattermost-webapp#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
       "requires": {
         "@mattermost/compass-components": "^0.2.12",
         "@mattermost/compass-icons": "^0.1.10",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -88,7 +88,7 @@
     "core-js": "3.20.2",
     "debounce": "1.2.1",
     "luxon": "2.0.2",
-    "mattermost-webapp": "github:mattermost/mattermost-webapp#fc13e7e224a8b05e660e585f78febcc975921efd",
+    "mattermost-webapp": "github:mattermost/mattermost-webapp#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
     "parse-duration": "1.0.2",
     "qs": "6.10.2",
     "react": "16.13.1",


### PR DESCRIPTION
#### Summary
Fix the following by upgrading to the mattermost-webapp version that includes https://github.com/mattermost/mattermost-webapp/pull/9617:
```
npm ERR! npm WARN tarball tarball data for mmjstool@git+ssh://git@github.com/mattermost/mattermost-utilities.git#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac (sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg==) seems to be corrupted. Trying again.
npm ERR! npm WARN tarball tarball data for mmjstool@git+ssh://git@github.com/mattermost/mattermost-utilities.git#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac (sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg==) seems to be corrupted. Trying again.
npm ERR! npm ERR! code EINTEGRITY
npm ERR! npm ERR! sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg== integrity checksum failed when using sha512: wanted sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg== but got sha512-UlDFQ3W7nzOfkSuVgDPNrqvoNZeH5E1CY/lDzVx4EZ5OQ80MHU4bLqTNQjYY+h/NsaCEEWs2cV03Jxm5fGhGaA==. (2434429 bytes)
```

#### Ticket Link
N/A

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
