### PR TITLE
Hackathon 2022 global task inbox Redux RHS

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -152,6 +152,7 @@
   "HhLp57": "quote",
   "HvAcYh": "{text}{rest, plural, =0 {} one { and other} other { and {rest} others}}",
   "Hzwzgs": "Broadcast updates in the {oneChannel, plural, one {channel} other {channels}}",
+  "I0NIMp": "Your tasks",
   "I2zEie": "Celebrate success and learn from mistakes with retrospective reports. Filter timeline events for process review, stakeholder engagement, and auditing purposes.",
   "I5DYM+": "Learn AND reflect",
   "I5NMJ8": "More",

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -13,6 +13,7 @@ import {getCurrentChannelId} from 'mattermost-webapp/packages/mattermost-redux/s
 import {PlaybookRun} from 'src/types/playbook_run';
 import {selectToggleRHS, canIPostUpdateForRun} from 'src/selectors';
 import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
+import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 import {
     PLAYBOOK_RUN_CREATED,
     PLAYBOOK_RUN_UPDATED,
@@ -65,6 +66,10 @@ import {
     SetChecklistItemsFilter,
     SetEachChecklistCollapsedState,
     SET_EACH_CHECKLIST_COLLAPSED_STATE,
+    OPEN_BACKSTAGE_RHS,
+    CLOSE_BACKSTAGE_RHS,
+    CloseBackstageRHS,
+    OpenBackstageRHS,
 } from 'src/types/actions';
 import {clientExecuteCommand} from 'src/client';
 import {GlobalSettings} from 'src/types/settings';
@@ -349,4 +354,14 @@ export const setChecklistItemsFilter = (channelId: string, nextState: ChecklistI
     type: SET_CHECKLIST_ITEMS_FILTER,
     channelId,
     nextState,
+});
+
+export const closeBackstageRHS = (): CloseBackstageRHS => ({
+    type: CLOSE_BACKSTAGE_RHS,
+});
+
+export const openBackstageRHS = (section: BackstageRHSSection, viewMode: BackstageRHSViewMode): OpenBackstageRHS => ({
+    type: OPEN_BACKSTAGE_RHS,
+    section,
+    viewMode,
 });

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -3,7 +3,7 @@
 
 import React, {useEffect} from 'react';
 import {Switch, Route, NavLink, useRouteMatch} from 'react-router-dom';
-import {useSelector, useDispatch} from 'react-redux';
+import {useSelector} from 'react-redux';
 import {useIntl} from 'react-intl';
 import styled from 'styled-components';
 import Icon from '@mdi/react';
@@ -23,8 +23,6 @@ import {BackstageNavbar} from 'src/components/backstage/backstage_navbar';
 import {applyTheme} from 'src/components/backstage/css_utils';
 
 import BackstageRHS from 'src/components/backstage/rhs/rhs';
-import {openBackstageRHS} from 'src/actions';
-import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 
 import {ToastProvider} from './toast_banner';
 import LHSNavigation from './lhs_navigation';
