### PR TITLE
MM-45401: Ellipsize Playbook link in Run Details Page RHS

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -71,7 +71,7 @@ const RHSInfoOverview = ({run, runMetadata, role}: Props) => {
                 name={formatMessage({defaultMessage: 'Playbook'})}
                 onClick={() => navigateToUrl(pluginUrl(`/playbooks/${run.playbook_id}`))}
             >
-                {playbook && <Link to={pluginUrl(`/playbooks/${run.playbook_id}`)}>{playbook.title}</Link>}
+                {playbook && <PlaybookLink to={pluginUrl(`/playbooks/${run.playbook_id}`)}>{playbook.title}</PlaybookLink>}
             </Item>
             <Item
                 icon={AccountOutlineIcon}
@@ -182,6 +182,14 @@ const Item = (props: ItemProps) => {
         </OverviewRow>
     );
 };
+
+const PlaybookLink = styled(Link)`
+    max-width: 230px;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
 
 const OverviewRow = styled.div<{onClick?: () => void}>`
     padding: 10px 24px;


### PR DESCRIPTION
#### Summary
Add `text-overflow: ellipsis` to the Playbook link in the Overview section of the RHS of the Run Details Page.

![image](https://user-images.githubusercontent.com/3924815/176134820-b517f33d-fe71-4350-954c-9cd4bfb055d4.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45401

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
