### PR TITLE
disable hover menu in checkist while dragging

### DIFF
--- a/webapp/src/components/backstage/playbooks/playbook_preview_checklists.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_checklists.tsx
@@ -66,6 +66,7 @@ const PlaybookPreviewChecklists = (props: Props) => {
                                     playbookRunId={''}
                                     dragging={false}
                                     disabled={true}
+                                    menuEnabled={true}
                                     collapsibleDescription={false}
                                     newItem={false}
                                 />

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -34,6 +34,7 @@ interface ChecklistItemProps {
     itemNum: number;
     channelId: string;
     playbookRunId: string;
+    menuEnabled: boolean;
     onChange?: (item: ChecklistItemState) => void;
     draggableProvided?: DraggableProvided;
     dragging: boolean;
@@ -116,7 +117,7 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             editing={isEditing}
         >
             <CheckboxContainer>
-                {showMenu && !props.disabled &&
+                {showMenu && !props.disabled && props.menuEnabled &&
                     <ChecklistItemHoverMenu
                         playbookRunId={props.playbookRunId}
                         checklistNum={props.checklistNum}
@@ -367,9 +368,9 @@ const ChecklistItemTitleWrapper = styled.div`
 const DragButton = styled.i<{isVisible: boolean}>`
     cursor: pointer;
     width: 4px;
-    margin-right: 4px; 
-    margin-left: 4px;  
-    margin-top: 1px; 
+    margin-right: 4px;
+    margin-left: 4px;
+    margin-top: 1px;
     color: rgba(var(--center-channel-color-rgb), 0.56);
     ${({isVisible}) => !isVisible && `
         visibility: hidden

--- a/webapp/src/components/checklist_item/checklist_item_draggable.tsx
+++ b/webapp/src/components/checklist_item/checklist_item_draggable.tsx
@@ -15,6 +15,7 @@ interface Props {
     item: ChecklistItemType;
     itemIndex: number;
     newItem: boolean;
+    menuEnabled: boolean;
     cancelAddingItem: () => void;
 }
 
@@ -39,6 +40,7 @@ const DraggableChecklistItem = (props: Props) => {
                     draggableProvided={draggableProvided}
                     dragging={snapshot.isDragging}
                     disabled={finished}
+                    menuEnabled={props.menuEnabled}
                     collapsibleDescription={true}
                     newItem={props.newItem}
                     cancelAddingItem={props.cancelAddingItem}

--- a/webapp/src/components/rhs/rhs_checklist.tsx
+++ b/webapp/src/components/rhs/rhs_checklist.tsx
@@ -29,6 +29,7 @@ interface Props {
     playbookRun: PlaybookRun;
     checklist: Checklist;
     checklistIndex: number;
+    menuEnabled: boolean;
 }
 
 const RHSChecklist = (props: Props) => {
@@ -100,6 +101,7 @@ const RHSChecklist = (props: Props) => {
                                     item={checklistItem}
                                     itemIndex={index}
                                     newItem={false}
+                                    menuEnabled={props.menuEnabled}
                                     cancelAddingItem={() => {
                                         setAddingItem(false);
                                     }}
@@ -114,6 +116,7 @@ const RHSChecklist = (props: Props) => {
                                 item={emptyChecklistItem()}
                                 itemIndex={-1}
                                 newItem={true}
+                                menuEnabled={props.menuEnabled}
                                 cancelAddingItem={() => {
                                     setAddingItem(false);
                                 }}

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -98,6 +98,7 @@ const RHSChecklistList = (props: Props) => {
     const finished = props.playbookRun.current_status === PlaybookRunStatus.Finished;
     const filterOptions = makeFilterOptions(checklistItemsFilter, preferredName);
     const overdueTasksNum = overdueTasks(props.playbookRun.checklists);
+    const [menuEnabled, setMenuEnabled] = useState(true);
 
     const selectOption = (value: string, checked: boolean) => {
         telemetryEventForPlaybookRun(props.playbookRun.id, 'checklists_filter_selected');
@@ -113,6 +114,11 @@ const RHSChecklistList = (props: Props) => {
             ...checklistItemsFilter,
             [value]: checked,
         }));
+    };
+
+    const onDragStart = () => {
+        // block hover menu on checklists
+        setMenuEnabled(false);
     };
 
     const onDragEnd = (result: DropResult) => {
@@ -172,6 +178,9 @@ const RHSChecklistList = (props: Props) => {
 
             // Persist the new data in the server
             clientMoveChecklistItem(props.playbookRun.id, srcChecklistIdx, srcIdx, dstChecklistIdx, dstIdx);
+
+            // allow again to see hover menu
+            setMenuEnabled(true);
         }
 
         // Move a whole checklist
@@ -285,7 +294,10 @@ const RHSChecklistList = (props: Props) => {
                     }
                 </MainTitle>
             </MainTitleBG>
-            <DragDropContext onDragEnd={onDragEnd}>
+            <DragDropContext
+                onDragEnd={onDragEnd}
+                onDragStart={onDragStart}
+            >
                 <Droppable
                     droppableId={'all-checklists'}
                     direction={'vertical'}
@@ -318,6 +330,7 @@ const RHSChecklistList = (props: Props) => {
                                                     playbookRun={props.playbookRun}
                                                     checklist={checklist}
                                                     checklistIndex={checklistIndex}
+                                                    menuEnabled={menuEnabled}
                                                 />
                                             </CollapsibleChecklist>
                                         );


### PR DESCRIPTION
#### Summary
Disable the checklist menu that appears when doing hover if we are currently doing drag&drop.
Menu hover is disabled for:
- the item you are currently dragging 
- any other item you may hover while dragging.

A Flag has to be managed at the top dropable level, so a new prop needs to be passed to checklist and checklist_item. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43415

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
