### PR TITLE
MM-41684 - Support null targets and values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
+	golang.org/x/tools v0.1.9 // indirect
 	gopkg.in/guregu/null.v4 v4.0.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
-	golang.org/x/tools v0.1.9 // indirect
-	gopkg.in/guregu/null.v4 v4.0.0 // indirect
+	gopkg.in/guregu/null.v4 v4.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
+	gopkg.in/guregu/null.v4 v4.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1476,7 +1476,6 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.4 h1:zNWRjYUW32G9KirMXYHQHVNFkXvMI7LpgNW2AgYAoIs=
 github.com/yuin/goldmark v1.4.4/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
@@ -1607,7 +1606,6 @@ golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1678,7 +1676,6 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211013171255-e13a2654a71e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 h1:0qxwC5n+ttVOINCBeRHO0nq9X7uy8SDsPoi5OaCdIEI=
@@ -1832,7 +1829,6 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210818153620-00dd8d7831e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1931,8 +1927,6 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
-golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -2118,6 +2118,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/guregu/null.v4 v4.0.0 h1:1Wm3S1WEA2I26Kq+6vcW+w0gcDo44YKYD7YIEJNHDjg=
+gopkg.in/guregu/null.v4 v4.0.0/go.mod h1:YoQhUrADuG3i9WqesrCmpNRwm1ypAgSHYqoOcTu/JrI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.1/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/go.sum
+++ b/go.sum
@@ -1476,6 +1476,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.4 h1:zNWRjYUW32G9KirMXYHQHVNFkXvMI7LpgNW2AgYAoIs=
 github.com/yuin/goldmark v1.4.4/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
@@ -1606,6 +1607,7 @@ golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1676,6 +1678,7 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211013171255-e13a2654a71e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 h1:0qxwC5n+ttVOINCBeRHO0nq9X7uy8SDsPoi5OaCdIEI=
@@ -1829,6 +1832,7 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210818153620-00dd8d7831e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1927,6 +1931,8 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
+golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
+golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/server/app/export_test.go
+++ b/server/app/export_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"gopkg.in/guregu/null.v4"
 	"reflect"
 	"strings"
 	"testing"
@@ -32,7 +33,7 @@ func TestGeneratePlaybookExport(t *testing.T) {
 				Title:       "Title 1",
 				Description: "Description 1",
 				Type:        MetricTypeCurrency,
-				Target:      147,
+				Target:      null.IntFrom(147),
 			},
 		},
 	}

