### PR TITLE
MM-44962: Playbooks List and Playbook Editor UI changes to match new LHS experience

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -360,6 +360,7 @@
   "hVFgh4": "Include finished",
   "hXIYHG": "Install and enable the Channel Export plugin to support exporting the channel",
   "hfrrC7": "Team Initials",
+  "hjteuA": "All the playbooks that you can access will show here",
   "hrgo+E": "Archive",
   "hw83pa": "Track key metrics and measure value",
   "hzt6l8": "Use Markdown to create a template.",

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -69,7 +69,6 @@ const BackstageTitlebarItem = styled(NavLink)`
 `;
 
 const BackstageBody = styled.div`
-    z-index: 1;
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/webapp/src/components/backstage/backstage_list_header.tsx
+++ b/webapp/src/components/backstage/backstage_list_header.tsx
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
-const BackstageListHeader = styled.div`
+const BackstageListHeader = styled.div<{$edgeless?: boolean}>`
     font-weight: 600;
     padding: 0 1.6rem;
     font-size: 14px;
@@ -9,6 +9,10 @@ const BackstageListHeader = styled.div`
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
     background-color: rgba(var(--center-channel-color-rgb), 0.04);
     border-radius: 4px;
+    ${({$edgeless}) => $edgeless && css`
+        border-width: 1px 0;
+        border-radius: 0;
+    `}
 `;
 
 export default BackstageListHeader;

--- a/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
+++ b/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
@@ -416,6 +416,7 @@ const TitleHeaderBackdrop = styled.div`
 `;
 
 const Editor = styled.main<{$headingVisible: boolean}>`
+    flex: 1 1 auto;
     min-height: 100%;
     display: grid;
     background-color: rgba(var(--center-channel-color-rgb), 0.04);

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -47,9 +47,11 @@ import useConfirmPlaybookArchiveModal from './archive_playbook_modal';
 import NoContentPage from './playbook_list_getting_started';
 import useConfirmPlaybookRestoreModal from './restore_playbook_modal';
 
-const ContainerMedium = styled.article`
-    margin: 0 auto;
-    max-width: 1160px;
+const ContainerMedium = styled.article<{$newLHSEnabled: boolean}>`
+    ${({$newLHSEnabled}) => !$newLHSEnabled && css`
+        margin: 0 auto;
+        max-width: 1160px;
+    `}
     padding: 0 20px;
     scroll-margin-top: 20px;
 `;
@@ -333,7 +335,10 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
             {content.current}
             {canCreatePlaybooks && (
                 <>
-                    <ContainerMedium ref={selectorRef}>
+                    <ContainerMedium
+                        ref={selectorRef}
+                        $newLHSEnabled={newLHSEnabled}
+                    >
                         {props.firstTimeUserExperience || (!hasPlaybooks && !isFiltering) ? (
                             <AltCreatePlaybookHeader>
                                 <AltHeading>

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -58,6 +58,10 @@ const PlaybookListContainer = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.9);
 `;
 
+const TableContainer = styled.div`
+    overflow: clip;
+`;
+
 const CreatePlaybookHeader = styled(BackstageSubheader)`
     margin-top: 4rem;
     padding: 4rem 0 3.2rem;
@@ -195,7 +199,7 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
         };
 
         return (
-            <>
+            <TableContainer>
                 <Header
                     data-testid='titlePlaybook'
                     level={2}
@@ -307,7 +311,7 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                     totalCount={totalCount}
                     setPage={setPage}
                 />
-            </>
+            </TableContainer>
         );
     };
 

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -13,10 +13,6 @@ import {Redirect} from 'react-router-dom';
 
 import {displayPlaybookCreateModal} from 'src/actions';
 import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
-import LeftDots from 'src/components/assets/left_dots';
-import LeftFade from 'src/components/assets/left_fade';
-import RightDots from 'src/components/assets/right_dots';
-import RightFade from 'src/components/assets/right_fade';
 import BackstageListHeader from 'src/components/backstage/backstage_list_header';
 import PlaybookListRow from 'src/components/backstage/playbook_list_row';
 import {ExpandRight} from 'src/components/backstage/playbook_runs/shared';
@@ -63,9 +59,8 @@ const ContainerMedium = styled.article`
 `;
 
 const PlaybookListContainer = styled.div`
-    font-family: $font-family;
+    flex: 1 1 auto;
     color: rgba(var(--center-channel-color-rgb), 0.90);
-
 `;
 
 const CreatePlaybookHeader = styled(BackstageSubheader)`
