### PR TITLE
MM-42422: Remove unused string

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1,6 +1,7 @@
 {
   "+/x2FM": "Select a playbook",
   "+8G9qr": "Default text for the retrospective.",
+  "+PMJAg": "Begin following for {followers, plural, =1 {one user} other {# users}}",
   "+QgvjN": "Assign the owner role to",
   "+Tmpup": "You automatically receive updates when this playbook is run.",
   "+hddg7": "Add to run timeline",
@@ -317,7 +318,6 @@
   "gt6BhE": "Run details",
   "guunZt": "Assign",
   "gy/Kkr": "(edited)",
-  "hCMWC+": "Begin following for {followers, plural, =0 {no user} =1 {one user} other {# users}}",
   "hO9EdA": "Invite {numInvitedUsers, plural, =0 {no members} =1 {one member} other {# members}} to the channel",
   "hVFgh4": "Include finished",
   "hXIYHG": "Install and enable the Channel Export plugin to support exporting the channel",

--- a/webapp/src/components/backstage/playbooks/playbook_preview_actions.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_actions.tsx
@@ -105,7 +105,7 @@ const PlaybookPreviewActions = (props: Props) => {
                     />
                     <CardSubEntry
                         title={formatMessage(
-                            {defaultMessage: 'Begin following for {followers, plural, =0 {no user} =1 {one user} other {# users}}'},
+                            {defaultMessage: 'Begin following for {followers, plural, =1 {one user} other {# users}}'},
                             {followers: props.followerIds.length}
                         )}
                         extraInfo={(


### PR DESCRIPTION
#### Summary
We got a report from a translator asking what this sentence with "no user" meant, but it turns out that this sentence is never shown to the user, as that entry is only rendered if there is at least one user auto-following runs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42422

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
