### PR TITLE
Refactor logic from createPlaybookRun 

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -413,7 +413,7 @@ func (h *PlaybookRunHandler) addToTimelineDialog(w http.ResponseWriter, r *http.
 }
 
 func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, userID string) (*app.PlaybookRun, error) {
-	// 1. Validate initial data
+	// Validate initial data
 	if playbookRun.ID != "" {
 		return nil, errors.Wrap(app.ErrMalformedPlaybookRun, "playbook run already has an id")
 	}
@@ -434,7 +434,7 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 		return nil, errors.Wrap(app.ErrMalformedPlaybookRun, "missing name of playbook run")
 	}
 
-	// 2. Retrieve channel if needed and validate it
+	// Retrieve channel if needed and validate it
 	// If a channel is specified, ensure it's from the given team (if one provided), or
 	// just grab the team for that channel.
 	var channel *model.Channel
@@ -452,7 +452,7 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 		}
 	}
 
-	// 3. Copy data from playbook if needed
+	// Copy data from playbook if needed
 	public := true
 	var playbook *app.Playbook
 	if playbookRun.PlaybookID != "" {
@@ -476,7 +476,7 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 		playbookRun.SetConfigurationFromPlaybook(*playbook)
 	}
 
-	// 4. Check the permissions on the channel: the user must be able to create it or,
+	// Check the permissions on the channel: the user must be able to create it or,
 	// if one's already provided, they need to be able to manage it.
 	if channel == nil {
 		permission := model.PermissionCreatePrivateChannel
@@ -504,7 +504,7 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 		}
 	}
 
-	// 5. Check the permissions on the provided post: the user must have access to the post's channel
+	// Check the permissions on the provided post: the user must have access to the post's channel
 	if playbookRun.PostID != "" {
 		post, err := h.pluginAPI.Post.GetPost(playbookRun.PostID)
 		if err != nil {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -175,30 +175,30 @@ type PlaybookRun struct {
 	MetricsData []RunMetricData `json:"metrics_data"`
 }
 
-func (i *PlaybookRun) Clone() *PlaybookRun {
-	newPlaybookRun := *i
+func (r *PlaybookRun) Clone() *PlaybookRun {
+	newPlaybookRun := *r
 	var newChecklists []Checklist
-	for _, c := range i.Checklists {
+	for _, c := range r.Checklists {
 		newChecklists = append(newChecklists, c.Clone())
 	}
 	newPlaybookRun.Checklists = newChecklists
 
-	newPlaybookRun.StatusPosts = append([]StatusPost(nil), i.StatusPosts...)
-	newPlaybookRun.TimelineEvents = append([]TimelineEvent(nil), i.TimelineEvents...)
-	newPlaybookRun.InvitedUserIDs = append([]string(nil), i.InvitedUserIDs...)
-	newPlaybookRun.InvitedGroupIDs = append([]string(nil), i.InvitedGroupIDs...)
-	newPlaybookRun.ParticipantIDs = append([]string(nil), i.ParticipantIDs...)
-	newPlaybookRun.WebhookOnCreationURLs = append([]string(nil), i.WebhookOnCreationURLs...)
-	newPlaybookRun.WebhookOnStatusUpdateURLs = append([]string(nil), i.WebhookOnStatusUpdateURLs...)
-	newPlaybookRun.MetricsData = append([]RunMetricData(nil), i.MetricsData...)
+	newPlaybookRun.StatusPosts = append([]StatusPost(nil), r.StatusPosts...)
+	newPlaybookRun.TimelineEvents = append([]TimelineEvent(nil), r.TimelineEvents...)
+	newPlaybookRun.InvitedUserIDs = append([]string(nil), r.InvitedUserIDs...)
+	newPlaybookRun.InvitedGroupIDs = append([]string(nil), r.InvitedGroupIDs...)
+	newPlaybookRun.ParticipantIDs = append([]string(nil), r.ParticipantIDs...)
+	newPlaybookRun.WebhookOnCreationURLs = append([]string(nil), r.WebhookOnCreationURLs...)
+	newPlaybookRun.WebhookOnStatusUpdateURLs = append([]string(nil), r.WebhookOnStatusUpdateURLs...)
+	newPlaybookRun.MetricsData = append([]RunMetricData(nil), r.MetricsData...)
 
 	return &newPlaybookRun
 }
 
-func (i *PlaybookRun) MarshalJSON() ([]byte, error) {
+func (r *PlaybookRun) MarshalJSON() ([]byte, error) {
 	type Alias PlaybookRun
 
-	old := (*Alias)(i.Clone())
+	old := (*Alias)(r.Clone())
 	// replace nils with empty slices for the frontend
 	if old.Checklists == nil {
 		old.Checklists = []Checklist{}


### PR DESCRIPTION
#### Summary
When working on my hackathon idea, I quickly realized I had to copy code from the API layer to create a playbook run, because the `createPlaybookRun` function, containing a lot of important logic, lived there. This PR refactors the important pieces out of that function and into the PlaybookRun struct; namely: populating the run's checklist from the playbook and copying the playbook configuration into the run configuration. The logic is not changed at all, this simply moves code around.

This, in the first place, makes the code much more readable and modularized. As a side effect, it helps me to reuse this logic in my hackathon project :sunglasses: 

#### Ticket Link
--

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
