### PR TITLE
MM-41862: Fix infinite scroll column sorting in runs list

### DIFF
--- a/webapp/src/components/backstage/playbooks/playbook_usage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_usage.tsx
@@ -31,7 +31,7 @@ const PlaybookUsage = (props: Props) => {
 
     useEffect(() => {
         setFetchParams((oldParams) => {
-            return {...oldParams, playbook_id: props.playbook.id};
+            return {...oldParams, playbook_id: props.playbook.id, page: 0};
         });
     }, [props.playbook.id, setFetchParams]);
 

--- a/webapp/src/components/backstage/playbooks/stats_view.tsx
+++ b/webapp/src/components/backstage/playbooks/stats_view.tsx
@@ -69,7 +69,7 @@ const StatsView = (props: Props) => {
 
             props.setFilterPill(pill(text));
             props.setFetchParams((oldParams) => {
-                return {...oldParams, ...nextFetchParamsTime};
+                return {...oldParams, ...nextFetchParamsTime, page: 0};
             });
         }
     };
@@ -103,7 +103,7 @@ const StatsView = (props: Props) => {
 
             props.setFilterPill(pill(text));
             props.setFetchParams((oldParams) => {
-                return {...oldParams, ...nextFetchParamsTime};
+                return {...oldParams, ...nextFetchParamsTime, page: 0};
             });
         }
     };
@@ -111,7 +111,7 @@ const StatsView = (props: Props) => {
     const clearFilter = () => {
         props.setFilterPill(null);
         props.setFetchParams((oldParams) => {
-            return {...oldParams, ...DefaultFetchPlaybookRunsParamsTime};
+            return {...oldParams, ...DefaultFetchPlaybookRunsParamsTime, page: 0};
         });
     };
 

--- a/webapp/src/components/backstage/runs_list/filters.tsx
+++ b/webapp/src/components/backstage/runs_list/filters.tsx
@@ -83,7 +83,7 @@ const Filters = ({fetchParams, setFetchParams, fixedTeam, fixedPlaybook, fixedFi
     const myRunsOnly = fetchParams.participant_or_follower_id === 'me';
     const setMyRunsOnly = (checked?: boolean) => {
         setFetchParams((oldParams) => {
-            return {...oldParams, participant_or_follower_id: checked ? 'me' : ''};
+            return {...oldParams, participant_or_follower_id: checked ? 'me' : '', page: 0};
         });
     };
 

--- a/webapp/src/components/backstage/runs_list/run_list_header.tsx
+++ b/webapp/src/components/backstage/runs_list/run_list_header.tsx
@@ -32,7 +32,7 @@ const RunListHeader = ({fetchParams, setFetchParams}: Props) => {
             const newDirection = fetchParams.direction === 'asc' ? 'desc' : 'asc';
 
             setFetchParams((oldParams: FetchPlaybookRunsParams) => {
-                return {...oldParams, direction: newDirection};
+                return {...oldParams, direction: newDirection, page: 0};
             });
             return;
         }
@@ -44,7 +44,7 @@ const RunListHeader = ({fetchParams, setFetchParams}: Props) => {
         }
 
         setFetchParams((oldParams: FetchPlaybookRunsParams) => {
-            return {...oldParams, sort: colName, direction: newDirection};
+            return {...oldParams, sort: colName, direction: newDirection, page: 0};
         });
     }
     return (


### PR DESCRIPTION
#### Summary

The `useRunsList` appends the newly fetched runs to the existing array, so pagination is transparent to the caller. You just set the page to the next one, and the returned `playbookRunsList` contains all the runs for all the pages you've already fetched. 

That's why we need to manually reset the page to 0 when changing the sorting strategy (either using a different field or setting the opposite direction). Otherwise, the `useRunsList` hook will simply add the newly fetched runs to the existing array, which will now contain elements from two different sorting strategies. Thus, potentially containing duplicate elements. This, in turns, makes the InfiniteScroll component buggy, as it ends up containing elements with the same key value.

This bug affected the main list of runs and the list of runs in the playbook usage (affected both by sorting by the columns and by a specific point in time). All those cases are shown in the video below:

https://user-images.githubusercontent.com/3924815/156462447-0d08547c-ac48-4884-8f6c-5d24f5ba364d.mp4

An alternative solution would be to refactor the `useRunsList` hook so that it simply returns what the caller asked for, not appending anything to the existing data. I think that solution is better, but it implies refactoring all callers of `useRunsList`, and I did not want to risk adding more bugs here and there trying to solve this specific one. If you agree this alternative solution is better, we can create a ticket a fix it afterwards to avoid risks in v1.25.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41862

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