@@ -114,7 +109,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
     const canCreatePlaybooks = useCanCreatePlaybooksOnAnyTeam();
     const teams = useSelector<GlobalState, Team[]>(getMyTeams);
     const content = useRef<JSX.Element | null>(null);
-    const dispatch = useDispatch();
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const [importTargetTeam, setImportTargetTeam] = useState('');
     const selectorRef = useRef<HTMLDivElement>(null);
@@ -122,7 +116,7 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
     const [
         playbooks,
         {isLoading, totalCount, params},
-        {setPage, sortBy, setSelectedPlaybook, archivePlaybook, restorePlaybook, duplicatePlaybook, setSearchTerm, isFiltering, setWithArchived},
+        {setPage, sortBy, setSelectedPlaybook, archivePlaybook, duplicatePlaybook, setSearchTerm, isFiltering, setWithArchived},
     ] = usePlaybooksCrud({team_id: '', per_page: BACKSTAGE_LIST_PER_PAGE});
 
     const [confirmArchiveModal, openConfirmArchiveModal] = useConfirmPlaybookArchiveModal(archivePlaybook);
@@ -194,38 +188,33 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
 
         return (
             <>
-                <RightDots/>
-                <RightFade/>
-                <LeftDots/>
-                <LeftFade/>
-                <ContainerMedium>
-                    <PlaybooksHeader data-testid='titlePlaybook'>
-                        <Heading>
-                            {formatMessage({defaultMessage: 'Playbooks'})}
-                        </Heading>
-                        <ExpandRight/>
-                        <SearchInput
-                            testId={'search-filter'}
-                            default={params.search_term}
-                            onSearch={setSearchTerm}
-                            placeholder={formatMessage({defaultMessage: 'Search for a playbook'})}
-                        />
-                        <HorizontalSpacer size={12}/>
-                        <CheckboxInput
-                            testId={'with-archived'}
-                            text={formatMessage({defaultMessage: 'With archived'})}
-                            checked={params.with_archived}
-                            onChange={setWithArchived}
-                        />
-                        <HorizontalSpacer size={12}/>
-                        <input
-                            type='file'
-                            accept='*.json,application/JSON'
-                            onChange={importUpload}
-                            ref={fileInputRef}
-                            style={{display: 'none'}}
-                        />
-                        { teams.length > 1 &&
+                <PlaybooksHeader data-testid='titlePlaybook'>
+                    <Heading>
+                        {formatMessage({defaultMessage: 'Playbooks'})}
+                    </Heading>
+                    <ExpandRight/>
+                    <SearchInput
+                        testId={'search-filter'}
+                        default={params.search_term}
+                        onSearch={setSearchTerm}
+                        placeholder={formatMessage({defaultMessage: 'Search for a playbook'})}
+                    />
+                    <HorizontalSpacer size={12}/>
+                    <CheckboxInput
+                        testId={'with-archived'}
+                        text={formatMessage({defaultMessage: 'With archived'})}
+                        checked={params.with_archived}
+                        onChange={setWithArchived}
+                    />
+                    <HorizontalSpacer size={12}/>
+                    <input
+                        type='file'
+                        accept='*.json,application/JSON'
+                        onChange={importUpload}
+                        ref={fileInputRef}
+                        style={{display: 'none'}}
+                    />
+                    {teams.length > 1 &&
                         <TeamSelector
                             placeholder={
                                 <ImportButton/>
@@ -240,8 +229,8 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                                 }
                             }}
                         />
-                        }
-                        { teams.length <= 1 &&
+                    }
+                    {teams.length <= 1 &&
                         <ImportButton
                             onClick={() => {
                                 if (fileInputRef && fileInputRef.current) {
@@ -249,61 +238,60 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                                 }
                             }}
                         />
-                        }
-                        {canCreatePlaybooks &&
+                    }
+                    {canCreatePlaybooks &&
                         <>
                             <HorizontalSpacer size={12}/>
                             <PlaybookModalButton/>
                         </>
-                        }
-                    </PlaybooksHeader>
-                    <BackstageListHeader>
-                        <div className='row'>
-                            <div className='col-sm-4'>
-                                <SortableColHeader
-                                    name={formatMessage({defaultMessage: 'Name'})}
-                                    direction={params.direction}
-                                    active={params.sort === 'title'}
-                                    onClick={() => sortBy('title')}
-                                />
-                            </div>
-                            <div className='col-sm-2'>
-                                <SortableColHeader
-                                    name={formatMessage({defaultMessage: 'Checklists'})}
-                                    direction={params.direction}
-                                    active={params.sort === 'stages'}
-                                    onClick={() => sortBy('stages')}
-                                />
-                            </div>
-                            <div className='col-sm-2'>
-                                <SortableColHeader
-                                    name={'Tasks'}
-                                    direction={params.direction}
-                                    active={params.sort === 'steps'}
-                                    onClick={() => sortBy('steps')}
-                                />
-                            </div>
-                            <div className='col-sm-2'>
-                                <SortableColHeader
-                                    name={formatMessage({defaultMessage: 'Runs'})}
-                                    direction={params.direction}
-                                    active={params.sort === 'runs'}
-                                    onClick={() => sortBy('runs')}
-                                />
-                            </div>
-                            <div className='col-sm-2'>
-                                <FormattedMessage defaultMessage='Actions'/>
-                            </div>
+                    }
+                </PlaybooksHeader>
+                <BackstageListHeader>
+                    <div className='row'>
+                        <div className='col-sm-4'>
+                            <SortableColHeader
+                                name={formatMessage({defaultMessage: 'Name'})}
+                                direction={params.direction}
+                                active={params.sort === 'title'}
+                                onClick={() => sortBy('title')}
+                            />
                         </div>
