### PR TITLE
MM-44190: fix stuck hover menu not showing again, use css for hover menu visibility

### DIFF
--- a/webapp/src/components/backstage/playbooks/playbook_preview_checklists.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_preview_checklists.tsx
@@ -65,7 +65,6 @@ const PlaybookPreviewChecklists = (props: Props) => {
                                     playbookRunId={''}
                                     dragging={false}
                                     disabled={true}
-                                    menuEnabled={true}
                                     collapsibleDescription={false}
                                     newItem={false}
                                 />

--- a/webapp/src/components/checklist/checklist_list.tsx
+++ b/webapp/src/components/checklist/checklist_list.tsx
@@ -17,6 +17,8 @@ import {
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
+import classNames from 'classnames';
+
 import Portal from 'src/components/portal';
 
 import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
@@ -74,10 +76,10 @@ const ChecklistList = (props: Props) => {
     );
     const [addingChecklist, setAddingChecklist] = useState(false);
     const [newChecklistName, setNewChecklistName] = useState('');
+    const [isDragging, setIsDragging] = useState(false);
 
     const playbook = props.playbook;
     const updatePlaybook = useUpdatePlaybook(playbook?.id);
-    const [menuEnabled, setMenuEnabled] = useState(true);
     const checklists = props.playbookRun?.checklists || playbook?.checklists || [];
     const FinishButton = allComplete(checklists) ? StyledPrimaryButton : StyledTertiaryButton;
     const active = (props.playbookRun !== undefined) && (props.playbookRun.current_status === PlaybookRunStatus.InProgress);
@@ -140,11 +142,12 @@ const ChecklistList = (props: Props) => {
     };
 
     const onDragStart = () => {
-        // block hover menu on checklists
-        setMenuEnabled(false);
+        setIsDragging(true);
     };
 
     const onDragEnd = (result: DropResult) => {
+        setIsDragging(false);
+
         // If the item is dropped out of any droppable zones, do nothing
         if (!result.destination) {
             return;
@@ -203,9 +206,6 @@ const ChecklistList = (props: Props) => {
             if (props.playbookRun) {
                 clientMoveChecklistItem(props.playbookRun.id, srcChecklistIdx, srcIdx, dstChecklistIdx, dstIdx);
             }
-
-            // allow again to see hover menu
-            setMenuEnabled(true);
         }
 
         // Move a whole checklist
@@ -304,6 +304,7 @@ const ChecklistList = (props: Props) => {
                     {(droppableProvided: DroppableProvided) => (
                         <ChecklistsContainer
                             {...droppableProvided.droppableProps}
+                            className={classNames('checklists', {isDragging})}
                             ref={droppableProvided.innerRef}
                         >
                             {checklists.map((checklist: Checklist, checklistIndex: number) => (
@@ -342,7 +343,6 @@ const ChecklistList = (props: Props) => {
                                                     checklist={checklist}
                                                     checklistIndex={checklistIndex}
                                                     onUpdateChecklist={(newChecklist: Checklist) => onUpdateChecklist(checklistIndex, newChecklist)}
-                                                    menuEnabled={menuEnabled && !archived}
                                                 />
                                             </CollapsibleChecklist>
                                         );

--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -28,7 +28,6 @@ window['__react-beautiful-dnd-disable-dev-warnings'] = true;
 interface Props {
     playbookRun?: PlaybookRun;
     disabled: boolean;
-    menuEnabled: boolean;
     checklist: Checklist;
     checklistIndex: number;
     onUpdateChecklist: (newChecklist: Checklist) => void;
@@ -140,7 +139,6 @@ const GenericChecklist = (props: Props) => {
                                 <DraggableChecklistItem
                                     key={keys[index]}
                                     playbookRun={props.playbookRun}
-                                    menuEnabled={props.menuEnabled}
                                     disabled={props.disabled}
                                     checklistIndex={props.checklistIndex}
                                     item={checklistItem}
@@ -159,7 +157,6 @@ const GenericChecklist = (props: Props) => {
                             <DraggableChecklistItem
                                 key={'new_checklist_item'}
                                 playbookRun={props.playbookRun}
-                                menuEnabled={props.menuEnabled}
                                 disabled={false}
                                 checklistIndex={props.checklistIndex}
                                 item={emptyChecklistItem()}

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -21,7 +21,7 @@ import Portal from 'src/components/portal';
 import {DateTimeOption} from 'src/components/datetime_selector';
 import {Mode} from '../datetime_input';
 
-import ChecklistItemHoverMenu from './hover_menu';
+import ChecklistItemHoverMenu, {HoverMenu} from './hover_menu';
 import ChecklistItemDescription from './description';
 import ChecklistItemTitle from './title';
 import AssignTo from './assign_to';
@@ -34,7 +34,6 @@ interface ChecklistItemProps {
     checklistNum: number;
     itemNum: number;
     playbookRunId?: string;
-    menuEnabled: boolean;
     onChange?: (item: ChecklistItemState) => ReturnType<typeof setChecklistItemState> | undefined;
     draggableProvided?: DraggableProvided;
     dragging: boolean;
@@ -201,13 +200,12 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
         <ItemContainer
             ref={props.draggableProvided?.innerRef}
             {...props.draggableProvided?.draggableProps}
-            onMouseEnter={() => setShowMenu(true)}
-            onMouseLeave={() => setShowMenu(false)}
             data-testid='checkbox-item-container'
             editing={isEditing}
+            $disabled={props.disabled}
         >
             <CheckboxContainer>
-                {showMenu && !props.disabled && props.menuEnabled &&
+                {!props.disabled && !props.dragging &&
                     <ChecklistItemHoverMenu
                         playbookRunId={props.playbookRunId}
                         checklistNum={props.checklistNum}
@@ -231,7 +229,8 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
                     title={formatMessage({defaultMessage: 'Drag me to reorder'})}
                     className={'icon icon-drag-vertical'}
                     {...props.draggableProvided?.dragHandleProps}
-                    isVisible={showMenu && !props.disabled}
+                    isVisible={!props.disabled}
+                    isDragging={props.dragging}
                 />
                 <CheckBoxButton
                     disabled={props.disabled || props.checklistItem.state === ChecklistItemState.Skip || props.playbookRunId === undefined}
@@ -312,22 +311,6 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
 
     return content;
 };
-
-const ItemContainer = styled.div<{editing: boolean}>`
-    margin-bottom: 4px;
-    padding: 8px 0px;
-
-
-    ${({editing}) => editing && css`
-        background-color: var(--button-bg-08);
-    `}
-
-    ${({editing}) => !editing && css`
-        &:hover{
-            background: var(--center-channel-color-04);
-        }
-    `}
-`;
 
 export const CheckboxContainer = styled.div`
     align-items: flex-start;
@@ -433,15 +416,19 @@ const ChecklistItemTitleWrapper = styled.div`
     width: 100%;
 `;
 
-const DragButton = styled.i<{isVisible: boolean}>`
+const DragButton = styled.i<{isVisible: boolean, isDragging: boolean}>`
     cursor: pointer;
     width: 4px;
     margin-right: 4px;
     margin-left: 4px;
     margin-top: 1px;
     color: rgba(var(--center-channel-color-rgb), 0.56);
-    ${({isVisible}) => !isVisible && `
-        visibility: hidden
+    opacity: 0;
+    ${({isVisible}) => !isVisible && css`
+        visibility: hidden;
+    `}
+    ${({isDragging}) => isDragging && css`
+        opacity: 1;
     `}
 `;
 
@@ -455,4 +442,34 @@ const Row = styled.div`
 
     margin-left: 35px;
     margin-top: 8px;
+`;
+
+const ItemContainer = styled.div<{editing: boolean, $disabled: boolean}>`
+    margin-bottom: 4px;
+    padding: 8px 0px;
+
+    ${HoverMenu} {
+        opacity: 0;
+    }
+
+    .checklists:not(.isDragging) & {
+        // not dragging and hover or focus-within
+        &:hover,
+        &:focus-within {
+            ${DragButton},
+            ${HoverMenu} {
+                opacity: 1;
+            }
+        }
+    }
+
+    ${({editing}) => editing && css`
+        background-color: var(--button-bg-08);
+    `}
+
+    ${({editing, $disabled}) => !editing && !$disabled && css`
+        .checklists:not(.isDragging) &:hover {
+            background: var(--center-channel-color-04);
+        }
+    `}
 `;

--- a/webapp/src/components/checklist_item/checklist_item_draggable.tsx
+++ b/webapp/src/components/checklist_item/checklist_item_draggable.tsx
@@ -15,7 +15,6 @@ interface Props {
     item: ChecklistItemType;
     itemIndex: number;
     newItem: boolean;
-    menuEnabled: boolean;
     disabled?: boolean;
     cancelAddingItem: () => void;
     onUpdateChecklistItem?: (newItem: ChecklistItemType) => void;
@@ -40,9 +39,8 @@ const DraggableChecklistItem = (props: Props) => {
                     playbookRunId={props.playbookRun?.id}
                     onChange={(newState: ChecklistItemState) => props.playbookRun && setChecklistItemState(props.playbookRun.id, props.checklistIndex, props.itemIndex, newState)}
                     draggableProvided={draggableProvided}
-                    dragging={snapshot.isDragging}
+                    dragging={snapshot.isDragging || snapshot.combineWith != null}
                     disabled={props.disabled || finished}
-                    menuEnabled={props.menuEnabled}
                     collapsibleDescription={true}
                     newItem={props.newItem}
                     cancelAddingItem={props.cancelAddingItem}

--- a/webapp/src/components/checklist_item/hover_menu.tsx
+++ b/webapp/src/components/checklist_item/hover_menu.tsx
@@ -126,7 +126,7 @@ const ChecklistItemHoverMenu = (props: Props) => {
     );
 };
 
-const HoverMenu = styled.div`
+export const HoverMenu = styled.div`
     display: flex;
     align-items: center;
     padding: 0px 3px;

--- a/webapp/src/components/rhs/rhs_checklist.tsx
+++ b/webapp/src/components/rhs/rhs_checklist.tsx
@@ -31,7 +31,6 @@ interface Props {
     playbook?: PlaybookWithChecklist;
     checklist: Checklist;
     checklistIndex: number;
-    menuEnabled: boolean;
 }
 
 const RHSChecklist = (props: Props) => {
@@ -111,7 +110,6 @@ const RHSChecklist = (props: Props) => {
                                     item={checklistItem}
                                     itemIndex={index}
                                     newItem={false}
-                                    menuEnabled={props.menuEnabled}
                                     cancelAddingItem={() => {
                                         setAddingItem(false);
                                     }}
@@ -126,7 +124,6 @@ const RHSChecklist = (props: Props) => {
                                 item={emptyChecklistItem()}
                                 itemIndex={-1}
                                 newItem={true}
-                                menuEnabled={props.menuEnabled}
                                 cancelAddingItem={() => {
                                     setAddingItem(false);
                                 }}


### PR DESCRIPTION
#### Summary
- Fix: hover menu disappearing after drag/drop sequencing (use css instead of state)
- Remove: hover background color change on drag-over and when disabled (e.g. archived playbook)

![CleanShot 2022-06-06 at 09 36 34](https://user-images.githubusercontent.com/11724372/172191701-f27c08ca-d2c4-4ca1-9147-3818877cac97.gif)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-44190