### PR TITLE
MM-41615 - Fix for backstage height needs to be reverted

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -37,7 +37,7 @@ const BackstageContainer = styled.div`
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-    height: calc(100% - 40px);
+    height: 100%;
 `;
 
 const BackstageTitlebarItem = styled(NavLink)`


### PR DESCRIPTION
#### Summary
- The original webapp PR https://github.com/mattermost/mattermost-webapp/pull/9639 is reverted https://github.com/mattermost/mattermost-webapp/pull/9755 -- if that gets into 6.4.0 (it should) then we won't need #1020 .  This is the revert for #1020 .

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-41615

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
