### PR TITLE
run eslint over e2e tests on make check-style + add only check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,7 @@ ifneq ($(HAS_WEBAPP),)
 	cd webapp && npm run check-types
 endif
 
-	@if grep -rin -e 'it\.only' -e 'describe\.only' tests-e2e/cypress/integration; then \
-		echo "\nThere are at least one e2e test marked as only, only should be removed.\n"; \
-		exit 1; \
-	fi
+	cd tests-e2e && npm run check
 
 ifneq ($(HAS_SERVER),)
 	@if ! [ -x "$$(command -v golangci-lint)" ]; then \

--- a/tests-e2e/.eslintrc
+++ b/tests-e2e/.eslintrc
@@ -4,7 +4,7 @@
     "plugin:cypress/recommended",
     "plugin:react/recommended"
   ],
-  "plugins": ["mattermost", "import", "cypress", "@typescript-eslint"],
+  "plugins": ["mattermost", "import", "cypress", "@typescript-eslint", "no-only-tests"],
   "globals": {
     "Cypress": true,
     "cy": true
@@ -13,6 +13,7 @@
     "react": { "version": "16" }
   },
   "rules": {
+    "no-only-tests/no-only-tests": ["error", {"focus": ["only"]}],
     "import/no-unresolved": 2,
     "comma-dangle": 0,
     "dot-location": [
@@ -51,7 +52,7 @@
         "max-nested-callbacks": 0,
         "no-process-env": 0,
         "no-unused-expressions": 0,
-        "max-lines": 0,
+        "max-lines": 0
       }
     }
   ]

--- a/tests-e2e/cypress/integration/adminconsole/analytics_spec.js
+++ b/tests-e2e/cypress/integration/adminconsole/analytics_spec.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const {onlyOn} = require('@cypress/skip-test');
-
 // ***************************************************************
 // - [#] indicates a test step (e.g. # Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)

--- a/tests-e2e/cypress/integration/channels/playbook_run_actions.js
+++ b/tests-e2e/cypress/integration/channels/playbook_run_actions.js
@@ -620,7 +620,7 @@ describe('channels > actions', () => {
                 cy.apiRunPlaybook({
                     teamId: testTeam.id,
                     playbookId: playbook.id,
-                    playbookRunName: playbookRunName,
+                    playbookRunName,
                     ownerUserId: testUser.id,
                 });
             }).then((playbookRun) => {

--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -134,7 +134,6 @@ describe('channels > rhs > header', () => {
                 });
             });
 
-
             // # type text in textarea
             cy.get('#rhsContainer').findByTestId('textarea-description').should('be.visible').type('new summary{ctrl+enter}');
 

