### PR TITLE
Fix long string overflow in status update reminder

### DIFF
--- a/webapp/src/components/update_request_post.tsx
+++ b/webapp/src/components/update_request_post.tsx
@@ -139,21 +139,14 @@ export const UpdateRequestPost = (props: Props) => {
     );
 };
 
-const PostUpdateButtonCommon = css`
-    justify-content: center;
-    flex: 1;
-    max-width: 135px;
-    margin: 4px;
-`;
-
 const SelectWrapper = styled(StyledSelect)`
     margin: 4px;
 `;
 
 const PostUpdatePrimaryButton = styled(PrimaryButton)`
-    ${PostUpdateButtonCommon} {
-    }
-
+    justify-content: center;
+    flex: 1;
+    margin: 4px;
     white-space: nowrap;
 `;
 


### PR DESCRIPTION
#### Summary
![image](https://user-images.githubusercontent.com/11724372/165975778-c168aaeb-2222-4cf8-b701-e64b73cb6839.png)

<img width="483" alt="CleanShot 2022-04-29 at 10 23 29@2x" src="https://user-images.githubusercontent.com/11724372/165975801-a6fe7737-ce08-4adb-9106-fe751b9d0af4.png">


#### Ticket Link
None


#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | N
Gated by experimental feature flag? | NA
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.
