### PR TITLE
e2e: enable retries on flaky viewport test

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -230,7 +230,9 @@ describe('channels > rhs > checklist', () => {
             cy.findByText(newTasktext).should('exist');
         });
 
-        it('assignee selector is shifted up if it falls below window', () => {
+        it('assignee selector is shifted up if it falls below window', {
+            retries: {runMode: 3},
+        }, () => {
             // Hover over a checklist item at the end
             cy.findAllByTestId('checkbox-item-container').eq(10).trigger('mouseover').within(() => {
                 // Click the profile icon


### PR DESCRIPTION
This test fails some low percentage of the time in CI but still seems useful to keep, so retry on failure for now. This could be a Cypress issue (I've seen a few different viewport related failures on various tests) or an actual UI inconsistency, I haven't been able to repro locally so I'm not sure which. 