### PR TITLE
handle optimistic updates to checkbox in checklist item

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -312,11 +312,12 @@ export async function setDueDate(playbookRunId: string, checklistNum: number, it
 }
 
 export async function setChecklistItemState(playbookRunID: string, checklistNum: number, itemNum: number, newState: ChecklistItemState) {
-    return doPut(`${apiUrl}/runs/${playbookRunID}/checklists/${checklistNum}/item/${itemNum}/state`,
-        JSON.stringify({
-            new_state: newState,
-        }),
-    );
+    const body = JSON.stringify({new_state: newState});
+    try {
+        return await doPut<void>(`${apiUrl}/runs/${playbookRunID}/checklists/${checklistNum}/item/${itemNum}/state`, body);
+    } catch (error) {
+        return {error: error as ClientError};
+    }
 }
 
 export async function clientRemoveChecklistItem(playbookRunID: string, checklistNum: number, itemNum: number) {

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -7,6 +7,7 @@ import {useIntl} from 'react-intl';
 import styled, {css} from 'styled-components';
 import {DraggableProvided} from 'react-beautiful-dnd';
 import {UserProfile} from 'mattermost-redux/types/users';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 import {
     clientEditChecklistItem,
@@ -34,7 +35,7 @@ interface ChecklistItemProps {
     itemNum: number;
     playbookRunId?: string;
     menuEnabled: boolean;
-    onChange?: (item: ChecklistItemState) => void;
+    onChange?: (item: ChecklistItemState) => undefined | Promise<void | {error: ClientError}>;
     draggableProvided?: DraggableProvided;
     dragging: boolean;
     disabled: boolean;
@@ -223,11 +224,7 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
                 <CheckBoxButton
                     disabled={props.disabled || props.checklistItem.state === ChecklistItemState.Skip || props.playbookRunId === undefined}
                     item={props.checklistItem}
-                    onChange={(item: ChecklistItemState) => {
-                        if (props.onChange) {
-                            props.onChange(item);
-                        }
-                    }}
+                    onChange={(item: ChecklistItemState) => props.onChange?.(item)}
                 />
                 <ChecklistItemTitleWrapper
                     onClick={() => props.collapsibleDescription && props.checklistItem.description !== '' && toggleDescription()}

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -7,7 +7,6 @@ import {useIntl} from 'react-intl';
 import styled, {css} from 'styled-components';
 import {DraggableProvided} from 'react-beautiful-dnd';
 import {UserProfile} from 'mattermost-redux/types/users';
-import {ClientError} from 'mattermost-redux/client/client4';
 
 import {
     clientEditChecklistItem,
@@ -15,6 +14,7 @@ import {
     setDueDate as clientSetDueDate,
     setAssignee,
     clientSetChecklistItemCommand,
+    setChecklistItemState,
 } from 'src/client';
 import {ChecklistItem as ChecklistItemType, ChecklistItemState} from 'src/types/playbook';
 import {usePortal} from 'src/hooks';
@@ -35,7 +35,7 @@ interface ChecklistItemProps {
     itemNum: number;
     playbookRunId?: string;
     menuEnabled: boolean;
-    onChange?: (item: ChecklistItemState) => undefined | Promise<void | {error: ClientError}>;
+    onChange?: (item: ChecklistItemState) => ReturnType<typeof setChecklistItemState> | undefined;
     draggableProvided?: DraggableProvided;
     dragging: boolean;
     disabled: boolean;

--- a/webapp/src/components/checklist_item/checklist_item_draggable.tsx
+++ b/webapp/src/components/checklist_item/checklist_item_draggable.tsx
@@ -37,9 +37,7 @@ const DraggableChecklistItem = (props: Props) => {
                     checklistNum={props.checklistIndex}
                     itemNum={props.itemIndex}
                     playbookRunId={props.playbookRun?.id}
-                    onChange={(newState: ChecklistItemState) => {
-                        return props.playbookRun ? setChecklistItemState(props.playbookRun.id, props.checklistIndex, props.itemIndex, newState) : undefined;
-                    }}
+                    onChange={(newState: ChecklistItemState) => props.playbookRun && setChecklistItemState(props.playbookRun.id, props.checklistIndex, props.itemIndex, newState)}
                     draggableProvided={draggableProvided}
                     dragging={snapshot.isDragging}
                     disabled={finished}

--- a/webapp/src/components/checklist_item/checklist_item_draggable.tsx
+++ b/webapp/src/components/checklist_item/checklist_item_draggable.tsx
@@ -38,9 +38,7 @@ const DraggableChecklistItem = (props: Props) => {
                     itemNum={props.itemIndex}
                     playbookRunId={props.playbookRun?.id}
                     onChange={(newState: ChecklistItemState) => {
-                        if (props.playbookRun) {
-                            setChecklistItemState(props.playbookRun.id, props.checklistIndex, props.itemIndex, newState);
-                        }
+                        return props.playbookRun ? setChecklistItemState(props.playbookRun.id, props.checklistIndex, props.itemIndex, newState) : undefined;
                     }}
                     draggableProvided={draggableProvided}
                     dragging={snapshot.isDragging}

--- a/webapp/src/components/checklist_item/inputs.tsx
+++ b/webapp/src/components/checklist_item/inputs.tsx
@@ -16,7 +16,7 @@ interface CheckBoxButtonProps {
 export const CheckBoxButton = (props: CheckBoxButtonProps) => {
     const [isChecked, setIsChecked] = useState(props.item.state === ChecklistItemState.Closed);
 
-    // handleOnChange optimistic update approach: first doe UI change, then
+    // handleOnChange optimistic update approach: first do UI change, then
     // call to server and finally revert UI state if there's error
     //
     // There are two main reasons why we do this:


### PR DESCRIPTION
### Summary
Optimistic approach to checkbox state management.
The main reasons why I pushed for this change are:
- offer a more responsive UI in a task that I'd expect to be quick as a user
- be more defensive to websocket failures where users don't see the UI update and even could click several times keeping a trash value

Approach:

**client.ts**
`doPut`and `doFetchWithResponse` already throw a ClientError if status is not OK
Catch that error and return it as data.

**checklist_item_draggable and checklist_item**
type the return value and add the possibility of `undefined`

**inputs**
do the following:
1. handle current value and setter through useState
2. onChange: calculate the new value and set it immediately
3. onChange: await prop passed with `setChecklistItemState`
4. if the result is not undefined and has a property error, set the previous value 

0/5 in types mess, `Promise<void | {error: ClientError}> | undefined` is not elegant.
I kept `{error: ClientError}` instead of `ClientError` to be consistent with other client functions.

### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-43834

### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
