### PR TITLE
force empty title in menuItem to prevent trigger title from propagating

### DIFF
--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -182,6 +182,10 @@ export const DropdownMenuItem = (props: { children: React.ReactNode, onClick: ()
             onClick={props.onClick}
             className={props.className}
             role={'button'}
+
+            // Prevent trigger icon (parent) from propagating title prop to options
+            // Menu items use to be full text (not just icons) so don't need title
+            title=''
         >
             {props.children}
         </DropdownMenuItemStyled>


### PR DESCRIPTION
#### Summary
Force the` DropdownMenuItem` title to an empty string. It's needed to prevent the trigger icon from appearing for all his children.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-44193

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