-                    </BackstageListHeader>
-                    {listBody}
-                    <PaginationRow
-                        page={params.page}
-                        perPage={params.per_page}
-                        totalCount={totalCount}
-                        setPage={setPage}
-                    />
-                </ContainerMedium>
+                        <div className='col-sm-2'>
+                            <SortableColHeader
+                                name={formatMessage({defaultMessage: 'Checklists'})}
+                                direction={params.direction}
+                                active={params.sort === 'stages'}
+                                onClick={() => sortBy('stages')}
+                            />
+                        </div>
+                        <div className='col-sm-2'>
+                            <SortableColHeader
+                                name={'Tasks'}
+                                direction={params.direction}
+                                active={params.sort === 'steps'}
+                                onClick={() => sortBy('steps')}
+                            />
+                        </div>
+                        <div className='col-sm-2'>
+                            <SortableColHeader
+                                name={formatMessage({defaultMessage: 'Runs'})}
+                                direction={params.direction}
+                                active={params.sort === 'runs'}
+                                onClick={() => sortBy('runs')}
+                            />
+                        </div>
+                        <div className='col-sm-2'>
+                            <FormattedMessage defaultMessage='Actions'/>
+                        </div>
+                    </div>
+                </BackstageListHeader>
+                {listBody}
+                <PaginationRow
+                    page={params.page}
+                    perPage={params.per_page}
+                    totalCount={totalCount}
+                    setPage={setPage}
+                />
             </>
         );
     };

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -7,7 +7,7 @@ import {Team} from 'mattermost-redux/types/teams';
 import React, {useRef, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 import {Redirect} from 'react-router-dom';
 
@@ -23,6 +23,7 @@ import {SortableColHeader} from 'src/components/sortable_col_header';
 import {BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
 import {
     useCanCreatePlaybooksOnAnyTeam,
+    useExperimentalFeaturesEnabled,
     usePlaybooksCrud,
     usePlaybooksRouting,
 } from 'src/hooks';
@@ -58,8 +59,12 @@ const PlaybookListContainer = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.9);
 `;
 
-const TableContainer = styled.div`
+const TableContainer = styled.div<{$newLHSEnabled: boolean;}>`
     overflow: clip;
+    ${({$newLHSEnabled}) => !$newLHSEnabled && css`
+        margin: 0 auto;
+        max-width: 1160px;
+    `}
 `;
 
 const CreatePlaybookHeader = styled(BackstageSubheader)`
@@ -136,6 +141,8 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
 
     const {view, edit} = usePlaybooksRouting<Playbook>({onGo: setSelectedPlaybook});
 
+    const newLHSEnabled = useExperimentalFeaturesEnabled();
+
     const hasPlaybooks = Boolean(playbooks?.length);
 
     if (props.firstTimeUserExperience && hasPlaybooks) {
@@ -199,7 +206,7 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
         };
 
         return (
-            <TableContainer>
+            <TableContainer $newLHSEnabled={newLHSEnabled}>
                 <Header
                     data-testid='titlePlaybook'
                     level={2}

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -15,7 +15,6 @@ import {displayPlaybookCreateModal} from 'src/actions';
 import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 import BackstageListHeader from 'src/components/backstage/backstage_list_header';
 import PlaybookListRow from 'src/components/backstage/playbook_list_row';
-import {ExpandRight} from 'src/components/backstage/playbook_runs/shared';
 import SearchInput from 'src/components/backstage/search_input';
 import {BackstageSubheader, HorizontalSpacer} from 'src/components/backstage/styles';
 import TemplateSelector from 'src/components/templates/template_selector';
@@ -35,21 +34,17 @@ import {RegularHeading} from 'src/styles/headings';
 
 import {importFile} from 'src/client';
 
-import TeamSelector from '../team/team_selector';
-
 import {pluginUrl} from 'src/browser_routing';
+
+import Header from '../widgets/header';
+
+import TeamSelector from '../team/team_selector';
 
 import CheckboxInput from './runs_list/checkbox_input';
 
 import useConfirmPlaybookArchiveModal from './archive_playbook_modal';
 import NoContentPage from './playbook_list_getting_started';
 import useConfirmPlaybookRestoreModal from './restore_playbook_modal';
-
-const PlaybooksHeader = styled(BackstageSubheader)`
-    display: flex;
-    padding: 4rem 0 3.2rem;
-    align-items: center;
-`;
 
 const ContainerMedium = styled.article`
     margin: 0 auto;
@@ -60,13 +55,16 @@ const ContainerMedium = styled.article`
 
 const PlaybookListContainer = styled.div`
     flex: 1 1 auto;
-    color: rgba(var(--center-channel-color-rgb), 0.90);
+    color: rgba(var(--center-channel-color-rgb), 0.9);
 `;
 
 const CreatePlaybookHeader = styled(BackstageSubheader)`
     margin-top: 4rem;
     padding: 4rem 0 3.2rem;
+    display: grid;
+    justify-items: space-between;
 `;
+
 export const Heading = styled.h1`
     ${RegularHeading} {
     }
@@ -102,6 +100,16 @@ export const AltHeading = styled(Heading)`
 const AltSub = styled(Sub)`
     text-align: center;
     margin-bottom: 36px;
+`;
+
+const TitleActions = styled.div`
+    display: flex;
+`;
+
+const PlaybooksListFilters = styled.div`
+    display: flex;
+    padding: 16px;
+    align-items: center;
 `;
 
 const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
@@ -188,11 +196,49 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
 
         return (
             <>
-                <PlaybooksHeader data-testid='titlePlaybook'>
-                    <Heading>
-                        {formatMessage({defaultMessage: 'Playbooks'})}
-                    </Heading>
-                    <ExpandRight/>
+                <Header
+                    data-testid='titlePlaybook'
+                    level={2}
+                    heading={formatMessage({defaultMessage: 'Playbooks'})}
+                    subtitle={formatMessage({defaultMessage: 'All the playbooks that you can access will show here'})}
+                    right={(
+                        <TitleActions>
+                            {teams.length > 1 && (
+                                <TeamSelector
+                                    placeholder={<ImportButton/>}
+                                    onlyPlaceholder={true}
+                                    enableEdit={true}
+                                    teams={teams}
+                                    onSelectedChange={(teamId: string) => {
+                                        setImportTargetTeam(teamId);
+                                        if (fileInputRef && fileInputRef.current) {
+                                            fileInputRef.current.click();
+                                        }
+                                    }}
+                                />
+                            )}
+                            {teams.length <= 1 && (
+                                <ImportButton
+                                    onClick={() => {
+                                        if (fileInputRef && fileInputRef.current) {
+                                            fileInputRef.current.click();
+                                        }
+                                    }}
+                                />
+                            )}
+                            {canCreatePlaybooks && (
+                                <>
+                                    <HorizontalSpacer size={12}/>
+                                    <PlaybookModalButton/>
+                                </>
+                            )}
+                        </TitleActions>
+                    )}
+                    css={`
+                        border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+                    `}
+                />
+                <PlaybooksListFilters>
                     <SearchInput
                         testId={'search-filter'}
                         default={params.search_term}
@@ -214,39 +260,8 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                         ref={fileInputRef}
                         style={{display: 'none'}}
                     />
-                    {teams.length > 1 &&
-                        <TeamSelector
-                            placeholder={
-                                <ImportButton/>
-                            }
-                            onlyPlaceholder={true}
-                            enableEdit={true}
-                            teams={teams}
-                            onSelectedChange={(teamId: string) => {
-                                setImportTargetTeam(teamId);
-                                if (fileInputRef && fileInputRef.current) {
-                                    fileInputRef.current.click();
-                                }
-                            }}
-                        />
-                    }
-                    {teams.length <= 1 &&
-                        <ImportButton
-                            onClick={() => {
-                                if (fileInputRef && fileInputRef.current) {
-                                    fileInputRef.current.click();
-                                }
-                            }}
-                        />
-                    }
-                    {canCreatePlaybooks &&
-                        <>
-                            <HorizontalSpacer size={12}/>
-                            <PlaybookModalButton/>
-                        </>
-                    }
-                </PlaybooksHeader>
-                <BackstageListHeader>
+                </PlaybooksListFilters>
+                <BackstageListHeader $edgeless={true}>
                     <div className='row'>
                         <div className='col-sm-4'>
                             <SortableColHeader

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -60,6 +60,7 @@ const PlaybookListContainer = styled.div`
 `;
 
 const TableContainer = styled.div<{$newLHSEnabled: boolean;}>`
+    overflow: hidden;
     overflow: clip;
     ${({$newLHSEnabled}) => !$newLHSEnabled && css`
         margin: 0 auto;

--- a/webapp/src/components/backstage/playbook_list_row.tsx
+++ b/webapp/src/components/backstage/playbook_list_row.tsx
@@ -50,7 +50,7 @@ const PlaybookItem = styled.div`
     padding-bottom: 15px;
     align-items: center;
     margin: 0;
-    border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+    border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
 `;
 
 const PlaybookItemTitle = styled.div`

--- a/webapp/src/components/pagination_row.tsx
+++ b/webapp/src/components/pagination_row.tsx
@@ -8,11 +8,16 @@ import styled from 'styled-components';
 const PaginationRowDiv = styled.div`
     margin: 10px 0 20px;
     font-size: 14px;
+    display: grid;
+    align-items: center;
+    grid-template-columns: minmax(20rem, min-content) auto minmax(20rem, min-content);
+    justify-content: space-between;
+    padding: 0 2px;
 `;
 
-const CountDiv = styled.div`
-    padding-top: 8px;
+const Count = styled.span`
     color: rgba(var(--center-channel-color-rgb), 0.56);
+    white-space: nowrap;
 `;
 
 const Button = styled.button`
@@ -43,35 +48,40 @@ export function PaginationRow(props: Props) {
 
     return (
         <PaginationRowDiv>
-            <div className='row'>
-                <div className='text-center col-sm-2'>
-                    {
-                        (props.page > 0) &&
-                        <Button
-                            className='btn btn-link'
-                            onClick={onPrevPage}
-                        >
-                            <FormattedMessage defaultMessage='Previous'/>
-                        </Button>
-                    }
-                </div>
-                <CountDiv className='text-center col-sm-8'>
-                    <FormattedMessage
-                        defaultMessage='{from, number}–{to, number} of {total, number} total'
-                        values={{from, to, total: props.totalCount}}
-                    />
-                </CountDiv>
-                <div className='text-center col-sm-2'>
-                    {
-                        showNextPage &&
-                        <Button
-                            className='btn btn-link'
-                            onClick={onNextPage}
-                        >
-                            <FormattedMessage defaultMessage='Next'/>
-                        </Button>}
-                </div>
-            </div>
+            {props.page > 0 && (
+                <Button
+                    className='btn btn-link'
+                    onClick={onPrevPage}
+                    css={`
+                        grid-column: 1;
+                        justify-self: start;
+                    `}
+                >
+                    <FormattedMessage defaultMessage='Previous'/>
+                </Button>
+            )}
+            <Count
+                css={`
+                    grid-column: 2;
+                `}
+            >
+                <FormattedMessage
+                    defaultMessage='{from, number}–{to, number} of {total, number} total'
+                    values={{from, to, total: props.totalCount}}
+                />
+            </Count>
+            {showNextPage && (
+                <Button
+                    className='btn btn-link'
+                    onClick={onNextPage}
+                    css={`
+                        grid-column: 3;
+                        justify-self: end;
+                    `}
+                >
+                    <FormattedMessage defaultMessage='Next'/>
+                </Button>
+            )}
         </PaginationRowDiv>
     );
 }

--- a/webapp/src/components/templates/template_item.tsx
+++ b/webapp/src/components/templates/template_item.tsx
@@ -51,8 +51,8 @@ const Item = styled.div`
     border-radius: 8px;
     box-sizing: border-box;
     box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
-    aspect-ratio: 284 / 300;
     max-width: 360px;
+    height: 100%;
     &:not(:hover):not(:focus) {
         ${HoverPanel} {
             display: none;

--- a/webapp/src/components/templates/template_selector.tsx
+++ b/webapp/src/components/templates/template_selector.tsx
@@ -52,7 +52,7 @@ export const TemplateDropdown = (props: TemplateDropdownProps) => {
 const SelectorGrid = styled.div`
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: min(4vw, 5rem);
+    gap: min(4vw, 4rem);
     place-items: flex-start center;
     padding: 0 0 100px;
 `;

--- a/webapp/src/components/templates/template_selector.tsx
+++ b/webapp/src/components/templates/template_selector.tsx
@@ -52,7 +52,7 @@ export const TemplateDropdown = (props: TemplateDropdownProps) => {
 const SelectorGrid = styled.div`
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: min(4vw, 4rem);
+    gap: 2.5rem;
     place-items: flex-start center;
     padding: 0 0 100px;
 `;

--- a/webapp/src/components/widgets/header.tsx
+++ b/webapp/src/components/widgets/header.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 type Props = {
     heading: ReactNode;
     level?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-    paddingLevel?: 0 | 1 | 2
     subtitle?: ReactNode;
     right?: ReactNode;
 };

--- a/webapp/src/components/widgets/header.tsx
+++ b/webapp/src/components/widgets/header.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ReactNode, Fragment, HTMLAttributes} from 'react';
+import styled from 'styled-components';
+
+type Props = {
+    heading: ReactNode;
+    level?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+    paddingLevel?: 0 | 1 | 2
+    subtitle?: ReactNode;
+    right?: ReactNode;
+};
+
+type HeadingTag = keyof Pick<JSX.IntrinsicElements, 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>;
+
+const Headings: Array<typeof Fragment | HeadingTag> = [Fragment, 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+
+const Header = ({
+    level = 0,
+    heading,
+    subtitle,
+    right,
+    ...attrs
+}: Props & HTMLAttributes<HTMLElement>) => {
+    const H = Headings[level];
+    return (
+        <HeaderEl {...attrs}>
+            <div className='left'>
+                <H>{heading}</H>
+                {subtitle ? <p>{subtitle}</p> : null}
+            </div>
+            <Spacer/>
+            {right}
+        </HeaderEl>
+    );
+};
+
+const HeaderEl = styled.header`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        margin: 0;
+        line-height: 1;
+    }
+
+    h2 {
+        color: rgba(var(--center-channel-color-rgb), 1);
+        font-size: 16px;
+        font-weight: 600;
+    }
+
+    > div p {
+        margin: 6px 0 0;
+        color: rgba(var(--center-channel-color-rgb), 0.56);
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 16px;
+    }
+`;
+
+const Spacer = styled.div`
+    flex: 1;
+`;
+
+export default Header;

--- a/webapp/src/types/global.d.ts
+++ b/webapp/src/types/global.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {} from 'styled-components/cssprop';


### PR DESCRIPTION
#### Summary
Changes overall layout to match new designs but without additional functionality; new UX/functionality will come in subsequent PRs.

- Update Playbooks List design
  - Make full-width (constrained to `max-width: 1160px` on old page; unconstrained on LHS-enabled screen)
  - Minor page hierarchy changes
- Update Playbook Editor design
  - Make full-width 
- (https://github.com/mattermost/mattermost-plugin-playbooks/commit/a1c1496f46b81a778af9f6239cc0661bc5ed5d7a) Fix: Global Header menus disappearing on Playbooks List page in Safari
(I couldn't repro this one locally, but could repro on community—the fix applied in devtools fixes it)

New list screen
<img width="700" alt="CleanShot 2022-06-13 at 23 29 31@2x" src="https://user-images.githubusercontent.com/11724372/173493563-58f0964a-0372-4d3b-9a46-5be46d503ea5.png">

Current list screen (`width` constrained if `experimental == false`, all other changes ungated)
<img width="1125" alt="CleanShot 2022-06-13 at 23 48 58@2x" src="https://user-images.githubusercontent.com/11724372/173495511-39ed40f8-af5f-4df4-9ce9-09f221f3e67a.png">

Global Header menus disappearing in Safari (community.mattermost.com)
<img width="400" alt="image" src="https://user-images.githubusercontent.com/11724372/173497872-174899c0-2a3a-4a18-bd65-5e2b1b5f7671.gif">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/11724372/173493856-dff90404-e51d-49be-af02-7b0e1dcd6ea8.gif">

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-44962

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | N
Gated by experimental feature flag? | Y&N
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.
