### PR TITLE
update run status ask for confirmation if accidental cancel

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -30,6 +30,7 @@ describe('channels > rhs > status update', () => {
                 broadcastChannelId: testChannel.id,
                 reminderTimerDefaultSeconds: 3600,
                 reminderMessageTemplate: defaultReminderMessage,
+                retrospectiveEnabled: false,
             }).then((playbook) => {
                 testPlaybook = playbook;
             });

--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -64,7 +64,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get dialog modal.
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // # Type the invalid data
                 cy.findByTestId('update_run_status_textbox').clear().type(' {enter} {enter}  ');
 
@@ -79,7 +79,7 @@ describe('channels > rhs > status update', () => {
             });
 
             // * Verify that the Post update dialog has gone.
-            cy.get('.GenericModal').should('not.exist');
+            cy.findByRole('dialog', {name: /post update/i}).should('not.exist');
         });
 
         it('lets users with no access to the playbook post an update', () => {
@@ -118,7 +118,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get dialog modal.
-                cy.get('.GenericModal').within(() => {
+                cy.findByRole('dialog', {name: /post update/i}).within(() => {
                     // # Enter valid data
                     cy.findByTestId('update_run_status_textbox').type(updateMessage);
 
@@ -127,7 +127,7 @@ describe('channels > rhs > status update', () => {
                 });
 
                 // * Verify that the Post update dialog has gone.
-                cy.get('.GenericModal').should('not.exist');
+                cy.findByRole('dialog', {name: /post update/i}).should('not.exist');
 
                 // * Verify that the status update was posted.
                 cy.getLastPost().within(() => {
@@ -144,7 +144,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // * Verify the first message is there.
                 cy.findByTestId('update_run_status_textbox').within(() => {
                     cy.findByText(defaultReminderMessage).should('exist');
@@ -171,7 +171,7 @@ describe('channels > rhs > status update', () => {
             cy.get('#cancelModalButton').click({force: true});
 
             // * Verify post update has the same information
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // * Verify the message was remembered
                 cy.findByTestId('update_run_status_textbox').within(() => {
                     cy.findByText(updateMessage).should('exist');
@@ -196,12 +196,12 @@ describe('channels > rhs > status update', () => {
             cy.get('#confirmModalButton').click({force: true});
 
             // * Verify the status update was posted.
-            cy.uiGetNthPost(-3).within(() => {
+            cy.getStyledComponent('CustomPostContent').within(() => {
                 cy.findByText(updateMessage).should('exist');
             });
 
             // * Verify the run was finished.
-            cy.uiGetNthPost(-2).within(() => {
+            cy.getLastPost().within(() => {
                 cy.findByText('marked this run as finished.').should('exist');
             });
         });
@@ -265,7 +265,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get the dialog modal.
-                cy.get('.GenericModal').within(() => {
+                cy.findByRole('dialog', {name: /post update/i}).within(() => {
                     // * Verify the first message is there.
                     cy.findByTestId('update_run_status_textbox').within(() => {
                         cy.findByText(defaultReminderMessage).should('exist');
@@ -284,7 +284,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get the dialog modal.
-                cy.get('.GenericModal').within(() => {
+                cy.findByRole('dialog', {name: /post update/i}).within(() => {
                     // * Verify the first message is there.
                     cy.findByTestId('update_run_status_textbox').within(() => {
                         cy.findByText(firstMessage).should('exist');
@@ -300,7 +300,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '1 hour');
@@ -319,7 +319,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '15 minutes');
@@ -338,7 +338,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '1 hour, 30 minutes');
@@ -357,7 +357,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
+            cy.findByRole('dialog', {name: /post update/i}).within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '7 days');

--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -205,37 +205,90 @@ describe('channels > rhs > status update', () => {
                 cy.findByText('marked this run as finished.').should('exist');
             });
         });
-    });
 
-    describe('shows the last update in update message', () => {
-        it('shows the default when we have not made an update before', () => {
-            // # Run the `/playbook update` slash command.
-            cy.executeSlashCommand('/playbook update');
+        describe('prevents user from losing changes', () => {
+            it('go back and save', () => {
+                // # Run the `/playbook update` slash command.
+                cy.executeSlashCommand('/playbook update');
 
-            // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
-                // * Verify the first message is there.
-                cy.findByTestId('update_run_status_textbox').within(() => {
-                    cy.findByText(defaultReminderMessage).should('exist');
+                // # Get dialog modal.
+                cy.get('#playbooks_update_run_status_dialog').within(() => {
+                    // # Type the invalid data
+                    cy.findByTestId('update_run_status_textbox').clear().type('My valid and important changes that I don\'t want to lose');
+
+                    // * Click cancel
+                    cy.findByTestId('modal-cancel-button').click();
                 });
+
+                // * Go back from unsaved changes modal
+                cy.get('#confirm-modal-light').within(() => {
+                    cy.findByTestId('modal-cancel-button').click();
+                });
+
+                // # Submit the dialog.
+                cy.get('#playbooks_update_run_status_dialog').within(() => {
+                    cy.get('button.confirm').click();
+                });
+
+                // * Verify that the Post update and unsaved changes modals have gone.
+                cy.get('#playbooks_update_run_status_dialog').should('not.exist');
+                cy.get('#confirm-modal-light').should('not.exist');
+            });
+
+            it('discard explicitily', () => {
+                // # Run the `/playbook update` slash command.
+                cy.executeSlashCommand('/playbook update');
+
+                // # Get dialog modal.
+                cy.get('#playbooks_update_run_status_dialog').within(() => {
+                    // # Type the invalid data
+                    cy.findByTestId('update_run_status_textbox').clear().type('My valid and important changes that I don\'t want to lose');
+
+                    // * Click cancel
+                    cy.findByTestId('modal-cancel-button').click();
+                });
+
+                // * Discard explicitily from unsaved changes
+                cy.get('#confirm-modal-light').within(() => {
+                    cy.get('button.confirm').click();
+                });
+
+                // * Verify that the Post update and unsaved changes modals have gone.
+                cy.get('#playbooks_update_run_status_dialog').should('not.exist');
+                cy.get('#confirm-modal-light').should('not.exist');
             });
         });
 
-        it('when we have made a previous update', () => {
-            const now = Date.now();
-            const firstMessage = 'Update - ' + now;
+        describe('shows the last update in update message', () => {
+            it('shows the default when we have not made an update before', () => {
+                // # Run the `/playbook update` slash command.
+                cy.executeSlashCommand('/playbook update');
 
-            // # Create a first status update
-            cy.updateStatus(firstMessage);
+                // # Get the dialog modal.
+                cy.get('.GenericModal').within(() => {
+                    // * Verify the first message is there.
+                    cy.findByTestId('update_run_status_textbox').within(() => {
+                        cy.findByText(defaultReminderMessage).should('exist');
+                    });
+                });
+            });
 
-            // # Run the `/playbook update` slash command.
-            cy.executeSlashCommand('/playbook update');
+            it('when we have made a previous update', () => {
+                const now = Date.now();
+                const firstMessage = 'Update - ' + now;
 
-            // # Get the dialog modal.
-            cy.get('.GenericModal').within(() => {
-                // * Verify the first message is there.
-                cy.findByTestId('update_run_status_textbox').within(() => {
-                    cy.findByText(firstMessage).should('exist');
+                // # Create a first status update
+                cy.updateStatus(firstMessage);
+
+                // # Run the `/playbook update` slash command.
+                cy.executeSlashCommand('/playbook update');
+
+                // # Get the dialog modal.
+                cy.get('.GenericModal').within(() => {
+                    // * Verify the first message is there.
+                    cy.findByTestId('update_run_status_textbox').within(() => {
+                        cy.findByText(firstMessage).should('exist');
+                    });
                 });
             });
         });

--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -5,8 +5,7 @@
 // - [#] indicates a test step (e.g. # Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
-
-import * as TIMEOUTS from '../../fixtures/timeouts';
+import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('channels > rhs > status update', () => {
     const defaultReminderMessage = '# Default reminder message';

--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -6,6 +6,8 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('channels > rhs > status update', () => {
     const defaultReminderMessage = '# Default reminder message';
     let testTeam;
@@ -225,6 +227,10 @@ describe('channels > rhs > status update', () => {
                 cy.get('#confirm-modal-light').within(() => {
                     cy.findByTestId('modal-cancel-button').click();
                 });
+
+                // # Delay in between the modal switch to ensure the
+                // # animation has fully happened
+                cy.wait(TIMEOUTS.TWO_SEC);
 
                 // # Submit the dialog.
                 cy.getStatusUpdateDialog().within(() => {

--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -65,7 +65,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get dialog modal.
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // # Type the invalid data
                 cy.findByTestId('update_run_status_textbox').clear().type(' {enter} {enter}  ');
 
@@ -80,7 +80,7 @@ describe('channels > rhs > status update', () => {
             });
 
             // * Verify that the Post update dialog has gone.
-            cy.findByRole('dialog', {name: /post update/i}).should('not.exist');
+            cy.getStatusUpdateDialog().should('not.exist');
         });
 
         it('lets users with no access to the playbook post an update', () => {
@@ -119,7 +119,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get dialog modal.
-                cy.findByRole('dialog', {name: /post update/i}).within(() => {
+                cy.getStatusUpdateDialog().within(() => {
                     // # Enter valid data
                     cy.findByTestId('update_run_status_textbox').type(updateMessage);
 
@@ -128,7 +128,7 @@ describe('channels > rhs > status update', () => {
                 });
 
                 // * Verify that the Post update dialog has gone.
-                cy.findByRole('dialog', {name: /post update/i}).should('not.exist');
+                cy.getStatusUpdateDialog().should('not.exist');
 
                 // * Verify that the status update was posted.
                 cy.getLastPost().within(() => {
@@ -145,7 +145,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // * Verify the first message is there.
                 cy.findByTestId('update_run_status_textbox').within(() => {
                     cy.findByText(defaultReminderMessage).should('exist');
@@ -172,7 +172,7 @@ describe('channels > rhs > status update', () => {
             cy.get('#cancelModalButton').click({force: true});
 
             // * Verify post update has the same information
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // * Verify the message was remembered
                 cy.findByTestId('update_run_status_textbox').within(() => {
                     cy.findByText(updateMessage).should('exist');
@@ -213,7 +213,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get dialog modal.
-                cy.get('#playbooks_update_run_status_dialog').within(() => {
+                cy.getStatusUpdateDialog().within(() => {
                     // # Type the invalid data
                     cy.findByTestId('update_run_status_textbox').clear().type('My valid and important changes that I don\'t want to lose');
 
@@ -227,12 +227,12 @@ describe('channels > rhs > status update', () => {
                 });
 
                 // # Submit the dialog.
-                cy.get('#playbooks_update_run_status_dialog').within(() => {
+                cy.getStatusUpdateDialog().within(() => {
                     cy.get('button.confirm').click();
                 });
 
                 // * Verify that the Post update and unsaved changes modals have gone.
-                cy.get('#playbooks_update_run_status_dialog').should('not.exist');
+                cy.getStatusUpdateDialog().should('not.exist');
                 cy.get('#confirm-modal-light').should('not.exist');
             });
 
@@ -241,7 +241,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get dialog modal.
-                cy.get('#playbooks_update_run_status_dialog').within(() => {
+                cy.getStatusUpdateDialog().within(() => {
                     // # Type the invalid data
                     cy.findByTestId('update_run_status_textbox').clear().type('My valid and important changes that I don\'t want to lose');
 
@@ -255,7 +255,7 @@ describe('channels > rhs > status update', () => {
                 });
 
                 // * Verify that the Post update and unsaved changes modals have gone.
-                cy.get('#playbooks_update_run_status_dialog').should('not.exist');
+                cy.getStatusUpdateDialog().should('not.exist');
                 cy.get('#confirm-modal-light').should('not.exist');
             });
         });
@@ -266,7 +266,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get the dialog modal.
-                cy.findByRole('dialog', {name: /post update/i}).within(() => {
+                cy.getStatusUpdateDialog().within(() => {
                     // * Verify the first message is there.
                     cy.findByTestId('update_run_status_textbox').within(() => {
                         cy.findByText(defaultReminderMessage).should('exist');
@@ -285,7 +285,7 @@ describe('channels > rhs > status update', () => {
                 cy.executeSlashCommand('/playbook update');
 
                 // # Get the dialog modal.
-                cy.findByRole('dialog', {name: /post update/i}).within(() => {
+                cy.getStatusUpdateDialog().within(() => {
                     // * Verify the first message is there.
                     cy.findByTestId('update_run_status_textbox').within(() => {
                         cy.findByText(firstMessage).should('exist');
@@ -301,7 +301,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '1 hour');
@@ -320,7 +320,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '15 minutes');
@@ -339,7 +339,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '1 hour, 30 minutes');
@@ -358,7 +358,7 @@ describe('channels > rhs > status update', () => {
             cy.executeSlashCommand('/playbook update');
 
             // # Get the dialog modal.
-            cy.findByRole('dialog', {name: /post update/i}).within(() => {
+            cy.getStatusUpdateDialog().within(() => {
                 // * Verify the default is as expected
                 cy.get('#reminder_timer_datetime').within(() => {
                     cy.get('[class$=singleValue]').should('have.text', '7 days');

--- a/tests-e2e/cypress/integration/channels/update_request_post_spec.js
+++ b/tests-e2e/cypress/integration/channels/update_request_post_spec.js
@@ -72,7 +72,7 @@ describe('channels > run dialog', () => {
             });
         });
 
-        it('in threads view', () => {
+        it('in threads view', {retries: {runMode: 3}}, () => {
             // # Navigate to the application
             cy.visit(`${testTeam.name}/channels/test-run`);
 

--- a/tests-e2e/cypress/integration/runs/details_spec.js
+++ b/tests-e2e/cypress/integration/runs/details_spec.js
@@ -131,10 +131,9 @@ describe('runs > details', () => {
                     ownerUserId: testUser.id,
                 });
             }).then((run) => {
-                playbookRun = run
-            })
+                playbookRun = run;
+            });
         });
-
 
         it('should show that status updates were disabled', () => {
             // # Visit the playbook run preview
@@ -167,10 +166,9 @@ describe('runs > details', () => {
                     ownerUserId: testUser.id,
                 });
             }).then((run) => {
-                playbookRun = run
-            })
+                playbookRun = run;
+            });
         });
-
 
         it('should show the retrospectives were disabled message', () => {
             // # Visit the playbook run preview

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -188,7 +188,7 @@ Cypress.Commands.add('updateStatus', (message, reminderQuery) => {
     cy.executeSlashCommand('/playbook update');
 
     // # Get the interactive dialog modal.
-    cy.get('.GenericModal').within(() => {
+    cy.getStatusUpdateDialog().within(() => {
         // # remove what's there if applicable, and type the new update in the textbox.
         cy.findByTestId('update_run_status_textbox').clear().type(message);
 
@@ -203,7 +203,7 @@ Cypress.Commands.add('updateStatus', (message, reminderQuery) => {
     });
 
     // * Verify that the interactive dialog has gone.
-    cy.get('.GenericModal').should('not.exist');
+    cy.getStatusUpdateDialog().should('not.exist');
 
     // # Return the post ID of the status update.
     return cy.getLastPostId();
@@ -241,6 +241,10 @@ Cypress.Commands.add('uiSwitchChannel', (channelName) => {
     cy.get('#quickSwitchInput').type(channelName);
     cy.get('#suggestionList > div:first-child').should('contain', channelName).click();
     cy.get('#channelHeaderTitle').contains(channelName);
+});
+
+Cypress.Commands.add('getStatusUpdateDialog', () => {
+    return cy.findByRole('dialog', {name: /post update/i});
 });
 
 Cypress.Commands.add('getStyledComponent', (className) => {

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -225,8 +225,6 @@ const UpdateRunStatusModal = ({
                 confirmButtonText={hasPermission ? formatMessage({defaultMessage: 'Post update'}) : formatMessage({defaultMessage: 'Ok'})}
                 handleCancel={() => true}
                 {...modalProps}
-
-                // handleCancel={onTentativeHide}
                 onHide={onTentativeHide}
                 handleConfirm={hasPermission ? onSubmit : null}
                 autoCloseOnConfirmButton={false}

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -13,6 +13,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import GenericModal, {Description, Label} from 'src/components/widgets/generic_modal';
+import UnsavedChangesModal from 'src/components/widgets/unsaved_changes_modal';
+
 import {
     useDateTimeInput,
     useMakeOption,
@@ -24,7 +26,6 @@ import {usePost, useRun} from 'src/hooks';
 import MarkdownTextbox from '../markdown_textbox';
 import {pluginUrl} from 'src/browser_routing';
 import {postStatusUpdate} from 'src/client';
-import {formatDuration} from '../formatted_duration';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {nearest} from 'src/utils';
 import Tooltip from 'src/components/widgets/tooltip';
@@ -74,6 +75,7 @@ const UpdateRunStatusModal = ({
     }
 
     const [showModal, setShowModal] = useState(true);
+    const [showUnsaved, setShowUnsaved] = useState(false);
     const [finishRun, setFinishRun] = useState(providedFinishRunChecked || false);
 
     const {input: reminderInput, reminder} = useReminderTimerOption(run, finishRun, providedReminder);
@@ -102,6 +104,21 @@ const UpdateRunStatusModal = ({
             {outstanding});
     }
 
+    const onTentativeHide = () => {
+        if (providedMessage === message || message === defaultMessage || message === '') {
+            onActualHide();
+        } else {
+            setShowUnsaved(true);
+        }
+    };
+
+    const onActualHide = () => {
+        modalProps.onHide?.();
+        setTimeout(() => {
+            setShowUnsaved(false);
+        }, 300);
+    };
+
     const onConfirm = () => {
         if (hasPermission && message?.trim() && currentUserId && channelId && run?.team_id) {
             postStatusUpdate(
@@ -109,13 +126,13 @@ const UpdateRunStatusModal = ({
                 {message, reminder, finishRun},
                 {user_id: currentUserId, channel_id: channelId, team_id: run?.team_id}
             );
-            setShowModal(false);
+            onActualHide();
         }
     };
 
     const onSubmit = () => {
         if (finishRun) {
-            setShowModal(false);
+            onActualHide();
 
             dispatch(modals.openModal(makeUncontrolledConfirmModalDefinition({
                 show: true,
@@ -200,22 +217,32 @@ const UpdateRunStatusModal = ({
     );
 
     return (
-        <GenericModal
-            show={showModal}
-            modalHeaderText={formatMessage({defaultMessage: 'Post update'})}
-            cancelButtonText={hasPermission ? formatMessage({defaultMessage: 'Cancel'}) : formatMessage({defaultMessage: 'Close'})}
-            confirmButtonText={hasPermission ? formatMessage({defaultMessage: 'Post update'}) : formatMessage({defaultMessage: 'Ok'})}
-            handleCancel={() => true}
-            handleConfirm={hasPermission ? onSubmit : null}
-            autoCloseOnConfirmButton={false}
-            isConfirmDisabled={!(hasPermission && message?.trim() && currentUserId && channelId && run?.team_id && isReminderValid)}
-            {...modalProps}
-            id={ID}
-            footer={footer}
-            components={{FooterContainer}}
-        >
-            {hasPermission ? form : warning}
-        </GenericModal>
+        <>
+            <GenericModal
+                show={showModal && !showUnsaved}
+                modalHeaderText={formatMessage({defaultMessage: 'Post update'})}
+                cancelButtonText={hasPermission ? formatMessage({defaultMessage: 'Cancel'}) : formatMessage({defaultMessage: 'Close'})}
+                confirmButtonText={hasPermission ? formatMessage({defaultMessage: 'Post update'}) : formatMessage({defaultMessage: 'Ok'})}
+                handleCancel={() => true}
+                {...modalProps}
+
+                // handleCancel={onTentativeHide}
+                onHide={onTentativeHide}
+                handleConfirm={hasPermission ? onSubmit : null}
+                autoCloseOnConfirmButton={false}
+                isConfirmDisabled={!(hasPermission && message?.trim() && currentUserId && channelId && run?.team_id && isReminderValid)}
+                id={ID}
+                footer={footer}
+                components={{FooterContainer}}
+            >
+                {hasPermission ? form : warning}
+            </GenericModal>
+            <UnsavedChangesModal
+                show={showUnsaved}
+                onConfirm={onActualHide}
+                onCancel={() => setShowUnsaved(false)}
+            />
+        </>
     );
 };
 


### PR DESCRIPTION
#### Summary
If the user leaves without saving changes in update_run_status modal, a confirmation modal will be shown.
E2E tests added

This modal has a mix of visibility state management that makes it a bit harder to make changes: inside the component uses useState(showModal), and from the outside is controlled by modalProps.onHide().  That is the main reason why I had to replace some setShowModal with modalProps.onHide().

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-43513

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
