### PR TITLE
MM-44647 Fix inverted check for default owner.

### DIFF
--- a/server/api/graphql_root.go
+++ b/server/api/graphql_root.go
@@ -144,7 +144,7 @@ func (r *RootResolver) UpdatePlaybook(ctx context.Context, args struct {
 
 	addToSetmap(setmap, "InviteUsersEnabled", args.Updates.InviteUsersEnabled)
 	if args.Updates.DefaultOwnerID != nil {
-		if c.pluginAPI.User.HasPermissionToTeam(*args.Updates.DefaultOwnerID, currentPlaybook.TeamID, model.PermissionViewTeam) {
+		if !c.pluginAPI.User.HasPermissionToTeam(*args.Updates.DefaultOwnerID, currentPlaybook.TeamID, model.PermissionViewTeam) {
 			return "", errors.Wrap(app.ErrNoPermissions, "default owner can't view team")
 		}
 		addToSetmap(setmap, "DefaultCommanderID", args.Updates.DefaultOwnerID)

--- a/server/api_graphql_playbooks_test.go
+++ b/server/api_graphql_playbooks_test.go
@@ -82,6 +82,18 @@ func TestGraphQLPlaybooks(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	t.Run("change default owner", func(t *testing.T) {
+		err := gqlTestPlaybookUpdate(e, t, e.BasicPlaybook.ID, map[string]interface{}{
+			"defaultOwnerID": e.RegularUser.Id,
+		})
+		require.NoError(t, err)
+
+		err = gqlTestPlaybookUpdate(e, t, e.BasicPlaybook.ID, map[string]interface{}{
+			"defaultOwnerID": e.RegularUserNotInTeam.Id,
+		})
+		require.Error(t, err)
+	})
 }
 
 func gqlTestPlaybookUpdate(e *TestEnvironment, t *testing.T, playbookID string, updates map[string]interface{}) error {


### PR DESCRIPTION
#### Summary
Fixes default owner not saving in graphql. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44647
