### PR TITLE
Mm 45351 viewer test rdp

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
@@ -6,15 +6,27 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
+// Note that this test check the basic behavior in Run details page as participant / viewer
+// It relies on the Channel RHS Checklist test to cover the full behavior of the checklists
+
 describe('runs > run details page > checklist', () => {
     let testTeam;
     let testUser;
+    let testViewerUser;
     let testPublicPlaybook;
+    let testRun;
+    const taskIndex = 0;
 
     before(() => {
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
             testUser = user;
+
+            // Create another user in the same team
+            cy.apiCreateUser().then(({user: viewer}) => {
+                testViewerUser = viewer;
+                cy.apiAddUserToTeam(testTeam.id, testViewerUser.id);
+            });
 
             // # Login as testUser
             cy.apiLogin(testUser);
@@ -24,6 +36,22 @@ describe('runs > run details page > checklist', () => {
                 teamId: testTeam.id,
                 title: 'Public Playbook',
                 memberIDs: [],
+                checklists: [
+                    {
+                        title: 'Stage 1',
+                        items: [
+                            {title: 'Step 1'},
+                            {title: 'Step 2'},
+                        ],
+                    },
+                    {
+                        title: 'Stage 2',
+                        items: [
+                            {title: 'Step 1'},
+                            {title: 'Step 2'},
+                        ],
+                    },
+                ],
             }).then((playbook) => {
                 testPublicPlaybook = playbook;
             });
@@ -43,18 +71,77 @@ describe('runs > run details page > checklist', () => {
             playbookRunName: 'the run name',
             ownerUserId: testUser.id,
         }).then((playbookRun) => {
+            testRun = playbookRun;
+
             // # Visit the playbook run
             cy.visit(`/playbooks/run_details/${playbookRun.id}`);
         });
     });
 
-    it('is visible', () => {
-        // * Verify the tasks section is present
-        cy.findByTestId('run-checklist-section').should('be.visible');
+    const getChecklist = () => cy.findByTestId('run-checklist-section');
+    const getChecklistTasks = () => getChecklist().findAllByTestId('checkbox-item-container');
+
+    const commonTests = () => {
+        it('is visible', () => {
+            // * Verify the tasks section is present
+            getChecklist().should('be.visible');
+        });
+
+        it('has title', () => {
+            // * Verify the task section has a title
+            getChecklist().find('h3').contains('Tasks');
+        });
+
+        it('can see the tasks', () => {
+            // * Verify tasks are shown
+            getChecklistTasks().should('have.length', 4);
+        });
+    };
+
+    describe('as participant', () => {
+        commonTests();
+
+        it('click marks task as done', () => {
+            // # Click first task
+            getChecklistTasks().eq(taskIndex).find('.checkbox').check();
+
+            // *  Assert checkbox is checked
+            getChecklistTasks().eq(taskIndex).find('.checkbox').should('be.checked');
+        });
+
+        it('has hover menu', () => {
+            // # Hover over the checklist item
+            getChecklistTasks().eq(taskIndex).trigger('mouseover');
+
+            // # Click dot menu
+            getChecklistTasks().eq(taskIndex).findByTitle('More').click();
+
+            // * Assert actions are available
+            cy.findByRole('button', {name: 'Skip task'}).should('be.visible');
+            cy.findByRole('button', {name: 'Duplicate task'}).should('be.visible');
+        });
     });
 
-    it('has title', () => {
-        // * Verify the task section has a title
-        cy.findByTestId('run-checklist-section').find('h3').contains('Tasks');
+    describe('as viewer', () => {
+        beforeEach(() => {
+            cy.apiLogin(testViewerUser).then(() => {
+                cy.visit(`/playbooks/run_details/${testRun.id}`);
+            });
+        });
+
+        commonTests();
+
+        it('click does not work', () => {
+            // # Click first task
+            getChecklistTasks().eq(taskIndex).find('.checkbox').should('be.disabled');
+        });
+
+        it('has not hover menu', () => {
+            // # Hover over the checklist item
+            getChecklistTasks().eq(taskIndex).trigger('mouseover');
+
+            // # Click dot menu
+            getChecklistTasks().eq(taskIndex).findByTitle('More').should('not.exist');
+        });
     });
 });

--- a/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
@@ -105,7 +105,7 @@ describe('runs > run details page > checklist', () => {
             // # Click first task
             getChecklistTasks().eq(taskIndex).find('.checkbox').check();
 
-            // *  Assert checkbox is checked
+            // * Assert checkbox is checked
             getChecklistTasks().eq(taskIndex).find('.checkbox').should('be.checked');
         });
 

--- a/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
@@ -140,7 +140,7 @@ describe('runs > run details page > checklist', () => {
             // # Hover over the checklist item
             getChecklistTasks().eq(taskIndex).trigger('mouseover');
 
-            // # Click dot menu
+            // * Check that the hover menu is not rendered
             getChecklistTasks().eq(taskIndex).findByTitle('More').should('not.exist');
         });
     });

--- a/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_checklist_spec.js
@@ -6,7 +6,7 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-// Note that this test check the basic behavior in Run details page as participant / viewer
+// Note that this test checks the basic behavior in Run details page as participant / viewer
 // It relies on the Channel RHS Checklist test to cover the full behavior of the checklists
 
 describe('runs > run details page > checklist', () => {

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -34,13 +34,32 @@ const editAndPublishRetro = () => {
     getRetro().get('.icon-check-all').should('be.visible');
 };
 
+const getMetricInput = (index) => getRetro().getStyledComponent('InputContainer').eq(index);
+
+const verifyMetricInput = (index, title, target, description) => {
+    getMetricInput(index).within(() => {
+        cy.getStyledComponent('Title').contains(title);
+
+        if (target) {
+            cy.getStyledComponent('TargetTitle').contains(target);
+        } else {
+            cy.getStyledComponent('TargetTitle').should('not.exist');
+        }
+
+        if (description) {
+            cy.getStyledComponent('HelpText').contains(description);
+        }
+    });
+};
+
 const getRetro = () => cy.findByTestId('run-retrospective-section');
 
-describe('runs > run details page > retrospective', () => {
+describe('runs > run details page', () => {
     let testTeam;
     let testUser;
     let testViewerUser;
     let testPublicPlaybook;
+    let testPublicPlaybookWithMetrics;
     let testRun;
 
     before(() => {
@@ -66,6 +85,36 @@ describe('runs > run details page > retrospective', () => {
             }).then((playbook) => {
                 testPublicPlaybook = playbook;
             });
+
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Public Playbook',
+                memberIDs: [],
+                createPublicPlaybookRun: true,
+                metrics: [
+                    {
+                        title: 'title1',
+                        description: 'description1',
+                        type: 'metric_duration',
+                        target: 720000,
+                    },
+                    {
+                        title: 'title2',
+                        description: 'description2',
+                        type: 'metric_currency',
+                        target: 40,
+                    },
+                    {
+                        title: 'title3',
+                        description: 'description3',
+                        type: 'metric_integer',
+                        target: 30,
+                    },
+                ]
+            }).then((playbook) => {
+                testPublicPlaybookWithMetrics = playbook;
+            });
         });
     });
 
@@ -75,62 +124,331 @@ describe('runs > run details page > retrospective', () => {
 
         // # Login as testUser
         cy.apiLogin(testUser);
-
-        cy.apiRunPlaybook({
-            teamId: testTeam.id,
-            playbookId: testPublicPlaybook.id,
-            playbookRunName: 'the run name',
-            ownerUserId: testUser.id,
-        }).then((playbookRun) => {
-            testRun = playbookRun;
-
-            // # Visit the playbook run
-            cy.visit(`/playbooks/run_details/${playbookRun.id}`);
-        });
-    });
-    const commonTests = () => {
-        it('is visible', () => {
-            // * Verify the retrospective section is present
-            getRetro().should('be.visible');
-        });
-
-        it('has title', () => {
-            // * Verify the retrospective section has a title
-            getRetro().find('h3').contains('Retrospective');
-        });
-
-        it('has template text', () => {
-            // * Verify the retrospective section has a title
-            getRetro().findByTestId('retro-report-text').contains('This is a retrospective template.');
-        });
-    };
-
-    describe('as participant', () => {
-        commonTests();
-
-        it('publishing posts to run channel', () => {
-            editAndPublishRetro();
-
-            // # Switch to the run channel
-            cy.findByTestId('runinfo-channel').click();
-
-            // * Verify the modified retro text is posted
-            cy.getStyledComponent('CustomPostContent').should('exist').contains('Edited retrospective.');
-        });
-
-        it('can be published once', () => {
-            editAndPublishRetro();
-            getRetro().findByText('Publish').should('not.be.enabled');
-        });
     });
 
-    describe('as viewer', () => {
-        beforeEach(() => {
-            cy.apiLogin(testViewerUser).then(() => {
-                cy.visit(`/playbooks/run_details/${testRun.id}`);
+    describe('retrospective', () => {
+        const commonTests = () => {
+            it('is visible', () => {
+                // * Verify the retrospective section is present
+                getRetro().should('be.visible');
+            });
+
+            it('has title', () => {
+                // * Verify the retrospective section has a title
+                getRetro().find('h3').contains('Retrospective');
+            });
+
+            it('has template text', () => {
+                // * Verify the retrospective section has a title
+                getRetro().findByTestId('retro-report-text').contains('This is a retrospective template.');
+            });
+
+            it('has no metrics', () => {
+                // * Verify there are no metric for this playbook
+                getRetro().getStyledComponent('InputContainer').should('not.exist');
+            });
+        };
+        describe('as participant', () => {
+            beforeEach(() => {
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: testPublicPlaybook.id,
+                    playbookRunName: 'the run name',
+                    ownerUserId: testUser.id,
+                }).then((playbookRun) => {
+                    testRun = playbookRun;
+
+                    // # Visit the playbook run
+                    cy.visit(`/playbooks/run_details/${playbookRun.id}`);
+                });
+            });
+
+            commonTests();
+
+            it('publishing posts to run channel', () => {
+                editAndPublishRetro();
+
+                // # Switch to the run channel
+                cy.findByTestId('runinfo-channel').click();
+
+                // * Verify the modified retro text is posted
+                cy.getStyledComponent('CustomPostContent').should('exist').contains('Edited retrospective.');
+            });
+
+            it('can be published once', () => {
+                editAndPublishRetro();
+
+                // * Verify the button is disabled
+                getRetro().findByText('Publish').should('not.be.enabled');
             });
         });
 
-        commonTests();
+        describe('as viewer', () => {
+            before(() => {
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: testPublicPlaybook.id,
+                    playbookRunName: 'the run name',
+                    ownerUserId: testUser.id,
+                }).then((playbookRun) => {
+                    testRun = playbookRun;
+
+                    // # Visit the playbook run
+                    cy.visit(`/playbooks/run_details/${playbookRun.id}`);
+                });
+            });
+            beforeEach(() => {
+                cy.apiLogin(testViewerUser).then(() => {
+                    cy.visit(`/playbooks/run_details/${testRun.id}`);
+                });
+            });
+
+            commonTests();
+
+            it('text is not clickable', () => {
+                getRetro().findByTestId('retro-report-text').click();
+                getRetro().find('textarea').should('not.exist');
+            });
+
+            it('there is no publish button', () => {
+                getRetro().findByText('Publish').should('not.exist');
+            });
+        });
+    });
+
+    describe('metrics', () => {
+        const commonTests = () => {
+            it('inputs info(title, target, description) and order', () => {
+                // * Verify the created metrics
+                verifyMetricInput(0, 'title1', '12 minutes', 'description1');
+                verifyMetricInput(1, 'title2', '40', 'description2');
+                verifyMetricInput(2, 'title3', '30', 'description3');
+            });
+        };
+
+        describe('as participant', () => {
+            beforeEach(() => {
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: testPublicPlaybookWithMetrics.id,
+                    playbookRunName: 'the run name',
+                    ownerUserId: testUser.id,
+                }).then((playbookRun) => {
+                    testRun = playbookRun;
+                });
+            });
+            beforeEach(() => {
+                cy.visit(`/playbooks/run_details/${testRun.id}`);
+            });
+
+            commonTests();
+
+            it('inputs, null and zero values', () => {
+                // # Set targets to null and update playbook
+                testPublicPlaybookWithMetrics.metrics[0].target = null;
+                testPublicPlaybookWithMetrics.metrics[1].target = 0;
+                cy.apiUpdatePlaybook(testPublicPlaybookWithMetrics).then(() => {
+                    // # Navigate directly to the retro tab
+                    cy.visit(`/playbooks/run_details/${testRun.id}`);
+
+                    // * Verify if Target text(top | left) is removed
+                    verifyMetricInput(0, 'title1', null, 'description1');
+                    verifyMetricInput(1, 'title2', '0', 'description2');
+                    verifyMetricInput(2, 'title3', '30', 'description3');
+                });
+            });
+
+            it('auto save', () => {
+                getRetro().within(() => {
+                    // # Enter metric values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).type('12:11:10')
+                        .tab().type('56')
+                        .tab().type('123');
+
+                    // # Click outside
+                    cy.findByText('Retrospective').click({force: true});
+
+                    // * Validate if values persist
+                    cy.get('input[type=text]').eq(0).should('have.value', '12:11:10');
+                    cy.get('input[type=text]').eq(1).should('have.value', '56');
+                    cy.get('input[type=text]').eq(2).should('have.value', '123');
+
+                    // # Enter new values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).clear().type('12:00:10')
+                        .tab().clear().type('20')
+                        .tab().clear().type('21');
+                });
+
+                // # Wait 2 sec to auto save
+                cy.wait(2000);
+
+                // # Reload page
+                cy.visit(`/playbooks/run_details/${testRun.id}`);
+
+                getRetro().within(() => {
+                    // * Validate if values are saved
+                    cy.get('input[type=text]').eq(0).should('have.value', '12:00:10');
+                    cy.get('input[type=text]').eq(1).should('have.value', '20');
+                    cy.get('input[type=text]').eq(2).should('have.value', '21');
+                });
+            });
+
+            it('save empty and zero values', () => {
+                getRetro().within(() => {
+                    // # Enter metric values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).clear().type('00:00:00')
+                        .tab().type('7')
+                        .tab().type('0');
+
+                    // # Click outside
+                    cy.findByText('Retrospective').click({force: true});
+
+                    // * Validate if values persist
+                    cy.get('input[type=text]').eq(0).should('have.value', '00:00:00');
+                    cy.get('input[type=text]').eq(1).should('have.value', '7');
+                    cy.get('input[type=text]').eq(2).should('have.value', '0');
+
+                    // # Clear first two metrics values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).clear()
+                        .tab().clear();
+
+                    // # Click outside
+                    cy.findByText('Retrospective').click({force: true});
+
+                    // * Validate if values persist
+                    cy.get('input[type=text]').eq(0).should('have.value', '');
+                    cy.get('input[type=text]').eq(1).should('have.value', '');
+                    cy.get('input[type=text]').eq(2).should('have.value', '0');
+                });
+            });
+
+            it('only valid values are saved. check error messages', () => {
+                getRetro().within(() => {
+                    // # Enter invalid metric values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).type('5')
+                        .tab().type('56d')
+                        .tab().type('125');
+
+                    // * Validate error messages
+                    cy.getStyledComponent('ErrorText').eq(0).contains('Please enter a duration in the format: dd:hh:mm (e.g., 12:00:00).');
+                    cy.getStyledComponent('ErrorText').eq(1).contains('Please enter a number.');
+
+                    // # Click outside
+                    cy.findByText('Retrospective').click({force: true});
+                });
+
+                // # Reload page and navigate to the retro tab
+                cy.visit(`/playbooks/run_details/${testRun.id}`);
+
+                getRetro().within(() => {
+                    // * Validate that values are not saved
+                    cy.get('input[type=text]').eq(0).should('have.value', '');
+                    cy.get('input[type=text]').eq(1).should('have.value', '');
+                    cy.get('input[type=text]').eq(2).should('have.value', '125');
+
+                    // # Enter new metric values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).type('s')
+                        .tab().type('d')
+                        .tab().type('k');
+                });
+            });
+
+            it.only('publish retro', () => {
+                getRetro().within(() => {
+                    //# Enter metric invalid values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).type('20:00:12d')
+                        .tab().type('56')
+                        .tab().type('125v');
+
+                    // # Publish
+                    cy.findByRole('button', {name: 'Publish'}).click();
+                });
+
+                // * Verify we're not showing the publish retro confirmation modal
+                cy.get('#confirm-modal-light').should('not.exist');
+
+                getRetro().within(() => {
+                    //# Enter empty metric values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).clear()
+                        .tab().clear()
+                        .tab().clear().type(24);
+
+                    // # Publish
+                    cy.findByRole('button', {name: 'Publish'}).click();
+
+                    // * Validate error messages
+                    cy.getStyledComponent('ErrorText').eq(0).contains('Please fill in the metric value.');
+                    cy.getStyledComponent('ErrorText').eq(1).contains('Please fill in the metric value.');
+                    cy.getStyledComponent('ErrorText').should('have.length', 2);
+                });
+
+                // * Verify we're not showing the publish retro confirmation modal
+                cy.get('#confirm-modal-light').should('not.exist');
+
+                getRetro().within(() => {
+                    //# Enter valid metric values
+                    cy.get('input[type=text]').eq(0).click();
+                    cy.get('input[type=text]').eq(0).type('09:87:12')
+                        .tab().type(123);
+
+                    // # Publish
+                    cy.findByRole('button', {name: 'Publish'}).click();
+                });
+
+                // * Verify we're showing the publish retro confirmation modal
+                cy.get('#confirm-modal-light').contains('Are you sure you want to publish?');
+
+                // # Publish
+                cy.findByRole('button', {name: 'Publish'}).click();
+
+                getRetro().within(() => {
+                    // * Verify that retro got published
+                    cy.get('.icon-check-all').should('be.visible');
+
+                    // * Verify that metrics inputs are disabled
+                    cy.get('input[type=text]').each(($el) => {
+                        cy.wrap($el).should('not.be.enabled');
+                    });
+                });
+            });
+        });
+
+        describe('as viewer', () => {
+            before(() => {
+                cy.apiLogin(testUser);
+
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: testPublicPlaybookWithMetrics.id,
+                    playbookRunName: 'the run name',
+                    ownerUserId: testUser.id,
+                }).then((playbookRun) => {
+                    testRun = playbookRun;
+                });
+            });
+
+            beforeEach(() => {
+                cy.apiLogin(testViewerUser).then(() => {
+                    cy.visit(`/playbooks/run_details/${testRun.id}`);
+                });
+            });
+
+            commonTests();
+
+            it('are not editable', () => {
+                // * Verify that inputs are disabled
+                getMetricInput(0).find('input').should('be.disabled');
+                getMetricInput(1).find('input').should('be.disabled');
+                getMetricInput(2).find('input').should('be.disabled');
+            });
+        });
     });
 });

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -36,7 +36,7 @@ const editAndPublishRetro = () => {
 
 const getMetricInput = (index) => getRetro().getStyledComponent('InputContainer').eq(index);
 
-const verifyMetricInput = (index, title, target, description) => {
+const verifyMetricInput = (index, title, target, description, placeholder) => {
     getMetricInput(index).within(() => {
         cy.getStyledComponent('Title').contains(title);
 
@@ -48,6 +48,9 @@ const verifyMetricInput = (index, title, target, description) => {
 
         if (description) {
             cy.getStyledComponent('HelpText').contains(description);
+        }
+        if (placeholder) {
+            cy.get('input').should('have.attr', 'placeholder', placeholder);
         }
     });
 };
@@ -220,9 +223,9 @@ describe('runs > run details page', () => {
         const commonTests = () => {
             it('inputs info(title, target, description) and order', () => {
                 // * Verify the created metrics
-                verifyMetricInput(0, 'title1', '12 minutes', 'description1');
-                verifyMetricInput(1, 'title2', '40', 'description2');
-                verifyMetricInput(2, 'title3', '30', 'description3');
+                verifyMetricInput(0, 'title1', '12 minutes', 'description1', 'Add value (in dd:hh:mm)');
+                verifyMetricInput(1, 'title2', '40', 'description2', 'Add value');
+                verifyMetricInput(2, 'title3', '30', 'description3', 'Add value');
             });
         };
 
@@ -252,9 +255,9 @@ describe('runs > run details page', () => {
                     cy.visit(`/playbooks/run_details/${testRun.id}`);
 
                     // * Verify changes are reflected
-                    verifyMetricInput(0, 'title1', null, 'description1');
-                    verifyMetricInput(1, 'title2', '0', 'description2');
-                    verifyMetricInput(2, 'title3', '30', 'description3');
+                    verifyMetricInput(0, 'title1', null, 'description1', 'Add value (in dd:hh:mm)');
+                    verifyMetricInput(1, 'title2', '0', 'description2', 'Add value');
+                    verifyMetricInput(2, 'title3', '30', 'description3', 'Add value');
 
                     // # recover the original data for playbook
                     testPublicPlaybookWithMetrics.metrics[0].target = 720000;

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -361,7 +361,7 @@ describe('runs > run details page', () => {
 
             it('publish retro', () => {
                 getRetro().within(() => {
-                    //# Enter metric invalid values
+                    // # Enter metric invalid values
                     cy.get('input[type=text]').eq(0).click();
                     cy.get('input[type=text]').eq(0).type('20:00:12d')
                         .tab().type('56')

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -251,10 +251,15 @@ describe('runs > run details page', () => {
                     // # Navigate directly to the retro tab
                     cy.visit(`/playbooks/run_details/${testRun.id}`);
 
-                    // * Verify if Target text(top | left) is removed
+                    // * Verify changes are reflected
                     verifyMetricInput(0, 'title1', null, 'description1');
                     verifyMetricInput(1, 'title2', '0', 'description2');
                     verifyMetricInput(2, 'title3', '30', 'description3');
+
+                    // # recover the original data for playbook
+                    testPublicPlaybookWithMetrics.metrics[0].target = 720000;
+                    testPublicPlaybookWithMetrics.metrics[1].target = 40;
+                    cy.apiUpdatePlaybook(testPublicPlaybookWithMetrics);
                 });
             });
 

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -139,7 +139,7 @@ describe('runs > run details page', () => {
             });
 
             it('has template text', () => {
-                // * Verify the retrospective section has a title
+                // * Verify the retrospective text is rendered
                 getRetro().findByTestId('retro-report-text').contains('This is a retrospective template.');
             });
 

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -359,7 +359,7 @@ describe('runs > run details page', () => {
                 });
             });
 
-            it.only('publish retro', () => {
+            it('publish retro', () => {
                 getRetro().within(() => {
                     //# Enter metric invalid values
                     cy.get('input[type=text]').eq(0).click();

--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -6,15 +6,53 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
+const editAndPublishRetro = () => {
+    getRetro().within(() => {
+        // # Start editing
+        cy.findByTestId('retro-report-text').click();
+
+        // * Verify the provided template text is pre-filled
+        cy.focused().should('include.text', 'This is a retrospective template.');
+
+        // # Change the retro text
+        cy.focused().clear().type('Edited retrospective.');
+
+        // # Save it by clicking outside the text area
+        cy.findByText('Report').click();
+
+        // # Publish
+        cy.findByRole('button', {name: 'Publish'}).click();
+    });
+
+    // * Verify we're showing the publish retro confirmation modal
+    cy.get('#confirm-modal-light').contains('Are you sure you want to publish?');
+
+    // # Publish
+    cy.findByRole('button', {name: 'Publish'}).click();
+
+    // * Verify that retro got published
+    getRetro().get('.icon-check-all').should('be.visible');
+};
+
+const getRetro = () => cy.findByTestId('run-retrospective-section');
+
 describe('runs > run details page > retrospective', () => {
     let testTeam;
     let testUser;
+    let testViewerUser;
     let testPublicPlaybook;
+    let testRun;
 
     before(() => {
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
             testUser = user;
+
+            // Create another user in the same team
+            cy.apiCreateUser().then(({user: viewer}) => {
+                testViewerUser = viewer;
+                cy.apiAddUserToTeam(testTeam.id, testViewerUser.id);
+            });
 
             // # Login as testUser
             cy.apiLogin(testUser);
@@ -24,6 +62,7 @@ describe('runs > run details page > retrospective', () => {
                 teamId: testTeam.id,
                 title: 'Public Playbook',
                 memberIDs: [],
+                retrospectiveTemplate: 'This is a retrospective template.',
             }).then((playbook) => {
                 testPublicPlaybook = playbook;
             });
@@ -43,18 +82,55 @@ describe('runs > run details page > retrospective', () => {
             playbookRunName: 'the run name',
             ownerUserId: testUser.id,
         }).then((playbookRun) => {
+            testRun = playbookRun;
+
             // # Visit the playbook run
             cy.visit(`/playbooks/run_details/${playbookRun.id}`);
         });
     });
+    const commonTests = () => {
+        it('is visible', () => {
+            // * Verify the retrospective section is present
+            getRetro().should('be.visible');
+        });
 
-    it('is visible', () => {
-        // * Verify the retrospective section is present
-        cy.findByTestId('run-retrospective-section').should('be.visible');
+        it('has title', () => {
+            // * Verify the retrospective section has a title
+            getRetro().find('h3').contains('Retrospective');
+        });
+
+        it('has template text', () => {
+            // * Verify the retrospective section has a title
+            getRetro().findByTestId('retro-report-text').contains('This is a retrospective template.');
+        });
+    };
+
+    describe('as participant', () => {
+        commonTests();
+
+        it('publishing posts to run channel', () => {
+            editAndPublishRetro();
+
+            // # Switch to the run channel
+            cy.findByTestId('runinfo-channel').click();
+
+            // * Verify the modified retro text is posted
+            cy.getStyledComponent('CustomPostContent').should('exist').contains('Edited retrospective.');
+        });
+
+        it('can be published once', () => {
+            editAndPublishRetro();
+            getRetro().findByText('Publish').should('not.be.enabled');
+        });
     });
 
-    it('has title', () => {
-        // * Verify the retrospective section has a title
-        cy.findByTestId('run-retrospective-section').find('h3').contains('Retrospective');
+    describe('as viewer', () => {
+        beforeEach(() => {
+            cy.apiLogin(testViewerUser).then(() => {
+                cy.visit(`/playbooks/run_details/${testRun.id}`);
+            });
+        });
+
+        commonTests();
     });
 });

--- a/tests-e2e/cypress/integration/runs/rdp_main_summary_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_summary_spec.js
@@ -141,6 +141,7 @@ describe('runs > run details page > summary', () => {
             // # Mouseover the summary
             cy.findByTestId('run-summary-section').trigger('mouseover');
 
+            // * Verify that the edit button is not rendered
             cy.findByTestId('run-summary-section').findByTestId('hover-menu-edit-button').should('not.exist');
         });
     });

--- a/tests-e2e/cypress/integration/runs/rdp_main_summary_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_summary_spec.js
@@ -9,12 +9,20 @@
 describe('runs > run details page > summary', () => {
     let testTeam;
     let testUser;
+    let testRun;
+    let testViewerUser;
     let testPublicPlaybook;
 
     before(() => {
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
             testUser = user;
+
+            // Create another user in the same team
+            cy.apiCreateUser().then(({user: viewer}) => {
+                testViewerUser = viewer;
+                cy.apiAddUserToTeam(testTeam.id, testViewerUser.id);
+            });
 
             // # Login as testUser
             cy.apiLogin(testUser);
@@ -43,69 +51,97 @@ describe('runs > run details page > summary', () => {
             playbookRunName: 'the run name',
             ownerUserId: testUser.id,
         }).then((playbookRun) => {
+            testRun = playbookRun;
+
             // # Visit the playbook run
             cy.visit(`/playbooks/run_details/${playbookRun.id}`);
         });
     });
 
-    it('is visible', () => {
-        // * Verify the summary section is present
-        cy.findByTestId('run-summary-section').should('be.visible');
-    });
-
-    it('has title', () => {
-        // * Verify the summary section is present
-        cy.findByTestId('run-summary-section').find('h3').contains('Summary');
-    });
-
-    it('has a placeholder', () => {
-        // * Assert the placeholder content
-        cy.findByTestId('run-summary-section').within(() => {
-            cy.findByTestId('rendered-text').contains('Add a run summary');
+    const commonTests = () => {
+        it('is visible', () => {
+            // * Verify the summary section is present
+            cy.findByTestId('run-summary-section').should('be.visible');
         });
-    });
 
-    it('can be edited', () => {
-        // # Mouseover the summary
-        cy.findByTestId('run-summary-section').trigger('mouseover');
+        it('has title', () => {
+            // * Verify the summary section is present
+            cy.findByTestId('run-summary-section').find('h3').contains('Summary');
+        });
+    };
 
-        cy.findByTestId('run-summary-section').within(() => {
+    describe('as participant', () => {
+        commonTests();
+
+        it('has a placeholder', () => {
+            // * Assert the placeholder content
+            cy.findByTestId('run-summary-section').findByTestId('rendered-text').contains('Add a run summary');
+        });
+
+        it('can be edited', () => {
+            // # Mouseover the summary
+            cy.findByTestId('run-summary-section').trigger('mouseover');
+
+            cy.findByTestId('run-summary-section').within(() => {
             // # Click the edit icon
-            cy.findByTestId('hover-menu-edit-button').click();
+                cy.findByTestId('hover-menu-edit-button').click();
 
-            // # Write a summary
-            cy.findByTestId('editabletext-markdown-textbox1').clear().type('This is my new summary');
+                // # Write a summary
+                cy.findByTestId('editabletext-markdown-textbox1').clear().type('This is my new summary');
 
-            // # Save changes
-            cy.findByTestId('checklist-item-save-button').click();
+                // # Save changes
+                cy.findByTestId('checklist-item-save-button').click();
 
-            // * Assert that data has changed
-            cy.findByTestId('rendered-text').contains('This is my new summary');
+                // * Assert that data has changed
+                cy.findByTestId('rendered-text').contains('This is my new summary');
+            });
+
+            // * Assert last edition date is visible
+            cy.findByTestId('run-summary-section').contains('Last edited');
         });
 
-        // * Assert last edition date is visible
-        cy.findByTestId('run-summary-section').contains('Last edited');
+        it('can be canceled', () => {
+            // # Mouseover the summary
+            cy.findByTestId('run-summary-section').trigger('mouseover');
+
+            cy.findByTestId('run-summary-section').within(() => {
+            // # Click the edit icon
+                cy.findByTestId('hover-menu-edit-button').click();
+
+                // # Write a summary
+                cy.findByTestId('editabletext-markdown-textbox1').clear().type('This is my new summary');
+
+                // # Cancel changes
+                cy.findByText('Cancel').click();
+
+                // * Assert that data has not changed
+                cy.findByTestId('rendered-text').contains('Add a run summary');
+            });
+
+            // * Assert last edition date is not visible
+            cy.findByTestId('run-summary-section').should('not.contain', 'Last edited');
+        });
     });
 
-    it('can be canceled', () => {
-        // # Mouseover the summary
-        cy.findByTestId('run-summary-section').trigger('mouseover');
-
-        cy.findByTestId('run-summary-section').within(() => {
-            // # Click the edit icon
-            cy.findByTestId('hover-menu-edit-button').click();
-
-            // # Write a summary
-            cy.findByTestId('editabletext-markdown-textbox1').clear().type('This is my new summary');
-
-            // # Cancel changes
-            cy.findByText('Cancel').click();
-
-            // * Assert that data has not changed
-            cy.findByTestId('rendered-text').contains('Add a run summary');
+    describe('as viewer', () => {
+        beforeEach(() => {
+            cy.apiLogin(testViewerUser).then(() => {
+                cy.visit(`/playbooks/run_details/${testRun.id}`);
+            });
         });
 
-        // * Assert last edition date is not visible
-        cy.findByTestId('run-summary-section').should('not.contain', 'Last edited');
+        commonTests();
+
+        it('has a placeholder', () => {
+            // * Assert the placeholder content
+            cy.findByTestId('run-summary-section').findByTestId('rendered-text').contains('There\'s no summary');
+        });
+
+        it('can not be edited', () => {
+            // # Mouseover the summary
+            cy.findByTestId('run-summary-section').trigger('mouseover');
+
+            cy.findByTestId('run-summary-section').findByTestId('hover-menu-edit-button').should('not.exist');
+        });
     });
 });

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -421,6 +421,7 @@
   "lBqu4h": "Restore playbook",
   "lJ48wN": "Private playbook",
   "lJyq2a": "Run not found",
+  "lKeJ+i": "There's no summary",
   "lQT7iD": "Create Playbook",
   "lUfDe1": "Export the playbook run channel and save it for later analysis.",
   "lZwZi+": "Day: {date}",

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -107,7 +107,7 @@ const Retrospective = ({
                 }
                 <PublishButton
                     onClick={onPublishClick}
-                    disabled={notEditable}
+                    disabled={isPublished}
                 >
                     {formatMessage({defaultMessage: 'Publish'})}
                 </PublishButton>
@@ -133,9 +133,11 @@ const Retrospective = ({
                         title={formatMessage({defaultMessage: 'Retrospective'})}
                         id={id}
                     />
-                    <HeaderButtonsRight>
-                        {renderPublishComponent()}
-                    </HeaderButtonsRight>
+                    {role === Role.Participant ? (
+                        <HeaderButtonsRight>
+                            {renderPublishComponent()}
+                        </HeaderButtonsRight>
+                    ) : null}
                 </Header>
                 <StyledContent>
                     {playbook?.metrics && metricsAvailable &&

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
@@ -38,6 +38,8 @@ const Summary = ({
         </TimestampContainer>
     );
 
+    const placeholder = role === Role.Participant ? formatMessage({defaultMessage: 'Add a run summary'}) : formatMessage({defaultMessage: 'There\'s no summary'});
+
     return (
         <Container
             id={id}
@@ -52,7 +54,7 @@ const Summary = ({
             </Header>
             <MarkdownEdit
                 disabled={Role.Viewer === role}
-                placeholder={formatMessage({defaultMessage: 'Add a run summary'})}
+                placeholder={placeholder}
                 value={playbookRun.summary}
                 onSave={(value) => {
                     updatePlaybookRunDescription(playbookRun.id, value);


### PR DESCRIPTION
#### Summary
Continuation on the e2e effort for Run Details Page
It covers summary, checklist and retro.

The checklist test covers some basic points and relies on full tests done for Channels RHS checklist.

The retrospective is slightly different from other sections because when we definitely remove the old page we will:
- move the retro component inside the new playbook run folder
- remove the older tests (retrospective_spec and metrics_spec)

Also some small changes:
- different placeholder in summary when the user is viewer (instead of "add a summary")
- hide publish retro button if user is viewer (instead of disabled)


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45351

#### Checklist
- [ ] ~~Telemetry updated~~
- [X] Gated by experimental feature flag
- [X] Unit tests updated
