### PR TITLE
MM-42854: Use div instead of span to fix a bug in Safari

### DIFF
--- a/webapp/src/components/actions_modal_trigger.tsx
+++ b/webapp/src/components/actions_modal_trigger.tsx
@@ -121,12 +121,12 @@ const Legend = styled.legend`
     margin: 0;
 `;
 
-const Label = styled.span`
+const Label = styled.div`
     font-size: 11px;
     color: rgba(var(--center-channel-color-rgb), 0.64);
 `;
 
-const Title = styled.span`
+const Title = styled.div`
     font-size: 14px;
     font-weight: 600;
     color: var(--center-channel-color);


### PR DESCRIPTION
#### Summary
Webkit-based browsers seem not to apply `flex-direction: column` when the children are `span`, so this PR changes the trigger header elements to `div` instead to fix the bug. Firefox and Chrome render both implementations in the same way.

I was only able to test this using Midori, which renders the whole webapp in a terrible way, but I was able to reproduce the bug and to confirm that this solution fixes it. However, I still need someone to take a look in Safari.

Screenshot of the solution in Midori:

![image](https://user-images.githubusercontent.com/3924815/160601555-baebdbd6-6151-46cd-a202-d57663455a65.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42854

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
