### PR TITLE
create a new telemetry event for run details page view

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -17,6 +17,7 @@ import {Role} from 'src/components/backstage/playbook_runs/shared';
 import {pluginErrorUrl} from 'src/browser_routing';
 import {ErrorPageTypes} from 'src/constants';
 import {PlaybookRun} from 'src/types/playbook_run';
+import {usePlaybookRunViewTelemetry, PlaybookRunTarget} from 'src/hooks/telemetry';
 
 import Summary from './summary';
 import {ParticipantStatusUpdate, ViewerStatusUpdate} from './status_update';
@@ -33,6 +34,7 @@ import RHSTimeline from './rhs_timeline';
 const RHSRunInfoTitle = <FormattedMessage defaultMessage={'Run info'}/>;
 
 const useRHS = (playbookRun?: PlaybookRun|null) => {
+    usePlaybookRunViewTelemetry(PlaybookRunTarget.Details, playbookRun?.id);
     const [isOpen, setIsOpen] = useState(true);
     const [scrollable, setScrollable] = useState(true);
     const [section, setSection] = useState<RHSContent>(RHSContent.RunInfo);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -34,6 +34,7 @@ const Retrospective = ({
     role,
 }: Props) => {
     usePlaybookRunViewTelemetry(PlaybookRunTarget.Retrospective, playbookRun.id);
+
     const allowRetrospectiveAccess = useAllowRetrospectiveAccess();
     const {formatMessage} = useIntl();
     const [showConfirmation, setShowConfirmation] = useState(false);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -34,7 +34,6 @@ const Retrospective = ({
     role,
 }: Props) => {
     usePlaybookRunViewTelemetry(PlaybookRunTarget.Retrospective, playbookRun.id);
-
     const allowRetrospectiveAccess = useAllowRetrospectiveAccess();
     const {formatMessage} = useIntl();
     const [showConfirmation, setShowConfirmation] = useState(false);

--- a/webapp/src/hooks/telemetry.ts
+++ b/webapp/src/hooks/telemetry.ts
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import {useLocation} from 'react-use';
 
 import {telemetryEventForPlaybook, telemetryEventForPlaybookRun} from 'src/client';
 
@@ -9,8 +10,13 @@ export enum PlaybookTarget {
 }
 
 export enum PlaybookRunTarget {
+
+    // @deprecated triggered at old run details
     Overview = 'view_run_overview',
+
+    // @deprecated triggered at old run details
     Retrospective = 'view_run_retrospective',
+    Details = 'view_run_details',
     ChannelsRHSDetails = 'view_run_channels_rhs_details',
 }
 
@@ -23,7 +29,12 @@ export const usePlaybookViewTelemetry = (target: PlaybookTarget, playbookID?: st
 };
 
 export const usePlaybookRunViewTelemetry = (target: PlaybookRunTarget, playbookRunID?: string) => {
+    const {pathname} = useLocation();
     useEffect(() => {
+        // Needed until we remove the old run details
+        if (pathname?.includes('/playbooks/run_details/') && target === PlaybookRunTarget.Retrospective) {
+            return;
+        }
         if (playbookRunID) {
             telemetryEventForPlaybookRun(playbookRunID, target);
         }


### PR DESCRIPTION
#### Summary
Implement telemetry event for tracking views of the run details page.

New event instead of reusing previous ones. Additionally, a hack has been included in the telemetry hook to prevent retrospective events to be triggered when we re-use the component inside run-details page.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45546

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
