### PR TITLE
automatically open runactions modal when navigating from post-status

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/status_update_spec.js
@@ -87,6 +87,9 @@ describe('channels > rhs > status update', () => {
 
             // * Check that we are now in run overview page
             cy.url().should('include', `/playbooks/runs/${testRun.id}`);
+
+            // * Check that the run actions modal is already opened
+            cy.findByRole('dialog', {name: /Run Actions/i}).should('exist');
         });
 
         it('prevents posting an update message with only whitespace', () => {
@@ -345,6 +348,9 @@ describe('channels > rhs > status update', () => {
                 // * Verify that the Post update and unsaved changes modals have gone.
                 cy.getStatusUpdateDialog().should('not.exist');
                 cy.get('#confirm-modal-light').should('not.exist');
+
+                // * Verify that the run actions modal is opened.
+                cy.findByRole('dialog', {name: /Run Actions/i}).should('exist');
             });
         });
 

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -35,7 +35,7 @@ import CheckboxInput from 'src/components/backstage/runs_list/checkbox_input';
 import {makeUncontrolledConfirmModalDefinition} from 'src/components/widgets/confirmation_modal';
 import {modals, browserHistory} from 'src/webapp_globals';
 import {Checklist, ChecklistItemState} from 'src/types/playbook';
-import {openUpdateRunStatusModal/*, showRunActionsModal*/} from 'src/actions';
+import {openUpdateRunStatusModal, showRunActionsModal} from 'src/actions';
 import {VerticalSpacer} from 'src/components/backstage/styles';
 import RouteLeavingGuard from 'src/components/backstage/route_leaving_guard';
 
@@ -272,6 +272,13 @@ const UpdateRunStatusModal = ({
         </WarningBlock>
     );
 
+    const preopenRunActionsModal = () => {
+        // Open modal only if there are already broadcast channels
+        if (run?.broadcast_channel_ids.length) {
+            dispatch(showRunActionsModal());
+        }
+    };
+
     return (
         <>
             <GenericModal
@@ -304,9 +311,7 @@ const UpdateRunStatusModal = ({
                 }}
                 navigate={(path) => {
                     modalProps.onHide?.();
-
-                    // Uncomment once https://github.com/mattermost/mattermost-plugin-playbooks/pull/1153 is merged
-                    // dispatch(showRunActionsModal());
+                    preopenRunActionsModal();
                     browserHistory.push(path);
                 }}
                 shouldBlockNavigation={(newLoc) => {
@@ -318,11 +323,10 @@ const UpdateRunStatusModal = ({
                         return true;
                     }
 
-                    // don't block nav but hide modal
                     if (locChanged) {
                         modalProps.onHide?.();
+                        preopenRunActionsModal();
                     }
-
                     return false;
                 }}
             />

--- a/webapp/src/types/playbook_run.ts
+++ b/webapp/src/types/playbook_run.ts
@@ -24,7 +24,6 @@ export interface PlaybookRun {
     reminder_message_template: string;
     reminder_timer_default_seconds: number;
     status_update_enabled: boolean;
-    status_update_broadcast_channels_enabled: boolean;
     broadcast_channel_ids: string[];
     status_update_broadcast_webhooks_enabled: boolean;
     webhook_on_status_update_urls: string[];


### PR DESCRIPTION
#### Summary
Opens automatically run actions modal when the user navigates from post update modal (RHS)

We use the link in two situations in the modal:
- when there are broadcast channels -> we do open the modal in the navigation
- when there's no followers or broadcast -> we do NOT automatically open the modal

#### Ticket Link
Completes https://mattermost.atlassian.net/browse/MM-43130

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
