### PR TITLE
MM-44160: Fix empty channel selector

### DIFF
--- a/tests-e2e/cypress/integration/runs/actions_spec.js
+++ b/tests-e2e/cypress/integration/runs/actions_spec.js
@@ -33,7 +33,7 @@ describe('runs > actions', () => {
     });
 
     beforeEach(() => {
-        const now = Date.now()
+        const now = Date.now();
         const runName = 'Playbook Run ' + now;
         cy.apiRunPlaybook({
             teamId: testTeam.id,
@@ -140,6 +140,31 @@ describe('runs > actions', () => {
 
     describe('trigger: when a status update is posted', () => {
         describe('action: Broadcast update to selected channels', () => {
+            it('shows channel information on first load', () => {
+                // # Open the run actions modal
+                openRunActionsModal();
+
+                // # Enable broadcast to channels
+                cy.findByText('Broadcast update to selected channels').click();
+
+                // # Select a couple of channels
+                cy.findByText('Select channels').click().type('town square{enter}off-topic{enter}');
+
+                // # Save the changes
+                saveRunActionsModal();
+
+                // # Reload the page, so that the store is not pre-populated when visiting Channels
+                cy.visit(`/playbooks/runs/${testRun.id}/overview`);
+
+                // # Open the run actions modal
+                openRunActionsModal();
+
+                // * Check that the channels previously added are shown with their full name,
+                // * verifying that the store has been populated by the modal component.
+                cy.findByText('Town Square').should('exist');
+                cy.findByText('Off-Topic').should('exist');
+            });
+
             it('broadcasts to two channels configured when it is enabled', () => {
                 // # Open the run actions modal
                 openRunActionsModal();

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {SelectComponentsConfig, components as defaultComponents} from 'react-select';
-import {useSelector} from 'react-redux';
+import {useSelector, useDispatch} from 'react-redux';
 import {createSelector} from 'reselect';
 
 import {getAllChannels, getChannelsInTeam, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
@@ -10,7 +10,7 @@ import General from 'mattermost-redux/constants/general';
 
 import {Channel, ChannelMembership} from 'mattermost-redux/types/channels';
 import {Team} from 'mattermost-redux/types/teams';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
 
 import {useIntl} from 'react-intl';
 
@@ -71,8 +71,15 @@ const filterChannels = (channelIDs: string[], channels: Channel[]): Channel[] =>
 };
 
 const ChannelSelector = (props: Props & {className?: string}) => {
+    const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const selectableChannels = useSelector(getMyPublicAndPrivateChannelsInTeam(props.teamId));
+
+    useEffect(() => {
+        if (props.teamId !== '' && selectableChannels.length === 0) {
+            dispatch(fetchMyChannelsAndMembers(props.teamId));
+        }
+    }, [props.teamId]);
 
     const onChange = (channels: Channel[], {action}: {action: string}) => {
         if (action === 'clear') {

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -64,13 +64,13 @@ const getMyPublicAndPrivateChannelsInTeam = (teamId: string) => createSelector(
     },
 );
 
-const filterChannels = (channelIDs: string[], allPublicChannels: Channel[]): Channel[] => {
-    if (!channelIDs || !allPublicChannels) {
+const filterChannels = (channelIDs: string[], channels: Channel[]): Channel[] => {
+    if (!channelIDs || !channels) {
         return [];
     }
 
     const channelsMap = new Map<string, Channel>();
-    allPublicChannels.forEach((channel: Channel) => channelsMap.set(channel.id, channel));
+    channels.forEach((channel: Channel) => channelsMap.set(channel.id, channel));
 
     const result: Channel[] = [];
     channelIDs.forEach((id: string) => {
@@ -143,7 +143,7 @@ const ChannelSelector = (props: Props & {className?: string}) => {
                channel.id.toLowerCase() === term.toLowerCase();
     };
 
-    const values = filterChannels(props.channelIds, allPublicChannels);
+    const values = filterChannels(props.channelIds, [...allPublicChannels, ...selectableChannels]);
 
     const components = props.selectComponents || defaultComponents;
 

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -26,7 +26,7 @@ export interface Props {
     captureMenuScroll: boolean;
     shouldRenderValue: boolean;
     placeholder?: string;
-    teamId?: string;
+    teamId: string;
 }
 
 const getMyPublicAndPrivateChannelsInTeam = (teamId: string) => createSelector(
@@ -72,9 +72,7 @@ const filterChannels = (channelIDs: string[], channels: Channel[]): Channel[] =>
 
 const ChannelSelector = (props: Props & {className?: string}) => {
     const {formatMessage} = useIntl();
-    const currentTeamId = useSelector(getCurrentTeamId);
-    const teamId = props.teamId || currentTeamId;
-    const selectableChannels = useSelector(getMyPublicAndPrivateChannelsInTeam(teamId));
+    const selectableChannels = useSelector(getMyPublicAndPrivateChannelsInTeam(props.teamId));
 
     const onChange = (channels: Channel[], {action}: {action: string}) => {
         if (action === 'clear') {

--- a/webapp/src/components/backstage/playbook_edit/automation/broadcast.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/broadcast.tsx
@@ -2,8 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useSelector} from 'react-redux';
 
 import {FormattedMessage} from 'react-intl';
+
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import {AutomationHeader, AutomationTitle, SelectorWrapper} from 'src/components/backstage/playbook_edit/automation/styles';
 import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
@@ -17,6 +20,8 @@ interface Props {
 }
 
 export const Broadcast = (props: Props) => {
+    const teamId = useSelector(getCurrentTeamId);
+
     return (
         <AutomationHeader>
             <AutomationTitle>
@@ -32,6 +37,7 @@ export const Broadcast = (props: Props) => {
                     enabled={props.enabled}
                     channelIds={props.channelIds}
                     onChannelsSelected={props.onChannelsSelected}
+                    teamId={teamId}
                 />
             </SelectorWrapper>
         </AutomationHeader>

--- a/webapp/src/components/broadcast_channel_selector.tsx
+++ b/webapp/src/components/broadcast_channel_selector.tsx
@@ -15,7 +15,7 @@ interface Props {
     enabled: boolean;
     channelIds: string[];
     onChannelsSelected: (channelIds: string[]) => void;
-    teamId?: string;
+    teamId: string;
 }
 
 const BroadcastChannelSelector = (props: Props) => {

--- a/webapp/src/components/run_actions_modal.tsx
+++ b/webapp/src/components/run_actions_modal.tsx
@@ -9,7 +9,6 @@ import styled from 'styled-components';
 import {hideRunActionsModal} from 'src/actions';
 import {isRunActionsModalVisible} from 'src/selectors';
 import {PlaybookRun} from 'src/types/playbook_run';
-import {useChannel} from 'src/hooks/general';
 import {updateRunActions} from 'src/client';
 
 import Action from 'src/components/actions_modal_action';
@@ -26,8 +25,7 @@ const RunActionsModal = ({playbookRun}: Props) => {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
     const show = useSelector(isRunActionsModalVisible);
-    const runChannel = useChannel(playbookRun.channel_id);
-    const teamId = runChannel?.team_id || '';
+    const teamId = playbookRun.team_id || '';
 
     const [broadcastToChannelsEnabled, setBroadcastToChannelsEnabled] = useState(playbookRun.status_update_broadcast_channels_enabled);
     const [sendOutgoingWebhookEnabled, setSendOutgoingWebhookEnabled] = useState(playbookRun.status_update_broadcast_webhooks_enabled);


### PR DESCRIPTION
#### Summary
**The problem**: When visiting the run overview page directly, the Redux store is not pre-populated by Channels, so the Run Actions modal did not have the information on the channels the user is a member of, thus showing an empty dropdown menu in the channel selector (and showing any channel already added as `Unknown channel`, even if the user had access to them).

**The solution**: When first mounting the channel selector, if the store is empty, just populate the Redux store with the channels the user is a member of.

@lieut-data, I was considering adding a cache similar to #1177 to prevent a problem of the same type in the future in this component. I decided not to do it, though, as it seems rare that we will have more than one of these components mounted at the same time, and much more rare to have a lot of them. But 0/5 on adding that preemptively. Thoughts?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44160

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
