### PR TITLE
MM-42249: remove import loading icon

### DIFF
--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -40,8 +40,6 @@ import {RegularHeading} from 'src/styles/headings';
 
 import {importFile, fetchPlaybookRuns} from 'src/client';
 
-import Spinner from '../assets/icons/spinner';
-
 import TeamSelector from '../team/team_selector';
 
 import {navigateToPluginUrl, pluginUrl} from 'src/browser_routing';
@@ -119,7 +117,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
     const content = useRef<JSX.Element | null>(null);
     const dispatch = useDispatch();
     const fileInputRef = useRef<HTMLInputElement | null>(null);
-    const [importUploading, setImportUploading] = useState(false);
     const [importTargetTeam, setImportTargetTeam] = useState('');
     const selectorRef = useRef<HTMLDivElement>(null);
 
@@ -188,11 +185,9 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                     teamId = importTargetTeam;
                 }
 
-                setImportUploading(true);
                 const reader = new FileReader();
                 reader.onload = async (ev) => {
                     const {id} = await importFile(ev?.target?.result, teamId);
-                    setImportUploading(false);
                     navigateToPluginUrl(`/playbooks/${id}`);
                 };
                 reader.readAsArrayBuffer(file);
@@ -235,9 +230,7 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                         { teams.length > 1 &&
                         <TeamSelector
                             placeholder={
-                                <ImportButton
-                                    spin={importUploading}
-                                />
+                                <ImportButton/>
                             }
                             onlyPlaceholder={true}
                             enableEdit={true}
@@ -257,7 +250,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                                     fileInputRef.current.click();
                                 }
                             }}
-                            spin={importUploading}
                         />
                         }
                         {canCreatePlaybooks &&
@@ -364,13 +356,12 @@ function swapEnds(arr: Array<any>) {
     return [arr[arr.length - 1], ...arr.slice(1, -1), arr[0]];
 }
 
-const ImportButton = (props: {onClick?: () => void, spin: boolean}) => {
+const ImportButton = (props: {onClick?: () => void}) => {
     return (
         <TertiaryButton
             onClick={props.onClick}
         >
             <FormattedMessage defaultMessage='Import'/>
-            {props.spin && <Spinner/>}
         </TertiaryButton>
     );
 };


### PR DESCRIPTION
#### Summary
The current loading icon "wobbles" on import. Instead of trying to fix this, I've opted to just remove the loading icon altogether on the assumption that the import step is unlikely to be slow for the amount of data we're importing.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-42249

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
