### PR TITLE
[GH-19356] MM-41063, MM-40565: Increase new task dialog description length

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -24,6 +24,8 @@ import (
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 )
 
+const checklistItemDescriptionCharLimit = 4000
+
 const (
 	// PlaybookRunCreatedWSEvent is for playbook run creation.
 	PlaybookRunCreatedWSEvent = "playbook_run_created"
@@ -584,9 +586,10 @@ func (s *PlaybookRunServiceImpl) OpenAddChecklistItemDialog(triggerID, playbookR
 			{
 				DisplayName: "Description",
 				Name:        DialogFieldItemDescriptionKey,
-				Type:        "text",
+				Type:        "textarea",
 				Default:     "",
 				Optional:    true,
+				MaxLength:   checklistItemDescriptionCharLimit,
 			},
 		},
 		SubmitLabel:    "Add task",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
<!--
A description of what this pull request does
-->

Increases the maximum length of the Add New Task dialog to match with the default character limit in webapp, which is 4000.

Also changes the description input type to `textarea` to support easier entry for long texts.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/19356

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
