### PR TITLE
Mm 41664 playbook key metrics tab backend

### DIFF
--- a/client/playbook.go
+++ b/client/playbook.go
@@ -99,4 +99,10 @@ type PlaybookStats struct {
 	ActiveRunsPerDayTimes         [][]int64 `json:"active_runs_per_day_times"`
 	ActiveParticipantsPerDay      []int     `json:"active_participants_per_day"`
 	ActiveParticipantsPerDayTimes [][]int64 `json:"active_participants_per_day_times"`
+
+	MetricOverallAverage       []int64   `json:"metric_overall_average"`
+	MetricRollingAverage       []int64   `json:"metric_rolling_average"`
+	MetricRollingAverageChange []int64   `json:"metric_rolling_average_change"`
+	MetricValueRange           [][]int64 `json:"metric_value_range"`
+	MetricRollingValues        [][]int64 `json:"metric_rolling_values"`
 }

--- a/client/playbook.go
+++ b/client/playbook.go
@@ -99,10 +99,4 @@ type PlaybookStats struct {
 	ActiveRunsPerDayTimes         [][]int64 `json:"active_runs_per_day_times"`
 	ActiveParticipantsPerDay      []int     `json:"active_participants_per_day"`
 	ActiveParticipantsPerDayTimes [][]int64 `json:"active_participants_per_day_times"`
-
-	MetricOverallAverage       []int64   `json:"metric_overall_average"`
-	MetricRollingAverage       []int64   `json:"metric_rolling_average"`
-	MetricRollingAverageChange []int64   `json:"metric_rolling_average_change"`
-	MetricValueRange           [][]int64 `json:"metric_value_range"`
-	MetricRollingValues        [][]int64 `json:"metric_rolling_values"`
 }

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -53,6 +53,11 @@ type PlaybookStats struct {
 	ActiveRunsPerDayTimes         [][]int64 `json:"active_runs_per_day_times"`
 	ActiveParticipantsPerDay      []int     `json:"active_participants_per_day"`
 	ActiveParticipantsPerDayTimes [][]int64 `json:"active_participants_per_day_times"`
+	MetricOverallAverage          []int64   `json:"metric_overall_average"`
+	MetricRollingAverage          []int64   `json:"metric_rolling_average"`
+	MetricRollingAverageChange    []int64   `json:"metric_rolling_average_change"`
+	MetricValueRange              [][]int64 `json:"metric_value_range"`
+	MetricRollingValues           [][]int64 `json:"metric_rolling_values"`
 }
 
 func parsePlaybookStatsFilters(u *url.URL) (*sqlstore.StatsFilters, error) {
@@ -96,6 +101,11 @@ func (h *StatsHandler) playbookStats(w http.ResponseWriter, r *http.Request) {
 	activeRunsPerDay, activeRunsPerDayTimes := h.statsStore.ActiveRunsPerDayLastXDays(14, filters)
 	activeParticipantsPerDay, activeParticipantsPerDayTimes := h.statsStore.ActiveParticipantsPerDayLastXDays(14, filters)
 
+	metricOverallAverage := h.statsStore.MetricOverallAverage(filters)
+	// metricRollingAverageChange := h.statsStore.MetricOverallAverage(0, 0, filters)
+	metricValueRange := h.statsStore.MetricValueRange(filters)
+	metricRollingValues := h.statsStore.MetricRollingValuesLastXRuns(14, 0, filters)
+
 	ReturnJSON(w, &PlaybookStats{
 		RunsInProgress:                h.statsStore.TotalInProgressPlaybookRuns(filters),
 		ParticipantsActive:            h.statsStore.TotalActiveParticipants(filters),
@@ -107,5 +117,8 @@ func (h *StatsHandler) playbookStats(w http.ResponseWriter, r *http.Request) {
 		ActiveRunsPerDayTimes:         activeRunsPerDayTimes,
 		ActiveParticipantsPerDay:      activeParticipantsPerDay,
 		ActiveParticipantsPerDayTimes: activeParticipantsPerDayTimes,
+		MetricOverallAverage:          metricOverallAverage,
+		MetricRollingValues:           metricRollingValues,
+		MetricValueRange:              metricValueRange,
 	}, http.StatusOK)
 }

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -159,7 +159,3 @@ func getAverage(nums []int64) int64 {
 	}
 	return sum / int64(len(nums))
 }
-
-func getMetricRollingAverageChange() {
-
-}

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -61,7 +61,7 @@ type PlaybookStats struct {
 }
 
 const (
-	MetricChartPeriod          = 14
+	MetricChartPeriod          = 10
 	MetricRollingAveragePeriod = 10
 )
 

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -1761,6 +1761,9 @@ func (p *PlaybookBuilder) WithUpdateAt(updateAt int64) *PlaybookBuilder {
 }
 
 func (p *PlaybookBuilder) WithMetrics(names []string) *PlaybookBuilder {
+	if len(names) == 0 {
+		return p
+	}
 	p.Metrics = metricsFromNames(names)
 
 	return p

--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -304,6 +304,8 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 	return counts, daysAsTimes
 }
 
+// MetricOverallAverage returns list of average values of playbook's metrics.
+// Only published metrics values are included.
 func (s *StatsStore) MetricOverallAverage(filters *StatsFilters) []int64 {
 	query := s.store.builder.
 		Select("FLOOR(AVG(m.Value))").
@@ -327,8 +329,10 @@ func (s *StatsStore) MetricOverallAverage(filters *StatsFilters) []int64 {
 	return overallAverage
 }
 
+// MetricValueRange returns min and max values for each metric
+// Only published metrics are included.
 func (s *StatsStore) MetricValueRange(filters *StatsFilters) [][]int64 {
-	// retrieve metric configs metricsConfigsIDs for playbook
+	// first retrieve metric configs metricsConfigsIDs for playbook
 	metricsConfigsIDs, err := s.retrieveMetricConfigs(filters.PlaybookID)
 	if err != nil {
 		s.log.Warnf("Error retrieving metrics configs ids for playbook %w", err)
@@ -340,6 +344,7 @@ func (s *StatsStore) MetricValueRange(filters *StatsFilters) [][]int64 {
 		Max *int64
 	}
 
+	// for each metric config finds min and max values
 	valueRange := make([][]int64, len(metricsConfigsIDs))
 	for i, id := range metricsConfigsIDs {
 		query := s.store.builder.
@@ -360,6 +365,8 @@ func (s *StatsStore) MetricValueRange(filters *StatsFilters) [][]int64 {
 	return valueRange
 }
 
+// MetricRollingValuesLastXRuns for each metric returns list of last `x` published values, starting from `offset`
+// first element in the list is most recent
 func (s *StatsStore) MetricRollingValuesLastXRuns(x int, offset int, filters *StatsFilters) [][]int64 {
 	// retrieve metric configs metricsConfigsIDs for playbook
 	metricsConfigsIDs, err := s.retrieveMetricConfigs(filters.PlaybookID)
@@ -392,6 +399,8 @@ func (s *StatsStore) MetricRollingValuesLastXRuns(x int, offset int, filters *St
 	return metricsValues
 }
 
+// MetricRollingAverageAndChange for each metric returns average of last `x` published values and
+// change with comparison to the previous period
 func (s *StatsStore) MetricRollingAverageAndChange(x int, filters *StatsFilters) (metricRollingAverage []int64, metricRollingAverageChange []int64) {
 	metricValuesWholePeriod := s.MetricRollingValuesLastXRuns(2*x, 0, filters)
 

--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -306,6 +306,7 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 
 // MetricOverallAverage returns list of average values of playbook's metrics.
 // Only published metrics values are included.
+// Returns empty list when Playbook doesn't have metrics or there are no any published metrics values
 func (s *StatsStore) MetricOverallAverage(filters *StatsFilters) []int64 {
 	query := s.store.builder.
 		Select("FLOOR(AVG(m.Value))").
@@ -331,6 +332,7 @@ func (s *StatsStore) MetricOverallAverage(filters *StatsFilters) []int64 {
 
 // MetricValueRange returns min and max values for each metric
 // Only published metrics are included.
+// If there are no any published values, returns empty list
 func (s *StatsStore) MetricValueRange(filters *StatsFilters) [][]int64 {
 	// first retrieve metric configs metricsConfigsIDs for playbook
 	metricsConfigsIDs, err := s.retrieveMetricConfigs(filters.PlaybookID)
@@ -367,6 +369,8 @@ func (s *StatsStore) MetricValueRange(filters *StatsFilters) [][]int64 {
 
 // MetricRollingValuesLastXRuns for each metric returns list of last `x` published values, starting from `offset`
 // first element in the list is most recent
+// Retruns empty list if Playbook doesn't have metrics.
+// Returns list with null values, if Playbook has metrics but there are no any published values
 func (s *StatsStore) MetricRollingValuesLastXRuns(x int, offset int, filters *StatsFilters) [][]int64 {
 	// retrieve metric configs metricsConfigsIDs for playbook
 	metricsConfigsIDs, err := s.retrieveMetricConfigs(filters.PlaybookID)
@@ -401,6 +405,7 @@ func (s *StatsStore) MetricRollingValuesLastXRuns(x int, offset int, filters *St
 
 // MetricRollingAverageAndChange for each metric returns average of last `x` published values and
 // change with comparison to the previous period
+// returns empty list if there are no available published metrics values
 func (s *StatsStore) MetricRollingAverageAndChange(x int, filters *StatsFilters) (metricRollingAverage []int64, metricRollingAverageChange []int64) {
 	metricValuesWholePeriod := s.MetricRollingValuesLastXRuns(2*x, 0, filters)
 

--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -371,6 +371,8 @@ func (s *StatsStore) MetricRollingValuesLastXRuns(x int, offset int, filters *St
 		s.log.Warnf("Error retrieving metrics configs ids for playbook %w", err)
 		return [][]int64{}
 	}
+
+	//NOTE: It would be possible to turn this into a single statement; keep in mind if the playbookStats call becomes slow
 	metricsValues := make([][]int64, 0)
 	for _, id := range metricsConfigsIDs {
 		query := s.store.builder.

--- a/server/sqlstore/stats_test.go
+++ b/server/sqlstore/stats_test.go
@@ -305,7 +305,7 @@ type MetricStatsTest struct {
 
 func TestMetricsStats(t *testing.T) {
 	rand.Seed(1)
-	const x = 14
+	const x = 7
 	testCases := []MetricStatsTest{
 		{
 			numMetrics:           0,
@@ -518,7 +518,7 @@ func getMetricRollingAverage(x, offset int, testCase *MetricStatsTest) []int64 {
 }
 
 func getMetricValueRange(testCase *MetricStatsTest) [][]int64 {
-	minMaxes := make([][]int64, len(testCase.Playbook.Metrics))
+	minMaxes := make([][]int64, 0)
 
 	mins := make(map[string]int64)
 	maxes := make(map[string]int64)
@@ -532,10 +532,9 @@ func getMetricValueRange(testCase *MetricStatsTest) [][]int64 {
 			}
 		}
 	}
-	for i, mc := range testCase.Playbook.Metrics {
+	for _, mc := range testCase.Playbook.Metrics {
 		if _, ok := mins[mc.ID]; ok {
-			minMaxes[i] = []int64{mins[mc.ID], maxes[mc.ID]}
-
+			minMaxes = append(minMaxes, []int64{mins[mc.ID], maxes[mc.ID]})
 		}
 	}
 	return minMaxes


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR Adds backend functionality to spit out metrics statistics info. Front-end will display statistics info on the  `Playbook Key metrics` tab.
PR adds these fields to the `Playbook` stats API:

- `MetricOverallAverage []int64` - Average value for each metric, indexed by metric, in the same order as `playbook.metrics`. Only published metrics are included in the calculations. 
- `MetricRollingAverage []int64` - Average values for the last published `x` runs.
- `MetricRollingAverageChange []int64` - Last 10 days average diff compared to previous 10 days average. For example, value +15 means that the last 10 days value went up by 15% compared to the previous period.
- `MetricValueRange [][]int64` - Each array contains two values, min and max values for each metric.
- `MetricRollingValues [][]int64` - Each array is a list of the last `x` published values. The first element in the list is the most recent.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41664

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~ [ ] Telemetry updated~~ 
- ~~ [ ] Gated by experimental feature flag~~ 
- [x] Unit tests updated
