### PR TITLE
Remove followers run action flag

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -484,8 +484,6 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 			playbookRun.DefaultOwnerID = pb.DefaultOwnerID
 		}
 
-		playbookRun.StatusUpdateBroadcastFollowersEnabled = true
-
 		playbookRun.StatusUpdateBroadcastChannelsEnabled = pb.BroadcastEnabled
 		playbookRun.BroadcastChannelIDs = pb.BroadcastChannelIDs
 

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -135,10 +135,6 @@ type PlaybookRun struct {
 	// the run status update event, false otherwise.
 	StatusUpdateBroadcastChannelsEnabled bool `json:"status_update_broadcast_channels_enabled"`
 
-	// StatusUpdateBroadcastFollowersEnabled is true if the followers broadcast action is enabled for
-	// the run status update event, false otherwise.
-	StatusUpdateBroadcastFollowersEnabled bool `json:"status_update_broadcast_followers_enabled"`
-
 	// StatusUpdateBroadcastWebhooksEnabled is true if the webhooks broadcast action is enabled for
 	// the run status update event, false otherwise.
 	StatusUpdateBroadcastWebhooksEnabled bool `json:"status_update_broadcast_webhooks_enabled"`

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -795,9 +795,7 @@ func (s *PlaybookRunServiceImpl) UpdateStatus(playbookRunID, userID string, opti
 		s.broadcastPlaybookRunMessageToChannels(playbookRunToModify.BroadcastChannelIDs, originalPost.Clone(), statusUpdateMessage, playbookRunToModify)
 	}
 
-	if playbookRunToModify.StatusUpdateBroadcastFollowersEnabled {
-		s.dmPostToRunFollowers(originalPost.Clone(), statusUpdateMessage, playbookRunID, userID)
-	}
+	s.dmPostToRunFollowers(originalPost.Clone(), statusUpdateMessage, playbookRunID, userID)
 
 	// Remove pending reminder (if any), even if current reminder was set to "none" (0 minutes)
 	if err = s.SetNewReminder(playbookRunID, options.Reminder); err != nil {
@@ -913,10 +911,8 @@ func (s *PlaybookRunServiceImpl) FinishPlaybookRun(playbookRunID, userID string)
 		s.broadcastPlaybookRunMessageToChannels(playbookRunToModify.BroadcastChannelIDs, &model.Post{Message: message}, finishMessage, playbookRunToModify)
 	}
 
-	if playbookRunToModify.StatusUpdateBroadcastFollowersEnabled {
-		runFinishedMessage := s.buildRunFinishedMessage(playbookRunToModify, user.Username)
-		s.dmPostToRunFollowers(&model.Post{Message: runFinishedMessage}, finishMessage, playbookRunToModify.ID, userID)
-	}
+	runFinishedMessage := s.buildRunFinishedMessage(playbookRunToModify, user.Username)
+	s.dmPostToRunFollowers(&model.Post{Message: runFinishedMessage}, finishMessage, playbookRunToModify.ID, userID)
 
 	// Remove pending reminder (if any), even if current reminder was set to "none" (0 minutes)
 	s.RemoveReminder(playbookRunID)
@@ -2478,9 +2474,8 @@ func (s *PlaybookRunServiceImpl) PublishRetrospective(playbookRunID, publisherID
 
 	telemetryString := fmt.Sprintf("?telem_action=follower_clicked_retrospective_dm&telem_run_id=%s", playbookRunToPublish.ID)
 	retrospectivePublishedMessage := fmt.Sprintf("@%s published the retrospective report for [%s](%s%s).\n%s", publisherUser.Username, playbookRunToPublish.Name, retrospectiveURL, telemetryString, retrospective.Text)
-	if playbookRunToPublish.StatusUpdateBroadcastFollowersEnabled {
-		s.dmPostToRunFollowers(&model.Post{Message: retrospectivePublishedMessage}, retroMessage, playbookRunToPublish.ID, publisherID)
-	}
+	s.dmPostToRunFollowers(&model.Post{Message: retrospectivePublishedMessage}, retroMessage, playbookRunToPublish.ID, publisherID)
+
 	event := &TimelineEvent{
 		PlaybookRunID: playbookRunID,
 		CreateAt:      now,

--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -471,19 +471,18 @@ func TestUpdateStatus(t *testing.T) {
 		follower1ID := "follower1ID"
 		follower2ID := "follower2ID"
 		playbookRun := &app.PlaybookRun{
-			ID:                                    playbookRunID,
-			Name:                                  "Name",
-			TeamID:                                teamID,
-			ChannelID:                             homeChannelID,
-			BroadcastChannelIDs:                   []string{broadcastChannelID1, broadcastChannelID2},
-			StatusUpdateBroadcastChannelsEnabled:  true,
-			OwnerUserID:                           "user_id",
-			ReporterUserID:                        "user_id",
-			CurrentStatus:                         app.StatusInProgress,
-			CreateAt:                              1620018358404,
-			WebhookOnStatusUpdateURLs:             []string{server.URL},
-			StatusUpdateBroadcastWebhooksEnabled:  true,
-			StatusUpdateBroadcastFollowersEnabled: true,
+			ID:                                   playbookRunID,
+			Name:                                 "Name",
+			TeamID:                               teamID,
+			ChannelID:                            homeChannelID,
+			BroadcastChannelIDs:                  []string{broadcastChannelID1, broadcastChannelID2},
+			StatusUpdateBroadcastChannelsEnabled: true,
+			OwnerUserID:                          "user_id",
+			ReporterUserID:                       "user_id",
+			CurrentStatus:                        app.StatusInProgress,
+			CreateAt:                             1620018358404,
+			WebhookOnStatusUpdateURLs:            []string{server.URL},
+			StatusUpdateBroadcastWebhooksEnabled: true,
 		}
 		statusUpdateOptions := app.StatusUpdateOptions{
 			Message:  "latest-message",
@@ -633,19 +632,18 @@ func TestUpdateStatus(t *testing.T) {
 		follower1ID := "follower1ID"
 		follower2ID := "follower2ID"
 		playbookRun := &app.PlaybookRun{
-			ID:                                    playbookRunID,
-			Name:                                  "Name",
-			TeamID:                                teamID,
-			ChannelID:                             homeChannelID,
-			BroadcastChannelIDs:                   []string{broadcastChannelID1, broadcastChannelID2},
-			StatusUpdateBroadcastChannelsEnabled:  false,
-			OwnerUserID:                           "user_id",
-			ReporterUserID:                        "user_id",
-			CurrentStatus:                         app.StatusInProgress,
-			CreateAt:                              1620018358404,
-			WebhookOnStatusUpdateURLs:             []string{server.URL},
-			StatusUpdateBroadcastWebhooksEnabled:  false,
-			StatusUpdateBroadcastFollowersEnabled: false,
+			ID:                                   playbookRunID,
+			Name:                                 "Name",
+			TeamID:                               teamID,
+			ChannelID:                            homeChannelID,
+			BroadcastChannelIDs:                  []string{broadcastChannelID1, broadcastChannelID2},
+			StatusUpdateBroadcastChannelsEnabled: false,
+			OwnerUserID:                          "user_id",
+			ReporterUserID:                       "user_id",
+			CurrentStatus:                        app.StatusInProgress,
+			CreateAt:                             1620018358404,
+			WebhookOnStatusUpdateURLs:            []string{server.URL},
+			StatusUpdateBroadcastWebhooksEnabled: false,
 		}
 		statusUpdateOptions := app.StatusUpdateOptions{
 			Message:  "latest-message",
@@ -735,8 +733,8 @@ func TestUpdateStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, broadcastChannel1)
 		require.False(t, broadcastChannel2)
-		require.False(t, broadcastFollower1)
-		require.False(t, broadcastFollower2)
+		require.True(t, broadcastFollower1)
+		require.True(t, broadcastFollower2)
 
 		select {
 		case <-webhookChan:

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1967,7 +1967,7 @@ var migrations = []Migration{
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastChannelsEnabled to table IR_Incident")
 				}
 				if err := dropColumnMySQL(e, "IR_Incident", "StatusUpdateBroadcastFollowersEnabled"); err != nil {
-					return errors.Wrapf(err, "failed droping column StatusUpdateBroadcastFollowersEnabled from table IR_Incident")
+					return errors.Wrapf(err, "failed dropping column StatusUpdateBroadcastFollowersEnabled from table IR_Incident")
 				}
 				if err := addColumnToMySQLTable(e, "IR_Incident", "StatusUpdateBroadcastWebhooksEnabled", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastWebhooksEnabled to table IR_Incident")
@@ -1977,7 +1977,7 @@ var migrations = []Migration{
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastChannelsEnabled to table IR_Incident")
 				}
 				if err := dropColumnPG(e, "IR_Incident", "StatusUpdateBroadcastFollowersEnabled"); err != nil {
-					return errors.Wrapf(err, "failed droping column StatusUpdateBroadcastFollowersEnabled from table IR_Incident")
+					return errors.Wrapf(err, "failed dropping column StatusUpdateBroadcastFollowersEnabled from table IR_Incident")
 				}
 				if err := addColumnToPGTable(e, "IR_Incident", "StatusUpdateBroadcastWebhooksEnabled", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastWebhooksEnabled to table IR_Incident")

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -1954,12 +1954,20 @@ var migrations = []Migration{
 		fromVersion: semver.MustParse("0.51.0"),
 		toVersion:   semver.MustParse("0.52.0"),
 		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			// moved migration code to the next version to remove an unnecessary column
+			return nil
+		},
+	},
+	{
+		fromVersion: semver.MustParse("0.52.0"),
+		toVersion:   semver.MustParse("0.53.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
 			if e.DriverName() == model.DatabaseDriverMysql {
 				if err := addColumnToMySQLTable(e, "IR_Incident", "StatusUpdateBroadcastChannelsEnabled", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastChannelsEnabled to table IR_Incident")
 				}
-				if err := addColumnToMySQLTable(e, "IR_Incident", "StatusUpdateBroadcastFollowersEnabled", "BOOLEAN DEFAULT TRUE"); err != nil {
-					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastFollowersEnabled to table IR_Incident")
+				if err := dropColumnMySQL(e, "IR_Incident", "StatusUpdateBroadcastFollowersEnabled"); err != nil {
+					return errors.Wrapf(err, "failed droping column StatusUpdateBroadcastFollowersEnabled from table IR_Incident")
 				}
 				if err := addColumnToMySQLTable(e, "IR_Incident", "StatusUpdateBroadcastWebhooksEnabled", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastWebhooksEnabled to table IR_Incident")
@@ -1968,8 +1976,8 @@ var migrations = []Migration{
 				if err := addColumnToPGTable(e, "IR_Incident", "StatusUpdateBroadcastChannelsEnabled", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastChannelsEnabled to table IR_Incident")
 				}
-				if err := addColumnToPGTable(e, "IR_Incident", "StatusUpdateBroadcastFollowersEnabled", "BOOLEAN DEFAULT TRUE"); err != nil {
-					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastFollowersEnabled to table IR_Incident")
+				if err := dropColumnPG(e, "IR_Incident", "StatusUpdateBroadcastFollowersEnabled"); err != nil {
+					return errors.Wrapf(err, "failed droping column StatusUpdateBroadcastFollowersEnabled from table IR_Incident")
 				}
 				if err := addColumnToPGTable(e, "IR_Incident", "StatusUpdateBroadcastWebhooksEnabled", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column StatusUpdateBroadcastWebhooksEnabled to table IR_Incident")

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -185,7 +185,7 @@ func NewPlaybookRunStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQ
 			"COALESCE(ReminderMessageTemplate, '') ReminderMessageTemplate", "ReminderTimerDefaultSeconds", "StatusUpdateEnabled",
 			"ConcatenatedInvitedUserIDs", "ConcatenatedInvitedGroupIDs", "DefaultCommanderID AS DefaultOwnerID",
 			"ConcatenatedBroadcastChannelIDs", "ConcatenatedWebhookOnCreationURLs", "Retrospective", "RetrospectiveEnabled", "MessageOnJoin", "RetrospectivePublishedAt", "RetrospectiveReminderIntervalSeconds",
-			"RetrospectiveWasCanceled", "ConcatenatedWebhookOnStatusUpdateURLs", "StatusUpdateBroadcastChannelsEnabled", "StatusUpdateBroadcastFollowersEnabled", "StatusUpdateBroadcastWebhooksEnabled",
+			"RetrospectiveWasCanceled", "ConcatenatedWebhookOnStatusUpdateURLs", "StatusUpdateBroadcastChannelsEnabled", "StatusUpdateBroadcastWebhooksEnabled",
 			"COALESCE(CategoryName, '') CategoryName").
 		Column(participantsCol).
 		From("IR_Incident AS i").
@@ -460,7 +460,6 @@ func (s *playbookRunStore) CreatePlaybookRun(playbookRun *app.PlaybookRun) (*app
 			"ConcatenatedWebhookOnStatusUpdateURLs": rawPlaybookRun.ConcatenatedWebhookOnStatusUpdateURLs,
 			"CategoryName":                          rawPlaybookRun.CategoryName,
 			"StatusUpdateBroadcastChannelsEnabled":  rawPlaybookRun.StatusUpdateBroadcastChannelsEnabled,
-			"StatusUpdateBroadcastFollowersEnabled": rawPlaybookRun.StatusUpdateBroadcastFollowersEnabled,
 			"StatusUpdateBroadcastWebhooksEnabled":  rawPlaybookRun.StatusUpdateBroadcastWebhooksEnabled,
 			// Preserved for backwards compatibility with v1.2
 			"ActiveStage":      0,
@@ -518,7 +517,6 @@ func (s *playbookRunStore) UpdatePlaybookRun(playbookRun *app.PlaybookRun) error
 			"RetrospectiveWasCanceled":              rawPlaybookRun.RetrospectiveWasCanceled,
 			"ConcatenatedWebhookOnStatusUpdateURLs": rawPlaybookRun.ConcatenatedWebhookOnStatusUpdateURLs,
 			"StatusUpdateBroadcastChannelsEnabled":  rawPlaybookRun.StatusUpdateBroadcastChannelsEnabled,
-			"StatusUpdateBroadcastFollowersEnabled": rawPlaybookRun.StatusUpdateBroadcastFollowersEnabled,
 			"StatusUpdateBroadcastWebhooksEnabled":  rawPlaybookRun.StatusUpdateBroadcastWebhooksEnabled,
 		}).
 		Where(sq.Eq{"ID": rawPlaybookRun.ID}))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR removes the `broadcast to followers` flag from run data mode. There is no need for such a flag based on business requirements. 

#### Ticket Link

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [x] Unit tests updated
