### PR TITLE
MM-45446: Auto scroll infrastructure

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -2,10 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React, {useEffect} from 'react';
-import {Switch, Route, NavLink, useRouteMatch} from 'react-router-dom';
+import {Switch, Route, NavLink, useLocation, useRouteMatch} from 'react-router-dom';
 import {useSelector} from 'react-redux';
 import {useIntl} from 'react-intl';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 import Icon from '@mdi/react';
 import {mdiThumbsUpDown, mdiClipboardPlayMultipleOutline} from '@mdi/js';
 
@@ -26,12 +26,18 @@ import {ToastProvider} from './toast_banner';
 import LHSNavigation from './lhs_navigation';
 import MainBody from './main_body';
 
-const BackstageContainer = styled.div`
+const BackstageContainer = styled.div<{isRunDetailsPage: boolean}>`
     background: var(--center-channel-bg);
     display: flex;
     flex-direction: column;
     overflow-y: auto;
     height: 100%;
+
+    ${({isRunDetailsPage}) => isRunDetailsPage && css`
+        // Accounts for the run header, so when scrolling with
+        // anchor links, the sections are not hidden under it.
+        scroll-padding-top: 64px;
+    `}
 `;
 
 const BackstageTitlebarItem = styled(NavLink)`
@@ -75,6 +81,11 @@ const BackstageBody = styled.div`
 `;
 
 const Backstage = () => {
+    const {pathname} = useLocation();
+
+    // TODO: Change  to /playbooks/runs when we get the new run details page to production
+    const isRunDetailsPage = pathname.startsWith('/playbooks/run_details');
+
     const currentTheme = useSelector<GlobalState, Theme>(getTheme);
     useEffect(() => {
         // This class, critical for all the styling to work, is added by ChannelController,
@@ -98,6 +109,7 @@ const Backstage = () => {
     return (
         <BackstageContainer
             id={BackstageID}
+            isRunDetailsPage={isRunDetailsPage}
         >
             <ToastProvider>
                 {!newLHSEnabled &&

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -37,6 +37,8 @@ const BackstageContainer = styled.div<{isRunDetailsPage: boolean}>`
         // Accounts for the run header, so when scrolling with
         // anchor links, the sections are not hidden under it.
         scroll-padding-top: 64px;
+
+        scroll-behavior: smooth;
     `}
 `;
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/checklists.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/checklists.tsx
@@ -10,12 +10,13 @@ import RHSChecklistList, {ChecklistParent} from 'src/components/rhs/rhs_checklis
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 
 interface Props {
+    id: string;
     playbookRun: PlaybookRun;
     role: Role;
 }
-const Checklists = ({playbookRun, role}: Props) => {
+const Checklists = ({id, playbookRun, role}: Props) => {
     return (
-        <Container>
+        <Container id={id}>
             <RHSChecklistList
                 playbookRun={playbookRun}
                 parentContainer={ChecklistParent.RunDetails}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/checklists.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/checklists.tsx
@@ -18,6 +18,7 @@ const Checklists = ({id, playbookRun, role}: Props) => {
     return (
         <Container id={id}>
             <RHSChecklistList
+                id={id}
                 playbookRun={playbookRun}
                 parentContainer={ChecklistParent.RunDetails}
                 viewerMode={role === Role.Viewer}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -53,6 +53,13 @@ const useRHS = (playbookRun?: PlaybookRun|null) => {
     return {isOpen, section, title, subtitle, open, close};
 };
 
+export enum PlaybookRunIDs {
+    SectionSummary = 'playbook-run-summary',
+    SectionStatusUpdate = 'playbook-run-status-update',
+    SectionChecklists = 'playbook-run-checklists',
+    SectionRetrospective = 'playbook-run-retrospective',
+}
+
 const PlaybookRunDetails = () => {
     const dispatch = useDispatch();
     const match = useRouteMatch<{playbookRunId: string}>();
@@ -132,27 +139,32 @@ const PlaybookRunDetails = () => {
                 <Main isRHSOpen={RHS.isOpen}>
                     <Body>
                         <Summary
+                            id={PlaybookRunIDs.SectionSummary}
                             playbookRun={playbookRun}
                             role={role}
                         />
                         {role === Role.Participant ? (
                             <ParticipantStatusUpdate
+                                id={PlaybookRunIDs.SectionStatusUpdate}
                                 openRHS={RHS.open}
                                 playbookRun={playbookRun}
                             />
                         ) : (
                             <ViewerStatusUpdate
+                                id={PlaybookRunIDs.SectionStatusUpdate}
                                 openRHS={RHS.open}
                                 lastStatusUpdate={statusUpdates?.length ? statusUpdates[0] : undefined}
                                 playbookRun={playbookRun}
                             />
                         )}
                         <Checklists
+                            id={PlaybookRunIDs.SectionChecklists}
                             playbookRun={playbookRun}
                             role={role}
                         />
                         {role === Role.Participant ? <FinishRun playbookRun={playbookRun}/> : null}
                         <Retrospective
+                            id={PlaybookRunIDs.SectionRetrospective}
                             playbookRun={playbookRun}
                             playbook={playbook ?? null}
                             role={role}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -5,7 +5,7 @@ import React, {useState, useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {FormattedMessage} from 'react-intl';
 import styled from 'styled-components';
-import {useRouteMatch, Redirect} from 'react-router-dom';
+import {useLocation, useRouteMatch, Redirect} from 'react-router-dom';
 import {selectTeam} from 'mattermost-webapp/packages/mattermost-redux/src/actions/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
@@ -63,6 +63,7 @@ export enum PlaybookRunIDs {
 const PlaybookRunDetails = () => {
     const dispatch = useDispatch();
     const match = useRouteMatch<{playbookRunId: string}>();
+    const {hash: urlHash} = useLocation();
     const playbookRunId = match.params.playbookRunId;
     const playbookRun = useRun(playbookRunId);
     const playbook = usePlaybook(playbookRun?.playbook_id);
@@ -88,6 +89,17 @@ const PlaybookRunDetails = () => {
 
         dispatch(selectTeam(teamId));
     }, [dispatch, playbookRun?.team_id]);
+
+    // When first loading the page, the element with the ID corresponding to the URL
+    // hash is not mounted, so the browser fails to automatically scroll to such section.
+    // To fix this, we need to manually scroll to the component
+    useEffect(() => {
+        if (urlHash !== '') {
+            setTimeout(() => {
+                document.querySelector(urlHash)?.scrollIntoView();
+            }, 300);
+        }
+    }, [urlHash]);
 
     // loading state
     if (playbookRun === undefined) {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -18,6 +18,7 @@ import {TertiaryButton} from 'src/components/assets/buttons';
 import {PAST_TIME_SPEC} from 'src/components/time_spec';
 
 interface Props {
+    id: string;
     playbookRun: PlaybookRun;
     playbook: PlaybookWithChecklist | null;
     role: Role;
@@ -26,6 +27,7 @@ interface Props {
 const DEBOUNCE_2_SECS = 2000;
 
 const Retrospective = ({
+    id,
     playbookRun,
     playbook,
     role,
@@ -42,7 +44,7 @@ const Retrospective = ({
 
     if (!allowRetrospectiveAccess) {
         return (
-            <Container>
+            <Container id={id}>
                 <AnchorLinkTitle
                     title={formatMessage({defaultMessage: 'Retrospective'})}
                     id='retrospective'
@@ -115,7 +117,7 @@ const Retrospective = ({
     }, DEBOUNCE_2_SECS);
 
     return (
-        <Container>
+        <Container id={id}>
             <div>
                 <Header>
                     <AnchorLinkTitle

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -47,7 +47,7 @@ const Retrospective = ({
             <Container id={id}>
                 <AnchorLinkTitle
                     title={formatMessage({defaultMessage: 'Retrospective'})}
-                    id='retrospective'
+                    id={id}
                 />
                 <BannerWrapper>
                     <UpgradeBanner
@@ -122,7 +122,7 @@ const Retrospective = ({
                 <Header>
                     <AnchorLinkTitle
                         title={formatMessage({defaultMessage: 'Retrospective'})}
-                        id='retrospective'
+                        id={id}
                     />
                     <HeaderButtonsRight>
                         {renderPublishComponent()}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -63,12 +63,13 @@ const getDueInfo = (playbookRun: PlaybookRun, now: DateTime) => {
 };
 
 interface ViewerProps {
+    id: string;
     playbookRun: PlaybookRun;
     lastStatusUpdate?: StatusPostComplete;
     openRHS: (section: RHSContent, title: React.ReactNode, subtitle?: React.ReactNode) => void;
 }
 
-export const ViewerStatusUpdate = ({playbookRun, openRHS, lastStatusUpdate}: ViewerProps) => {
+export const ViewerStatusUpdate = ({id, playbookRun, openRHS, lastStatusUpdate}: ViewerProps) => {
     const {formatMessage} = useIntl();
     const fiveSeconds = 5000;
     const now = useNow(fiveSeconds);
@@ -87,7 +88,7 @@ export const ViewerStatusUpdate = ({playbookRun, openRHS, lastStatusUpdate}: Vie
     };
 
     return (
-        <Container>
+        <Container id={id}>
             <Header>
                 <AnchorLinkTitle
                     title={formatMessage({defaultMessage: 'Recent status update'})}
@@ -118,11 +119,12 @@ export const ViewerStatusUpdate = ({playbookRun, openRHS, lastStatusUpdate}: Vie
 };
 
 interface ParticipantProps {
+    id: string;
     playbookRun: PlaybookRun;
     openRHS: (section: RHSContent, title: React.ReactNode, subtitle?: React.ReactNode) => void;
 }
 
-export const ParticipantStatusUpdate = ({playbookRun, openRHS}: ParticipantProps) => {
+export const ParticipantStatusUpdate = ({id, playbookRun, openRHS}: ParticipantProps) => {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
     const fiveSeconds = 5000;
@@ -141,7 +143,7 @@ export const ParticipantStatusUpdate = ({playbookRun, openRHS}: ParticipantProps
     ));
 
     return (
-        <Container>
+        <Container id={id}>
             <Content isShort={true}>
                 <IconWrapper>
                     <IconClock

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -92,7 +92,7 @@ export const ViewerStatusUpdate = ({id, playbookRun, openRHS, lastStatusUpdate}:
             <Header>
                 <AnchorLinkTitle
                     title={formatMessage({defaultMessage: 'Recent status update'})}
-                    id='recent-update'
+                    id={id}
                 />
                 <RightWrapper>
                     <IconWrapper>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
@@ -14,12 +14,13 @@ import {AnchorLinkTitle, Role} from 'src/components/backstage/playbook_runs/shar
 import {PAST_TIME_SPEC} from 'src/components/time_spec';
 
 interface Props {
+    id: string;
     playbookRun: PlaybookRun;
     role: Role,
 }
 
 const Summary = ({
-    playbookRun, role,
+    id, playbookRun, role,
 }: Props) => {
     const {formatMessage} = useIntl();
 
@@ -38,7 +39,7 @@ const Summary = ({
     );
 
     return (
-        <Container>
+        <Container id={id}>
             <Header>
                 <AnchorLinkTitle
                     title={title}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
@@ -43,7 +43,7 @@ const Summary = ({
             <Header>
                 <AnchorLinkTitle
                     title={title}
-                    id='summary'
+                    id={id}
                 />
                 {playbookRun.summary_modified_at > 0 && modifiedAtMessage}
             </Header>

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -44,6 +44,7 @@ import {AnchorLinkTitle} from '../backstage/playbook_runs/shared';
 interface Props {
     playbookRun: PlaybookRun;
     parentContainer: ChecklistParent;
+    id?: string;
     viewerMode: boolean;
 }
 
@@ -52,7 +53,7 @@ export enum ChecklistParent {
     RunDetails = 'run_details',
 }
 
-const RHSChecklistList = ({playbookRun, parentContainer, viewerMode}: Props) => {
+const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const channelId = useSelector(getCurrentChannelId);
@@ -145,7 +146,7 @@ const RHSChecklistList = ({playbookRun, parentContainer, viewerMode}: Props) => 
     const title = parentContainer === ChecklistParent.RunDetails ? (
         <AnchorLinkTitle
             title={formatMessage({defaultMessage: 'Tasks'})}
-            id={'checklist'}
+            id={id || ''}
         />
     ) : <>{formatMessage({defaultMessage: 'Checklists'})}</>;
 


### PR DESCRIPTION
#### Summary
This simply sets up the infrastructure needed to automatically scroll to every element in the main section of the page when using an anchor link. Try, for example, to visit `/playbooks/run_details/<run_id>#playbook-run-retrospective` to see it.

I'll add the actual navigation links in other PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45446

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
