### PR TITLE
Configure playbooks for Notice.txt file auto-generation

### DIFF
--- a/.config/notice-file/Readme.md
+++ b/.config/notice-file/Readme.md
@@ -25,4 +25,4 @@ devDependencies: []
 | description | string | Field content will be used as notice file description. See third line of `NOTICE.txt` file. |
 | dependencies | array | If any dependency name mentioned, it will be automatically added even if it is not a first-level dependency. |
 | devDependencies | array | If any dependency name mentioned, it will be added when it is referenced in devDependency section. |
-| search | array | Pipeline will search for package.json files mentioned here. Globstar format is supported ie. `x/**/go.mod`. |
+| search | array | Pipeline will search for package.json/go.mod files mentioned here. Globstar format is supported ie. `x/**/go.mod`. |

--- a/.config/notice-file/Readme.md
+++ b/.config/notice-file/Readme.md
@@ -1,0 +1,28 @@
+# Notice.txt File Configuration
+
+We are automatically generating Notice.txt by using first-level dependencies of the project. The related pipeline uses `config.yaml` stored in this folder.
+
+
+## Configuration
+
+Sample:
+
+```
+title: "Mattermost Playbooks"
+copyright: "©2015-present Mattermost, Inc.  All Rights Reserved.  See LICENSE for license information."
+description: "This document includes a list of open source components used in Mattermost Playbooks, including those that have been modified."
+search:
+  - "go.mod"
+  - "client/go.mod"
+dependencies: []
+devDependencies: []
+```
+
+| Field | Type   | Purpose |
+| :--   | :--    | :--     |
+| title | string | Field content will be used as a title of the application. See first line of `NOTICE.txt` file. |
+| copyright | string | Field content will be used as a copyright message. See second line of `NOTICE.txt` file. |
+| description | string | Field content will be used as notice file description. See third line of `NOTICE.txt` file. |
+| dependencies | array | If any dependency name mentioned, it will be automatically added even if it is not a first-level dependency. |
+| devDependencies | array | If any dependency name mentioned, it will be added when it is referenced in devDependency section. |
+| search | array | Pipeline will search for package.json files mentioned here. Globstar format is supported ie. `x/**/go.mod`. |

--- a/.config/notice-file/config.yaml
+++ b/.config/notice-file/config.yaml
@@ -1,0 +1,12 @@
+---
+
+title: "Mattermost Playbooks"
+copyright: "©2015-present Mattermost, Inc.  All Rights Reserved.  See LICENSE for license information."
+description: "This document includes a list of open source components used in Mattermost Playbooks, including those that have been modified."
+search:
+  - "go.mod"
+  - "client/go.mod"
+dependencies: []
+devDependencies: []
+
+...


### PR DESCRIPTION
#### Summary
We created a tool to automatically generate NOTICE.txt from project folders. And there is a scheduled pipeline configured to run at every Monday which creates a PR if there is a change.

Some sections need to be managed by developers at Notice.txt. And pipeline needs locations/files to search the dependencies. That configuration need to be stored in this repo, so developers will manage those and configure tool without leaving this repo.

Tool repo: https://github.com/mattermost/notice-file-generator

We selected `.config/notice-file` to store the configuration files. And it is configurable, feel free to change it if another location is more convenient.


#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
