### PR TITLE
MM-42509: Change initial fetch to get only in progress runs

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -370,6 +370,35 @@ describe('channels > rhs', () => {
                 });
             });
         });
+
+        it.only('when navigating directly to a finished playbook run channel and clicking on the button', () => {
+            // # Run the playbook
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            const playbookRunChannelName = 'playbook-run-' + now;
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                // # End the playbook run
+                cy.apiFinishRun(playbookRun.id);
+            });
+
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # Click the icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click({force: true});
+            });
+
+            // * Verify RHS Home shows the run details
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Run details').should('exist');
+            });
+        });
     });
 
     describe('is toggled', () => {

--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -371,7 +371,7 @@ describe('channels > rhs', () => {
             });
         });
 
-        it.only('when navigating directly to a finished playbook run channel and clicking on the button', () => {
+        it('when navigating directly to a finished playbook run channel and clicking on the button', () => {
             // # Run the playbook
             const now = Date.now();
             const playbookRunName = 'Playbook Run (' + now + ')';

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -42,6 +42,7 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
                 per_page: 0,
                 team_id: currentTeam.id,
                 participant_id: currentUserId,
+                statuses: [PlaybookRunStatus.InProgress],
             });
             store.dispatch(receivedTeamPlaybookRuns(fetched.items));
         }


### PR DESCRIPTION
#### Summary
In community, in my case, the first request to retrieve runs gets 86 of them, of which only 6 are in progress. This request happens every time the team changes, to populate the Redux store with all the team runs. However, I suspect`*` we only need the runs in progress, which are the ones where we need to automatically open the RHS on channel switch.

This PR changes that initial request to get only in progress runs.

`*` I say suspect because the logic there is a bit complex, and I'm not 100% sure of all the implications, but I'm confident enough to at least try this in community for a while and see how it behaves. I tested it thoroughly locally, but only time, in community, will tell.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42509

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
