### PR TITLE
MM-45090: Track channel action update

### DIFF
--- a/server/api/actions.go
+++ b/server/api/actions.go
@@ -201,7 +201,7 @@ func (a *ActionsHandler) updateChannelAction(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	err := a.channelActionsService.Update(newChannelAction)
+	err := a.channelActionsService.Update(newChannelAction, userID)
 	if err != nil {
 		a.HandleErrorWithCode(w, http.StatusInternalServerError, fmt.Sprintf("unable to update action with ID %q", newChannelAction.ID), err)
 		return

--- a/server/app/action.go
+++ b/server/app/action.go
@@ -117,9 +117,9 @@ type ChannelActionStore interface {
 // ChannelActionTelemetry defines the methods that the ChannelAction service needs from RudderTelemetry.
 // userID is the user initiating the event.
 type ChannelActionTelemetry interface {
-	// RunChannelAction tracks the execution of a channel action
+	// RunChannelAction tracks the execution of a channel action, performed by the specified user.
 	RunChannelAction(action GenericChannelAction, userID string)
 
-	// UpdateChannelAction tracks the update of a channel action
+	// UpdateChannelAction tracks the update of a channel action, performed by the specified user.
 	UpdateChannelAction(action GenericChannelAction, userID string)
 }

--- a/server/app/action.go
+++ b/server/app/action.go
@@ -75,7 +75,7 @@ type ChannelActionService interface {
 	Validate(action GenericChannelAction) error
 
 	// Update updates an existing action identified by action.ID
-	Update(action GenericChannelAction) error
+	Update(action GenericChannelAction, userID string) error
 
 	// UserHasJoinedChannel is called when userID has joined channelID. If actorID is not blank, userID
 	// was invited by actorID.
@@ -119,4 +119,7 @@ type ChannelActionStore interface {
 type ChannelActionTelemetry interface {
 	// RunChannelAction tracks the execution of a channel action
 	RunChannelAction(action GenericChannelAction, userID string)
+
+	// UpdateChannelAction tracks the update of a channel action
+	UpdateChannelAction(action GenericChannelAction, userID string)
 }

--- a/server/app/actions_service.go
+++ b/server/app/actions_service.go
@@ -178,7 +178,7 @@ func checkValidPromptRunPlaybookFromKeywordsPayload(payload PromptRunPlaybookFro
 	return nil
 }
 
-func (a *channelActionServiceImpl) Update(action GenericChannelAction) error {
+func (a *channelActionServiceImpl) Update(action GenericChannelAction, userID string) error {
 	oldAction, err := a.Get(action.ID)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve existing action with ID %q", action.ID)
@@ -190,7 +190,13 @@ func (a *channelActionServiceImpl) Update(action GenericChannelAction) error {
 		}
 	}
 
-	return a.store.Update(action)
+	if err := a.store.Update(action); err != nil {
+		return err
+	}
+
+	a.telemetry.UpdateChannelAction(action, userID)
+
+	return nil
 }
 
 // UserHasJoinedChannel is called when userID has joined channelID. If actorID is not blank, userID

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -177,6 +177,10 @@ func (t *NoopTelemetry) AutoUnfollowPlaybook(playbook app.Playbook, userID strin
 func (t *NoopTelemetry) RunChannelAction(action app.GenericChannelAction, userID string) {
 }
 
+// UpdateChannelAction does nothing
+func (t *NoopTelemetry) UpdateChannelAction(action app.GenericChannelAction, userID string) {
+}
+
 // RunAction does nothing
 func (t *NoopTelemetry) RunAction(playbookRun *app.PlaybookRun, userID, triggerType, actionType string, numBroadcasts int) {
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -595,6 +595,7 @@ func (t *RudderTelemetry) ChangeDigestSettings(userID string, old app.DigestNoti
 func channelActionProperties(action app.GenericChannelAction, userID string) map[string]interface{} {
 	return map[string]interface{}{
 		"UserActualID": userID,
+		"ChannelID":    action.ChannelID,
 		"ActionType":   action.ActionType,
 		"TriggerType":  action.TriggerType,
 	}

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -75,8 +75,9 @@ const (
 	eventSettings = "settings"
 	actionDigest  = "digest"
 
-	eventChannelAction     = "channel_action"
-	actionRunChannelAction = "run_channel_action"
+	eventChannelAction        = "channel_action"
+	actionRunChannelAction    = "run_channel_action"
+	actionChannelActionUpdate = "update_channel_action"
 
 	eventRunAction         = "playbookrun_action"
 	actionRunAction        = "run_playbookrun_action"
@@ -602,6 +603,13 @@ func channelActionProperties(action app.GenericChannelAction, userID string) map
 func (t *RudderTelemetry) RunChannelAction(action app.GenericChannelAction, userID string) {
 	properties := channelActionProperties(action, userID)
 	properties["Action"] = actionRunChannelAction
+	t.track(eventChannelAction, properties)
+}
+
+// UpdateRunActions tracks actions settings update
+func (t *RudderTelemetry) UpdateChannelAction(action app.GenericChannelAction, userID string) {
+	properties := channelActionProperties(action, userID)
+	properties["Action"] = actionChannelActionUpdate
 	t.track(eventChannelAction, properties)
 }
 


### PR DESCRIPTION
#### Summary
This adds telemetry to track every update of channel actions. On top of that, it adds the `ChannelID` property to every telemetry event related to channel actions; this should have been there from the beginning.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45090

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [X] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