--- a/server/app/export_test.go
+++ b/server/app/export_test.go
@@ -2,10 +2,11 @@ package app
 
 import (
 	"encoding/json"
-	"gopkg.in/guregu/null.v4"
 	"reflect"
 	"strings"
 	"testing"
+
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -2,8 +2,9 @@ package app
 
 import (
 	"encoding/json"
-	"gopkg.in/guregu/null.v4"
 	"strings"
+
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"gopkg.in/guregu/null.v4"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -83,12 +84,12 @@ type PlaybookMember struct {
 }
 
 type PlaybookMetricConfig struct {
-	ID          string `json:"id" export:"-"`
-	PlaybookID  string `json:"playbook_id" export:"-"`
-	Title       string `json:"title" export:"title"`
-	Description string `json:"description" export:"description"`
-	Type        string `json:"type" export:"type"`
-	Target      int64  `json:"target" export:"target"`
+	ID          string   `json:"id" export:"-"`
+	PlaybookID  string   `json:"playbook_id" export:"-"`
+	Title       string   `json:"title" export:"title"`
+	Description string   `json:"description" export:"description"`
+	Type        string   `json:"type" export:"type"`
+	Target      null.Int `json:"target" export:"target"`
 }
 
 func (pm PlaybookMember) Clone() PlaybookMember {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -2,9 +2,10 @@ package app
 
 import (
 	"encoding/json"
-	"gopkg.in/guregu/null.v4"
 	"strings"
 	"time"
+
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"gopkg.in/guregu/null.v4"
 	"strings"
 	"time"
 
@@ -335,7 +336,7 @@ type SQLStatusPost struct {
 
 type RunMetricData struct {
 	MetricConfigID string
-	Value          int64
+	Value          null.Int
 }
 
 type RetrospectiveUpdate struct {

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1794,4 +1794,27 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.48.0"),
+		toVersion:   semver.MustParse("0.49.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if e.DriverName() == model.DatabaseDriverMysql {
+				if _, err := e.Exec(`ALTER TABLE IR_MetricConfig MODIFY COLUMN Target BIGINT`); err != nil {
+					return errors.Wrapf(err, "failed creating table IR_MetricConfig")
+				}
+				if _, err := e.Exec(`ALTER TABLE IR_Metric MODIFY COLUMN Value BIGINT`); err != nil {
+					return errors.Wrapf(err, "failed creating table IR_MetricConfig")
+				}
+			} else {
+				if _, err := e.Exec(`ALTER TABLE IR_MetricConfig ALTER COLUMN Target DROP NOT NULL`); err != nil {
+					return errors.Wrapf(err, "failed creating table IR_MetricConfig")
+				}
+				if _, err := e.Exec(`ALTER TABLE IR_Metric ALTER COLUMN Value DROP NOT NULL`); err != nil {
+					return errors.Wrapf(err, "failed creating table IR_MetricConfig")
+				}
+			}
+
+			return nil
+		},
+	},
 }

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"fmt"
+	"gopkg.in/guregu/null.v4"
 	"math/rand"
 	"sort"
 	"strings"
@@ -274,7 +275,7 @@ func TestUpdatePlaybookRun(t *testing.T) {
 
 					//second update will update values
 					for i := range old.MetricsData {
-						old.MetricsData[i].Value *= 10
+						old.MetricsData[i].Value = null.IntFrom(old.MetricsData[i].Value.ValueOrZero() * 10)
 					}
 					old.Retrospective = "Retro3"
 					return &old
@@ -1047,7 +1048,7 @@ func generateMetricData(playbook app.Playbook) []app.RunMetricData {
 		metrics = append(metrics,
 			app.RunMetricData{
 				MetricConfigID: mc.ID,
-				Value:          int64(i + 10),
+				Value:          null.IntFrom(int64(i + 10)),
 			},
 		)
 	}

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -2,12 +2,13 @@ package sqlstore
 
 import (
 	"fmt"
-	"gopkg.in/guregu/null.v4"
 	"math/rand"
 	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/golang/mock/gomock"
 	"github.com/jmoiron/sqlx"

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -2,10 +2,11 @@ package sqlstore
 
 import (
 	"fmt"
-	"gopkg.in/guregu/null.v4"
 	"sort"
 	"strconv"
 	"testing"
+
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/golang/mock/gomock"
 	"github.com/jmoiron/sqlx"

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"fmt"
+	"gopkg.in/guregu/null.v4"
 	"sort"
 	"strconv"
 	"testing"
@@ -60,7 +61,7 @@ func metricsFromNames(names []string) []app.PlaybookMetricConfig {
 			Title:       names[i],
 			Description: "description: " + strconv.Itoa(i),
 			Type:        types[i%len(types)],
-			Target:      int64(i),
+			Target:      null.IntFrom(int64(i)),
 		}
 	}
 	return metrics

--- a/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
@@ -440,6 +440,81 @@ describe('playbooks > edit_metrics', () => {
                 verifyViewsAndEdits(0, 0);
             });
         });
+
+        describe('nullable and 0-able targets', () => {
+            it('can add 0 targets and no (null) targets', () => {
+                // # Visit the selected playbook
+                cy.visit(`/playbooks/playbooks/${testPlaybook.id}/edit`);
+
+                // # Switch to Retrospective tab
+                cy.get('#root').findByText('Retrospective').click();
+
+                // # Add and verify duration
+                addMetric('Duration', 'test duration', '0:0:0', 'test description');
+                verifyViewMetric(0, 'test duration', 'less than 1 minute per run', 'test description');
+
+                // # Verify it shows 0:0:0, then turn it into null.
+                cy.findAllByTestId('edit-metric').eq(0).click();
+                cy.get('input[type=text]').eq(2).should('have.value', '00:00:00')
+                    .clear();
+                cy.findByRole('button', {name: 'Add'}).click();
+                verifyViewMetric(0, 'test duration', '', 'test description');
+
+                // * Verify it has null value when editing again.
+                cy.findAllByTestId('edit-metric').eq(0).click();
+                cy.get('input[type=text]').eq(2).should('have.value', '');
+                cy.findByRole('button', {name: 'Add'}).click();
+
+                // # Add and verify currency
+                addMetric('Dollars', 'test money', '0', 'test description 2');
+                verifyViewMetric(1, 'test money', '0', 'test description 2');
+
+                // # Verify it shows 0, then turn it into null.
+                cy.findAllByTestId('edit-metric').eq(1).click();
+                cy.get('input[type=text]').eq(2).should('have.value', '0')
+                    .clear();
+                cy.findByRole('button', {name: 'Add'}).click();
+                verifyViewMetric(1, 'test money', '', 'test description 2');
+
+                // * Verify it has null value when editing again.
+                cy.findAllByTestId('edit-metric').eq(1).click();
+                cy.get('input[type=text]').eq(2).should('have.value', '');
+                cy.findByRole('button', {name: 'Add'}).click();
+
+                // # Add and verify Integer
+                addMetric('Integer', 'test number', '0', 'test description 3');
+                verifyViewMetric(2, 'test number', '0', 'test description 3');
+
+                // # Verify it shows 0, then turn it into null.
+                cy.findAllByTestId('edit-metric').eq(2).click();
+                cy.get('input[type=text]').eq(2).should('have.value', '0')
+                    .clear();
+                cy.findByRole('button', {name: 'Add'}).click();
+                verifyViewMetric(2, 'test number', '', 'test description 3');
+
+                // * Verify it has null value when editing again.
+                cy.findAllByTestId('edit-metric').eq(2).click();
+                cy.get('input[type=text]').eq(2).should('have.value', '');
+                cy.findByRole('button', {name: 'Add'}).click();
+
+                // * Verify we have three valid metrics and are editing none.
+                verifyViewsAndEdits(3, 0);
+
+                // # Save -- for the next batch of tests
+                cy.findByTestId('save_playbook').click();
+
+                // # Go back to editing
+                cy.visit(`/playbooks/playbooks/${testPlaybook.id}/edit`);
+
+                // # Switch to Retrospective tab
+                cy.get('#root').findByText('Retrospective').click();
+
+                // * Verify we saved the metrics
+                verifyViewMetric(0, 'test duration', '', 'test description');
+                verifyViewMetric(1, 'test money', '', 'test description 2');
+                verifyViewMetric(2, 'test number', '', 'test description 3');
+            });
+        });
     });
 });
 
