### PR TITLE
MM-42728: fix every other chart label

### DIFF
--- a/webapp/src/components/backstage/playbooks/bar_graph.tsx
+++ b/webapp/src/components/backstage/playbooks/bar_graph.tsx
@@ -72,9 +72,15 @@ const BarGraph = (props: BarGraphProps) => {
                     tooltips: {
                         callbacks: {
                             title(tooltipItems: any) {
-                                if (props.tooltipTitleCallback) {
-                                    return props.tooltipTitleCallback(tooltipItems[0].xLabel);
+                                if (props.labels) {
+                                    const label = props.labels[tooltipItems[0].index];
+                                    if (props.tooltipTitleCallback) {
+                                        return props.tooltipTitleCallback(label);
+                                    }
+
+                                    return label;
                                 }
+
                                 return tooltipItems[0].xLabel;
                             },
                             label(tooltipItem: any) {

--- a/webapp/src/components/backstage/playbooks/line_graph.tsx
+++ b/webapp/src/components/backstage/playbooks/line_graph.tsx
@@ -62,9 +62,15 @@ const LineGraph = (props: LineGraphProps) => {
                     tooltips: {
                         callbacks: {
                             title(tooltipItems: any) {
-                                if (props.tooltipTitleCallback) {
-                                    return props.tooltipTitleCallback(tooltipItems[0].xLabel);
+                                if (props.labels) {
+                                    const label = props.labels[tooltipItems[0].index];
+                                    if (props.tooltipTitleCallback) {
+                                        return props.tooltipTitleCallback(label);
+                                    }
+
+                                    return label;
                                 }
+
                                 return tooltipItems[0].xLabel;
                             },
                             label(tooltipItem: any) {


### PR DESCRIPTION
#### Summary
The labelling of the x-axis intentionally omits every other tick so as not to clutter the UI, but this unintentionally results in that data not displaying on hover. Reference the original labels prop when rendering instead.

Before:
![CleanShot 2022-03-29 at 17 42 46](https://user-images.githubusercontent.com/1023171/160703604-b0618b7c-3797-486f-bc16-c5d31c50839e.gif)

After:
![CleanShot 2022-03-29 at 17 48 02](https://user-images.githubusercontent.com/1023171/160704388-4d24f544-9e00-4363-8af2-f49cb0ca042f.gif)

I haven't written a unit test for this, since it involves hovering over a graph and I don't know how to do that.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-42728

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
