### PR TITLE
MM-42437: Create a new channel for the do-not-broadcast test

### DIFF
--- a/tests-e2e/cypress/integration/channels/broadcast_spec.js
+++ b/tests-e2e/cypress/integration/channels/broadcast_spec.js
@@ -161,39 +161,47 @@ describe('channels > broadcast', () => {
     });
 
     it('does not broadcast when broadcast is disabled, even if broadcastChannelIds contain data', () => {
-        // # Create a playbook with broadcast disabled, but with broadcastChannelIds containing channel1
-        cy.apiCreateTestPlaybook({
-            teamId: testTeam.id,
-            title: 'Playbook - disabled public broadcast',
-            userId: testUser.id,
-            broadcastChannelIds: [testPublicChannel1.id],
-            broadcastEnabled: false,
-        }).then((playbook) => {
-            // # Create a new playbook run with that playbook
-            const now = Date.now();
-            const playbookRunName = `Playbook Run (${now})`;
-            const playbookRunChannelName = `playbook-run-${now}`;
-            cy.apiRunPlaybook({
+        // # Create a brand new channel
+        cy.apiCreateChannel(
+            testTeam.id,
+            'public-channel-do-not-broadcast',
+            'Public Channel 1 - do not broadcast',
+            'O',
+        ).then(({channel}) => {
+            // # Create a playbook with broadcast disabled, but with broadcastChannelIds containing channel1
+            cy.apiCreateTestPlaybook({
                 teamId: testTeam.id,
-                playbookId: playbook.id,
-                playbookRunName,
-                ownerUserId: testUser.id,
-            });
+                title: 'Playbook - disabled public broadcast',
+                userId: testUser.id,
+                broadcastChannelIds: [channel.id],
+                broadcastEnabled: false,
+            }).then((playbook) => {
+                // # Create a new playbook run with that playbook
+                const now = Date.now();
+                const playbookRunName = `Playbook Run (${now})`;
+                const playbookRunChannelName = `playbook-run-${now}`;
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: playbook.id,
+                    playbookRunName,
+                    ownerUserId: testUser.id,
+                });
 
-            // # Navigate directly to the application and the playbook run channel
-            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+                // # Navigate directly to the application and the playbook run channel
+                cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
 
-            // # Update the playbook run's status
-            const updateMessage = 'Update - ' + now;
-            cy.updateStatus(updateMessage);
+                // # Update the playbook run's status
+                const updateMessage = 'Update - ' + now;
+                cy.updateStatus(updateMessage);
 
-            // # Navigate to the broadcast channel
-            cy.visit(`/${testTeam.name}/channels/${testPublicChannel1.name}`);
+                // # Navigate to the broadcast channel
+                cy.visit(`/${testTeam.name}/channels/${channel.name}`);
 
-            // * Verify that the last post is the system post containing the join message,
-            // so no announcement nor update was posted
-            cy.getLastPostId().then((lastPostId) => {
-                cy.get(`#postMessageText_${lastPostId}`).contains('You joined the channel');
+                // * Verify that the last post is the system post containing the join message,
+                // so no announcement nor update was posted
+                cy.getLastPostId().then((lastPostId) => {
+                    cy.get(`#postMessageText_${lastPostId}`).contains('You joined the channel');
+                });
             });
         });
     });


### PR DESCRIPTION
#### Summary
This is a fix for a test-bug introduced in #1088. The test added there relies on the channel being completely empty, so we need to create a brand new channel instead of relying on one that was used by other tests before.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42437

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
