### PR TITLE
[MM-43880] Allow one-character playbook names

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2194,7 +2194,7 @@ func (s *PlaybookRunServiceImpl) createPlaybookRunChannel(playbookRun *PlaybookR
 		if appErr, ok := err.(*model.AppError); ok {
 			// Let the user correct display name errors:
 			if appErr.Id == "model.channel.is_valid.display_name.app_error" ||
-				appErr.Id == "model.channel.is_valid.2_or_more.app_error" {
+				appErr.Id == "model.channel.is_valid.1_or_more.app_error" {
 				return nil, ErrChannelDisplayNameInvalid
 			}
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2308,7 +2308,7 @@ func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, ownerID, postID, c
 				DisplayName: "Run name",
 				Name:        DialogFieldNameKey,
 				Type:        "text",
-				MinLength:   2,
+				MinLength:   1,
 				MaxLength:   64,
 				Default:     defaultChannelNameTemplate,
 			},

--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -88,7 +88,7 @@ func TestCreatePlaybookRun(t *testing.T) {
 		mattermostConfig := &model.Config{}
 		mattermostConfig.SetDefaults()
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
-		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.2_or_more.app_error"})
+		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.1_or_more.app_error"})
 
 		s := app.NewPlaybookRunService(client, store, poster, logger, configService, scheduler, telemetryService, pluginAPI, playbookService, channelActionService, licenseChecker, metrics.NewMetrics(metrics.InstanceInfo{}))
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
Allow one-character playbook names. Channel allows one-character name (`master` on `mattermost-server`), and playbook run name which is a channel name should support one-character naming. The pull request edits the checks on the `model.AppError`.
<!--
A description of what this pull request does
-->

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/20108
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
