### PR TITLE
MM-44500: fix template item hover, fix playbook menu being clipped

### DIFF
--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -62,8 +62,8 @@ const PlaybookListContainer = styled.div`
 `;
 
 const TableContainer = styled.div<{$newLHSEnabled: boolean;}>`
-    overflow: hidden;
-    overflow: clip;
+    overflow-x: hidden;
+    overflow-x: clip;
     ${({$newLHSEnabled}) => !$newLHSEnabled && css`
         margin: 0 auto;
         max-width: 1160px;

--- a/webapp/src/components/templates/template_item.tsx
+++ b/webapp/src/components/templates/template_item.tsx
@@ -64,7 +64,7 @@ type ThumbnailProps = {$color?: string;}
 const Thumbnail = styled.div<ThumbnailProps>`
     display: grid;
     place-items: center;
-    padding: 15%;
+    padding: 15% 0;
     background: ${({$color}) => $color};
     height: 50%;
     border-radius: 8px 8px 0 0;


### PR DESCRIPTION
#### Summary
- fix:template item hover in Safari
- fix: playbook menu being clipped

|  before  |  after  |
|---|---|
| <img width="347" alt="CleanShot 2022-06-29 at 23 35 50@2x" src="https://user-images.githubusercontent.com/11724372/176594525-104cc0bb-e9f3-4ce2-a672-faf4a804bde9.png">  |  <img width="331" alt="CleanShot 2022-06-29 at 23 36 38@2x" src="https://user-images.githubusercontent.com/11724372/176594519-b267419b-11a6-4241-ad13-5bbef025bdf1.png"> |
| <img width="331" alt="" src="https://user-images.githubusercontent.com/11724372/176594636-59023b3a-a0a1-4f80-9257-4dfb7068cee1.png">  |  <img width="331" alt="" src="https://user-images.githubusercontent.com/11724372/176594646-09141e80-c978-4554-9053-5257cac28a79.png"> |



#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-44500

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | N
Gated by experimental feature flag? | N
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.
