### PR TITLE
Update CircleCI images to Go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,18 +11,18 @@ executors:
 aliases:
   - &restore_go_cache
     restore_cache:
-      key: go-mod-v1-{{ checksum "go.sum" }}
+      key: go-mod-v2-{{ checksum "go.sum" }}
   - &save_go_cache
     save_cache:
-      key: go-mod-v1-{{ checksum "go.sum" }}
+      key: go-mod-v2-{{ checksum "go.sum" }}
       paths:
         - /go/pkg/mod
   - &restore_cypress_cache
     restore_cache:
-      key: deploy-go-{{ checksum "go.sum" }}-npm-{{ checksum "./webapp/package-lock.json" }}-test-npm-{{ checksum "./tests-e2e/package-lock.json" }}
+      key: v2-deploy-go-{{ checksum "go.sum" }}-npm-{{ checksum "./webapp/package-lock.json" }}-test-npm-{{ checksum "./tests-e2e/package-lock.json" }}
   - &save_cypress_cache
     save_cache:
-      key: deploy-go-{{ checksum "go.sum" }}-npm-{{ checksum "./webapp/package-lock.json" }}-test-npm-{{ checksum "./tests-e2e/package-lock.json" }}
+      key: v2-deploy-go-{{ checksum "go.sum" }}-npm-{{ checksum "./webapp/package-lock.json" }}-test-npm-{{ checksum "./tests-e2e/package-lock.json" }}
       paths:
         - /go/pkg/mod
         - ./webapp/node_modules
@@ -35,7 +35,7 @@ commands:
     steps:
       - restore_cache:
           name: Restore npm cache
-          key: v2-npm-{{ checksum "./webapp/package-lock.json" }}-{{ arch }}
+          key: v3-npm-{{ checksum "./webapp/package-lock.json" }}-{{ arch }}
       - run:
           name: Getting JavaScript dependencies
           command: |
@@ -43,7 +43,7 @@ commands:
             NODE_ENV=development npm install --ignore-scripts --no-save
       - save_cache:
           name: Save npm cache
-          key: v2-npm-{{ checksum "./webapp/package-lock.json" }}-{{ arch }}
+          key: v3-npm-{{ checksum "./webapp/package-lock.json" }}-{{ arch }}
           paths:
             - ./webapp/node_modules
 
@@ -330,7 +330,7 @@ jobs:
   e2e-cypress-tests-cloud:
     resource_class: xlarge
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.3
+      - image: cimg/go:1.18.1-node
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17
@@ -405,7 +405,7 @@ jobs:
   e2e-cypress-tests-master:
     resource_class: xlarge
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.3
+      - image: cimg/go:1.18.1-node
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.1
+      - image: docker.io/casscap/mm-builder-test:0.0.2
 
 aliases:
   - &restore_go_cache
@@ -109,9 +109,6 @@ commands:
           name: Set and restore Postgres DB
           command: |
             whoami
-            sudo apt-get update
-            sudo apt-get install libxss1
-            sudo apt-get install postgresql-client
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" -c "CREATE DATABASE migrated;"
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" -c "CREATE DATABASE latest;"
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" mattermost_test < tests-e2e/db-setup/mattermost.sql
@@ -333,7 +330,7 @@ jobs:
   e2e-cypress-tests-cloud:
     resource_class: xlarge
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.1
+      - image: docker.io/casscap/mm-builder-test:0.0.2
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17
@@ -408,7 +405,7 @@ jobs:
   e2e-cypress-tests-master:
     resource_class: xlarge
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.1
+      - image: docker.io/casscap/mm-builder-test:0.0.2
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
 
 aliases:
   - &restore_go_cache
@@ -251,7 +251,7 @@ jobs:
 
   test-MySQL57-Postgres10:
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
       - image: cimg/postgres:10.17
         command: "postgres -N 200"
         environment:
@@ -270,7 +270,7 @@ jobs:
 
   test-MySQL8-Postgres11:
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
       - image: cimg/postgres:11.13
         command: "postgres -N 200"
         environment:
@@ -289,7 +289,7 @@ jobs:
 
   test-MariaDB10-Postgres12:
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
       - image: cimg/postgres:12.9
         command: "postgres -N 200"
         environment:
@@ -309,7 +309,7 @@ jobs:
   # "latest" db versions
   test-MySQL8-Postgres14:
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
       - image: cimg/postgres:14.1
         command: "postgres -N 200"
         environment:
@@ -330,7 +330,7 @@ jobs:
   e2e-cypress-tests-cloud:
     resource_class: xlarge
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17
@@ -405,7 +405,7 @@ jobs:
   e2e-cypress-tests-master:
     resource_class: xlarge
     docker:
-      - image: docker.io/casscap/mm-builder-test:0.0.2
+      - image: cimg/go:1.18.1-node
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: docker.io/mattermost/mattermost-build-server:20220415_golang-1.18.1
-      - image: docker.io/mattermost/mattermost-build-webapp:20210524_node-16
+      - image: docker.io/casscap/mm-builder-test:0.0.1
 
 aliases:
   - &restore_go_cache
@@ -334,10 +333,9 @@ jobs:
   e2e-cypress-tests-cloud:
     resource_class: xlarge
     docker:
