### PR TITLE
usePortal cleanup side effects in useEffect

### DIFF
--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -636,9 +636,9 @@ export const usePrevious = (value: any) => {
 // Create a portal to render while dragging
 export const usePortal = (parent: HTMLElement) => {
     const [portal] = useState(document.createElement('div'));
-
     useEffect(() => {
         parent.appendChild(portal);
+        return () => portal.remove();
     }, [parent, portal]);
 
     return portal;


### PR DESCRIPTION
#### Summary
We are currently leaving tons of empty div nodes in the DOM.
 
<img width="754" alt="Screenshot 2022-05-23 at 18 55 41" src="https://user-images.githubusercontent.com/4096774/169870340-fae2edc3-b925-4616-a352-2ee0e1a6c6b7.png">

This is done by usePortal hook which adds a new div node at the end of the body to make drag&drop possible. We are currently adding one portal (div node) per draggable item, but we don't remove these nodes when we unmount the component which needed them.

This could degrade perf if opened and closed several times in the same session the Run RHS since it's creating a div node per draggable item (and one run could have dozens).

I added a call to the cleanup part of useEffect to remove the nodes once the component is unmounted. After this change, all div are removed once we close the RHS.

Further discussion: 
- do we need a portal per element? 
- can we share one portal among all checklist items?  


#### Ticket Link
No ticket

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