--- a/tests-e2e/cypress/integration/playbooks/creation_button_spec_ignore_.js
+++ b/tests-e2e/cypress/integration/playbooks/creation_button_spec_ignore_.js
@@ -65,9 +65,6 @@ describe('playbooks > creation button', () => {
     });
 
     it('auto creates a playbook with "Blank" template option', () => {
-        const url = 'playbooks/new';
-        const playbookName = 'Untitled playbook';
-
         // # Open the product
         cy.visit('/playbooks');
 
@@ -82,8 +79,6 @@ describe('playbooks > creation button', () => {
     });
 
     it('opens Service Outage Incident page from its template option', () => {
-        const playbookName = 'Incident Resolution';
-
         // # Open the product
         cy.visit('/playbooks');
 

--- a/tests-e2e/cypress/integration/playbooks/edit_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_spec.js
@@ -130,7 +130,6 @@ describe('playbooks > edit', () => {
     });
 
     describe('actions', () => {
-        let testPublicChannel;
         let testPrivateChannel;
         let testPlaybook;
 
@@ -144,9 +143,7 @@ describe('playbooks > edit', () => {
                 'public-channel',
                 'Public Channel',
                 'O'
-            ).then(({channel}) => {
-                testPublicChannel = channel;
-            });
+            );
 
             // # Create a private channel
             cy.apiCreateChannel(
@@ -727,7 +724,6 @@ describe('playbooks > edit', () => {
                 // MM-44678
                 it.skip('removes the owner and disables the setting if the user is no longer in the team', () => {
                     let userToRemove;
-                    let playbookId;
 
                     // # Create a playbook with a user that is later removed from the team
                     cy.apiLogin(testSysadmin)
@@ -750,8 +746,6 @@ describe('playbooks > edit', () => {
                                     memberIDs: [testUser.id, testSysadmin.id],
                                     defaultOwnerId: userToRemove.id,
                                     defaultOwnerEnabled: true,
-                                }).then((playbook) => {
-                                    playbookId = playbook.id;
                                 });
 
                                 // # Remove user from the team
@@ -843,8 +837,6 @@ describe('playbooks > edit', () => {
                 });
 
                 it('removes the channel and disables the setting if the channel no longer exists', () => {
-                    let playbookId;
-
                     // # Create a playbook with a user that is later removed from the team
                     cy.apiLogin(testSysadmin)
                         .then(() => {
@@ -867,8 +859,6 @@ describe('playbooks > edit', () => {
                                     memberIDs: [testUser.id, testSysadmin.id],
                                     announcementChannelId: channel.id,
                                     announcementChannelEnabled: true,
-                                }).then((playbook) => {
-                                    playbookId = playbook.id;
                                 });
 
                                 // # Delete channel

--- a/tests-e2e/cypress/integration/playbooks/feedback_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/feedback_spec.js
@@ -9,7 +9,6 @@
 describe('playbooks > feedback', () => {
     let testTeam;
     let testUser;
-    let testPlaybook;
 
     beforeEach(() => {
         // # Size the viewport to show the RHS without covering posts.
@@ -28,8 +27,6 @@ describe('playbooks > feedback', () => {
                 teamId: testTeam.id,
                 title: 'Test Playbook',
                 memberIDs: [],
-            }).then((playbook) => {
-                testPlaybook = playbook;
             });
 
             // # Login as the newly created testUser

--- a/tests-e2e/cypress/integration/playbooks/overview_spec_ignore_.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec_ignore_.js
@@ -13,7 +13,9 @@ describe('playbooks > overview', () => {
     let testUser;
     let testUserFollower;
     let testPublicPlaybook;
+    // eslint-disable-next-line no-unused-vars
     let testPrivateOnlyMinePlaybook;
+    // eslint-disable-next-line no-unused-vars
     let testPrivateSharedPlaybook;
     let testPlaybookOnTeamForSwitching;
     let testPlaybookOnOtherTeamForSwitching;
@@ -110,7 +112,7 @@ describe('playbooks > overview', () => {
     });
 
     describe('should switch to channels and prompt to run when clicking run', () => {
-        const openAndRunPlaybook = (team, playbook) => {
+        const openAndRunPlaybook = (team) => {
             // # Navigate directly to town square on the team
             cy.visit(`${team.name}/channels/town-square`);
 
@@ -229,6 +231,7 @@ describe('playbooks > overview', () => {
     });
 
     it('shows followers in actions preview', () => {
+        // eslint-disable-next-line no-unused-vars
         let playbookId;
         cy.apiCreatePlaybook({
             teamId: testTeam.id,

--- a/tests-e2e/cypress/support/index.js
+++ b/tests-e2e/cypress/support/index.js
@@ -191,7 +191,7 @@ function sysadminSetup(user) {
     });
 
     // # Reset roles
-    cy.apiGetClientLicense().then(({isLicensed, isCloudLicensed}) => {
+    cy.apiGetClientLicense().then(({isCloudLicensed}) => {
         //if (isLicensed) {
         //cy.apiResetRoles();
         //}

--- a/tests-e2e/package-lock.json
+++ b/tests-e2e/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-header": "3.1.1",
         "eslint-plugin-import": "2.23.4",
         "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#46ad99355644a719bf32082f472048f526605181",
+        "eslint-plugin-no-only-tests": "2.6.0",
         "eslint-plugin-react": "7.24.0"
       }
     },
@@ -5570,6 +5571,15 @@
       "integrity": "sha512-XIsRlgdUmVaJ+9P5sy45uN/cVzi5rPP2w/w06yuEIEYAH6CuVzjiY/dBjDqFKOi/Ebnoo40ur2oCtD3+yzrgVw==",
       "dev": true,
       "license": "Apache 2.0"
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.24.0",
@@ -18603,6 +18613,12 @@
       "integrity": "sha512-XIsRlgdUmVaJ+9P5sy45uN/cVzi5rPP2w/w06yuEIEYAH6CuVzjiY/dBjDqFKOi/Ebnoo40ur2oCtD3+yzrgVw==",
       "dev": true,
       "from": "eslint-plugin-mattermost@github:mattermost/eslint-plugin-mattermost#46ad99355644a719bf32082f472048f526605181"
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.24.0",

--- a/tests-e2e/package.json
+++ b/tests-e2e/package.json
@@ -31,7 +31,8 @@
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#46ad99355644a719bf32082f472048f526605181",
-    "eslint-plugin-react": "7.24.0"
+    "eslint-plugin-react": "7.24.0",
+    "eslint-plugin-no-only-tests": "2.6.0"
   },
   "scripts": {
     "cypress:open": "cross-env TZ=Etc/UTC cypress open",


### PR DESCRIPTION
#### Summary

I often forget  to remove `.only` modifiers in cypress e2e tests. I added https://github.com/mattermost/mattermost-plugin-playbooks/pull/1299 to tackle that with old-style grep/bash.

After @saturninoabril [comment](https://community-daily.mattermost.com/core/pl/fatrdcyqfpyy38po97io1uhioh), I suggest this improvement:
- check it in a more JS-native way
- check eslint rules, not only for `only` but also for the already existing rules as part of `make check-style` Makefile command.

I had to clean some existing failures, most of them unused-var. 1/5 with some of them.

I could ignore the rules for the `_ignore_.js` specs but I'm wondering if it's maybe better to clean them up (by removing them or fixing them).

#### Ticket Link
Nope

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
