### PR TITLE
e2e: package update

### DIFF
--- a/tests-e2e/cypress.json
+++ b/tests-e2e/cypress.json
@@ -36,7 +36,6 @@
         "webhookBaseUrl": "http://localhost:3000",
         "developerMode": false
     },
-    "reporter": "cypress-multi-reporters",
     "reporterOptions": {
         "configFile": "reporter-config.json"
     },

--- a/tests-e2e/package-lock.json
+++ b/tests-e2e/package-lock.json
@@ -11,7 +11,6 @@
         "axios-retry": "^3.1.9",
         "cypress": "7.7.0",
         "cypress-file-upload": "5.0.8",
-        "cypress-multi-reporters": "1.5.0",
         "cypress-plugin-tab": "1.0.5",
         "cypress-terminal-report": "3.2.2",
         "cypress-wait-until": "1.7.1",
@@ -23,7 +22,8 @@
         "mocha-junit-reporter": "2.0.0",
         "mochawesome": "^6.2.2",
         "mochawesome-merge": "^4.2.0",
-        "mochawesome-report-generator": "^5.2.0"
+        "mochawesome-report-generator": "^5.2.0",
+        "shelljs": "^0.8.5"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.171",
@@ -4910,21 +4910,6 @@
         "cypress": ">3.0.0"
       }
     },
-    "node_modules/cypress-multi-reporters": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cypress-multi-reporters/-/cypress-multi-reporters-1.5.0.tgz",
-      "integrity": "sha512-6rJ1rk1RpjZwTeydCDc8r3iOmWj2ZEYo++oDTJHNEu7eetb3W1cYDNo5CdxF/r0bo7TLQsOEpBHOCYBZfPVt/g==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "lodash": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "mocha": ">=3.1.2"
-      }
-    },
     "node_modules/cypress-plugin-tab": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
@@ -7006,7 +6991,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -11642,7 +11626,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "peer": true,
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -12611,10 +12594,9 @@
       }
     },
     "node_modules/shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "peer": true,
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -18062,15 +18044,6 @@
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
       "requires": {}
     },
-    "cypress-multi-reporters": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cypress-multi-reporters/-/cypress-multi-reporters-1.5.0.tgz",
-      "integrity": "sha512-6rJ1rk1RpjZwTeydCDc8r3iOmWj2ZEYo++oDTJHNEu7eetb3W1cYDNo5CdxF/r0bo7TLQsOEpBHOCYBZfPVt/g==",
-      "requires": {
-        "debug": "^4.1.1",
-        "lodash": "^4.17.15"
-      }
-    },
     "cypress-plugin-tab": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
@@ -19629,8 +19602,7 @@
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "peer": true
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -23248,7 +23220,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "peer": true,
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -24033,10 +24004,9 @@
       }
     },
     "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "peer": true,
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",

--- a/tests-e2e/package.json
+++ b/tests-e2e/package.json
@@ -6,7 +6,6 @@
     "axios-retry": "^3.1.9",
     "cypress": "7.7.0",
     "cypress-file-upload": "5.0.8",
-    "cypress-multi-reporters": "1.5.0",
     "cypress-plugin-tab": "1.0.5",
     "cypress-terminal-report": "3.2.2",
     "cypress-wait-until": "1.7.1",
@@ -18,7 +17,8 @@
     "mocha-junit-reporter": "2.0.0",
     "mochawesome": "^6.2.2",
     "mochawesome-merge": "^4.2.0",
-    "mochawesome-report-generator": "^5.2.0"
+    "mochawesome-report-generator": "^5.2.0",
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.171",


### PR DESCRIPTION
#951 uses `shelljs` for some file manipulation. @cpoile was seeing this:

![image](https://user-images.githubusercontent.com/3723666/150379167-4aee7e26-f0d2-4e74-8ee8-3a7012afc674.png)

I think that's because `shelljs` is currently only in `package-lock.json`. This PR explicitly adds it to `package.json` and updates the lockfile as well.

I also removed `cypress-multi-reporters` as it's no longer used.