### PR TITLE
enum types proposal

### DIFF
--- a/server/api/actions.go
+++ b/server/api/actions.go
@@ -102,26 +102,14 @@ func isValidTrigger(trigger string) bool {
 	return false
 }
 
-func isValidAction(action string) bool {
-	if action == "" {
-		return true
-	}
-
-	for _, elem := range app.ValidActionTypes {
-		if action == string(elem) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func parseGetChannelActionsOptions(query url.Values) (*app.GetChannelActionOptions, error) {
 	actionTypeStr := query.Get("action_type")
 	triggerTypeStr := query.Get("trigger_type")
 
-	if !isValidAction(actionTypeStr) {
-		return nil, fmt.Errorf("action_type %q not recognized; valid values are %v", actionTypeStr, app.ValidActionTypes)
+	var actionType app.ActionType
+	err := (&actionType).UnmarshalText([]byte(actionTypeStr))
+	if err != nil {
+		return nil, fmt.Errorf("action_type %q not recognized; valid values are %v", actionTypeStr, app.ActionTypes)
 	}
 
 	if !isValidTrigger(triggerTypeStr) {
@@ -129,7 +117,7 @@ func parseGetChannelActionsOptions(query url.Values) (*app.GetChannelActionOptio
 	}
 
 	return &app.GetChannelActionOptions{
-		ActionType:  app.ActionType(actionTypeStr),
+		ActionType:  actionType,
 		TriggerType: app.TriggerType(triggerTypeStr),
 	}, nil
 }

--- a/server/app/actions_service.go
+++ b/server/app/actions_service.go
@@ -96,7 +96,7 @@ func (a *channelActionServiceImpl) Create(action GenericChannelAction) (string, 
 	}
 
 	if len(actions) > 0 {
-		return "", fmt.Errorf("only one action of action type %q and trigger type %q is allowed", string(action.ActionType), string(action.TriggerType))
+		return "", fmt.Errorf("only one action of action type %q and trigger type %q is allowed", action.ActionType.String(), string(action.TriggerType))
 	}
 
 	if action.ActionType == ActionTypeWelcomeMessage && action.Enabled {

--- a/server/sqlstore/actions.go
+++ b/server/sqlstore/actions.go
@@ -108,7 +108,7 @@ func (c *channelActionStore) GetChannelActions(channelID string, options app.Get
 		query = query.Where(sq.Eq{"c.TriggerType": options.TriggerType})
 	}
 
-	if options.ActionType != "" {
+	if options.ActionType != app.ActionTypeUnknown {
 		query = query.Where(sq.Eq{"c.ActionType": options.ActionType})
 	}
 


### PR DESCRIPTION
THIS PR IS A PROPOSAL TO BE DISCUSSED - NOT AN ACTUAL PR TO BE MERGED

## current status
The current approach in many places is a combination of package constants, validation methods, and passing parameters as scalar types (string/int).  

## proposal
Create an enum type through [iota mechanism](https://go.dev/ref/spec#Iota) and implement key interfaces:
- [Scanner, Valuer](http://jmoiron.net/blog/built-in-interfaces): handles read/write conversions from database
- [Stringer](https://musse.dev/stringer-golang/): handles string version for errors or any readable format
- [Marshallers](https://pkg.go.dev/encoding#TextMarshaler): handle JSON serialization/deserialization  

All params used in functions must use the new type which implemented all this interfaces.

Given a type T with two options One and Two 
- It's not possible to create a HTTP response with a wrong value different from One and Two, if we forced it, it won't encode JSON
- It's not possible to read JSON body from HTTP requests if the value for type is different from One or Two
- It's not possible to store a wrong value in database
- It's not possible to read a wrong value from database 

## Benefits
**Safety**
The validation of the type is included in any of the serializations, from/to JSON and from/to database.

**Documentation**
It's clearer what are the possible values for a type with iota than just having a couple of constants that you are not sure if they are part of the same topic.

## Drawbacks
It's more boilerplate, not complicated code but indeed more.  