### PR TITLE
MM-43037: Fix prompt post deletion

### DIFF
--- a/server/api/signal.go
+++ b/server/api/signal.go
@@ -119,7 +119,10 @@ func (h *SignalHandler) ignoreKeywords(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ReturnJSON(w, &model.PostActionIntegrationResponse{}, http.StatusOK)
-	h.api.Post.DeleteEphemeralPost(req.UserId, req.PostId)
+	if err := h.api.Post.DeletePost(req.PostId); err != nil {
+		h.returnError("unable to delete original post", err, w)
+		return
+	}
 }
 
 func (h *SignalHandler) returnError(returnMessage string, err error, w http.ResponseWriter) {

--- a/tests-e2e/cypress/integration/channels/general_actions_spec.js
+++ b/tests-e2e/cypress/integration/channels/general_actions_spec.js
@@ -155,6 +155,80 @@ describe('channels > general actions', () => {
             });
         });
 
+        it('deletes the post and ignores the thread when clicking on No, ignore thread', () => {
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Public Playbook',
+                memberIDs: [],
+            });
+
+            // # Login as the non-sysadmin user first
+            // # to do the channel & action creation.
+            // # In the 'Select a playbook' dropdown later in this test,
+            // # sysadmin users could potentially see many other playbooks
+            // # besides the one created directly above. `testUser` will not.
+            cy.apiLogin(testUser);
+            cy.apiCreateChannel(
+                testTeam.id,
+                'action-channel',
+                'Action Channel',
+                'O'
+            ).then(({channel}) => {
+                // # Go to the test channel
+                cy.visit(`/${testTeam.name}/channels/${channel.name}`);
+
+                // # Open Channel Header and the Channel Actions modal
+                cy.get('#channelHeaderTitle').click();
+                cy.findByText('Channel Actions').click();
+
+                // # Set a keyword, enable the playbook trigger,
+                // # and select the Playbook to run
+                cy.contains('Add keywords').click().type('red alert{enter}');
+                cy.contains('Prompt to run a playbook').click();
+                cy.contains('Select a playbook').click();
+                cy.findByText('Public Playbook').click();
+
+                // # Save action
+                cy.findByRole('button', {name: /save/i}).click();
+
+                // # Post the trigger phrase
+                cy.uiPostMessageQuickly('error detected red alert!');
+
+                // * Verify that the bot posts the expected prompt
+                // # Click on No, ignore thread
+                cy.getLastPostId().then((postId) => {
+                    cy.get(`#post_${postId}`).within(() => {
+                        cy.contains('trigger for the Public Playbook').should('exist');
+                        cy.contains('No, ignore thread').should('exist').click();
+                    });
+                });
+
+                // # Reload the channel
+                cy.visit(`/${testTeam.name}/channels/${channel.name}`);
+
+                // * Verify that the prompt post is no longer there
+                cy.getLastPostId().then((postId) => {
+                    cy.get(`#post_${postId}`).within(() => {
+                        cy.contains('No, ignore thread').should('not.exist');
+                    });
+                });
+
+                // # Reply to the last thread with the trigger phrase
+                cy.getLastPostId().then((postId) => {
+                    cy.clickPostCommentIcon(postId);
+                    cy.postMessageReplyInRHS('error detected red alert!');
+                });
+
+                // * Verify that the bot did not post the prompt
+                cy.getLastPostId().then((postId) => {
+                    cy.get(`#post_${postId}`).within(() => {
+                        cy.contains('trigger for the Public Playbook').should('not.exist');
+                    });
+                });
+            });
+        });
+
         it('disabled triggers do not run even with a keyword set', () => {
             // # Create a public playbook
             cy.apiCreatePlaybook({


### PR DESCRIPTION
#### Summary
When porting the ephemeral post to a regular post, I forgot to change this call. Funnily enough, `DeleteEphemeralPost` does delete a regular post temporarily, but when reloading the page, it appears again.

I added an E2E test to check the behaviour of the `No, ignore thread` button too.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43037

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
