### PR TITLE
E2E: fix (2) flaky tests—new post actions menu

### DIFF
--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -80,7 +80,7 @@ Cypress.Commands.add('startPlaybookRunFromPostMenu', (playbookName, playbookRunN
 
     // post a second message because cypress has trouble finding latest post when there's only one message
     cy.findByTestId('post_textbox').clear().type('another new message here{enter}');
-    cy.clickPostDotMenu();
+    cy.clickPostActionsMenu();
     cy.findByTestId('playbookRunPostMenuIcon').click();
     cy.startPlaybookRun(playbookName, playbookRunName);
 });

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -424,6 +424,15 @@ Cypress.Commands.add('clickPostCommentIcon', (postId, location = 'CENTER') => {
     clickPostHeaderItem(postId, location, 'commentIcon');
 });
 
+/**
+ * Click actions menu by post ID or to most recent post (if post ID is not provided)
+ * @param {String} postId - Post ID
+ * @param {String} location - as 'CENTER', 'SEARCH'
+ */
+Cypress.Commands.add('clickPostActionsMenu', (postId, location = 'CENTER') => {
+    clickPostHeaderItem(postId, location, 'actions_button');
+});
+
 // Close RHS by clicking close button
 Cypress.Commands.add('closeRHS', () => {
     cy.get('#rhsCloseButton').should('be.visible').click();


### PR DESCRIPTION
#### Summary
- Adds `cy.clickPostActionsMenu`
- Fixes `cy.startPlaybookRunFromPostMenu`

Before
<img width="602" alt="CleanShot 2022-03-22 at 21 41 28@2x" src="https://user-images.githubusercontent.com/11724372/159613441-0c3e2f85-d134-4980-86c5-41ddc7416337.png">

After
(See checks)

#### Ticket Link
None

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | NA
Gated by experimental feature flag? | NA
Unit/E2E tests updated? | Y

[^1]: Yes / No / Not Applicable.
