### PR TITLE
MM-40153: Fix wrapping in run overview

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates.tsx
@@ -85,9 +85,6 @@ const PostContent = (props: PostContentProps) => {
         <StyledContent>
             <PostCard
                 post={post}
-                channelId={props.channelId}
-                playbookRunId={props.playbookRunId}
-                playbookId={props.playbookId}
                 team={props.team}
             />
         </StyledContent>

--- a/webapp/src/components/backstage/playbook_runs/shared.tsx
+++ b/webapp/src/components/backstage/playbook_runs/shared.tsx
@@ -15,6 +15,7 @@ export const Container = styled.div`
 
 export const Left = styled.div`
     flex: 2;
+    min-width: 0;
 `;
 
 export const Right = styled.div`

--- a/webapp/src/components/rhs/post_card.tsx
+++ b/webapp/src/components/rhs/post_card.tsx
@@ -30,6 +30,7 @@ const UpdateSection = styled.div`
 
 const UpdateContainer = styled.div`
     display: inline;
+    min-width: 0;
 `;
 
 const ProfilePic = styled.img`

--- a/webapp/src/components/rhs/post_card.tsx
+++ b/webapp/src/components/rhs/post_card.tsx
@@ -19,15 +19,9 @@ import {Client4} from 'mattermost-redux/client';
 import {browserHistory, Timestamp} from 'src/webapp_globals';
 
 import {isMobile} from 'src/mobile';
-import {ChannelNamesMap} from 'src/types/backstage';
 import {toggleRHS} from 'src/actions';
-import ShowMore from 'src/components/rhs/show_more';
 import PostText from 'src/components/post_text';
 import {useEnsureProfiles} from 'src/hooks';
-
-const NoRecentUpdates = styled.div`
-    color: rgba(var(--center-channel-color-rgb), 0.64);
-`;
 
 const UpdateSection = styled.div`
     display: flex;
@@ -87,9 +81,6 @@ function useAuthorInfo(userID: string) : [string, string] {
 interface Props {
     post: Post;
     team: Team;
-    playbookRunId: string;
-    playbookId: string
-    channelId: string;
 }
 
 const REL_UNITS = [


### PR DESCRIPTION
#### Summary
Flex children use `min-width: auto` by default, so setting `min-width: 0` avoids that they expand the width of their parents.

I also deleted some unused code I found.

Before:
![before](https://user-images.githubusercontent.com/3924815/151169006-33a39be9-f304-475f-9812-555a2912eeab.png)

And after:
![after](https://user-images.githubusercontent.com/3924815/151168995-981a7b9d-dfdc-46a0-a4af-8cab350185d9.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40153

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
