### PR TITLE
MM-39571 - Fix for: Longer-worded languages cause text to wrap in markdown_textarea

### DIFF
--- a/webapp/src/components/markdown_textbox.tsx
+++ b/webapp/src/components/markdown_textbox.tsx
@@ -152,7 +152,7 @@ function TextboxLinks({
                     <span>{'>'}{formatMessage({defaultMessage: 'quote'})}</span>
                 </HelpText>
             </div>
-            <div>
+            <NoWrap>
                 <button
                     onClick={togglePreview}
                     className='style--none textbox-preview-link color--link'
@@ -167,7 +167,7 @@ function TextboxLinks({
                 >
                     {formatMessage({defaultMessage: 'Help'})}
                 </Link>
-            </div>
+            </NoWrap>
         </div>
     );
 }
@@ -223,6 +223,10 @@ const HelpText = styled.span`
         padding: 0;
         background: transparent;
     }
+`;
+
+const NoWrap = styled.div`
+    white-space: nowrap;
 `;
 
 export default MarkdownTextbox;


### PR DESCRIPTION
#### Summary
- Added nowrap to the right column. I assumed that we wanted to keep the left as is (since there really isn't anything else we can do -- it's going to wrap)

#### Before:
![image](https://user-images.githubusercontent.com/1490756/150870522-69764f3d-907b-439e-8e28-10b763fbec31.png)

#### After:
![image](https://user-images.githubusercontent.com/1490756/150870369-d595eba5-fc74-40a5-81b9-b52059933725.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39571

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
