### PR TITLE
[MM-37705] Remove h1-h6 styling

### DIFF
--- a/webapp/src/components/rhs/rhs_shared.tsx
+++ b/webapp/src/components/rhs/rhs_shared.tsx
@@ -129,10 +129,5 @@ export const SmallerProfile = styled(Profile)`
 
 export const UpdateBody = styled.div`
     padding-right: 6px;
-
-    h1,h2,h3,h4,h5,h6 {
-        font-size: inherit;
-        font-weight: 600;
-    }
 `;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR removes h1-h6 styling from the `PostText` component

Before:
<img width="775" alt="Screen Shot 2022-01-31 at 15 44 26" src="https://user-images.githubusercontent.com/2340127/151788762-98419bf7-2590-40cd-880e-056bd6ed8d01.png">


After:
<img width="733" alt="Screen Shot 2022-01-31 at 15 45 28" src="https://user-images.githubusercontent.com/2340127/151788789-107febff-0319-4ee0-9233-7ca9d587a103.png">


#### Ticket Link

  Fixes: https://mattermost.atlassian.net/browse/MM-37705

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
