### PR TITLE
MM-38534: Remove message button on run overview

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -228,7 +228,6 @@
   "SmAUf9": "A reminder will be sent <b>{timestamp}</b>",
   "Sx3lHL": "Integer",
   "T5rX+W": "How often should an update be posted?",
-  "T7Ry38": "Message",
   "TBez4r": "There are no playbooks to view. You don't have permission to create playbooks in this workspace.",
   "TJo5E6": "Preview",
   "TSSNg/": "TOTAL RUNS started per week over the last 12 weeks",

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/participants.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/participants.tsx
@@ -98,23 +98,11 @@ interface ParticipantProps {
 }
 
 function Participant({userId, teamName, isOwner}: ParticipantProps) {
-    const [showMessage, setShowMessage] = useState(Boolean(isOwner));
     const user = useSelector<GlobalState, UserProfile>((state) => getUser(state, userId));
-    const {formatMessage} = useIntl();
 
     return (
-        <ParticipantRow
-            onMouseEnter={() => setShowMessage(true)}
-            onMouseLeave={() => !isOwner && setShowMessage(false)}
-        >
+        <ParticipantRow>
             <ProfileWithPosition userId={userId}/>
-            {showMessage && (
-                <SecondaryButtonRight
-                    onClick={() => navigateToUrl(`/${teamName}/messages/@${user.username}`)}
-                >
-                    {formatMessage({defaultMessage: 'Message'})}
-                </SecondaryButtonRight>
-            )}
         </ParticipantRow>
     );
 }


### PR DESCRIPTION
#### Summary
The "Message" button has been present on the run overview for sometime, ostensibly to allow users to directly reach out to the participants in question via a DM. I can't recall ever using this, and there are issues rendering this page with long titles.

Proposing we just remove the messaging functionality altogether as we look forward to a revamped run overview page in Q2.

<img width="374" alt="CleanShot 2022-03-29 at 18 17 17@2x" src="https://user-images.githubusercontent.com/1023171/160708694-46825d93-0aa1-479e-bd89-43c6786f6bb2.png">

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-38534
Fixes: https://mattermost.atlassian.net/browse/MM-39123

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
