### PR TITLE
MM-42845: Move the bar from the header to the modal body

### DIFF
--- a/webapp/src/components/actions_modal.tsx
+++ b/webapp/src/components/actions_modal.tsx
@@ -163,7 +163,7 @@ const ActionsModal = () => {
     );
 
     return (
-        <GenericModal
+        <StyledModal
             id={'channel-actions-modal'}
             modalHeaderText={header}
             show={show}
@@ -212,22 +212,27 @@ const ActionsModal = () => {
                     ))}
                 </TriggersContainer>
             </Scrollbars>
-        </GenericModal>
+        </StyledModal>
     );
 };
 
 const ModalHeader = styled(Modal.Header)`
-    :after {
-        content: '';
-        height: 1px;
-        width: 100%;
-        position: absolute;
-        left: 0px;
-        background: rgba(var(--center-channel-color-rgb), 0.08);
-    }
-
     &&&& {
         margin-bottom: 0;
+    }
+`;
+
+const StyledModal = styled(GenericModal)`
+    .modal-body {
+        :before {
+            content: '';
+            height: 1px;
+            width: 600px;
+            position: absolute;
+            left: -24px;
+            top: 0px;
+            background: rgba(var(--center-channel-color-rgb), 0.08);
+        }
     }
 `;
 


### PR DESCRIPTION
#### Summary
I could not reproduce the bug locally, so let's see if moving it from right after the header to right before the modal body (which ends up being the exact same spot) works.
![image](https://user-images.githubusercontent.com/3924815/160442915-2b60975b-e309-4739-a8e4-fb9998e8eb2c.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42845

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
