### PR TITLE
MM-41515 - Fix for: Cannot paginate playbooks

### DIFF
--- a/webapp/src/components/assets/right_dots.tsx
+++ b/webapp/src/components/assets/right_dots.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import React, {FC} from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 const Icon = styled.svg`
     position: absolute;
-    right: 0;
+    right: 8px;
     bottom: 0;
     max-height: 70%;
     height: auto;

--- a/webapp/src/components/assets/right_fade.tsx
+++ b/webapp/src/components/assets/right_fade.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const RightFade = styled.div`
     position: absolute;
     top: 85px;
-    right: 0;
+    right: 8px;
     height: 100%;
     width: 188px;
     z-index: -1;

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -37,7 +37,7 @@ const BackstageContainer = styled.div`
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-    height: 100%;
+    height: calc(100% - 40px);
 `;
 
 const BackstageTitlebarItem = styled(NavLink)`

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -8,10 +8,10 @@ import React, {useRef, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
-import styled, {css} from 'styled-components';
+import styled from 'styled-components';
 
 import {displayPlaybookCreateModal} from 'src/actions';
-import {GrayTertiaryButton, PrimaryButton, TertiaryButton, UpgradeButtonProps} from 'src/components/assets/buttons';
+import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 import LeftDots from 'src/components/assets/left_dots';
 import LeftFade from 'src/components/assets/left_fade';
 import NoContentPlaybookSvg from 'src/components/assets/no_content_playbooks_svg';
@@ -22,13 +22,10 @@ import PlaybookListRow from 'src/components/backstage/playbook_list_row';
 import {ExpandRight, HorizontalSpacer} from 'src/components/backstage/playbook_runs/shared';
 import SearchInput from 'src/components/backstage/search_input';
 import {BackstageSubheader} from 'src/components/backstage/styles';
-import TemplateSelector, {
-    isPlaybookCreationAllowed,
-} from 'src/components/backstage/template_selector';
-import UpgradeModal from 'src/components/backstage/upgrade_modal';
+import TemplateSelector from 'src/components/backstage/template_selector';
 import {PaginationRow} from 'src/components/pagination_row';
 import {SortableColHeader} from 'src/components/sortable_col_header';
-import {AdminNotificationType, BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
+import {BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
 import {
     useCanCreatePlaybooksOnAnyTeam,
     usePlaybooksCrud,


### PR DESCRIPTION
#### Summary
- There was a change made in https://github.com/mattermost/mattermost-webapp/pull/9639 where the height was changed from `height: calc(100% - 40px)` to `height: 100%`, which I don't totally understand. Boards made a fix in https://github.com/mattermost/focalboard/pull/2217 to change it back, and we're doing similar here. I'm not totally pleased with this solution, but I don't understand why the original change was made in webapp (waiting on an explanation) so I don't want to mess with webapp. And we're broken now, so this fixes our current problem. Hopefully in the future we can change it back.
- While working on this I also fixed the scrollbar problem I've been seeing for awhile:

Previous:
![image](https://user-images.githubusercontent.com/1490756/152389574-50f7fbcc-8175-4b3d-b5bb-d7f963a3e1d1.png)

Fixed:
![image](https://user-images.githubusercontent.com/1490756/152389425-4402d937-70af-4b6d-a10a-65a1d57f66bf.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-41515

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
