### PR TITLE
Add skipping daiy digest when there are only tasks due after today

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2829,16 +2829,21 @@ func buildAssignedTaskMessageSummary(runs []AssignedRun, locale string, timezone
 		}
 	}
 
-	// omit assigned tasks header if runs info is empty
-	if runsInfo.String() != "" {
-		if onlyDueUntilToday {
-			msg.WriteString(T("app.user.digest.tasks.num_assigned_due_until_today", total-tasksDoAfterToday))
-		} else {
-			msg.WriteString(T("app.user.digest.tasks.num_assigned", total))
-		}
-		msg.WriteString("\n\n")
-		msg.WriteString(runsInfo.String())
+	// if there are only tasks that are due after today and we need to show only tasks due now, skip a message
+	if onlyDueUntilToday && tasksDoAfterToday == total {
+		return ""
 	}
+
+	// add title
+	if onlyDueUntilToday {
+		msg.WriteString(T("app.user.digest.tasks.num_assigned_due_until_today", total-tasksDoAfterToday))
+	} else {
+		msg.WriteString(T("app.user.digest.tasks.num_assigned", total))
+	}
+
+	// add info about tasks
+	msg.WriteString("\n\n")
+	msg.WriteString(runsInfo.String())
 
 	// add summary info for tasks without a due date or due date after today
 	if tasksDoAfterToday > 0 && onlyDueUntilToday {

--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -1700,10 +1700,7 @@ func TestDMTodoDigestToUser(t *testing.T) {
 		require.Equal(t, expected, digestPost.Message)
 	})
 
-	t.Run("digest message with tasks due after today", func(t *testing.T) {
-		expected := "##### Your assigned tasks\n" +
-			":information_source: You have **3 assigned tasks due after today**. Please use `/playbook todo` to see all your tasks."
-
+	t.Run("no digest message. only tasks due after today", func(t *testing.T) {
 		now := model.GetMillis()
 		assignedRuns := []app.AssignedRun{
 			{
@@ -1735,7 +1732,7 @@ func TestDMTodoDigestToUser(t *testing.T) {
 
 		err = s.DMTodoDigestToUser(user.Id, false)
 		require.NoError(t, err)
-		require.Equal(t, expected, digestPost.Message)
+		require.Nil(t, digestPost)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR excludes summary info from daily digest message when there are only tasks due in the future and returns empty text. As a result, the daily digest message is skipped when we only have tasks due in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43586

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [x] Unit tests updated
