### PR TITLE
introduce navigation events

### DIFF
--- a/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
@@ -9,6 +9,7 @@ import {useIntl} from 'react-intl';
 import {PlaybookWithChecklist} from 'src/types/playbook';
 import MarkdownEdit from 'src/components/markdown_edit';
 import ChecklistList from 'src/components/checklist/checklist_list';
+import {usePlaybookNavigationTelemetry} from 'src/hooks/telemetry';
 
 import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
 
@@ -32,6 +33,8 @@ interface Props {
 type StyledAttrs = {className?: string};
 
 const Outline = ({playbook, refetch}: Props) => {
+    usePlaybookNavigationTelemetry('outline', playbook.id);
+
     const {formatMessage} = useIntl();
     const updatePlaybook = useUpdatePlaybook(playbook.id);
     const retrospectiveAccess = useAllowRetrospectiveAccess();

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -16,6 +16,7 @@ import Report from '../playbook_run_backstage/retrospective/report';
 import ConfirmModalLight from 'src/components/widgets/confirmation_modal_light';
 import {TertiaryButton} from 'src/components/assets/buttons';
 import {PAST_TIME_SPEC} from 'src/components/time_spec';
+import {usePlaybookRunNavigationTelemetry} from 'src/hooks/telemetry';
 
 interface Props {
     playbookRun: PlaybookRun;
@@ -30,6 +31,8 @@ const Retrospective = ({
     playbook,
     role,
 }: Props) => {
+    usePlaybookRunNavigationTelemetry('retrospective', playbookRun.id);
+
     const allowRetrospectiveAccess = useAllowRetrospectiveAccess();
     const {formatMessage} = useIntl();
     const [showConfirmation, setShowConfirmation] = useState(false);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/overview/overview.tsx
@@ -3,6 +3,8 @@
 
 import React from 'react';
 
+import {usePlaybookRunNavigationTelemetry} from 'src/hooks/telemetry';
+
 import Description from 'src/components/backstage/playbook_runs/playbook_run_backstage/overview/description';
 import Updates from 'src/components/backstage/playbook_runs/playbook_run_backstage/overview/updates';
 import Participants from 'src/components/backstage/playbook_runs/playbook_run_backstage/overview/participants';
@@ -13,6 +15,8 @@ import {Container, Left, Right} from 'src/components/backstage/playbook_runs/sha
 import {PlaybookRun} from 'src/types/playbook_run';
 
 export const Overview = (props: {playbookRun: PlaybookRun}) => {
+    usePlaybookRunNavigationTelemetry('overview', props.playbookRun.id);
+
     return (
         <Container>
             <Left>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/retrospective.tsx
@@ -15,7 +15,7 @@ import {Container, Content, Left, Right, Title} from 'src/components/backstage/p
 import UpgradeBanner from 'src/components/upgrade_banner';
 import {AdminNotificationType} from 'src/constants';
 
-import {useAllowPlaybookAndRunMetrics, useAllowRetrospectiveAccess} from 'src/hooks';
+import {useAllowPlaybookAndRunMetrics, useAllowRetrospectiveAccess, usePlaybookRunNavigationTelemetry} from 'src/hooks';
 import {PlaybookRun, RunMetricData} from 'src/types/playbook_run';
 import {Metric} from 'src/types/playbook';
 
@@ -43,6 +43,8 @@ interface Props {
 }
 
 export const Retrospective = (props: Props) => {
+    usePlaybookRunNavigationTelemetry('retrospective', props.playbookRun.id);
+
     const allowRetrospectiveAccess = useAllowRetrospectiveAccess();
     const {formatMessage} = useIntl();
     const [showConfirmation, setShowConfirmation] = useState(false);

--- a/webapp/src/components/backstage/playbooks/metrics/playbook_key_metrics.tsx
+++ b/webapp/src/components/backstage/playbooks/metrics/playbook_key_metrics.tsx
@@ -13,6 +13,7 @@ import {PlaybookRunStatus} from 'src/types/playbook_run';
 import MetricsRunList from 'src/components/backstage/playbooks/metrics/metrics_run_list';
 import NoMetricsPlaceholder from 'src/components/backstage/playbooks/metrics/no_metrics_placeholder';
 import {Metric} from 'src/types/playbook';
+import {usePlaybookNavigationTelemetry} from 'src/hooks/telemetry';
 
 const defaultPlaybookFetchParams = {
     page: 0,
@@ -36,6 +37,7 @@ const PlaybookKeyMetrics = ({
     stats,
     ...attrs
 }: Props & Attrs) => {
+    usePlaybookNavigationTelemetry('reports', playbookID);
     const allowStatsView = useAllowPlaybookAndRunMetrics();
     const [playbookRuns, totalCount, fetchParams, setFetchParams] = useRunsList(defaultPlaybookFetchParams);
 

--- a/webapp/src/components/backstage/playbooks/playbook_usage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_usage.tsx
@@ -10,6 +10,7 @@ import StatsView from 'src/components/backstage/playbooks/stats_view';
 import {useRunsList} from 'src/hooks';
 import RunList from '../runs_list/runs_list';
 import {PlaybookRunStatus} from 'src/types/playbook_run';
+import {usePlaybookNavigationTelemetry} from 'src/hooks/telemetry';
 
 const defaultPlaybookFetchParams = {
     page: 0,
@@ -31,6 +32,7 @@ const PlaybookUsage = ({
     stats,
     ...attrs
 }: Props & Attrs) => {
+    usePlaybookNavigationTelemetry('usage', playbookID);
     const [filterPill, setFilterPill] = useState<ReactNode>(null);
     const [playbookRuns, totalCount, fetchParams, setFetchParams] = useRunsList(defaultPlaybookFetchParams);
 

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -23,12 +23,14 @@ import {FINISHED, RunDetailsTutorialSteps, SKIPPED, TutorialTourCategories} from
 import {displayRhsRunDetailsTourDialog} from 'src/actions';
 import {useTutorialStepper} from '../tutorial/tutorial_tour_tip/manager';
 import {browserHistory} from 'src/webapp_globals';
+import {usePlaybookRunNavigationTelemetry} from 'src/hooks/telemetry';
 
 const RHSRunDetails = () => {
     const dispatch = useDispatch();
     const scrollbarsRef = useRef<Scrollbars>(null);
 
     const playbookRun = useSelector(currentPlaybookRun);
+    usePlaybookRunNavigationTelemetry('channels_rhs_details', playbookRun?.id);
 
     const prevStatus = usePrevious(playbookRun?.current_status);
 

--- a/webapp/src/hooks/index.ts
+++ b/webapp/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './general';
 export * from './crud';
 export * from './routing';
 export * from './permissions';
+export * from './telemetry';

--- a/webapp/src/hooks/telemetry.ts
+++ b/webapp/src/hooks/telemetry.ts
@@ -1,0 +1,19 @@
+import {useEffect} from 'react';
+
+import {telemetryEventForPlaybook, telemetryEventForPlaybookRun} from 'src/client';
+
+export const usePlaybookNavigationTelemetry = (target: string, playbookID?: string) => {
+    useEffect(() => {
+        if (playbookID) {
+            telemetryEventForPlaybook(playbookID, `navigate_playbook_${target}`);
+        }
+    }, [playbookID]);
+};
+
+export const usePlaybookRunNavigationTelemetry = (target: string, playbookRunID?: string) => {
+    useEffect(() => {
+        if (playbookRunID) {
+            telemetryEventForPlaybookRun(playbookRunID, `navigate_run_${target}`);
+        }
+    }, [playbookRunID]);
+};


### PR DESCRIPTION
#### Summary
Some of these events overlap with `click_*` variants, but I didn't want to untangle all the existing callers, and just opted to track the following key events:
* navigate_playbook_outline
* navigate_playbook_usage
* navigate_playbook_reports
* navigate_run_overview
* navigate_run_retrospective
* navigate_run_channels_rhs_details

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-45415