### PR TITLE
RHS: keep full assignee pill when due date and not state-open

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -369,7 +369,7 @@ describe('channels > rhs > checklist', () => {
             cy.findAllByTestId('checkbox-item-container').should('have.length', 12);
         });
 
-        it.only('switching between runs with the same checklist', () => {
+        it('switching between runs with the same checklist', () => {
             // # Create another run using the same playbook
             const playbookRunName2 = 'RunWithSameChecklist';
             cy.apiRunPlaybook({

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -136,7 +136,8 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             if (command !== '') {
                 return true;
             }
-            if (dueDate > 0 && props.checklistItem.state === ChecklistItemState.Open) {
+            const notFinished = [ChecklistItemState.Open, ChecklistItemState.InProgress].includes(props.checklistItem.state as ChecklistItemState);
+            if (dueDate > 0 && notFinished) {
                 return true;
             }
             return false;

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -129,11 +129,23 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             return null;
         }
 
+        const shouldHideName = () => {
+            if (isEditing) {
+                return false;
+            }
+            if (command !== '') {
+                return true;
+            }
+            if (dueDate > 0 && props.checklistItem.state === ChecklistItemState.Open) {
+                return true;
+            }
+            return false;
+        };
         return (
             <AssignTo
                 assignee_id={assigneeID || ''}
                 editable={isEditing}
-                withoutName={(command !== '' || dueDate > 0) && !isEditing}
+                withoutName={shouldHideName()}
                 onSelectedChange={onAssigneeChange}
             />
         );


### PR DESCRIPTION
#### Summary
Do not shrink assigned user pill (hide name) when due date but state closed or skip. Since due date is hidden, the user name should be shown.  

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-44194

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
