### PR TITLE
MM-41724: skip on close tour tip

### DIFF
--- a/webapp/src/components/tutorial/tutorial_tour_tip/manager.ts
+++ b/webapp/src/components/tutorial/tutorial_tour_tip/manager.ts
@@ -24,7 +24,6 @@ export interface TutorialTourTipManager {
     handleOpen: (e: React.MouseEvent) => void;
     handleHide: (e: React.MouseEvent) => void;
     handleSkipTutorial: (e: React.MouseEvent) => void;
-    handleDismiss: (e: React.MouseEvent) => void;
     handleSavePreferences: (step: number) => void;
     handlePrevious: (e: React.MouseEvent) => void;
     handleNext: (e?: React.MouseEvent) => void;
@@ -116,16 +115,6 @@ const useTutorialTourTipManager = ({
         setShow(true);
     };
 
-    const handleDismiss = (e: React.MouseEvent): void => {
-        handleEventPropagationAndDefault(e);
-        handleHide();
-
-        // open for discussion should we move forward if user dismiss like next time show them next tip instead of the same one.
-        handleNext(e);
-        const tag = telemetryTag + '_dismiss';
-        trackEvent('tutorial', tag);
-    };
-
     const handleSavePreferences = (nextStep: boolean | number): void => {
         let stepValue = currentStep;
         if (nextStep === true) {
@@ -171,7 +160,7 @@ const useTutorialTourTipManager = ({
             const tag = telemetryTag + '_skip';
             trackEvent('tutorial', tag);
         }
-        savePreferences(currentUserId, SKIPPED.toString());
+        handleSavePreferences(SKIPPED);
     };
 
     const getLastStep = () => {
@@ -190,7 +179,6 @@ const useTutorialTourTipManager = ({
         setShow,
         handleOpen,
         handleHide,
-        handleDismiss,
         handleNext,
         handlePrevious,
         handleSkipTutorial,

--- a/webapp/src/components/tutorial/tutorial_tour_tip/tutorial_tour_tip.tsx
+++ b/webapp/src/components/tutorial/tutorial_tour_tip/tutorial_tour_tip.tsx
@@ -87,7 +87,6 @@ const TutorialTourTip = ({
         setShow,
         handleOpen,
         handleHide,
-        handleDismiss,
         handleNext,
         handlePrevious,
         handleSkipTutorial,
@@ -165,7 +164,7 @@ const TutorialTourTip = ({
                 </h4>
                 <button
                     className='pb-tutorial-tour-tip__header__close'
-                    onClick={handleDismiss}
+                    onClick={handleSkipTutorial}
                 >
                     <i className='icon icon-close'/>
                 </button>


### PR DESCRIPTION
#### Summary
`close` will now skip the current tutorial. Previously `close` would glitch-hide then reshow the next tip. Clicking on the backdrop is unchanged and hides the tour tip without removing the dot (can reopen by clicking the dot.)


<img width="400" alt="image" src="https://user-images.githubusercontent.com/11724372/154320682-732f75a0-7dc5-41b6-9e91-08bf1910de01.png">


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-41724

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | Y
Gated by experimental feature flag? | N
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.
