### PR TITLE
upgrade banner position to avoid overflow

### DIFF
--- a/webapp/src/components/backstage/playbooks/upgrade_playbook_placeholder.tsx
+++ b/webapp/src/components/backstage/playbooks/upgrade_playbook_placeholder.tsx
@@ -17,7 +17,7 @@ const UpgradePlaybookPlaceholder = () => {
             titleText={formatMessage({defaultMessage: 'All the statistics you need'})}
             helpText={formatMessage({defaultMessage: 'Upgrade to view trends for total runs, active runs and participants involved in runs of this playbook.'})}
             notificationType={AdminNotificationType.MESSAGE_TO_PLAYBOOK_DASHBOARD}
-            verticalAdjustment={200}
+            verticalAdjustment={230}
             horizontalAdjustment={32}
             secondaryButton={true}
         />


### PR DESCRIPTION
#### Summary
Position correctly the upgrade banner in the PBE.

|  before  |  after  |
|----|----|
| <img width="1102" alt="Screenshot 2022-05-24 at 19 11 43" src="https://user-images.githubusercontent.com/4096774/170093921-6475c540-9edb-4c2b-bad5-88ed6daa3ada.png"> | <img width="1092" alt="Screenshot 2022-05-24 at 19 10 16" src="https://user-images.githubusercontent.com/4096774/170093974-784dc7b6-2452-48e5-9706-10e5cbdcaa87.png">|

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-44501

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
