### PR TITLE
Fix private/public icon update issue

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -64,7 +64,7 @@ import {
 } from 'src/types/actions';
 import {clientExecuteCommand} from 'src/client';
 import {GlobalSettings} from 'src/types/settings';
-import {ChecklistItemsFilter} from 'src/types/playbook';
+import {ChecklistItemsFilter, PlaybookWithChecklist} from 'src/types/playbook';
 import {modals} from 'src/webapp_globals';
 import {makeModalDefinition as makeUpdateRunStatusModalDefinition} from 'src/components/modals/update_run_status_modal';
 import {makePlaybookAccessModalDefinition} from 'src/components/backstage/playbook_access_modal';
@@ -137,10 +137,11 @@ export function openUpdateRunStatusModal(
 }
 
 export function displayEditPlaybookAccessModal(
-    playbookId: string
+    playbookId: string,
+    onPlaybookChange?: React.Dispatch<React.SetStateAction<PlaybookWithChecklist | undefined>>,
 ) {
     return async (dispatch: Dispatch<AnyAction>) => {
-        dispatch(modals.openModal(makePlaybookAccessModalDefinition({playbookId})));
+        dispatch(modals.openModal(makePlaybookAccessModalDefinition({playbookId, onPlaybookChange})));
     };
 }
 

--- a/webapp/src/components/backstage/playbook_access_modal.tsx
+++ b/webapp/src/components/backstage/playbook_access_modal.tsx
@@ -2,7 +2,7 @@ import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getProfilesInTeam, searchProfiles} from 'mattermost-webapp/packages/mattermost-redux/src/actions/users';
 import {GlobalState} from 'mattermost-webapp/packages/mattermost-redux/src/types/store';
 import {Team} from 'mattermost-webapp/packages/mattermost-redux/src/types/teams';
-import React, {ComponentProps, useState} from 'react';
+import React, {ComponentProps, useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 import GenericModal from 'src/components/widgets/generic_modal';
 import {AdminNotificationType, PROFILE_CHUNK_SIZE} from 'src/constants';
 import {useEditPlaybook, useHasPlaybookPermission, useAllowMakePlaybookPrivate} from 'src/hooks';
-import {Playbook, PlaybookMember} from 'src/types/playbook';
+import {Playbook, PlaybookMember, PlaybookWithChecklist} from 'src/types/playbook';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import {PlaybookPermissionGeneral, PlaybookRole} from 'src/types/permissions';
@@ -23,6 +23,7 @@ const ID = 'playbooks_access';
 
 type Props = {
     playbookId: string
+    onPlaybookChange?: React.Dispatch<React.SetStateAction<PlaybookWithChecklist | undefined>>
 } & Partial<ComponentProps<typeof GenericModal>>;
 
 export const makePlaybookAccessModalDefinition = (props: Props) => ({
@@ -65,6 +66,7 @@ const BlueArrow = styled.i`
 
 const PlaybookAccessModal = ({
     playbookId,
+    onPlaybookChange,
     ...modalProps
 }: Props) => {
     const {formatMessage} = useIntl();
@@ -87,6 +89,12 @@ const PlaybookAccessModal = ({
             });
         }
     };
+
+    useEffect(() => {
+        if (playbook) {
+            onPlaybookChange?.(playbook);
+        }
+    }, [playbook, onPlaybookChange]);
 
     const onRemoveUser = (userId: string) => {
         if (!playbook) {

--- a/webapp/src/components/backstage/playbook_access_modal.tsx
+++ b/webapp/src/components/backstage/playbook_access_modal.tsx
@@ -2,7 +2,7 @@ import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getProfilesInTeam, searchProfiles} from 'mattermost-webapp/packages/mattermost-redux/src/actions/users';
 import {GlobalState} from 'mattermost-webapp/packages/mattermost-redux/src/types/store';
 import {Team} from 'mattermost-webapp/packages/mattermost-redux/src/types/teams';
-import React, {ComponentProps, useEffect, useState} from 'react';
+import React, {ComponentProps, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -79,29 +79,31 @@ const PlaybookAccessModal = ({
     const [showUpgradeModal, setShowUpgradeModal] = useState(false);
     const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
 
+    const onChange = (update: Partial<PlaybookWithChecklist>) => {
+        if (playbook) {
+            const updatedPlaybook: PlaybookWithChecklist = {...playbook, ...update};
+            updatePlaybook(updatedPlaybook);
+            onPlaybookChange?.(updatedPlaybook);
+        }
+    };
+
     const onAddMember = (member: PlaybookMember) => {
         if (!playbook) {
             return;
         }
         if (!playbook.members.find((elem: PlaybookMember) => elem.user_id === member.user_id)) {
-            updatePlaybook({
+            onChange({
                 members: [...playbook.members, member],
             });
         }
     };
-
-    useEffect(() => {
-        if (playbook) {
-            onPlaybookChange?.(playbook);
-        }
-    }, [playbook, onPlaybookChange]);
 
     const onRemoveUser = (userId: string) => {
         if (!playbook) {
             return;
         }
         const idx = playbook.members.findIndex((elem: PlaybookMember) => elem.user_id === userId);
-        updatePlaybook({
+        onChange({
             members: [...playbook.members.slice(0, idx), ...playbook.members.slice(idx + 1)],
         });
     };
@@ -113,13 +115,13 @@ const PlaybookAccessModal = ({
         const idx = playbook.members.findIndex((elem: PlaybookMember) => elem.user_id === userId);
         const member = {...playbook.members[idx]};
         member.roles = roles;
-        updatePlaybook({
+        onChange({
             members: [...playbook.members.slice(0, idx), ...playbook.members.slice(idx + 1), member],
         });
     };
 
     const modifyPublic = (pub: boolean) => {
-        updatePlaybook({
+        onChange({
             public: pub,
         });
     };

--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -278,7 +278,7 @@ const Playbook = () => {
                         }
                     >
                         <DropdownMenuItem
-                            onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id))}
+                            onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id, setPlaybook))}
                         >
                             <FormattedMessage defaultMessage='Manage access'/>
                         </DropdownMenuItem>
@@ -311,7 +311,7 @@ const Playbook = () => {
                         }
                     </DotMenu>
                     <MembersIcon
-                        onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id))}
+                        onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id, setPlaybook))}
                     >
                         <i className={'icon icon-account-multiple-outline'}/>
                         {playbook.members.length}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
On the `Playbook preview` page, public/private icon did not update automatically when converting a playbook to private. 
A similar case was with the number of members, addin/removing a member did not update the number.
`Playbook access modal` and `Playbook preview` have their own copies of playbook object, so changes in the modal didn't reflect on the preview page. This PR fixes both issues by updating the preview page state from the modal.

Note: New Playbook editor has the same issues. I can't fix it now because it's under development.


https://user-images.githubusercontent.com/4368372/163686074-e9cd6a08-26cd-4c01-bc79-f41ad5e66f16.mp4


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41580

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [ ] Unit tests updated
