### PR TITLE
Check .only mark in e2e test as part of check-style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,6 @@ ifneq ($(HAS_SERVER),)
 	golangci-lint run ./...
 endif
 
-
-
 ## Builds the server, if it exists, for all supported architectures, unless MM_SERVICESETTINGS_ENABLEDEVELOPER is set
 .PHONY: server
 server:


### PR DESCRIPTION
#### Summary
Additional linter check in case we forget some `it.only` or `describe.only` in our e2e tests.

![Screenshot 2022-07-07 at 18 20 45](https://user-images.githubusercontent.com/4096774/177822743-30fed70a-97f5-4d2e-8789-9087805c69b3.png)

#### Ticket Link
no ticket

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
