### PR TITLE
Fix checklist item render issue

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -363,6 +363,28 @@ describe('channels > rhs > checklist', () => {
             // * Verify if filter was canceled
             cy.findAllByTestId('checkbox-item-container').should('have.length', 12);
         });
+
+        it.only('switching between runs with the same checklist', () => {
+            // # Create another run using the same playbook
+            const playbookRunName2 = 'RunWithSameChecklist';
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName: playbookRunName2,
+                ownerUserId: testUser.id,
+            });
+
+            // # Set due date for the first channel's task
+            setTaskDueDate(2, 'in 2 hours');
+
+            // # Switch to the second run channel
+            cy.get('#sidebarItem_runwithsamechecklist').click();
+
+            // * Verify that tasks do not have due dates
+            cy.findAllByTestId('checkbox-item-container').eq(2).within(() => {
+                cy.findAllByTestId('due-date-info-button').should('not.exist');
+            });
+        });
     });
 });
 

--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -114,7 +114,7 @@ const GenericChecklist = (props: Props) => {
         props.onUpdateChecklist(newChecklist);
     };
 
-    const keys = generateKeys(props.checklist.items.map((item) => item.title));
+    const keys = generateKeys(props.checklist.items.map((item) => props.playbookRun?.id + item.title));
 
     return (
         <Droppable


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR fixes issue with RHS Checklist item showing the due date of an item with the same name from another channel. It happened because items with the same name had the same `key` attribute values, and switching between channels did not render the list component.
Updated `key` generation logic, now its value is unique.

This recording shows the problem:

https://user-images.githubusercontent.com/4368372/167859688-d401720a-c88f-40d1-8ff8-8df0809f2797.mp4



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43936

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [ ] Unit tests updated