-      - image: docker.io/mattermost/mattermost-build-server:20220415_golang-1.18.1
+      - image: docker.io/casscap/mm-builder-test:0.0.1
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
-      - image: docker.io/mattermost/mattermost-build-webapp:20210524_node-16
       - image: cimg/postgres:10.17
         environment:
           POSTGRES_USER: mmuser
@@ -410,10 +408,9 @@ jobs:
   e2e-cypress-tests-master:
     resource_class: xlarge
     docker:
-      - image: docker.io/mattermost/mattermost-build-server:20220415_golang-1.18.1
+      - image: docker.io/casscap/mm-builder-test:0.0.1
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
-      - image: docker.io/mattermost/mattermost-build-webapp:20210524_node-16
       - image: cimg/postgres:10.17
         environment:
           POSTGRES_USER: mmuser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ orbs:
 executors:
   default:
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/mattermost/mattermost-build-server:20220415_golang-1.18.1
+      - image: docker.io/mattermost/mattermost-build-webapp:20210524_node-16
 
 aliases:
   - &restore_go_cache
@@ -333,9 +334,10 @@ jobs:
   e2e-cypress-tests-cloud:
     resource_class: xlarge
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/mattermost/mattermost-build-server:20220415_golang-1.18.1
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
+      - image: docker.io/mattermost/mattermost-build-webapp:20210524_node-16
       - image: cimg/postgres:10.17
         environment:
           POSTGRES_USER: mmuser
@@ -408,9 +410,10 @@ jobs:
   e2e-cypress-tests-master:
     resource_class: xlarge
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/mattermost/mattermost-build-server:20220415_golang-1.18.1
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
+      - image: docker.io/mattermost/mattermost-build-webapp:20210524_node-16
       - image: cimg/postgres:10.17
         environment:
           POSTGRES_USER: mmuser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
       - run:
           name: Getting Cypress & JavaScript dependencies
           command: |
-            apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+            apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
             cd webapp
             NODE_ENV=development npm install --ignore-scripts --no-save
             cd ../tests-e2e
@@ -251,7 +251,7 @@ jobs:
 
   test-MySQL57-Postgres10:
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/casscap/mm-builder-test:0.0.2
       - image: cimg/postgres:10.17
         command: "postgres -N 200"
         environment:
@@ -270,7 +270,7 @@ jobs:
 
   test-MySQL8-Postgres11:
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/casscap/mm-builder-test:0.0.2
       - image: cimg/postgres:11.13
         command: "postgres -N 200"
         environment:
@@ -289,7 +289,7 @@ jobs:
 
   test-MariaDB10-Postgres12:
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/casscap/mm-builder-test:0.0.2
       - image: cimg/postgres:12.9
         command: "postgres -N 200"
         environment:
@@ -309,7 +309,7 @@ jobs:
   # "latest" db versions
   test-MySQL8-Postgres14:
     docker:
-      - image: docker.io/mattermost/builder:go-1.16.5-node-16.4.0
+      - image: docker.io/casscap/mm-builder-test:0.0.2
       - image: cimg/postgres:14.1
         command: "postgres -N 200"
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ commands:
       - run:
           name: Install Playbooks
           command: |
-            make deploy
+            make deploy CGO_ENABLED=0
       - run:
           name: Run Cypress Tests
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
   e2e-cypress-tests-cloud:
     resource_class: xlarge
     docker:
-      - image: cimg/go:1.18.1-node
+      - image: docker.io/casscap/mm-builder-test:0.0.3
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17
@@ -405,7 +405,7 @@ jobs:
   e2e-cypress-tests-master:
     resource_class: xlarge
     docker:
-      - image: cimg/go:1.18.1-node
+      - image: docker.io/casscap/mm-builder-test:0.0.3
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
       - image: cimg/postgres:10.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
       - run:
           name: Getting Cypress & JavaScript dependencies
           command: |
-            sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+            apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
             cd webapp
             NODE_ENV=development npm install --ignore-scripts --no-save
             cd ../tests-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,9 @@ commands:
       - run:
           name: Set and restore Postgres DB
           command: |
+            sudo apt-get update
+            sudo apt-get install libxss1
+            sudo apt-get install postgresql-client
             whoami
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" -c "CREATE DATABASE migrated;"
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" -c "CREATE DATABASE latest;"
@@ -123,7 +126,7 @@ commands:
       - run:
           name: Getting Cypress & JavaScript dependencies
           command: |
-            apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+            sudo apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
             cd webapp
             NODE_ENV=development npm install --ignore-scripts --no-save
             cd ../tests-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,10 @@ commands:
       - run:
           name: Set and restore Postgres DB
           command: |
+            whoami
             sudo apt-get update
             sudo apt-get install libxss1
             sudo apt-get install postgresql-client
-            whoami
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" -c "CREATE DATABASE migrated;"
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" -c "CREATE DATABASE latest;"
             psql -d $TEST_DATABASE_URL -v "ON_ERROR_STOP=1" mattermost_test < tests-e2e/db-setup/mattermost.sql
@@ -126,7 +126,7 @@ commands:
       - run:
           name: Getting Cypress & JavaScript dependencies
           command: |
-            sudo apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+            sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
             cd webapp
             NODE_ENV=development npm install --ignore-scripts --no-save
             cd ../tests-e2e


### PR DESCRIPTION
The two changes to note besides the image bumps:

1) `CGO_ENABLED=0` - found some history in Community that suggested this might help
2) cache keys modified to ensure caches were regenerated
