### PR TITLE
e2e: Mochawesome reports for Gitlab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ commands:
             npm run test -- --spec "$(cat ./tests-to-run | tr '\n' ',')"
       - *save_cypress_cache
       - store_test_results:
-          path: tests-e2e/cypress/results
+          path: tests-e2e/cypress/results/junit
       - store_artifacts:
           path: tests-e2e/cypress/videos
 

--- a/tests-e2e/reporter-config.json
+++ b/tests-e2e/reporter-config.json
@@ -5,6 +5,7 @@
     },
     "mochawesomeReporterOptions": {
         "reportDir": "cypress/results/mochawesome",
+        "reportFilename": "[datetime]-[name]-report",
         "overwrite": false,
         "html": false,
         "json": true

--- a/tests-e2e/reporter-config.json
+++ b/tests-e2e/reporter-config.json
@@ -1,6 +1,12 @@
 {
-  "mochaJunitReporterReporterOptions": {
-    "mochaFile": "cypress/results/junit-[hash].xml"
-  },
-  "reporterEnabled": "spec, mocha-junit-reporter"
+    "reporterEnabled": "spec, mocha-junit-reporter, mochawesome",
+    "mochaJunitReporterReporterOptions": {
+        "mochaFile": "cypress/results/junit/junit-[hash].xml"
+    },
+    "mochawesomeReporterOptions": {
+        "reportDir": "results/mochawesome",
+        "overwrite": false,
+        "html": false,
+        "json": true
+    }
 }

--- a/tests-e2e/reporter-config.json
+++ b/tests-e2e/reporter-config.json
@@ -4,7 +4,7 @@
         "mochaFile": "cypress/results/junit/junit-[hash].xml"
     },
     "mochawesomeReporterOptions": {
-        "reportDir": "results/mochawesome",
+        "reportDir": "cypress/results/mochawesome",
         "overwrite": false,
         "html": false,
         "json": true


### PR DESCRIPTION
Turning on Mochawesome to generate run reports in Gitlab, similar to the main e2e suite. Example attached, though it's missing failure screenshots for the moment. 

[example mochawesome-report.zip](https://github.com/mattermost/mattermost-plugin-playbooks/files/8680277/mochawesome-report.zip)

