### PR TITLE
MM-40504 - Send ephemeral post to user on channel when `/playbooks todo` command is called

### DIFF
--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -564,6 +564,10 @@ type PlaybookRunService interface {
 	// UpdateDescription updates the description of the specified playbook run.
 	UpdateDescription(playbookRunID, description string) error
 
+	// EphermalPostTodoDigestToUser gathers the list of assigned tasks, participating runs, and overdue updates,
+	// and sends an ephermal postto userID on channelID. Use force = true to post even if there are no items.
+	EphermalPostTodoDigestToUser(userID string, channelID string, force bool) error
+
 	// DMTodoDigestToUser gathers the list of assigned tasks, participating runs, and overdue updates,
 	// and DMs the message to userID. Use force = true to DM even if there are no items.
 	DMTodoDigestToUser(userID string, force bool) error

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -564,9 +564,9 @@ type PlaybookRunService interface {
 	// UpdateDescription updates the description of the specified playbook run.
 	UpdateDescription(playbookRunID, description string) error
 
-	// EphermalPostTodoDigestToUser gathers the list of assigned tasks, participating runs, and overdue updates,
-	// and sends an ephermal postto userID on channelID. Use force = true to post even if there are no items.
-	EphermalPostTodoDigestToUser(userID string, channelID string, force bool) error
+	// EphemeralPostTodoDigestToUser gathers the list of assigned tasks, participating runs, and overdue updates,
+	// and sends an ephemeral post to userID on channelID. Use force = true to post even if there are no items.
+	EphemeralPostTodoDigestToUser(userID string, channelID string, force bool) error
 
 	// DMTodoDigestToUser gathers the list of assigned tasks, participating runs, and overdue updates,
 	// and DMs the message to userID. Use force = true to DM even if there are no items.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1732,9 +1732,9 @@ func (s *PlaybookRunServiceImpl) buildTodoDigestMessage(userID string, force boo
 	return &model.Post{Message: message}, nil
 }
 
-// EphermalPostTodoDigestToUser
-// builds todo digest message and sends an ephermal post to userID, channelID. Use force = true to send post even if there are no items.
-func (s *PlaybookRunServiceImpl) EphermalPostTodoDigestToUser(userID string, channelID string, force bool) error {
+// EphemeralPostTodoDigestToUser
+// builds todo digest message and sends an ephemeral post to userID, channelID. Use force = true to send post even if there are no items.
+func (s *PlaybookRunServiceImpl) EphemeralPostTodoDigestToUser(userID string, channelID string, force bool) error {
 	todoDigestMessage, err := s.buildTodoDigestMessage(userID, force)
 	if err != nil {
 		return err

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -835,7 +835,7 @@ func (r *Runner) timeSince(event app.TimelineEvent, reported time.Time) string {
 }
 
 func (r *Runner) actionTodo() {
-	if err := r.playbookRunService.DMTodoDigestToUser(r.args.UserId, true); err != nil {
+	if err := r.playbookRunService.EphermalPostTodoDigestToUser(r.args.UserId, r.args.ChannelId, true); err != nil {
 		r.warnUserAndLogErrorf("Error getting tasks and runs digest: %v", err)
 	}
 }

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -835,7 +835,7 @@ func (r *Runner) timeSince(event app.TimelineEvent, reported time.Time) string {
 }
 
 func (r *Runner) actionTodo() {
-	if err := r.playbookRunService.EphermalPostTodoDigestToUser(r.args.UserId, r.args.ChannelId, true); err != nil {
+	if err := r.playbookRunService.EphemeralPostTodoDigestToUser(r.args.UserId, r.args.ChannelId, true); err != nil {
 		r.warnUserAndLogErrorf("Error getting tasks and runs digest: %v", err)
 	}
 }

--- a/tests-e2e/cypress/integration/channels/slash_command/todo_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/todo_spec.js
@@ -202,16 +202,13 @@ describe('channels > slash command > todo', () => {
             // # Run a slash command to show the to-do list.
             cy.executeSlashCommand('/playbook todo');
 
-            // # Switch to playbooks DM channel
-            cy.visit(`/${team2.name}/messages/@playbooks`);
-
             cy.getLastPost().within((post) => {
                 // * Should show titles
                 cy.wrap(post).contains('You have 0 runs overdue.');
                 cy.wrap(post).contains('You have 0 outstanding tasks.');
                 cy.wrap(post).contains('You have 4 runs currently in progress:');
 
-                // * Should show three active runs
+                // * Should show four active runs
                 cy.get('li').then((liItems) => {
                     expect(liItems[0]).to.contain.text(run4.name);
                     expect(liItems[1]).to.contain.text(run1.name);
@@ -228,8 +225,8 @@ describe('channels > slash command > todo', () => {
             cy.apiChangeChecklistItemAssignee(run2.id, 0, 1, testUser.id);
             cy.apiChangeChecklistItemAssignee(run3.id, 1, 0, testUser.id);
 
-            // # Switch to playbooks DM channel
-            cy.visit(`/${team2.name}/messages/@playbooks`);
+            // # Navigate to a non-playbook run channel.
+            cy.visit(`/${team2.name}/channels/town-square`);
 
             // # Run a slash command to show the to-do list.
             cy.executeSlashCommand('/playbook todo');
@@ -239,11 +236,11 @@ describe('channels > slash command > todo', () => {
                 cy.wrap(post).contains('You have 0 runs overdue.');
                 cy.wrap(post).contains('You have 4 total outstanding tasks:');
 
-                // * Should show 3 runs
+                // * Should show 3 runs w/ tasks
                 cy.get('a').then((links) => {
-                    expect(links[1]).to.contain.text(run1.name);
-                    expect(links[2]).to.contain.text(run2.name);
-                    expect(links[3]).to.contain.text(run3.name);
+                    expect(links[0]).to.contain.text(run1.name);
+                    expect(links[1]).to.contain.text(run2.name);
+                    expect(links[2]).to.contain.text(run3.name);
                 });
 
                 cy.get('li').then((items) => {
@@ -272,10 +269,10 @@ describe('channels > slash command > todo', () => {
                 cy.wrap(post).contains('You have 0 runs overdue.');
                 cy.wrap(post).contains('You have 2 total outstanding tasks:');
 
-                // * Should show 2 runs
+                // * Should show 2 runs w/ tasks
                 cy.get('a').then((links) => {
-                    expect(links[1]).to.contain.text(run1.name);
-                    expect(links[2]).to.contain.text(run2.name);
+                    expect(links[0]).to.contain.text(run1.name);
+                    expect(links[1]).to.contain.text(run2.name);
                 });
 
                 cy.get('li').then((items) => {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
Currently, running /playbook todo currently posts from the playbooks bot as a DM to the user.
This PR makes the response an Ephemeral Post on the channel where the command is called.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-40504
Github issue - https://github.com/mattermost/mattermost-server/issues/19171

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated
