### PR TITLE
enable post navigation from timeline to channel

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_activity.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_activity.tsx
@@ -51,7 +51,6 @@ const RHSInfoActivity = ({run, role}: Props) => {
                             channelNames={channelNamesMap}
                             team={team}
                             deleteEvent={() => clientRemoveTimelineEvent(run.id, event.id)}
-                            disableLinks={true}
                             editable={role === Role.Participant}
                         />
                     );

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
@@ -81,7 +81,6 @@ const RHSTimeline = ({playbookRun, role}: Props) => {
                                     runCreateAt={DateTime.fromMillis(playbookRun.create_at)}
                                     channelNames={channelNamesMap}
                                     team={team}
-                                    disableLinks={true}
                                     deleteEvent={() => clientRemoveTimelineEvent(playbookRun.id, event.id)}
                                     editable={role === Role.Participant}
                                 />

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item.tsx
@@ -148,7 +148,6 @@ interface Props {
     channelNames: ChannelNamesMap;
     team: Team;
     deleteEvent: () => void;
-    disableLinks?: boolean;
     editable: boolean;
 }
 
@@ -307,9 +306,9 @@ const TimelineEventItem = (props: Props) => {
                     </Tooltip>
                 </TimeStamp>
                 <SummaryTitle
-                    onClick={(e) => props.disableLinks !== false && !statusPostDeleted && goToPost(e, props.event.post_id)}
+                    onClick={(e) => props.editable && !statusPostDeleted && goToPost(e, props.event.post_id)}
                     deleted={statusPostDeleted}
-                    postIdExists={props.event.post_id !== '' && props.disableLinks !== false}
+                    postIdExists={props.event.post_id !== '' && props.editable}
                 >
                     {summaryTitle}
                 </SummaryTitle>


### PR DESCRIPTION
#### Summary
Allow participants to navigate post-related events to channel post.

In separate PR, rhs internal navigation will be explored for status updates.

#### Ticket Link
no ticket

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
