### PR TITLE
Fix PublishedAt time generation issue

### DIFF
--- a/server/sqlstore/stats_test.go
+++ b/server/sqlstore/stats_test.go
@@ -468,6 +468,7 @@ func generateTestData(t *testing.T, testCase *MetricStatsTest, testNum int, db *
 	}
 
 	// create and publish runs
+	now := model.GetMillis()
 	numRunsWithMetrics = testCase.numPublishedRuns * testCase.ratioRunsWithMetrics / 100
 	testCase.publishedRunsWithMetrics = make([]*app.PlaybookRun, numRunsWithMetrics)
 	for i := 0; i < testCase.numPublishedRuns; i++ {
@@ -476,7 +477,8 @@ func generateTestData(t *testing.T, testCase *MetricStatsTest, testNum int, db *
 		require.NoError(t, err)
 
 		if i < numRunsWithMetrics {
-			now := model.GetMillis()
+			//Increase time by 10 sec. to avoid duplicate values. Otherwise, metric values sorted by `PublishedAt` may be inconsistent.
+			now += 100000
 			playbookRun.RetrospectivePublishedAt = now
 			playbookRun.RetrospectiveWasCanceled = false
 			playbookRun.MetricsData = generateRandomMetricData(playbook.Metrics)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR fixes `TestMetricsStats` test bug. There was a chance that two runs had the same published date, which caused inconsistency in sorting metrics values by `RetrospectivePublishedAt`.  

#### Ticket Link


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
