### PR TITLE
MM-45346: fix duedate selector in hover menu

### DIFF
--- a/webapp/src/components/create_playbook_modal.tsx
+++ b/webapp/src/components/create_playbook_modal.tsx
@@ -14,7 +14,7 @@ import {BaseInput} from './assets/inputs';
 import PublicPrivateSelector from './backstage/public_private_selector';
 import {TemplateDropdown} from './templates/template_selector';
 import MarkdownTextbox from './markdown_textbox';
-import TeamSelector from './team/team_selector';
+import TeamSelector, {SelectedButton} from './team/team_selector';
 import GenericModal, {InlineLabel} from './widgets/generic_modal';
 
 const ID = 'playbooks_create';
@@ -50,6 +50,10 @@ const TeamSelectorBorder = styled(BaseInput).attrs({as: 'div'})`
 	display: flex;
 	flex-direction: horizontal;
 	padding: 0;
+
+    ${SelectedButton} {
+        width: 100%;
+    }
 `;
 
 const PlaybookCreateModal = ({startingName, startingTeamId, startingTemplate, startingDescription, startingPublic, ...modalProps}: PlaybookCreateModalProps) => {

--- a/webapp/src/components/datetime_selector.tsx
+++ b/webapp/src/components/datetime_selector.tsx
@@ -11,8 +11,6 @@ import debounce from 'debounce';
 
 import {Placement} from '@floating-ui/react-dom-interactions';
 
-import {useUpdateEffect} from 'react-use';
-
 import Dropdown from 'src/components/dropdown';
 
 import {Timestamp} from 'src/webapp_globals';
@@ -64,14 +62,15 @@ export const DateTimeSelector = ({
 }: Props) => {
     const {locale, formatMessage} = useIntl();
 
-    const [isOpen, setOpen] = useState(false);
+    const [isOpen, realSetOpen] = useState(false);
+    const setOpen = (open: boolean) => {
+        props.onOpenChange?.(open);
+        realSetOpen(open);
+    };
+
     const toggleOpen = () => {
         setOpen(!isOpen);
     };
-
-    useUpdateEffect(() => {
-        props.onOpenChange?.(isOpen);
-    }, [isOpen]);
 
     // Allow the parent component to control the open state -- only after mounting.
     const [oldOpenToggle, setOldOpenToggle] = useState(props.controlledOpenToggle);
@@ -144,6 +143,9 @@ export const DateTimeSelector = ({
                 autoFocus={true}
                 components={components}
                 controlShouldRenderValue={false}
+                backspaceRemovesValue={false}
+                tabSelectsValue={false}
+                hideSelectedOptions={false}
                 menuIsOpen={true}
                 options={options}
                 placeholder={mode === Mode.DateTimeValue ? formatMessage({defaultMessage: 'Specify date/time (“in 4 hours”, “May 1”...)'}) : formatMessage({defaultMessage: 'Specify duration ("8 hours", "3 days"...)'})}

--- a/webapp/src/components/dropdown.tsx
+++ b/webapp/src/components/dropdown.tsx
@@ -88,7 +88,7 @@ const Dropdown = (props: DropdownProps) => {
         useDismiss(context),
     ]);
 
-    const MaybePortal = props.portal ? FloatingPortal : React.Fragment;
+    const MaybePortal = (props.portal ?? true) ? FloatingPortal : React.Fragment;
 
     return (
         <>

--- a/webapp/src/components/team/team_selector.tsx
+++ b/webapp/src/components/team/team_selector.tsx
@@ -40,8 +40,6 @@ interface Props {
     containerStyles?: ReturnType<typeof css>;
 }
 
-const dropdownYShift = 27;
-
 const RightAlign = styled.div`
 	flex-grow: 1;
 	text-align: right;


### PR DESCRIPTION
#### Summary
https://community.mattermost.com/core/pl/mrrgjqzmhfywbb7hyibmfkxuba

- (https://github.com/mattermost/mattermost-plugin-playbooks/commit/459de7e4b78cee20367ec3488a81b32340b12ae4) Fix: hover menu duedate selector not focusing
- Change: default to portal (during https://github.com/mattermost/mattermost-plugin-playbooks/pull/1306/files#diff-c0e4dc8aa5d743606c160185470180181a25616b7215650bc66d68c50178fb38R91 had mistakenly been set to default off, which did not cause any issues but is better to default on than default off)
- UX: Fix team selector dropdown button not full width

| before | after |
|---|---|
|  <img width="400" alt="image" src="https://user-images.githubusercontent.com/11724372/178362732-a19cba6e-e0ea-416c-beb6-cf28f5c33c62.gif">  |  <img width="400" alt="image" src="https://user-images.githubusercontent.com/11724372/178366578-297af71c-8bc6-4769-bb4d-ecdfba5614fd.gif"> |

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-45346

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? |
Gated by experimental feature flag? |
Unit/E2E tests updated? |

[^1]: Yes / No / Not Applicable.
