### PR TITLE
Disable CGO to fix playbooks build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Building Plugin Bundle
           command: |
-            make dist
+            make dist CGO_ENABLED=0
       - run:
           name: Generating Release Notes
           command: |


### PR DESCRIPTION
#### Summary
Deploy to community is failing with:
```
Unable to install plugin from URL "https://plugins-store.test.mattermost.com/ci/mattermost-plugin-playbooks-ci.tar.gz". Error: : Unable to restart plugin on upgrade., unable to start plugin: playbooks: Unrecognized remote plugin message:

This usually means that the plugin is either invalid or simply
needs to be recompiled to support the latest protocol.
```

This is similar to what we where seeing with e2e on CI so disabling CGO might help.
