### PR TITLE
fine tune run title control + toggle open in dotmenu

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
@@ -107,7 +107,6 @@ const Title = styled.h1`
     `;
 
 export const TitleButton = styled.div<{isActive: boolean}>`
-    /* padding-left: 16px; */
     padding: 2px 2px 2px 6px;
     display: inline-flex;
     border-radius: 4px;

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
@@ -9,7 +9,6 @@ import {useDispatch} from 'react-redux';
 
 import {showRunActionsModal} from 'src/actions';
 import {exportChannelUrl, getSiteUrl} from 'src/client';
-import {TitleButton} from '../../playbook_editor/controls';
 import {PlaybookRun, playbookRunIsActive} from 'src/types/playbook_run';
 import DotMenu, {DropdownMenuItem} from 'src/components/dot_menu';
 import {SemiBoldHeading} from 'src/styles/headings';
@@ -103,7 +102,19 @@ const Title = styled.h1`
     letter-spacing: -0.01em;
     font-size: 16px;
     line-height: 24px;
-    color: var(--center-channel-color);
     margin: 0;
     white-space: nowrap;
+    `;
+
+export const TitleButton = styled.div<{isActive: boolean}>`
+    /* padding-left: 16px; */
+    padding: 2px 2px 2px 6px;
+    display: inline-flex;
+    border-radius: 4px;
+    color: ${({isActive}) => (isActive ? 'var(--button-bg)' : 'var(--center-channel-color)')};
+    background: ${({isActive}) => (isActive ? 'rgba(var(--button-bg-rgb), 0.08)' : 'auto')};
+
+    &:hover {
+        background: ${({isActive}) => (isActive ? 'rgba(var(--button-bg-rgb), 0.08)' : 'rgba(var(--center-channel-color-rgb), 0.08)')};
+    }
 `;

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -80,7 +80,7 @@ const DotMenu = (props: DotMenuProps) => {
 
     const [isOpen, setOpen] = useState(false);
     const toggleOpen = () => {
-        setOpen(true);
+        setOpen(!isOpen);
     };
 
     useClickOutsideRef(refs.reference, () => {


### PR DESCRIPTION
#### Summary
Feedback on the run title:
- adjusted padding 
- hover/active/open styles as the channel context menu
- dot menu works like a toggle now **globally** (click again if open to close it). This affect lots of other dotmenus, but it seems globally desired 

```
2. The hover state on the run name is mis-aligned. Recommended change: padding: 2px 2px 2px 6px;
3. When the run name dropdown is open, the run name should stay in the highlighted state. Please check channel name dropdown for reference.
``` 

Demo:
https://user-images.githubusercontent.com/4096774/178491441-c1236ac1-63b3-40e1-b0c5-5febff991e02.mp4



#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-45674

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
