### PR TITLE
do not ask for channel actions if the channel has been already visited

### DIFF
--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -219,6 +219,12 @@ export const handleWebsocketChannelViewed = (getState: GetStateFunc, dispatch: D
     return async (msg: WebSocketMessage<{ channel_id: string }>) => {
         const channelId = msg.data.channel_id;
 
+        // if the user has already viewed the channel,
+        // there's no need to fetch actions again
+        if (hasViewedByChannelID(getState())[channelId]) {
+            return;
+        }
+
         // If there are no welcome message actions enabled, stop
         const actions = await fetchChannelActions(channelId, ChannelTriggerType.NewMemberJoins);
 
@@ -229,11 +235,9 @@ export const handleWebsocketChannelViewed = (getState: GetStateFunc, dispatch: D
             return;
         }
 
-        if (!hasViewedByChannelID(getState())[channelId]) {
-            const hasViewed = await fetchCheckAndSendMessageOnJoin(channelId);
-            if (hasViewed) {
-                dispatch(setHasViewedChannel(channelId));
-            }
+        const hasViewed = await fetchCheckAndSendMessageOnJoin(channelId);
+        if (hasViewed) {
+            dispatch(setHasViewedChannel(channelId));
         }
     };
 };


### PR DESCRIPTION
#### Summary
To attach the welcome message from channel actions, we are currently triggering 4 requests in each channel switch. The reason this happens is:
- several mark_as_read are sent in channel_switch, for old and new channels (not expected, but apparently they are preventing some race conditions)
- each mark_as_read generates a channel_viewed WebSocket event 
- each channel_viewed event is handled with fetch_actions and handle welcome if not previously viewed

The mitigation is done by changing the order of the WebSocket channel_viewed registered handler:
- return as soon as possible if the channel was already viewed
- fetch actions
- if welcome action is enabled -> execute it

This is not the definitive solution but improves the performance.


#### Ticket Link
Fixes (partially) https://mattermost.atlassian.net/browse/MM-43836 

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
