### PR TITLE
MM-41667 - Playbook metrics telemetry

### DIFF
--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -362,6 +362,7 @@ func (t *RudderTelemetry) UpdateRetrospective(playbookRun *app.PlaybookRun, user
 func (t *RudderTelemetry) PublishRetrospective(playbookRun *app.PlaybookRun, userID string) {
 	properties := playbookRunProperties(playbookRun, userID)
 	properties["Action"] = actionPublishRetrospective
+	properties["NumMetrics"] = len(playbookRun.MetricsData)
 	t.track(eventTasks, properties)
 }
 
@@ -403,6 +404,7 @@ func playbookProperties(playbook app.Playbook, userID string) map[string]interfa
 		"SignalAnyKeywordsEnabled":    playbook.SignalAnyKeywordsEnabled,
 		"NumSignalAnyKeywords":        len(playbook.SignalAnyKeywords),
 		"HasChannelNameTemplate":      playbook.ChannelNameTemplate != "",
+		"NumMetrics":                  len(playbook.Metrics),
 	}
 }
 

--- a/server/telemetry/rudder_test.go
+++ b/server/telemetry/rudder_test.go
@@ -391,6 +391,14 @@ func TestPlaybookProperties(t *testing.T) {
 		SignalAnyKeywordsEnabled:    true,
 		SignalAnyKeywords:           []string{"SEV1, SEV2"},
 		ChannelNameTemplate:         "channel_name_template",
+		Metrics: []app.PlaybookMetricConfig{{
+			ID:          "metricid",
+			PlaybookID:  "id",
+			Title:       "metric 1",
+			Description: "this is a descr",
+			Type:        "Duration",
+			Target:      12345,
+		}},
 	}
 
 	properties := playbookProperties(dummyPlaybook, dummyUserID)
@@ -424,6 +432,7 @@ func TestPlaybookProperties(t *testing.T) {
 		"SignalAnyKeywordsEnabled":    dummyPlaybook.SignalAnyKeywordsEnabled,
 		"NumSignalAnyKeywords":        len(dummyPlaybook.SignalAnyKeywords),
 		"HasChannelNameTemplate":      true,
+		"NumMetrics":                  1,
 	}
 
 	require.Equal(t, expectedProperties, properties)


### PR DESCRIPTION
#### Summary
- Add NumMetrics to every playbook telem event, and to the publish retro PlaybookRun event (it's useless to have it attached to every playbookRun event, it would just be noise)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-41667

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [x] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
