### PR TITLE
MM-41060: redir to regular playbooks list if playbooks exist

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/edit_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_spec.js
@@ -51,8 +51,8 @@ describe('playbooks > edit', () => {
                 cy.visit('/playbooks/playbooks');
 
                 // # Start a blank playbook
-                cy.findByTestId('titlePlaybook').findByText('Create playbook').click();
-                cy.get('#playbooks_create').findByText('Create playbook').click();
+                cy.findByText('Blank').click();
+                cy.get('#edit-playbook').click();
 
                 // # Add a slash command to a step
                 cy.get('#root').findByText('Add a slash command').click();
@@ -76,8 +76,8 @@ describe('playbooks > edit', () => {
                 cy.visit('/playbooks/playbooks');
 
                 // # Start a blank playbook
-                cy.findByTestId('titlePlaybook').findByText('Create playbook').click();
-                cy.get('#playbooks_create').findByText('Create playbook').click();
+                cy.findByText('Blank').click();
+                cy.get('#edit-playbook').click();
 
                 // # Add a slash command to a step
                 cy.get('#root').findByText('Add a slash command').click();
@@ -106,8 +106,8 @@ describe('playbooks > edit', () => {
                 cy.visit('/playbooks/playbooks');
 
                 // # Start a blank playbook
-                cy.findByTestId('titlePlaybook').findByText('Create playbook').click();
-                cy.get('#playbooks_create').findByText('Create playbook').click();
+                cy.findByText('Blank').click();
+                cy.get('#edit-playbook').click();
 
                 // # Add a slash command to a step
                 cy.get('#root').findByText('Add a slash command').click();

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -9,6 +9,8 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import styled from 'styled-components';
 
+import {Redirect} from 'react-router-dom';
+
 import {displayPlaybookCreateModal} from 'src/actions';
 import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 import LeftDots from 'src/components/assets/left_dots';
@@ -132,7 +134,11 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
 
     const {view, edit} = usePlaybooksRouting<Playbook>({onGo: setSelectedPlaybook});
 
-    const hasPlaybooks = playbooks?.length !== 0;
+    const hasPlaybooks = Boolean(playbooks?.length);
+
+    if (props.firstTimeUserExperience && hasPlaybooks) {
+        return <Redirect to={pluginUrl('/playbooks')}/>;
+    }
 
     const scrollToTemplates = () => {
         selectorRef.current?.scrollIntoView({behavior: 'smooth'});


### PR DESCRIPTION
#### Summary
When you land explicitly on `/playbooks/start`, and playbooks exist, redirect back to regular `/playbooks/playbooks`.


#### Ticket Link
- 1/N of https://mattermost.atlassian.net/browse/MM-41060

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | N
Gated by experimental feature flag? | N
Unit/E2E tests updated? | Y

[^1]: Yes / No / Not Applicable.
