### PR TITLE
Mm 44127 include event metadata with playbook run webhooks

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -171,7 +171,7 @@ type PlaybookRunWebhookEvent struct {
 	At int64 `json:"at"`
 
 	// UserId is the user who triggered the event.
-	UserId string `json:"user_id"`
+	UserID string `json:"user_id"`
 
 	// Payload is optional, event-specific metadata.
 	Payload interface{} `json:"payload"`
@@ -205,7 +205,7 @@ func (s *PlaybookRunServiceImpl) sendWebhooksOnCreation(playbookRun PlaybookRun)
 	event := PlaybookRunWebhookEvent{
 		Type:   PlaybookRunCreated,
 		At:     playbookRun.CreateAt,
-		UserId: playbookRun.ReporterUserID,
+		UserID: playbookRun.ReporterUserID,
 	}
 
 	payload := PlaybookRunWebhookPayload{
@@ -853,7 +853,7 @@ func (s *PlaybookRunServiceImpl) UpdateStatus(playbookRunID, userID string, opti
 		webhookEvent := PlaybookRunWebhookEvent{
 			Type:    StatusUpdated,
 			At:      channelPost.CreateAt,
-			UserId:  userID,
+			UserID:  userID,
 			Payload: options,
 		}
 
@@ -1000,7 +1000,7 @@ func (s *PlaybookRunServiceImpl) FinishPlaybookRun(playbookRunID, userID string)
 		webhookEvent := PlaybookRunWebhookEvent{
 			Type:   RunFinished,
 			At:     endAt,
-			UserId: userID,
+			UserID: userID,
 		}
 
 		s.sendWebhooksOnUpdateStatus(playbookRunID, &webhookEvent)
@@ -1069,7 +1069,7 @@ func (s *PlaybookRunServiceImpl) RestorePlaybookRun(playbookRunID, userID string
 		webhookEvent := PlaybookRunWebhookEvent{
 			Type:   RunRestored,
 			At:     restoreAt,
-			UserId: userID,
+			UserID: userID,
 		}
 
 		s.sendWebhooksOnUpdateStatus(playbookRunID, &webhookEvent)

--- a/server/app/playbook_run_service_test.go
+++ b/server/app/playbook_run_service_test.go
@@ -446,7 +446,7 @@ func TestUpdateStatus(t *testing.T) {
 		type webhookEvent struct {
 			Type    string                  `json:"type"`
 			At      int64                   `json:"at"`
-			UserId  string                  `json:"user_id"`
+			UserID  string                  `json:"user_id"`
 			Payload app.StatusUpdateOptions `json:"payload"`
 		}
 
@@ -500,7 +500,7 @@ func TestUpdateStatus(t *testing.T) {
 		event := &webhookEvent{
 			Type:    string(app.StatusUpdated),
 			At:      0,
-			UserId:  "user_id",
+			UserID:  "user_id",
 			Payload: statusUpdateOptions,
 		}
 		siteURL := "http://example.com"


### PR DESCRIPTION
extend the PlaybookRunWebhookPayload struct to include event specific metadata

update tests

#### Summary

extended the `PlaybookRunWebhookPayload` struct to include event specific metadata
added `PlaybookRunWebhookEvent` struct

for `timelineEventType="incident_created"` added `PlaybookRunWebhookEvent` (without event payload)

in `sendWebhooksOnUpdateStatus` added param: `event *PlaybookRunWebhookEvent`

for `timelineEventType="status_updated"` added `PlaybookRunWebhookEvent`. 
In `Payload interface{}` is set `StatusUpdateOptions` struct

for `timelineEventType="run_finished"`  added `PlaybookRunWebhookEvent` (without event payload)
for `timelineEventType="run_restored"` added `PlaybookRunWebhookEvent` (without event payload)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44127

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
