### PR TITLE
MM-45412: Fix categorization of users in owner dropdown list

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -82,6 +82,7 @@ const RHSInfoOverview = ({run, runMetadata, editable, onViewParticipants}: Props
                     editable={editable}
                     onSelectedChange={onOwnerChange}
                     dropdownMoveRightPx={0}
+                    channelId={run.channel_id}
                 />
             </Item>
             <Item

--- a/webapp/src/components/checklist_item/assign_to.tsx
+++ b/webapp/src/components/checklist_item/assign_to.tsx
@@ -1,11 +1,14 @@
 import React, {useState} from 'react';
+import {useSelector} from 'react-redux';
 import styled from 'styled-components';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {ControlProps, components} from 'react-select';
 import {UserProfile} from '@mattermost/types/users';
 
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+
 import ProfileSelector, {Option} from 'src/components/profile/profile_selector';
-import {useProfilesInCurrentChannel, useProfilesInTeam} from 'src/hooks';
+import {useProfilesInChannel, useProfilesInTeam} from 'src/hooks';
 import {ChecklistHoverMenuButton} from 'src/components/rhs/rhs_shared';
 
 interface AssignedToProps {
@@ -14,13 +17,16 @@ interface AssignedToProps {
     withoutName?: boolean;
     inHoverMenu?: boolean;
     dropdownMoveRightPx?: number;
+    channelId?: string; // If not provided, the ID of the current channel will be used
 
     onSelectedChange: (userType?: string, user?: UserProfile) => void;
 }
 
 const AssignTo = (props: AssignedToProps) => {
     const {formatMessage} = useIntl();
-    const profilesInChannel = useProfilesInCurrentChannel();
+    const currentChannelID = useSelector(getCurrentChannelId);
+    const channelID = props.channelId || currentChannelID;
+    const profilesInChannel = useProfilesInChannel(channelID);
     const profilesInTeam = useProfilesInTeam();
     const [profileSelectorToggle, setProfileSelectorToggle] = useState(false);
 


### PR DESCRIPTION
#### Summary
This fixes the bug in the Run Details Page where the members in the owner selector appeared in the wrong category. We can now pass an explicit channel ID to the `AssignTo` component instead of always relying on the ID of the current channel, which may not exist.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45412

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
