### PR TITLE
Add message for playbooks metrics admin notification

### DIFF
--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -214,6 +214,10 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		message = fmt.Sprintf("@%s requested access to view playbook statistics", author.Username)
 		title = "All the statistics you need"
 		text = "View trends for total runs, active runs, and participants involved in runs of this playbook."
+	case "start_trial_to_access_metrics":
+		message = fmt.Sprintf("@%s requested access to playbook key metrics feature", author.Username)
+		title = "Track key metrics and measure value"
+		text = "Use metrics to understand patterns and progress across runs, and track performance."
 	}
 
 	actions := []*model.PostAction{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
This PR adds message content for the `start_trial_to_access_metrics` admin notification. It was missing, and because of that admin was getting empty messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44366

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests updated~~
