### PR TITLE
modal manually centered

### DIFF
--- a/webapp/src/components/actions_modal.tsx
+++ b/webapp/src/components/actions_modal.tsx
@@ -22,6 +22,7 @@ interface Props {
     editable: boolean;
     onSave: () => void;
     children: React.ReactNode;
+    adjustTop?: number;
 }
 
 const ActionsModal = (props: Props) => {
@@ -58,7 +59,7 @@ const ActionsModal = (props: Props) => {
             autoCloseOnCancelButton={true}
             autoCloseOnConfirmButton={false}
             enforceFocus={true}
-            adjustTop={400}
+            adjustTop={props.adjustTop}
             components={{
                 Header: ModalHeader,
                 FooterContainer: ModalFooter,

--- a/webapp/src/components/channel_actions_modal.tsx
+++ b/webapp/src/components/channel_actions_modal.tsx
@@ -150,6 +150,7 @@ const ChannelActionsModal = () => {
             onHide={onHide}
             editable={editable}
             onSave={onSave}
+            adjustTop={350}
         >
             <TriggersContainer>
                 <Trigger

--- a/webapp/src/components/run_actions_modal.tsx
+++ b/webapp/src/components/run_actions_modal.tsx
@@ -65,6 +65,7 @@ const RunActionsModal = ({playbookRun}: Props) => {
             onHide={onHide}
             editable={true}
             onSave={onSave}
+            adjustTop={260}
         >
             <TriggersContainer>
                 <Trigger


### PR DESCRIPTION
#### Summary
Vertically center *more* the modals for run&channel actions.

I tried the centered property in react-modal but there were lots of conflicting injected styles. The channel actions modal has a fixed height, but the run actions modal has a variable height, so in some situations could not be perfectly aligned.
 
#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-44196


#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
