### PR TITLE
MM-44763: allow direct dropdown editing again

### DIFF
--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -141,10 +141,11 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             }
             return false;
         };
+
         return (
             <AssignTo
                 assignee_id={assigneeID || ''}
-                editable={isEditing}
+                editable={!props.disabled}
                 withoutName={shouldHideName()}
                 onSelectedChange={onAssigneeChange}
             />
@@ -174,9 +175,10 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
         if ((!dueDate || !isTaskOpenOrInProgress) && !isEditing) {
             return null;
         }
+
         return (
             <DueDateButton
-                editable={isEditing}
+                editable={!props.disabled}
                 date={dueDate}
                 mode={props.playbookRunId ? Mode.DateTimeValue : Mode.DurationValue}
                 onSelectedChange={onDueDateChange}


### PR DESCRIPTION
#### Summary
We unintentionally required users to enter edit mode for checklist items to be able to change the owner or due dates, but these should have stayed accessible directly:

<img width="449" alt="image" src="https://user-images.githubusercontent.com/1023171/171914798-e6937f05-f3e1-4b89-8c9e-2b7ddea20a60.png">

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-44763