@@ -470,7 +545,8 @@ const verifyViewMetric = (index, title, target, description) => {
         }
 
         if (description) {
-            cy.getStyledComponent('Detail').eq(1).contains(description);
+            const idx = target ? 1 : 0;
+            cy.getStyledComponent('Detail').eq(idx).contains(description);
         }
     });
 };

--- a/webapp/src/components/backstage/playbook_edit/metrics/metric_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit/metrics/metric_edit.tsx
@@ -18,7 +18,7 @@ interface Props {
     metric: Metric;
     setMetric: (setState: SetState) => void;
     otherTitles: string[];
-    onAdd: (target: number) => void;
+    onAdd: (target: number | null) => void;
     deleteClick: () => void;
     saveToggle: boolean;
     saveFailed: () => void;

--- a/webapp/src/components/backstage/playbook_edit/metrics/metric_view.tsx
+++ b/webapp/src/components/backstage/playbook_edit/metrics/metric_view.tsx
@@ -28,7 +28,7 @@ const MetricView = ({metric, editClick, deleteClick, disabled}: Props) => {
     }
 
     const targetStr = targetToString(metric.target, metric.type, true);
-    const target = metric.target ? `${targetStr} ${perRun}` : '';
+    const target = metric.target === null ? '' : `${targetStr} ${perRun}`;
 
     return (
         <ViewContainer>

--- a/webapp/src/components/backstage/playbook_edit/metrics/metrics.tsx
+++ b/webapp/src/components/backstage/playbook_edit/metrics/metrics.tsx
@@ -102,7 +102,7 @@ const Metrics = ({
         setChangesMade(true);
     };
 
-    const saveMetric = (target: number) => {
+    const saveMetric = (target: number | null) => {
         let length = playbook.metrics.length;
 
         if (curEditingMetric) {

--- a/webapp/src/components/backstage/playbook_edit/metrics/shared.ts
+++ b/webapp/src/components/backstage/playbook_edit/metrics/shared.ts
@@ -2,17 +2,13 @@
 // See LICENSE.txt for license information.
 
 import {Duration} from 'luxon';
-import styled from 'styled-components';
 
 import {MetricType} from 'src/types/playbook';
 import {formatDuration} from 'src/components/formatted_duration';
 
-export const targetToString = (target: number, type: MetricType, naturalDuration = false) => {
-    if (!target) {
-        if (type === MetricType.Integer || type === MetricType.Currency) {
-            return '0';
-        }
-        return naturalDuration ? formatDuration(Duration.fromMillis(0), 'long') : '00:00:00';
+export const targetToString = (target: number | null, type: MetricType, naturalDuration = false) => {
+    if (target === null) {
+        return '';
     }
 
     if (type === MetricType.Integer || type === MetricType.Currency) {
@@ -32,7 +28,7 @@ export const targetToString = (target: number, type: MetricType, naturalDuration
 
 export const stringToTarget = (target: string, type: MetricType) => {
     if (target === '') {
-        return 0;
+        return null;
     }
 
     if (type === MetricType.Integer || type === MetricType.Currency) {

--- a/webapp/src/types/playbook.ts
+++ b/webapp/src/types/playbook.ts
@@ -68,7 +68,7 @@ export interface Metric {
     type: MetricType;
     title: string;
     description: string;
-    target: number;
+    target: number | null;
 }
 
 export interface FetchPlaybooksParams {
@@ -225,7 +225,7 @@ export function isChecklistItem(arg: any): arg is ChecklistItem {
         typeof arg.command_last_run === 'number';
 }
 
-export const newMetric = (type: MetricType, title = '', description = '', target = 0): Metric => ({
+export const newMetric = (type: MetricType, title = '', description = '', target = null): Metric => ({
     id: '',
     type,
     title,


### PR DESCRIPTION
#### Summary
- I'm proposing to use the null.v4 pkg to support storing nulls in sql and json. Here I'm using it for the `int64` target and value fields, but the pkg supports strings and floats etc. It's pretty lightweight, simple to use and seamless (unless you want to do calculations in go, but then you'd have the same problem with using pointers I'd think).
- Here's the docs: https://pkg.go.dev/gopkg.in/guregu/null.v4 and the githup repo: https://github.com/guregu/null
- @lieut-data for visibility and if you want to comment or nix this addition.
- Added e2e tests to lock down our ability to remove target fields or add a 0 value for a target.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-41684

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
