### PR TITLE
do not log error if 0 actions in channel when a user joins

### DIFF
--- a/server/app/actions_service.go
+++ b/server/app/actions_service.go
@@ -221,8 +221,11 @@ func (a *channelActionServiceImpl) UserHasJoinedChannel(userID, channelID, actor
 		return
 	}
 
-	if len(actions) != 1 {
+	if len(actions) > 1 {
 		a.logger.Errorf("only one action of action type %s and trigger type %s is expected, but %d were retrieved", ActionTypeCategorizeChannel, TriggerTypeNewMemberJoins, len(actions))
+	}
+
+	if len(actions) != 1 {
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Avoid logging errors if we don't have actions in a channel and a new member joins.

Additionally, I changed the order in `getPlaybookRunByChannel` to have a more relevant error (before it reported permissions failure if the run does not exist).  Personally, I would omit this kind of error from the logs since it seems like an expected flow to me (to reproduce leave and rejoin a channel without a run).

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-43636

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
