### PR TITLE
Fix checkbox label wrapping

### DIFF
--- a/webapp/src/components/backstage/runs_list/checkbox_input.tsx
+++ b/webapp/src/components/backstage/runs_list/checkbox_input.tsx
@@ -11,6 +11,8 @@ const Component = styled.label`
     cursor: pointer;
     user-select: none;
     width: fit-content;
+    white-space: nowrap;
+
 
     transition: background-color 0.2s;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR fixes checkbox label wrapping on the runs list page. 
This change will fix a similar issue on other pages(where the same checkbox is used):
- Playbooks list page, `"With archived"` filter.
- Playbooks preview page, `"Auto-follow runs"`'
- Playbook run status update popup, `"Also mark the run as finished"`


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38718-Parts%20of%20/runs%20wrapping%20when%20content%20is%20wide

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
