### PR TITLE
[MM-44547] Fix webhook saving bug

### DIFF
--- a/webapp/src/components/backstage/playbook_editor/outline/inputs/webhooks_input.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/inputs/webhooks_input.tsx
@@ -13,7 +13,7 @@ import {moveRect} from './broadcast_channels_selector';
 
 type Props = {
     urls: string[];
-    onChange: (urls: string[]) => void;
+    onChange: (urls: string[]) => Promise<any>;
     errorText?: string;
     rows?: number;
     maxRows?: number;
@@ -54,10 +54,11 @@ export const WebhooksInput = (props: Props) => {
         </div>
     );
 
+    const errorTextTemp = props.errorText || formatMessage({defaultMessage: 'Invalid webhook URLs'});
+
     const isValid = (newURLs: string): boolean => {
         const maxRows = props.maxRows || 64;
         const maxErrorText = props.maxErrorText || formatMessage({defaultMessage: 'Invalid entry: the maximum number of webhooks allowed is 64'});
-        const errorTextTemp = props.errorText || formatMessage({defaultMessage: 'Invalid webhook URLs'});
 
         if (newURLs.split('\n').filter((v) => v.trim().length > 0).length > maxRows) {
             setInvalid(true);
@@ -103,10 +104,17 @@ export const WebhooksInput = (props: Props) => {
                         setOpen(false);
                     }}
                     onSave={() => {
-                        const filteredURLs = urls.filter((v) => v.trim().length > 0);
+                        const filteredURLs = urls.map((v) => v.trim()).filter((v) => v.length > 0);
                         if (isValid(filteredURLs.join('\n'))) {
-                            props.onChange(filteredURLs);
-                            setOpen(false);
+                            props.onChange(filteredURLs)
+                                .then(() => {
+                                    setURLs(filteredURLs);
+                                    setOpen(false);
+                                })
+                                .catch(() => {
+                                    setInvalid(true);
+                                    setErrorText(errorTextTemp);
+                                });
                         }
                     }}
                 />

--- a/webapp/src/components/backstage/playbook_editor/outline/section_status_updates.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_status_updates.tsx
@@ -84,16 +84,15 @@ const StatusUpdates = ({playbook}: Props) => {
                                     urls={playbook.webhook_on_status_update_urls}
                                     onChange={(newWebhookOnStatusUpdateURLs: string[]) => {
                                         if (newWebhookOnStatusUpdateURLs.length === 0) {
-                                            updatePlaybook({
+                                            return updatePlaybook({
                                                 webhookOnStatusUpdateEnabled: false,
                                                 webhookOnStatusUpdateURLs: [],
                                             });
-                                        } else {
-                                            updatePlaybook({
-                                                webhookOnStatusUpdateEnabled: true,
-                                                webhookOnStatusUpdateURLs: newWebhookOnStatusUpdateURLs,
-                                            });
                                         }
+                                        return updatePlaybook({
+                                            webhookOnStatusUpdateEnabled: true,
+                                            webhookOnStatusUpdateURLs: newWebhookOnStatusUpdateURLs,
+                                        });
                                     }}
                                 >
                                     <Placeholder label={webhookCount}/>


### PR DESCRIPTION

#### Summary
This PR does 2 things:
1. Trims webhooks and saves them as trimmed
2. Propagates to the user error returned from the server

https://user-images.githubusercontent.com/2340127/170251704-4d2a5347-75bf-4fe7-8f16-a87a9ad25bc7.mp4

#### Ticket Link
  Fixes: https://mattermost.atlassian.net/browse/MM-44547

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
