### PR TITLE
MM-40838: new & reworked templates

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/home_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/home_spec.js
@@ -59,11 +59,13 @@ describe('channels > rhs > home', () => {
         it('starter templates', () => {
             // templates are defined in `webapp/src/components/backstage/template_selector.tsx`
             const templates = [
-                {name: 'Blank', checklists: 'no checklists', actions: 'no actions'},
-                {name: 'Product Release', checklists: '4 checklists', actions: '2 actions'},
-                {name: 'Customer Onboarding', checklists: '4 checklists', actions: '2 actions'},
-                {name: 'Service Reliability Incident', checklists: '4 checklists', actions: '3 actions'},
-                {name: 'Feature Lifecycle', checklists: '5 checklists', actions: '2 actions'},
+                {name: 'Blank', checklists: '1 checklist', actions: '1 action'},
+                {name: 'Product Release', checklists: '4 checklists', actions: '3 actions'},
+                {name: 'Customer Onboarding', checklists: '4 checklists', actions: '3 actions'},
+                {name: 'Service Reliability Incident', checklists: '4 checklists', actions: '4 actions'},
+                {name: 'Feature Lifecycle', checklists: '5 checklists', actions: '3 actions'},
+                {name: 'Employee Onboarding', checklists: '5 checklists', actions: '2 actions'},
+                {name: 'Bug Bash', checklists: '5 checklists', actions: '3 actions'},
             ];
 
             // # Click the icon

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -10,6 +10,7 @@
         "chrono-node": "2.3.5",
         "core-js": "3.20.2",
         "debounce": "1.2.1",
+        "js-trim-multiline-string": "^1.0.8",
         "luxon": "2.0.2",
         "mattermost-webapp": "github:mattermost/mattermost-webapp#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
         "parse-duration": "1.0.2",
@@ -13686,6 +13687,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-trim-multiline-string": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/js-trim-multiline-string/-/js-trim-multiline-string-1.0.8.tgz",
+      "integrity": "sha512-EFAZ/l2Pgt0hVA+tPgt8y2tpB1KiTJdkWMj9N4OrA9olkrJ01KthyX5Z/ieT2xT8tqPxu3PnwuoCky4mDwMmwg=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -31024,6 +31030,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-trim-multiline-string": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/js-trim-multiline-string/-/js-trim-multiline-string-1.0.8.tgz",
+      "integrity": "sha512-EFAZ/l2Pgt0hVA+tPgt8y2tpB1KiTJdkWMj9N4OrA9olkrJ01KthyX5Z/ieT2xT8tqPxu3PnwuoCky4mDwMmwg=="
     },
     "js-yaml": {
       "version": "3.14.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -87,6 +87,7 @@
     "chrono-node": "2.3.5",
     "core-js": "3.20.2",
     "debounce": "1.2.1",
+    "js-trim-multiline-string": "^1.0.8",
     "luxon": "2.0.2",
     "mattermost-webapp": "github:mattermost/mattermost-webapp#4d7dc89146d33bc833c9926d296e8738fc7b7b0f",
     "parse-duration": "1.0.2",

--- a/webapp/src/components/backstage/template_selector.tsx
+++ b/webapp/src/components/backstage/template_selector.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Icon from '@mdi/react';
 import {mdiRocketLaunchOutline, mdiHandshakeOutline, mdiCodeBraces} from '@mdi/js';
+import {mtrim} from 'js-trim-multiline-string';
 
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -25,12 +26,35 @@ export interface PresetTemplate {
     template: DraftPlaybookWithChecklist;
 }
 
-export const PresetTemplates: PresetTemplate[] = [
+const preprocessTemplates = (presetTemplates: PresetTemplate[]): PresetTemplate[] => (
+    presetTemplates.map((pt) => ({
+        ...pt,
+        template: {
+            ...pt.template,
+            num_stages: pt.template?.checklists.length,
+            num_actions:
+				1 + // Channel creation is hard-coded
+                (pt.template.message_on_join_enabled ? 1 : 0) +
+                (pt.template.signal_any_keywords_enabled ? 1 : 0) +
+                (pt.template.run_summary_template_enabled ? 1 : 0),
+            checklists: pt.template?.checklists.map((checklist) => ({
+                ...checklist,
+                items: checklist.items?.map((item) => ({
+                    ...newChecklistItem(),
+                    ...item,
+                })) || [],
+            })),
+        },
+    }))
+);
+
+export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
     {
         title: 'Blank',
         icon: <FileIcon/>,
         template: {
             ...emptyPlaybook(),
+            description: 'Customize this playbook\'s description to give an overview of when and how this playbook is run.',
         },
     },
     {
@@ -44,7 +68,7 @@ export const PresetTemplates: PresetTemplate[] = [
         template: {
             ...emptyPlaybook(),
             title: 'Product Release',
-            num_stages: 4,
+            description: 'Customize this playbook to reflect your own product release process.',
             checklists: [
                 {
                     title: 'Prepare code',
@@ -87,34 +111,38 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
-            num_actions: 2,
             create_public_playbook_run: false,
+            channel_name_template: 'Release (vX.Y)',
             message_on_join_enabled: true,
             message_on_join:
-                'Hello and welcome!\n\n' +
-                'This channel was created as part of the **Product Release** playbook and is where conversations related to this release are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.',
-            categorize_channel_enabled: true,
+                mtrim`Hello and welcome!
+
+                This channel was created as part of the **Product Release** playbook and is where conversations related to this release are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.`,
+            run_summary_template_enabled: true,
             run_summary_template:
-                '**About**\n' +
-                '- Version number: TBD\n' +
-                '- Target-date: TBD\n' +
-                '\n' +
-                '**Resources**\n' +
-                '- Jira filtered view: [link TBC](#)\n' +
-                '- Blog post draft: [link TBC](#)\n',
+                mtrim`**About**
+                - Version number: TBD
+                - Target-date: TBD
+
+                **Resources**
+                - Jira filtered view: [link TBD](#)
+                - Blog post draft: [link TBD](#)`,
             reminder_message_template:
-                '**Changes since last update**\n' +
-                '\n' +
-                '**Outstanding PRs**\n' +
-                '\n',
+                mtrim`### Changes since last update
+                -
+
+                ### Outstanding PRs
+                - `,
             reminder_timer_default_seconds: 24 * 60 * 60, // 24 hours
             retrospective_template:
-                'Start\n' +
-                '\n' +
-                'Stop\n' +
-                '\n' +
-                'Keep\n' +
-                '\n',
+                mtrim`### Start
+                -
+
+                ### Stop
+                -
+
+                ### Keep
+                - `,
             retrospective_reminder_interval_seconds: 0, // Once
         },
     },
@@ -129,7 +157,11 @@ export const PresetTemplates: PresetTemplate[] = [
         template: {
             ...emptyPlaybook(),
             title: 'Customer Onboarding',
-            num_stages: 4,
+            description: 'Customize this playbook to reflect your own customer onboarding process.',
+
+            description: mtrim`New Mattermost customers are onboarded following a process similar to this playbook.
+
+            Customize this playbook to reflect your own customer onboarding process.`,
             checklists: [
                 {
                     title: 'Sales to Post-Sales Handoff',
@@ -180,30 +212,33 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
-            num_actions: 2,
             create_public_playbook_run: false,
+            channel_name_template: 'Customer Onboarding: <name>',
             message_on_join_enabled: true,
             message_on_join:
-                'Hello and welcome!\n\n' +
-                'This channel was created as part of the **Customer Onboarding** playbook and is where conversations related to this customer are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.',
-            categorize_channel_enabled: true,
+                mtrim`Hello and welcome!
+
+                This channel was created as part of the **Customer Onboarding** playbook and is where conversations related to this customer are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.`,
+            run_summary_template_enabled: true,
             run_summary_template:
-                '**About**\n' +
-                '- Account name: [TBD](#)\n' +
-                '- Salesforce opportunity: [TBD](#)\n' +
-                '- Order type:\n' +
-                '- Close date:\n' +
-                '\n' +
-                '**Team**\n' +
-                '- Sales Rep: @TBD\n' +
-                '- Customer Success Manager: @TBD\n',
+                mtrim`**About**
+                - Account name: [TBD](#)
+                - Salesforce opportunity: [TBD](#)
+                - Order type:
+                - Close date:
+
+                **Team**
+                - Sales Rep: @TBD
+                - Customer Success Manager: @TBD`,
             retrospective_template:
-                'What went well?\n' +
-                '\n' +
-                'What could’ve gone better?\n' +
-                '\n' +
-                'What should be changed for next time?\n' +
-                '\n',
+                mtrim`### What went well?
+                -
+
+                ### What could have gone better?
+                -
+
+                ### What should be changed for next time?
+                - `,
             retrospective_reminder_interval_seconds: 0, // Once
         },
     },
@@ -213,7 +248,7 @@ export const PresetTemplates: PresetTemplate[] = [
         template: {
             ...emptyPlaybook(),
             title: 'Service Reliability Incident',
-            num_stages: 4,
+            description: 'Customize this playbook to reflect your own incident response process.',
             checklists: [
                 {
                     title: 'Setup for triage',
@@ -250,45 +285,46 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
-            num_actions: 3,
             create_public_playbook_run: false,
+            channel_name_template: 'Incident: <name>',
             message_on_join_enabled: true,
             message_on_join:
-                'Hello and welcome!\n\n' +
-                'This channel was created as part of the **Service Reliability Incident** playbook and is where conversations related to this release are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.',
-            categorize_channel_enabled: true,
+                mtrim`Hello and welcome!
+
+                This channel was created as part of the **Service Reliability Incident** playbook and is where conversations related to this release are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.`,
+            run_summary_template_enabled: true,
             run_summary_template:
-                '**Summary**\n' +
-                '\n' +
-                '**Customer impact**\n' +
-                '\n' +
-                '**About**\n' +
-                '- Severity: #sev-1/2/3\n' +
-                '- Responders:\n' +
-                '- ETA to resolution:\n',
+                mtrim`**Summary**
+
+                **Customer impact**
+
+                **About**
+                - Severity: #sev-1/2/3
+                - Responders:
+                - ETA to resolution:`,
             reminder_message_template: '',
             reminder_timer_default_seconds: 60 * 60, // 1 hour
             retrospective_template:
-                '### Summary\n' +
-                'This should contain 2-3 sentences that give a reader an overview of what happened, what was the cause, and what was done. The briefer the better as this is what future teams will look at first for reference.\n' +
-                '\n' +
-                '### What was the impact?\n' +
-                'This section describes the impact of this playbook run as experienced by internal and external customers as well as stakeholders.\n' +
-                '\n' +
-                '### What were the contributing factors?\n' +
-                'This playbook may be a reactive protocol to a situation that is otherwise undesirable. If that\'s the case, this section explains the reasons that caused the situation in the first place. There may be multiple root causes - this helps stakeholders understand why.\n' +
-                '\n' +
-                '### What was done?\n' +
-                'This section tells the story of how the team collaborated throughout the event to achieve the outcome. This will help future teams learn from this experience on what they could try.\n' +
-                '\n' +
-                '### What did we learn?\n' +
-                'This section should include perspective from everyone that was involved to celebrate the victories and identify areas for improvement. For example: What went well? What didn\'t go well? What should be done differently next time?\n' +
-                '\n' +
-                '### Follow-up tasks\n' +
-                'This section lists the action items to turn learnings into changes that help the team become more proficient with iterations. It could include tweaking the playbook, publishing the retrospective, or other improvements. The best follow-ups will have a clear owner assigned as well as due date.\n' +
-                '\n' +
-                '### Timeline highlights\n' +
-                'This section is a curated log that details the most important moments. It can contain key communications, screen shots, or other artifacts. Use the built-in timeline feature to help you retrace and replay the sequence of events.\n',
+                mtrim`### Summary
+                This should contain 2-3 sentences that give a reader an overview of what happened, what was the cause, and what was done. The briefer the better as this is what future teams will look at first for reference.
+
+                ### What was the impact?
+                This section describes the impact of this playbook run as experienced by internal and external customers as well as stakeholders.
+
+                ### What were the contributing factors?
+                This playbook may be a reactive protocol to a situation that is otherwise undesirable. If that's the case, this section explains the reasons that caused the situation in the first place. There may be multiple root causes - this helps stakeholders understand why.
+
+                ### What was done?
+                This section tells the story of how the team collaborated throughout the event to achieve the outcome. This will help future teams learn from this experience on what they could try.
+
+                ### What did we learn?
+                This section should include perspective from everyone that was involved to celebrate the victories and identify areas for improvement. For example: What went well? What didn't go well? What should be done differently next time?
+
+                ### Follow-up tasks
+                This section lists the action items to turn learnings into changes that help the team become more proficient with iterations. It could include tweaking the playbook, publishing the retrospective, or other improvements. The best follow-ups will have a clear owner assigned as well as due date.
+
+                ### Timeline highlights
+                This section is a curated log that details the most important moments. It can contain key communications, screen shots, or other artifacts. Use the built-in timeline feature to help you retrace and replay the sequence of events.`,
             retrospective_reminder_interval_seconds: 24 * 60 * 60, // 24 hours
             signal_any_keywords_enabled: true,
             signal_any_keywords: ['sev-1', 'sev-2', '#incident', 'this is serious'],
@@ -305,7 +341,7 @@ export const PresetTemplates: PresetTemplate[] = [
         template: {
             ...emptyPlaybook(),
             title: 'Feature Lifecycle',
-            num_stages: 5,
+            description: 'Customize this playbook to reflect your own feature lifecycle process.',
             checklists: [
                 {
                     title: 'Plan',
@@ -321,18 +357,18 @@ export const PresetTemplates: PresetTemplate[] = [
                     items: [
                         newChecklistItem(
                             'Choose an engineering owner for the feature',
-                            'Expectations for the owner:\n' +
-                            '- Responsible for setting and meeting expectation for target dates\n' +
-                            '- Post weekly status update\n' +
-                            '- Demo feature at R&D meeting\n' +
-                            '- Ensure technical quality after release\n',
+                            mtrim`Expectations for the owner:
+                            - Responsible for setting and meeting expectation for target dates' +
+                            - Post weekly status update' +
+                            - Demo feature at R&D meeting' +
+                            - Ensure technical quality after release`,
                         ),
                         newChecklistItem('Identify and invite contributors to the feature channel'),
                         newChecklistItem(
                             'Schedule kickoff and recurring check-in meetings',
-                            'Expectations leaving the kickoff meeting:\n' +
-                            '- Alignment on the precise problem in addition to rough scope and target\n' +
-                            '- Clear next steps and deliverables for each individual\n',
+                            mtrim`Expectations leaving the kickoff meeting:
+                            - Alignment on the precise problem in addition to rough scope and target
+                            - Clear next steps and deliverables for each individual`,
                         ),
                     ],
                 },
@@ -353,18 +389,18 @@ export const PresetTemplates: PresetTemplate[] = [
                         newChecklistItem('Merge all feature and bug PRs to master'),
                         newChecklistItem(
                             'Demo to the community',
-                            'For example:\n' +
-                            '- R&D meeting\n' +
-                            '- Developer meeting\n' +
-                            '- Company wide meeting\n',
+                            mtrim`For example:
+                            - R&D meeting
+                            - Developer meeting
+                            - Company wide meeting`
                         ),
                         newChecklistItem('Build telemetry dashboard to measure adoption'),
                         newChecklistItem(
                             'Create launch kit for go-to-market teams',
-                            'Including but not exclusive to:\n' +
-                            '- release blog post\n' +
-                            '- one-pager\n' +
-                            '- demo video\n',
+                            mtrim`Including but not exclusive to:
+                            - release blog post
+                            - one-pager
+                            - demo video`,
                         ),
                     ],
                 },
@@ -376,49 +412,308 @@ export const PresetTemplates: PresetTemplate[] = [
                     ],
                 },
             ],
-            num_actions: 2,
             create_public_playbook_run: true,
+            channel_name_template: 'Feature: <name>',
             message_on_join_enabled: true,
             message_on_join:
-                'Hello and welcome!\n\n' +
-                'This channel was created as part of the **Feature Lifecycle** playbook and is where conversations related to developing this feature are held. You can customize this message using Markdown so that every new channel member can be welcomed with helpful context and resources.',
-            categorize_channel_enabled: true,
+                mtrim`Hello and welcome!
+
+                This channel was created as part of the **Feature Lifecycle** playbook and is where conversations related to developing this feature are held. You can customize this message using Markdown so that every new channel member can be welcomed with helpful context and resources.`,
+            run_summary_template_enabled: true,
             run_summary_template:
-                '**One-liner**\n' +
-                '<ie. Enable users to prescribe a description template so it\'s consistent for every run and therefore easier to read.>\n' +
-                '\n' +
-                '**Targets release**\n' +
-                '- Code complete: date\n' +
-                '- Customer release: month\n' +
-                '\n' +
-                '**Resources**\n' +
-                '- Jira Epic: <link>\n' +
-                '- UX prototype: <link>\n' +
-                '- Technical design: <link>\n' +
-                '- User docs: <link>\n',
+                mtrim`**One-liner**
+                <ie. Enable users to prescribe a description template so it\'s consistent for every run and therefore easier to read.>
+
+                **Targets release**
+                - Code complete: date
+                - Customer release: month
+
+                **Resources**
+                - Jira Epic: <link>
+                - UX prototype: <link>
+                - Technical design: <link>
+                - User docs: <link>`,
             reminder_message_template:
-                '**Demo**\n' +
-                '<Insert_GIF_here>\n' +
-                '\n' +
-                '**Changes since last week**\n' +
-                '- \n' +
-                '- \n' +
-                '\n' +
-                '**Risks**\n' +
-                '- \n' +
-                '- \n',
+                mtrim`### Demo
+                <Insert_GIF_here>
+
+                ### Changes since last week
+                -
+
+                ### Risks
+                - `,
             reminder_timer_default_seconds: 24 * 60 * 60, // 1 day
             retrospective_template:
-                'Start\n' +
-                '\n' +
-                'Stop\n' +
-                '\n' +
-                'Keep\n' +
-                '\n',
+                mtrim`### Start
+                -
+
+                ### Stop
+                -
+
+                ### Keep
+                - `,
             retrospective_reminder_interval_seconds: 0, // Once
         },
     },
-];
+    {
+        title: 'Employee Onboarding',
+        icon: (
+            <Icon
+                path={mdiHandshakeOutline}
+                size={2.5}
+            />
+        ),
+        template: {
+            ...emptyPlaybook(),
+            title: 'Employee Onboarding',
+            description: mtrim`Every new Mattermost Staff member completes this onboarding process when joining the company.
+
+            Customize this playbook to reflect your own employee onboarding process.`,
+            checklists: [
+                {
+                    title: 'Pre-day one',
+                    items: [
+                        newChecklistItem('Complete the [Onboarding Systems Form in the IT HelpDesk](https://helpdesk.mattermost.com/support/home)'),
+                        newChecklistItem(
+                            'Complete the onboarding template prior to your new staff member\'s start date',
+                            mtrim`Managers play a large role in setting their new direct report up for success and making them feel welcome by setting clear expectations and preparing the team and internal stakeholders for how they can help new colleagues integrate and connect organizationally and culturally.
+                                * **Onboarding Objectives:** Clarify the areas and projects your new team member should focus on in their first 90 days. Use the _Overview of the Role_ that you completed when you opened the role.
+                                * **AOR clarity:** Identify AORs that are relevant for your new hire, and indicate any AORs that your new hire will [DRI](https://handbook.mattermost.com/company/about-mattermost/list-of-terms#dri) or act as backup DRI. As needed, clarify AOR transitions with internal stakholders ahead of your new hire's start date. See [AOR page](https://handbook.mattermost.com/operations/operations/areas-of-responsibility) Include the interview panel and their respective focus areas.
+                                * **Assign an Onboarding Peer:** The Onboarding Peer or peers should be an individual or group of people that can help answer questions about the team, department and Mattermost. In many ways, an Onboarding Peer may be an [end-boss](https://handbook.mattermost.com/company/about-mattermost/mindsets#mini-boss-end-boss) for specific AORs. Managers should ask permission of a potential Onboarding Peer prior to assignment.`,
+                        ),
+                    ],
+                },
+                {
+                    title: 'Week one',
+                    items: [
+                        newChecklistItem(
+                            'Introduce our new staff member in the [Welcome Channel](https://community.mattermost.com/private-core/channels/welcome)',
+                            mtrim`All new hires are asked to complete a short bio and share with their Managers. Managers should include this bio in the welcome message.
+
+                                Be sure to include the hashtag \#newcolleague when posting your message.`,
+                        ),
+                        newChecklistItem(
+                            'Review Team [AORs](https://handbook.mattermost.com/operations/operations/areas-of-responsibility)',
+                            'This is also a good time to review the new hire\'s AOR and onboarding expectations.'
+                        ),
+                        newChecklistItem(
+                            'Review list of key internal partners',
+                            'Theser are individuals the new staff member will work with and who the new staff member should set up meetings with during their first month or two.',
+                        ),
+                        newChecklistItem(
+                            'Add to Mattermost channels',
+                            'Ensure your team member is added to appropriate channels based on team and role.',
+                        ),
+                        newChecklistItem(
+                            'Share team cadences',
+                            'Review specific team cadences, operating norms and relevant playbooks.',
+                        ),
+                    ],
+                },
+                {
+                    title: 'Month one',
+                    items: [
+                        newChecklistItem('Review Company and Team [V2MOMs](https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-v2mom)'),
+                        newChecklistItem('Align on role responsibilities and expectations'),
+                        newChecklistItem(
+                            'COM Introduction',
+                            'New team members are invited to introduce themselves at [COM](https://handbook.mattermost.com/operations/operations/company-cadence#customer-obsession-meeting-aka-com) during their second week. If they\'re not comfortable doing their own introduction, Managers will do so on their behalf.',
+                        ),
+                        newChecklistItem(
+                            '[Shoulder Check](https://handbook.mattermost.com/company/about-mattermost/mindsets#shoulder-check)',
+                            'Assess potential blindspots and ask for feedback.',
+                        ),
+                    ],
+                },
+                {
+                    title: 'Month two',
+                    items: [
+                        newChecklistItem(
+                            '90-day New Colleague Feedback',
+                            'Managers are notified to kick off the [New Colleague Review Process](https://handbook.mattermost.com/contributors/onboarding#new-colleague-90-day-feedback-process) on their new staff member\'s 65th day. The feedback will include a summary of the new staff member\'s responsibilities during the first 90 days. Managers should communicate these responsibilities to the new staff member during their first week.',
+                        ),
+                    ],
+                },
+                {
+                    title: 'Month three',
+                    items: [
+                        newChecklistItem('Deliver New Colleague Feedback'),
+                    ],
+                },
+            ],
+            create_public_playbook_run: false,
+            channel_name_template: 'Employee Onboarding: <name>',
+            message_on_join_enabled: true,
+            message_on_join:
+                mtrim`Hello and welcome!
+
+                This channel was created as part of the **Employee Onboarding** playbook and is where conversations related to onboarding this employee are held. You can customize this message using markdown so that every new channel member can be welcomed with helpful context and resources.`,
+            run_summary_template: '',
+            reminder_timer_default_seconds: 7 * 24 * 60 * 60, // once a week
+            retrospective_template:
+                mtrim`### What went well?
+                -
+
+                ### What could have gone better?
+                -
+
+                ### What should be changed for next time?
+                - `,
+            retrospective_reminder_interval_seconds: 0, // Once
+        },
+    },
+    {
+        title: 'Bug Bash',
+        icon: (
+            <Icon
+                path={mdiHandshakeOutline}
+                size={2.5}
+            />
+        ),
+        template: {
+            ...emptyPlaybook(),
+            title: 'Playbooks: Bug Bash',
+            description: mtrim`About once or twice a month, the Mattermost Playbooks team uses this playbook to run a 50 minute bug-bash testing the latest version of Playbooks.
+
+            Customize this playbook to reflect your own bug bash process.`,
+            create_public_playbook_run: true,
+            channel_name_template: 'Bug Bash (vX.Y)',
+            checklists: [
+                {
+                    title: 'Setup Testing Environment (Before Meeting)',
+                    items: [
+                        {
+                            title: 'Deploy the build in question to community-daily',
+                        },
+                        {
+                            title: 'Spin up a cloud instance running T0',
+                            command: '/cloud create playbooks-bug-bash-t0 --license te --image mattermost/mattermost-team-edition --test-data --version master',
+                        },
+                        {
+                            title: 'Spin up a cloud instance running E0',
+                            command: '/cloud create playbooks-bug-bash-e0 --license te --test-data --version master',
+                        },
+                        {
+                            title: 'Spin up a cloud instance running E10',
+                            command: '/cloud create playbooks-bug-bash-e10 --license e10 --test-data --version master',
+                        },
+                        {
+                            title: 'Spin up a cloud instance running E20',
+                            command: '/cloud create playbooks-bug-bash-e20 --license e20 --test-data --version master',
+                        },
+                        {
+                            title: 'Enable Open Servers & CRT for all Cloud Instances',
+                            description: mtrim`From a command line, login to each server in turn via [\`mmctl\`](https://github.com/mattermost/mmctl), and configure, e.g.:
+                                \`\`\`
+                                for server in playbooks-bug-bash-t0 playbooks-bug-bash-e0 playbooks-bug-bash-e10 playbooks-bug-bash-e20; do
+                                    mmctl auth login https://$server.test.mattermost.cloud --name $server --username sysadmin --password-file <(echo "Sys@dmin123");
+                                    mmctl config set TeamSettings.EnableOpenServer true;
+                                    mmctl config set ServiceSettings.CollapsedThreads default_on;
+                                done
+                                \`\`\``,
+                        },
+                        {
+                            title: 'Install the plugin to each instance',
+                            description: mtrim`From a command line, login to each server in turn via [\`mmctl\`](https://github.com/mattermost/mmctl), and configure, e.g.:
+                                \`\`\`
+                                for server in playbooks-bug-bash-t0 playbooks-bug-bash-e0 playbooks-bug-bash-e10 playbooks-bug-bash-e20; do
+                                    mmctl auth login https://$server.test.mattermost.cloud --name $server --username sysadmin --password-file <(echo "Sys@dmin123");
+                                    mmctl plugin install-url --force https://github.com/mattermost/mattermost-plugin-playbooks/releases/download/v1.22.0%2Balpha.3/playbooks-1.22.0+alpha.3.tar.gz
+                                done
+                                \`\`\``,
+                        },
+                        {
+                            title: 'Announce Bug Bash',
+                            description: 'Make sure the team and community is aware of the upcoming bug bash.',
+                        },
+                    ],
+                },
+                {
+                    title: 'Define Scope (10 Minutes)',
+                    items: [
+                        {
+                            title: 'Review GitHub commit diff',
+                        },
+                        {
+                            title: 'Identify new features to add to target testing areas checklist',
+                        },
+                        {
+                            title: 'Identify existing functionality to add to target testing areas checklist',
+                        },
+                        {
+                            title: 'Add relvant T0/E0/E10/E20 permutations',
+                        },
+                        {
+                            title: 'Assign owners',
+                        },
+                    ],
+                },
+                {
+                    title: 'Target Testing Areas (30 Minutes)',
+                },
+                {
+                    title: 'Triage (10 Minutes)',
+                    items: [
+                        {
+                            title: 'Review issues to identify what to fix for the upcoming release',
+                        },
+                        {
+                            title: 'Assign owners for all required bug fixes',
+                        },
+                    ],
+                },
+                {
+                    title: 'Clean Up',
+                    items: [
+                        {
+                            title: 'Clean up cloud instance running T0',
+                            command: '/cloud delete playbooks-bug-bash-t0',
+                        },
+                        {
+                            title: 'Clean up cloud instance running E0',
+                            command: '/cloud delete playbooks-bug-bash-e0',
+                        },
+                        {
+                            title: 'Clean up cloud instance running E10',
+                            command: '/cloud delete playbooks-bug-bash-e10',
+                        },
+                        {
+                            title: 'Clean up cloud instance running E20',
+                            command: '/cloud delete playbooks-bug-bash-e20',
+                        },
+                    ],
+                },
+            ],
+            status_update_enabled: true,
+            message_on_join: mtrim`Welcome! We're using this channel to run a 50 minute bug-bash the new version of Playbooks. The first 10 minutes will be spent identifying scope and ownership, followed by 30 minutes of targeted testing in the defined areas, and 10 minutes of triage.
+
+            When you find an issue, post a new thread in this channel tagged #bug and share any screenshots and reproduction steps. The owner of this bash will triage the messages into tickets as needed.`,
+            message_on_join_enabled: true,
+            retrospective_enabled: false,
+            run_summary_template_enabled: true,
+            run_summary_template: mtrim`The playbooks team is executing a bug bash to qualify the next shipping version.
+
+            As we encounter issues, simply start a new thread and tag with #bug (or #feature) to make tracking these easier.
+
+            **Release Link**: TBD
+            **Zoom**: TBD
+            **Triage Filter**: https://mattermost.atlassian.net/secure/RapidBoard.jspa?rapidView=68&projectKey=MM&view=planning.nodetail&quickFilter=332&issueLimit=100
+
+            | Servers |
+            | -- |
+            | [T0](https://playbooks-bug-bash-t0.test.mattermost.cloud) |
+            | [E0](https://playbooks-bug-bash-e0.test.mattermost.cloud) |
+            | [E10](https://playbooks-bug-bash-e10.test.mattermost.cloud) |
+            | [E20](https://playbooks-bug-bash-e20.test.mattermost.cloud) |
+
+            Login with:
+
+            | Username | Password |
+            | -- | -- |
+            | sysadmin | Sys@dmin123 |`,
+        },
+    },
+]);
 
 const presetTemplateOptions = PresetTemplates.map((template: PresetTemplate) => ({label: template.title, value: template.title}));
 

--- a/webapp/src/components/backstage/template_selector.tsx
+++ b/webapp/src/components/backstage/template_selector.tsx
@@ -157,8 +157,6 @@ export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
         template: {
             ...emptyPlaybook(),
             title: 'Customer Onboarding',
-            description: 'Customize this playbook to reflect your own customer onboarding process.',
-
             description: mtrim`New Mattermost customers are onboarded following a process similar to this playbook.
 
             Customize this playbook to reflect your own customer onboarding process.`,
@@ -582,28 +580,32 @@ export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
                 {
                     title: 'Setup Testing Environment (Before Meeting)',
                     items: [
-                        {
-                            title: 'Deploy the build in question to community-daily',
-                        },
-                        {
-                            title: 'Spin up a cloud instance running T0',
-                            command: '/cloud create playbooks-bug-bash-t0 --license te --image mattermost/mattermost-team-edition --test-data --version master',
-                        },
-                        {
-                            title: 'Spin up a cloud instance running E0',
-                            command: '/cloud create playbooks-bug-bash-e0 --license te --test-data --version master',
-                        },
-                        {
-                            title: 'Spin up a cloud instance running E10',
-                            command: '/cloud create playbooks-bug-bash-e10 --license e10 --test-data --version master',
-                        },
-                        {
-                            title: 'Spin up a cloud instance running E20',
-                            command: '/cloud create playbooks-bug-bash-e20 --license e20 --test-data --version master',
-                        },
-                        {
-                            title: 'Enable Open Servers & CRT for all Cloud Instances',
-                            description: mtrim`From a command line, login to each server in turn via [\`mmctl\`](https://github.com/mattermost/mmctl), and configure, e.g.:
+                        newChecklistItem(
+                            'Deploy the build in question to community-daily',
+                        ),
+                        newChecklistItem(
+                            'Spin up a cloud instance running T0',
+                            '',
+                            '/cloud create playbooks-bug-bash-t0 --license te --image mattermost/mattermost-team-edition --test-data --version master',
+                        ),
+                        newChecklistItem(
+                            'Spin up a cloud instance running E0',
+                            '',
+                            '/cloud create playbooks-bug-bash-e0 --license te --test-data --version master',
+                        ),
+                        newChecklistItem(
+                            'Spin up a cloud instance running E10',
+                            '',
+                            '/cloud create playbooks-bug-bash-e10 --license e10 --test-data --version master',
+                        ),
+                        newChecklistItem(
+                            'Spin up a cloud instance running E20',
+                            '',
+                            '/cloud create playbooks-bug-bash-e20 --license e20 --test-data --version master',
+                        ),
+                        newChecklistItem(
+                            'Enable Open Servers & CRT for all Cloud Instances',
+                            mtrim`From a command line, login to each server in turn via [\`mmctl\`](https://github.com/mattermost/mmctl), and configure, e.g.:
                                 \`\`\`
                                 for server in playbooks-bug-bash-t0 playbooks-bug-bash-e0 playbooks-bug-bash-e10 playbooks-bug-bash-e20; do
                                     mmctl auth login https://$server.test.mattermost.cloud --name $server --username sysadmin --password-file <(echo "Sys@dmin123");
@@ -611,76 +613,81 @@ export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
                                     mmctl config set ServiceSettings.CollapsedThreads default_on;
                                 done
                                 \`\`\``,
-                        },
-                        {
-                            title: 'Install the plugin to each instance',
-                            description: mtrim`From a command line, login to each server in turn via [\`mmctl\`](https://github.com/mattermost/mmctl), and configure, e.g.:
+                        ),
+                        newChecklistItem(
+                            'Install the plugin to each instance',
+                            mtrim`From a command line, login to each server in turn via [\`mmctl\`](https://github.com/mattermost/mmctl), and configure, e.g.:
                                 \`\`\`
                                 for server in playbooks-bug-bash-t0 playbooks-bug-bash-e0 playbooks-bug-bash-e10 playbooks-bug-bash-e20; do
                                     mmctl auth login https://$server.test.mattermost.cloud --name $server --username sysadmin --password-file <(echo "Sys@dmin123");
                                     mmctl plugin install-url --force https://github.com/mattermost/mattermost-plugin-playbooks/releases/download/v1.22.0%2Balpha.3/playbooks-1.22.0+alpha.3.tar.gz
                                 done
                                 \`\`\``,
-                        },
-                        {
-                            title: 'Announce Bug Bash',
-                            description: 'Make sure the team and community is aware of the upcoming bug bash.',
-                        },
+                        ),
+                        newChecklistItem(
+                            'Announce Bug Bash',
+                            'Make sure the team and community is aware of the upcoming bug bash.',
+                        ),
                     ],
                 },
                 {
                     title: 'Define Scope (10 Minutes)',
                     items: [
-                        {
-                            title: 'Review GitHub commit diff',
-                        },
-                        {
-                            title: 'Identify new features to add to target testing areas checklist',
-                        },
-                        {
-                            title: 'Identify existing functionality to add to target testing areas checklist',
-                        },
-                        {
-                            title: 'Add relvant T0/E0/E10/E20 permutations',
-                        },
-                        {
-                            title: 'Assign owners',
-                        },
+                        newChecklistItem(
+                            'Review GitHub commit diff',
+                        ),
+                        newChecklistItem(
+                            'Identify new features to add to target testing areas checklist',
+                        ),
+                        newChecklistItem(
+                            'Identify existing functionality to add to target testing areas checklist',
+                        ),
+                        newChecklistItem(
+                            'Add relvant T0/E0/E10/E20 permutations',
+                        ),
+                        newChecklistItem(
+                            'Assign owners',
+                        ),
                     ],
                 },
                 {
                     title: 'Target Testing Areas (30 Minutes)',
+                    items: [],
                 },
                 {
                     title: 'Triage (10 Minutes)',
                     items: [
-                        {
-                            title: 'Review issues to identify what to fix for the upcoming release',
-                        },
-                        {
-                            title: 'Assign owners for all required bug fixes',
-                        },
+                        newChecklistItem(
+                            'Review issues to identify what to fix for the upcoming release',
+                        ),
+                        newChecklistItem(
+                            'Assign owners for all required bug fixes',
+                        ),
                     ],
                 },
                 {
                     title: 'Clean Up',
                     items: [
-                        {
-                            title: 'Clean up cloud instance running T0',
-                            command: '/cloud delete playbooks-bug-bash-t0',
-                        },
-                        {
-                            title: 'Clean up cloud instance running E0',
-                            command: '/cloud delete playbooks-bug-bash-e0',
-                        },
-                        {
-                            title: 'Clean up cloud instance running E10',
-                            command: '/cloud delete playbooks-bug-bash-e10',
-                        },
-                        {
-                            title: 'Clean up cloud instance running E20',
-                            command: '/cloud delete playbooks-bug-bash-e20',
-                        },
+                        newChecklistItem(
+                            'Clean up cloud instance running T0',
+                            '',
+                            '/cloud delete playbooks-bug-bash-t0',
+                        ),
+                        newChecklistItem(
+                            'Clean up cloud instance running E0',
+                            '',
+                            '/cloud delete playbooks-bug-bash-e0',
+                        ),
+                        newChecklistItem(
+                            'Clean up cloud instance running E10',
+                            '',
+                            '/cloud delete playbooks-bug-bash-e10',
+                        ),
+                        newChecklistItem(
+                            'Clean up cloud instance running E20',
+                            '',
+                            '/cloud delete playbooks-bug-bash-e20',
+                        ),
                     ],
                 },
             ],

--- a/webapp/src/components/backstage/template_selector.tsx
+++ b/webapp/src/components/backstage/template_selector.tsx
@@ -33,7 +33,7 @@ const preprocessTemplates = (presetTemplates: PresetTemplate[]): PresetTemplate[
             ...pt.template,
             num_stages: pt.template?.checklists.length,
             num_actions:
-				1 + // Channel creation is hard-coded
+                1 + // Channel creation is hard-coded
                 (pt.template.message_on_join_enabled ? 1 : 0) +
                 (pt.template.signal_any_keywords_enabled ? 1 : 0) +
                 (pt.template.run_summary_template_enabled ? 1 : 0),
@@ -476,7 +476,7 @@ export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
                             'Complete the onboarding template prior to your new staff member\'s start date',
                             mtrim`Managers play a large role in setting their new direct report up for success and making them feel welcome by setting clear expectations and preparing the team and internal stakeholders for how they can help new colleagues integrate and connect organizationally and culturally.
                                 * **Onboarding Objectives:** Clarify the areas and projects your new team member should focus on in their first 90 days. Use the _Overview of the Role_ that you completed when you opened the role.
-                                * **AOR clarity:** Identify AORs that are relevant for your new hire, and indicate any AORs that your new hire will [DRI](https://handbook.mattermost.com/company/about-mattermost/list-of-terms#dri) or act as backup DRI. As needed, clarify AOR transitions with internal stakholders ahead of your new hire's start date. See [AOR page](https://handbook.mattermost.com/operations/operations/areas-of-responsibility) Include the interview panel and their respective focus areas.
+                                * **AOR clarity:** Identify AORs that are relevant for your new hire, and indicate any AORs that your new hire will [DRI](https://handbook.mattermost.com/company/about-mattermost/list-of-terms#dri) or act as backup DRI. As needed, clarify AOR transitions with internal stakeholders ahead of your new hire's start date. See [AOR page](https://handbook.mattermost.com/operations/operations/areas-of-responsibility) Include the interview panel and their respective focus areas.
                                 * **Assign an Onboarding Peer:** The Onboarding Peer or peers should be an individual or group of people that can help answer questions about the team, department and Mattermost. In many ways, an Onboarding Peer may be an [end-boss](https://handbook.mattermost.com/company/about-mattermost/mindsets#mini-boss-end-boss) for specific AORs. Managers should ask permission of a potential Onboarding Peer prior to assignment.`,
                         ),
                     ],
@@ -496,7 +496,7 @@ export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
                         ),
                         newChecklistItem(
                             'Review list of key internal partners',
-                            'Theser are individuals the new staff member will work with and who the new staff member should set up meetings with during their first month or two.',
+                            'These are individuals the new staff member will work with and who the new staff member should set up meetings with during their first month or two.',
                         ),
                         newChecklistItem(
                             'Add to Mattermost channels',
@@ -643,7 +643,7 @@ export const PresetTemplates: PresetTemplate[] = preprocessTemplates([
                             'Identify existing functionality to add to target testing areas checklist',
                         ),
                         newChecklistItem(
-                            'Add relvant T0/E0/E10/E20 permutations',
+                            'Add relevant T0/E0/E10/E20 permutations',
                         ),
                         newChecklistItem(
                             'Assign owners',

--- a/webapp/src/types/js-trim-multiline-string.d.ts
+++ b/webapp/src/types/js-trim-multiline-string.d.ts
@@ -1,0 +1,1 @@
+declare module 'js-trim-multiline-string';

--- a/webapp/src/types/playbook.ts
+++ b/webapp/src/types/playbook.ts
@@ -141,7 +141,7 @@ export function emptyPlaybook(): DraftPlaybookWithChecklist {
         signal_any_keywords_enabled: false,
         category_name: '',
         categorize_channel_enabled: false,
-        run_summary_template_enabled: true,
+        run_summary_template_enabled: false,
         run_summary_template: '',
         channel_name_template: '',
         default_playbook_member_role: '',


### PR DESCRIPTION
#### Summary
Introduce an `Employee Onboarding` playbook based on https://handbook.mattermost.com/operations/workplace/people/working-at-mattermost/onboarding/manager-onboarding-1#onboarding, and a bug bash playbook based on our own [Playbooks: Bug Bash](https://community.mattermost.com/playbooks/playbooks/zp1xp684zig5pg9np4ccixudoh) playbook:

<img width="1200" alt="CleanShot 2022-01-25 at 17 21 14@2x" src="https://user-images.githubusercontent.com/1023171/151061803-91275945-a75c-496d-b7fe-be43428b6823.png">

<img width="847" alt="CleanShot 2022-01-25 at 17 21 46@2x" src="https://user-images.githubusercontent.com/1023171/151061836-7d6b6642-c6b8-4013-98f5-c0afc49dcbd3.png">

<img width="858" alt="CleanShot 2022-01-25 at 17 22 06@2x" src="https://user-images.githubusercontent.com/1023171/151061875-c6fbb14e-9e69-4ac8-bf76-ed018087c992.png">

As per @calebroseland, introduce [`mtrim`](https://github.com/md-vanilla/js-trim-multiline-string) for easier handling of multi-line, indented strings.

Tidy up some of the existing templates, adding descriptions and unifying styling.

Note that I'm deferring the use of "new" icons in the template selector until the pending rework of this widget.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-41090

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
