### PR TITLE
MM-45618: Hide Key Metrics if server's not licensed

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_metrics.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_metrics.tsx
@@ -12,6 +12,7 @@ import {Section, SectionHeader} from 'src/components/backstage/playbook_runs/pla
 import {RunMetricData} from 'src/types/playbook_run';
 import {Metric, MetricType} from 'src/types/playbook';
 import {formatDuration} from 'src/components/formatted_duration';
+import {useAllowPlaybookAndRunMetrics} from 'src/hooks';
 
 interface Props {
     metricsData: RunMetricData[];
@@ -21,13 +22,14 @@ interface Props {
 
 const RHSInfoMetrics = ({metricsData, metricsConfig, editable}: Props) => {
     const {formatMessage} = useIntl();
+    const metricsAvailable = useAllowPlaybookAndRunMetrics();
 
     const metricDataByID = {} as Record<string, RunMetricData>;
     metricsData.forEach((mc) => {
         metricDataByID[mc.metric_config_id] = mc;
     });
 
-    if (!metricsConfig || metricsConfig.length === 0) {
+    if (!metricsAvailable || !metricsConfig || metricsConfig.length === 0) {
         return null;
     }
 


### PR DESCRIPTION
#### Summary
Before, when the server was not properly licensed, we were still showing the Key Metrics section, even when the Retrospective hid the metrics (in Professional) or the Retrospective altogether (in Starter).

This is what it looks now on every license:

##### Starter: placeholder in Retrospective, no Key Metrics section in RHS
![image](https://user-images.githubusercontent.com/3924815/178230594-507c8421-e976-43fa-85f5-b5955ce7b209.png)

##### Professional: Retrospective without metrics, no Key Metrics section in RHS
![image](https://user-images.githubusercontent.com/3924815/178230612-d9054240-a3cb-4b69-bd08-e5faec00ee3f.png)

##### Enterprise: Retrospective with metrics, Key Metrics section rendered in RHS
![image](https://user-images.githubusercontent.com/3924815/178230641-58f4992b-7af0-49dc-8e79-07df7c46fcb8.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45618

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
