### PR TITLE
Make plugin fetch consistant with webapp fetch.

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -62,6 +62,10 @@ export const getSiteUrl = (): string => {
     return siteURL;
 };
 
+export const getApiUrl = (): string => {
+    return apiUrl;
+};
+
 export async function fetchPlaybookRuns(params: FetchPlaybookRunsParams) {
     const queryParams = qs.stringify(params, {addQueryPrefix: true, indices: false});
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -15,7 +15,7 @@ import WebsocketEvents from 'mattermost-redux/constants/websocket';
 import {loadRolesIfNeeded} from 'mattermost-webapp/packages/mattermost-redux/src/actions/roles';
 import {FormattedMessage} from 'react-intl';
 
-import {ApolloClient, InMemoryCache, gql, ApolloProvider, NormalizedCacheObject} from '@apollo/client';
+import {ApolloClient, InMemoryCache, gql, ApolloProvider, NormalizedCacheObject, HttpLink} from '@apollo/client';
 
 import {GlobalSelectStyle} from 'src/components/backstage/styles';
 
@@ -60,7 +60,7 @@ import {
     WEBSOCKET_PLAYBOOK_ARCHIVED,
     WEBSOCKET_PLAYBOOK_RESTORED,
 } from 'src/types/websocket_events';
-import {fetchGlobalSettings, fetchSiteStats, notifyConnect, setSiteUrl} from 'src/client';
+import {fetchGlobalSettings, fetchSiteStats, getApiUrl, notifyConnect, setSiteUrl} from 'src/client';
 import {CloudUpgradePost} from 'src/components/cloud_upgrade_post';
 import {UpdatePost} from 'src/components/update_post';
 import {UpdateRequestPost} from 'src/components/update_request_post';
@@ -91,6 +91,44 @@ const ApolloWrapped = (props: {component: React.ReactNode, client: ApolloClient<
         </ApolloProvider>
     );
 };
+
+type WindowObject = {
+    location: {
+        origin: string;
+        protocol: string;
+        hostname: string;
+        port: string;
+    };
+    basename?: string;
+}
+
+// From mattermost-webapp/utils
+function getSiteURLFromWindowObject(obj: WindowObject): string {
+    let siteURL = '';
+    if (obj.location.origin) {
+        siteURL = obj.location.origin;
+    } else {
+        siteURL = obj.location.protocol + '//' + obj.location.hostname + (obj.location.port ? ':' + obj.location.port : '');
+    }
+
+    if (siteURL[siteURL.length - 1] === '/') {
+        siteURL = siteURL.substring(0, siteURL.length - 1);
+    }
+
+    if (obj.basename) {
+        siteURL += obj.basename;
+    }
+
+    if (siteURL[siteURL.length - 1] === '/') {
+        siteURL = siteURL.substring(0, siteURL.length - 1);
+    }
+
+    return siteURL;
+}
+
+function getSiteURL(): string {
+    return getSiteURLFromWindowObject(window);
+}
 
 export default class Plugin {
     removeRHSListener?: Unsubscribe;
@@ -233,37 +271,17 @@ export default class Plugin {
 
         // Consume the SiteURL so that the client is subpath aware. We also do this for Client4
         // in our version of the mattermost-redux, since webapp only does it in its copy.
-        const siteUrl = getConfig(store.getState())?.SiteURL || '';
+        const siteUrl = getSiteURL();
         setSiteUrl(siteUrl);
         Client4.setUrl(siteUrl);
 
         // Setup our graphql client
+        const graphqlFetch = (_: RequestInfo, options: any) => {
+            return fetch(`${getApiUrl()}/query`, Client4.getOptions(options));
+        };
         const graphqlClient = new ApolloClient({
-            uri: `${siteUrl}/plugins/${pluginId}/api/v0/query`,
+            link: new HttpLink({fetch: graphqlFetch}),
             cache: new InMemoryCache(),
-            defaultOptions: {
-                watchQuery: {
-                    context: {
-                        headers: {
-                            'X-Requested-With': 'XMLHttpRequest',
-                        },
-                    },
-                },
-                query: {
-                    context: {
-                        headers: {
-                            'X-Requested-With': 'XMLHttpRequest',
-                        },
-                    },
-                },
-                mutate: {
-                    context: {
-                        headers: {
-                            'X-Requested-With': 'XMLHttpRequest',
-                        },
-                    },
-                },
-            },
         });
 
         this.doRegistrations(registry, store, graphqlClient);


### PR DESCRIPTION
#### Summary
This should fix CORS issues on community caused by the SiteURL not being equal to the URL of access. For community the SiteURL is set to https://community.mattermost.com/ if you access community with https://community-daily.mattermost.com/ you will recieve CORS errors because our graphql and webapp clients are using the SiteURL for access. This PR changes both of those to use the same method as the webapp does by taking the URL from the window object.
