### PR TITLE
MM-45676: Increase margin between title and checklist box

### DIFF
--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -239,7 +239,7 @@ const MainTitle = styled.div<{parentContainer?: ChecklistParent}>`
 
     font-size: 16px;
     line-height: 24px;
-    padding: ${(props) => (props.parentContainer === ChecklistParent.RunDetails ? '12px 0 8px 0' : '12px 0 12px 8px')};
+    padding: ${(props) => (props.parentContainer === ChecklistParent.RunDetails ? '12px 0' : '12px 0 12px 8px')};
 `;
 
 const HoverRow = styled(HoverMenu)`


### PR DESCRIPTION
#### Summary
As stated in the ticket, the padding was increased from 8px to 12px. The functional issue was actually already solved by https://github.com/mattermost/mattermost-plugin-playbooks/pull/1313 :)

![image](https://user-images.githubusercontent.com/3924815/178567087-6950b020-8750-49b5-9221-5f0b9b45c9b3.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45676

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
