### PR TITLE
Mm 45608 create public playbooks from rhs when no e20

### DIFF
--- a/webapp/src/components/rhs/rhs_home.tsx
+++ b/webapp/src/components/rhs/rhs_home.tsx
@@ -33,7 +33,7 @@ import {
     usePlaybooksCrud,
     getPlaybookOrFetch,
     usePlaybooksRouting,
-    useCanCreatePlaybooksOnAnyTeam,
+    useHasTeamPermission,
 } from 'src/hooks';
 import {navigateToUrl} from 'src/browser_routing';
 
@@ -194,10 +194,15 @@ const RHSHome = () => {
     const hasCurrentRun = Boolean(currentRun);
     const [currentPlaybook, setCurrentPlaybook] = useState<Playbook | null>();
 
+    const permissionForPublic = useHasTeamPermission(currentTeam.id || '', 'playbook_public_create');
+    const permissionForPrivate = useHasTeamPermission(currentTeam.id || '', 'playbook_private_create');
+    const hasCreationRestrictions = !(permissionForPublic && permissionForPrivate) && Boolean(currentTeam.id);
+    const makePublicWithPermission = hasCreationRestrictions ? permissionForPublic : true;
+
     const [playbooks, {hasMore, isLoading}, {setPage}] = usePlaybooksCrud({team_id: currentTeam.id}, {infinitePaging: true});
     const {create} = usePlaybooksRouting<Playbook>();
 
-    const canCreatePlaybooks = useCanCreatePlaybooksOnAnyTeam();
+    const canCreatePlaybooks = permissionForPublic || permissionForPrivate;
 
     const newPlaybook = (template?: DraftPlaybookWithChecklist) => {
         if (template) {

--- a/webapp/src/components/rhs/rhs_home.tsx
+++ b/webapp/src/components/rhs/rhs_home.tsx
@@ -196,13 +196,10 @@ const RHSHome = () => {
 
     const permissionForPublic = useHasTeamPermission(currentTeam.id || '', 'playbook_public_create');
     const permissionForPrivate = useHasTeamPermission(currentTeam.id || '', 'playbook_private_create');
-    const hasCreationRestrictions = !(permissionForPublic && permissionForPrivate) && Boolean(currentTeam.id);
-    const makePublicWithPermission = hasCreationRestrictions ? permissionForPublic : true;
+    const canCreatePlaybooks = permissionForPublic || permissionForPrivate;
 
     const [playbooks, {hasMore, isLoading}, {setPage}] = usePlaybooksCrud({team_id: currentTeam.id}, {infinitePaging: true});
     const {create} = usePlaybooksRouting<Playbook>();
-
-    const canCreatePlaybooks = permissionForPublic || permissionForPrivate;
 
     const newPlaybook = (template?: DraftPlaybookWithChecklist) => {
         if (template) {


### PR DESCRIPTION
#### Summary
Environment:
- branch 7.1 (without new modal with team selector)
- below E20 (no private playbook permission)

Steps to reproduce:
- open RHS in a channel without RUNs
- click on "use" template to create a playbook

Result: 403 forbidden since we try to create a public playbook


3/5 on solution, I'm not very familiar with permissions. I've been inspired from create_playbook_modal but I'd appreciate some review.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45608

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated
