### PR TITLE
e2e: account for new actions post menu

### DIFF
--- a/tests-e2e/cypress/support/api/preference.js
+++ b/tests-e2e/cypress/support/api/preference.js
@@ -313,6 +313,12 @@ Cypress.Commands.add('apiDisableTutorials', (userId) => {
             category: 'crt_tutorial_triggered',
             name: userId,
             value: '999'
+        },
+        {
+            user_id: userId,
+            category: 'actions_menu',
+            name: 'actions_menu_tutorial_state',
+            value: '{"actions_menu_modal_viewed":true}'
         }
     ];
 


### PR DESCRIPTION
Thanks @agarciamontoro for pointing this out. This isn't a fully "correct" solution as the way we handle selecting items from the post hover menu is a bit weird, but it does resolve the failures caused by the new tour point there. 