### PR TITLE
MM-41513: Restrict private playbooks (#1017)

### DIFF
--- a/server/api_playbooks_test.go
+++ b/server/api_playbooks_test.go
@@ -735,6 +735,7 @@ func TestPlaybooksConversions(t *testing.T) {
 		defaultRolePermissions := e.Permissions.SaveDefaultRolePermissions()
 		defer func() {
 			e.Permissions.RestoreDefaultRolePermissions(defaultRolePermissions)
+			e.SetE20Licence()
 		}()
 		e.Permissions.RemovePermissionFromRole(model.PermissionPublicPlaybookMakePrivate.Id, model.PlaybookMemberRoleId)
 
@@ -744,9 +745,26 @@ func TestPlaybooksConversions(t *testing.T) {
 
 		e.Permissions.AddPermissionToRole(model.PermissionPublicPlaybookMakePrivate.Id, model.PlaybookMemberRoleId)
 
-		err = e.PlaybooksClient.Playbooks.Update(context.Background(), *e.BasicPlaybook)
-		require.NoError(t, err)
+		t.Run("E0", func(t *testing.T) {
+			e.RemoveLicense()
 
+			err := e.PlaybooksClient.Playbooks.Update(context.Background(), *e.BasicPlaybook)
+			requireErrorWithStatusCode(t, err, http.StatusForbidden)
+		})
+
+		t.Run("E10", func(t *testing.T) {
+			e.SetE10Licence()
+
+			err := e.PlaybooksClient.Playbooks.Update(context.Background(), *e.BasicPlaybook)
+			requireErrorWithStatusCode(t, err, http.StatusForbidden)
+		})
+
+		t.Run("E20", func(t *testing.T) {
+			e.SetE20Licence()
+
+			err = e.PlaybooksClient.Playbooks.Update(context.Background(), *e.BasicPlaybook)
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("private to public conversion", func(t *testing.T) {

--- a/server/app/permissions_service.go
+++ b/server/app/permissions_service.go
@@ -245,7 +245,7 @@ func (p *PermissionsService) PlaybookModifyWithFixes(userID string, playbook *Pl
 		}
 	}
 
-	return nil
+	return p.checkPlaybookLicenceRequirements(*playbook)
 }
 
 func (p *PermissionsService) DeletePlaybook(userID string, playbook Playbook) error {

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -419,6 +419,10 @@ func (e *TestEnvironment) CreateAdditionalPlaybooks() {
 	e.ArchivedPlaybook = archivedPlaybook
 }
 
+func (e *TestEnvironment) RemoveLicense() {
+	e.Srv.SetLicense(nil)
+}
+
 func (e *TestEnvironment) SetE10Licence() {
 	license := model.NewTestLicense()
 	license.SkuShortName = model.LicenseShortSkuE10

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -299,6 +299,7 @@
   "pK6+CW": "@{displayName} is not a member of the [{runName}]({overviewUrl}) channel. Would you like to add them to this channel? They will have access to all of the message history.",
   "pKLw8O": "Are you sure you want to delete this event? Deleted events will be permanently removed from the timeline.",
   "pjt3qA": "New checklist",
+  "q/Qo8l": "Private playbooks are only available in Mattermost Enterprise",
   "q0cpUe": "Add checklist",
   "q6f8x9": "Change since last update",
   "qp3Fk4": "A playbook is a workflow that your teams and tools should follow, including everything from checklists, actions, templates, and retrospectives.",

--- a/webapp/src/components/backstage/playbook_access_modal.tsx
+++ b/webapp/src/components/backstage/playbook_access_modal.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 
 import GenericModal from 'src/components/widgets/generic_modal';
 import {AdminNotificationType, PROFILE_CHUNK_SIZE} from 'src/constants';
-import {useEditPlaybook, useHasPlaybookPermission} from 'src/hooks';
+import {useEditPlaybook, useHasPlaybookPermission, useAllowMakePlaybookPrivate} from 'src/hooks';
 import {Playbook, PlaybookMember} from 'src/types/playbook';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
@@ -72,6 +72,7 @@ const PlaybookAccessModal = ({
     const [playbook, updatePlaybook] = useEditPlaybook(playbookId);
     const team = useSelector<GlobalState, Team>((state) => getTeam(state, playbook?.team_id || ''));
     const permissionToMakePrivate = useHasPlaybookPermission(PlaybookPermissionGeneral.Convert, playbook);
+    const licenseToMakePrivate = useAllowMakePlaybookPrivate();
 
     const [showUpgradeModal, setShowUpgradeModal] = useState(false);
     const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
@@ -153,7 +154,7 @@ const PlaybookAccessModal = ({
                     <HorizontalBlock>
                         <i className={'icon ' + (playbook.public ? 'icon-globe' : 'icon-lock-outline')}/>
                         <SubTitle>{getSubtitle(playbook)}</SubTitle>
-                        {(playbook.public && permissionToMakePrivate) &&
+                        {(playbook.public && permissionToMakePrivate && licenseToMakePrivate) &&
                         <>
                             <PrivateLink
                                 onClick={() => setShowMakePrivateConfirm(true)}

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -349,6 +349,18 @@ export function useAllowRetrospectiveAccess() {
     return useSelector(isE10LicensedOrDevelopment);
 }
 
+// useAllowPrivatePlaybooks returns whether the server is licenced for
+// creating private playbooks
+export function useAllowPrivatePlaybooks() {
+    return useSelector(isE20LicensedOrDevelopment);
+}
+
+// useAllowMakePlaybookPrivate returns whether the server is licenced for
+// converting public playbooks to private
+export function useAllowMakePlaybookPrivate() {
+    return useSelector(isE20LicensedOrDevelopment);
+}
+
 export function useEnsureProfiles(userIds: string[]) {
     const dispatch = useDispatch();
     type StringToUserProfileFn = (id: string) => UserProfile;


### PR DESCRIPTION
#### Summary
Cherry-picks #1017 to `release-1.23`, so we can release a v1.23.1 and add it to a new v6.3.7 (I think it's 7).

I tested this in the following v6.3.6 servers, and the cherry-pick seems to work as expected. @Phrynobatrachus, could you give it a second look?
- https://mm41513-e0.test.mattermost.cloud
- https://mm41513-e10.test.mattermost.cloud
- https://mm41513-e20.test.mattermost.cloud

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42888

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