@@ -79,10 +77,6 @@ const BackstageBody = styled.div`
 `;
 
 const Backstage = () => {
-    // Temporary code to trigger rhs always (until we have header button)
-    const dispatch = useDispatch();
-    dispatch(openBackstageRHS(BackstageRHSSection.TaskInbox, BackstageRHSViewMode.Overlap));
-
     const currentTheme = useSelector<GlobalState, Theme>(getTheme);
     useEffect(() => {
         // This class, critical for all the styling to work, is added by ChannelController,

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -3,7 +3,7 @@
 
 import React, {useEffect} from 'react';
 import {Switch, Route, NavLink, useRouteMatch} from 'react-router-dom';
-import {useSelector} from 'react-redux';
+import {useSelector, useDispatch} from 'react-redux';
 import {useIntl} from 'react-intl';
 import styled from 'styled-components';
 import Icon from '@mdi/react';
@@ -21,6 +21,10 @@ import {useExperimentalFeaturesEnabled, useForceDocumentTitle} from 'src/hooks';
 import CloudModal from 'src/components/cloud_modal';
 import {BackstageNavbar} from 'src/components/backstage/backstage_navbar';
 import {applyTheme} from 'src/components/backstage/css_utils';
+
+import BackstageRHS from 'src/components/backstage/rhs/rhs';
+import {openBackstageRHS} from 'src/actions';
+import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 
 import {ToastProvider} from './toast_banner';
 import LHSNavigation from './lhs_navigation';
@@ -75,6 +79,10 @@ const BackstageBody = styled.div`
 `;
 
 const Backstage = () => {
+    // Temporary code to trigger rhs always (until we have header button)
+    const dispatch = useDispatch();
+    dispatch(openBackstageRHS(BackstageRHSSection.TaskInbox, BackstageRHSViewMode.Overlap));
+
     const currentTheme = useSelector<GlobalState, Theme>(getTheme);
     useEffect(() => {
         // This class, critical for all the styling to work, is added by ChannelController,
@@ -116,6 +124,7 @@ const Backstage = () => {
                 }
                 <CloudModal/>
             </ToastProvider>
+            <BackstageRHS/>
         </BackstageContainer>
     );
 };

--- a/webapp/src/components/backstage/rhs/rhs.tsx
+++ b/webapp/src/components/backstage/rhs/rhs.tsx
@@ -1,0 +1,126 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import Scrollbars from 'react-custom-scrollbars';
+import {useDispatch, useSelector} from 'react-redux';
+import styled from 'styled-components';
+
+import {closeBackstageRHS} from 'src/actions';
+import {backstageRHS} from 'src/selectors';
+import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
+import {renderThumbVertical, renderTrackHorizontal, renderView} from 'src/components/rhs/rhs_shared';
+
+import TaskInbox, {TaskInboxTitle} from './task_inbox';
+
+const BackstageRHS = () => {
+    const sidebarRef = React.useRef(null);
+    const dispatch = useDispatch();
+    const isOpen = useSelector(backstageRHS.isOpen);
+    const viewMode = useSelector(backstageRHS.viewMode);
+    const section = useSelector(backstageRHS.section);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const renderTitle = () => {
+        switch (section) {
+        case BackstageRHSSection.TaskInbox:
+            return TaskInboxTitle;
+        default:
+            throw new Error('Unknown backstage section while rendering title');
+        }
+    };
+
+    return (
+        <Container
+            id='playbooks-sidebar-right'
+            role='complementary'
+            ref={sidebarRef}
+            isOpen={isOpen}
+            viewMode={viewMode}
+        >
+            <Header>
+                <HeaderTitle>{renderTitle()}</HeaderTitle>
+                <ExpandRight/>
+                <HeaderIcon>
+                    <i
+                        className='icon icon-close'
+                        onClick={() => dispatch(closeBackstageRHS())}
+                    />
+                </HeaderIcon>
+            </Header>
+            <Body>
+                <Scrollbars
+                    autoHide={true}
+                    autoHideTimeout={500}
+                    autoHideDuration={500}
+                    renderThumbVertical={renderThumbVertical}
+                    renderView={renderView}
+                    renderTrackHorizontal={renderTrackHorizontal}
+                    style={{position: 'relative'}}
+                >
+                    {section === BackstageRHSSection.TaskInbox ? <TaskInbox/> : null}
+                </Scrollbars>
+            </Body>
+        </Container>);
+};
+
+export default BackstageRHS;
+
+const Container = styled.div<{isOpen: boolean, viewMode: BackstageRHSViewMode}>`
+    display: ${({isOpen}) => (isOpen ? 'flex' : 'hidden')};
+    position: fixed;
+    width: 400px;
+    height: 100%;
+    flex-direction: column;
+    border-left: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+    right: 0;
+    z-index: 5;
+    background-color: var(--center-channel-bg);
+
+
+    @media screen and (min-width: 1600px) {
+        width: 500px;
+    }
+`;
+
+const Header = styled.div`
+    display: flex;
+    flex-direction: row;
+    height: 56px;
+    border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+`;
+
+const HeaderIcon = styled.div`
+    display: flex;
+    align-self: center;
+    justify-content: center;
+    cursor: pointer;
+    width: 32px;
+    height: 32px;
+    margin-right: 20px;
+    :hover {
+        background-color: rgba(var(--center-channel-color-rgb), 0.08);
+    }
+`;
+
+const HeaderTitle = styled.div`
+    margin: auto 0 auto 20px;
+    line-height: 32px;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--center-channel-color);
+    white-space: nowrap;
+`;
+
+const Body = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+`;
+
+export const ExpandRight = styled.div`
+    margin-left: auto;
+`;

--- a/webapp/src/components/backstage/rhs/task_inbox.tsx
+++ b/webapp/src/components/backstage/rhs/task_inbox.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export const TaskInboxTitle = <FormattedMessage defaultMessage={'Your tasks'}/>;
+
+const TaskInbox = () => {
+    return <div>{'Your cool inbox!'}</div>;
+};
+
+export default TaskInbox;

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -8,6 +8,7 @@ import {Channel} from 'mattermost-redux/types/channels';
 
 import {PlaybookRun} from 'src/types/playbook_run';
 import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
+import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 import {
     RECEIVED_TOGGLE_RHS_ACTION,
     ReceivedToggleRHSAction,
@@ -52,6 +53,10 @@ import {
     SET_EACH_CHECKLIST_COLLAPSED_STATE,
     SetChecklistItemsFilter,
     SET_CHECKLIST_ITEMS_FILTER,
+    OPEN_BACKSTAGE_RHS,
+    OpenBackstageRHS,
+    CLOSE_BACKSTAGE_RHS,
+    CloseBackstageRHS,
 } from 'src/types/actions';
 import {GlobalSettings} from 'src/types/settings';
 import {ChecklistItemsFilter} from 'src/types/playbook';
@@ -306,6 +311,34 @@ const checklistItemsFilterByChannel = (state: Record<string, ChecklistItemsFilte
     }
 };
 
+// Backstage RHS related reducer
+// Note That this is not the same as channel RHS management
+// TODO: make a refactor with some naming change now we have multiple RHS
+//       inside playbooks (channels RHS, Run details page RHS, backstage RHS)
+export type backstageRHSState = {
+    isOpen: boolean;
+    viewMode: BackstageRHSViewMode;
+    section: BackstageRHSSection;
+}
+const initialBackstageRHSState = {
+    isOpen: false,
+    viewMode: BackstageRHSViewMode.Overlap,
+    section: BackstageRHSSection.TaskInbox,
+};
+
+const backstageRHS = (state: backstageRHSState = initialBackstageRHSState, action: OpenBackstageRHS | CloseBackstageRHS) => {
+    switch (action.type) {
+    case OPEN_BACKSTAGE_RHS: {
+        const openAction = action as OpenBackstageRHS;
+        return {isOpen: true, viewMode: openAction.viewMode, section: openAction.section};
+    }
+    case CLOSE_BACKSTAGE_RHS:
+        return {...state, isOpen: false};
+    default:
+        return state;
+    }
+};
+
 const reducer = combineReducers({
     toggleRHSFunction,
     rhsOpen,
@@ -321,6 +354,7 @@ const reducer = combineReducers({
     rhsAboutCollapsedByChannel,
     checklistCollapsedState,
     checklistItemsFilterByChannel,
+    backstageRHS,
 });
 
 export default reducer;

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -40,6 +40,12 @@ export const selectToggleRHS = (state: GlobalState): () => void => pluginState(s
 
 export const isPlaybookRunRHSOpen = (state: GlobalState): boolean => pluginState(state).rhsOpen;
 
+export const backstageRHS = {
+    section: (state: GlobalState) => pluginState(state).backstageRHS.section,
+    isOpen: (state: GlobalState) => pluginState(state).backstageRHS.isOpen,
+    viewMode: (state: GlobalState) => pluginState(state).backstageRHS.viewMode,
+};
+
 export const getIsRhsExpanded = (state: WebGlobalState): boolean => state.views.rhs.isSidebarExpanded;
 
 export const getAdminAnalytics = (state: GlobalState): Record<string, number> => state.entities.admin.analytics as Record<string, number>;

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -5,6 +5,7 @@ import Integrations from 'mattermost-redux/action_types/integrations';
 
 import {PlaybookRun} from 'src/types/playbook_run';
 import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
+import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 import {pluginId} from 'src/manifest';
 import {GlobalSettings} from 'src/types/settings';
 import {ChecklistItemsFilter} from 'src/types/playbook';
@@ -34,6 +35,13 @@ export const SET_EACH_CHECKLIST_COLLAPSED_STATE = pluginId + '_set_every_checkli
 export const SET_CHECKLIST_COLLAPSED_STATE = pluginId + '_set_checklist_collapsed_state';
 export const SET_ALL_CHECKLISTS_COLLAPSED_STATE = pluginId + '_set_all_checklists_collapsed_state';
 export const SET_CHECKLIST_ITEMS_FILTER = pluginId + '_set_checklist_items_filter';
+
+// Backstage RHS related action types
+// Note That this is not the same as channel RHS management
+// TODO: make a refactor with some naming change now we have multiple RHS
+//       inside playbooks (channels RHS, Run details page RHS, backstage RHS)
+export const OPEN_BACKSTAGE_RHS = pluginId + '_open_backstage_rhs';
+export const CLOSE_BACKSTAGE_RHS = pluginId + '_close_backstage_rhs';
 
 export interface ReceivedToggleRHSAction {
     type: typeof RECEIVED_TOGGLE_RHS_ACTION;
@@ -166,4 +174,18 @@ export interface SetChecklistItemsFilter {
     type: typeof SET_CHECKLIST_ITEMS_FILTER;
     channelId: string;
     nextState: ChecklistItemsFilter;
+}
+
+// Backstage RHS related action types
+// Note That this is not the same as channel RHS management
+// TODO: make a refactor with some naming change now we have multiple RHS
+//       inside playbooks (channels RHS, Run details page RHS, backstage RHS)
+export interface OpenBackstageRHS {
+    type: typeof OPEN_BACKSTAGE_RHS;
+    section: BackstageRHSSection;
+    viewMode: BackstageRHSViewMode;
+}
+
+export interface CloseBackstageRHS {
+    type: typeof CLOSE_BACKSTAGE_RHS;
 }

--- a/webapp/src/types/backstage_rhs.ts
+++ b/webapp/src/types/backstage_rhs.ts
@@ -1,0 +1,8 @@
+export enum BackstageRHSSection {
+    TaskInbox = 'task-inbox',
+}
+
+export enum BackstageRHSViewMode {
+    Overlap = 'overlap',
+    Shared = 'shared',
+}


### PR DESCRIPTION
#### Summary
Some work preparing the foundations of task inbox.

Redux infrastructure created: two new actions `OPEN_BACKSTAGE_RHS`,`CLOSE_BACKSTAGE_RHS` and one reducer `backstageRHS`. They can be called through the action creators.

To open RHS:
```ts
    import {openBackstageRHS} from 'src/actions';
    import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';

    const dispatch = useDispatch();
    dispatch(openBackstageRHS(BackstageRHSSection.TaskInbox, BackstageRHSViewMode.Overlap));
```

To close RHS (X inside RHS already plugged):
```ts
    import {closeBackstageRHS} from 'src/actions';

    const dispatch = useDispatch();
    dispatch(closeBackstageRHS());
```

Naming is not perfect, some work would be needed to make this permanent since there are tons of references to RHS in an absolute way but now there are 3 different RHS. 

#### Ticket Link
No ticket

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
