### PR TITLE
Recover golangci staticcheck, gosimple and unused linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
   default:
     docker:
       - image: cimg/go:1.18.1-node
+        environment:
+          GOCI_LINT_V: 1.46.2
+
 
 aliases:
   - &restore_go_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
       - run:
           name: install golangci-lint 1.46.2
           command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | | sudo sh -s -- -b /usr/local/bin 1.46.2
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin 1.46.2
       - run:
           name: Checking code style
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,11 @@ jobs:
       - *restore_go_cache
       - npm-dependencies
       - npm-e2e-dependencies
+      # Base image already bundle a golanci-lint but it's not updated enough (staticcheck linter needed)
+      - run:
+          name: install golangci-lint 1.46.2
+          command: |
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.46.2
       - run:
           name: Checking code style
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ executors:
   default:
     docker:
       - image: cimg/go:1.18.1-node
-        environment:
-          GOCI_LINT_V: 1.46.2
-
 
 aliases:
   - &restore_go_cache
@@ -179,6 +176,11 @@ jobs:
       - *restore_go_cache
       - npm-dependencies
       - npm-e2e-dependencies
+      # Base image already bundle a golanci-lint but it's not updated enough (staticcheck linter needed)
+      - run:
+          name: install golangci-lint 1.46.2
+          command: |
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | | sudo sh -s -- -b /usr/local/bin 1.46.2
       - run:
           name: Checking code style
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
       - run:
           name: install golangci-lint 1.46.2
           command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin 1.46.2
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.46.2
       - run:
           name: Checking code style
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,11 +176,6 @@ jobs:
       - *restore_go_cache
       - npm-dependencies
       - npm-e2e-dependencies
-      # Base image already bundle a golanci-lint but it's not updated enough (staticcheck linter needed)
-      - run:
-          name: install golangci-lint 1.46.2
-          command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.46.2
       - run:
           name: Checking code style
           command: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,10 +23,11 @@ linters:
     - ineffassign
     - exportloopref
     - staticcheck
-    - structcheck
     - unconvert
     - unused
     - varcheck
+    # disabled until is compatible with go1.18 https://github.com/golangci/golangci-lint/issues/2649
+    # - structcheck
 
 linters-settings:
   gofmt:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ ifneq ($(HAS_SERVER),)
 	golangci-lint run ./...
 endif
 
+.PHONY: check-golangci
 check-golangci:
 ifneq ($(HAS_SERVER),)
 	@echo Ckecking golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ DLV_DEBUG_PORT := 2346
 DEFAULT_GOOS := $(shell go env GOOS)
 DEFAULT_GOARCH := $(shell go env GOARCH)
 
+GOLANGCI_CURRENT_MAJOR := $(shell golangci-lint --version | cut -f 4 -d ' ' | cut -f 1 -d '.')
+GOLANGCI_CURRENT_MINOR := $(shell golangci-lint --version | cut -f 4 -d ' ' | cut -f 2 -d '.')
+GOLANGCI_MINIMUM_MINOR := 46
+GOLANGCI_MINIMUM_MAJOR := 1
+GOLANCI_VERSION_ERRORMESSAGE := "Bad golangci-lint version: $(shell golangci-lint --version | cut -f 4 -d ' '). Please update at least to $(GOLANGCI_MINIMUM_MAJOR).$(GOLANGCI_MINIMUM_MINOR).X (https://golangci-lint.run/usage/install/)"
+
 export GO111MODULE=on
 
 # We need to export GOBIN to allow it to be set
@@ -69,8 +75,11 @@ ifneq ($(HAS_SERVER),)
 		exit 1; \
 	fi; \
 
-	@if [ $(shell golangci-lint --version | cut -f 4 -d ' ') != "1.46.2" ]; then \
-		echo "Bad golangci-lint version, please update to 1.46.2 (https://golangci-lint.run/usage/install/)"; \
+	@if [ $(GOLANGCI_CURRENT_MAJOR) -lt $(GOLANGCI_MINIMUM_MAJOR) ]; then \
+		echo $(GOLANCI_VERSION_ERRORMESSAGE) \
+		exit 1; \
+	elif [ $(GOLANGCI_CURRENT_MINOR) -lt $(GOLANGCI_MINIMUM_MINOR) ]; then \
+		echo $(GOLANCI_VERSION_ERRORMESSAGE) \
 		exit 1; \
 	fi; \
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ apply:
 
 ## Runs eslint and golangci-lint
 .PHONY: check-style
-check-style: apply webapp/node_modules
+check-style: apply webapp/node_modules check-golangci
 	@echo Checking for style guide compliance
 
 ifneq ($(HAS_WEBAPP),)
@@ -56,15 +56,26 @@ endif
 	cd tests-e2e && npm run check
 
 ifneq ($(HAS_SERVER),)
+	@echo Running golangci-lint
+	golangci-lint run ./...
+endif
+
+check-golangci:
+ifneq ($(HAS_SERVER),)
+	@echo Ckecking golangci-lint
+
 	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
 		echo "golangci-lint is not installed. Please see https://github.com/golangci/golangci-lint#install for installation instructions."; \
 		exit 1; \
 	fi; \
 
-	@echo Running golangci-lint
-	golangci-lint --version
-	golangci-lint run ./...
+	@if [ $(shell golangci-lint --version | cut -f 4 -d ' ') != "1.46.2" ]; then \
+		echo "Bad golangci-lint version, please update to 1.46.2 (https://golangci-lint.run/usage/install/)"; \
+		exit 1; \
+	fi; \
+
 endif
+
 
 ## Builds the server, if it exists, for all supported architectures, unless MM_SERVICESETTINGS_ENABLEDEVELOPER is set
 .PHONY: server

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ ifneq ($(HAS_SERVER),)
 		exit 1; \
 	fi; \
 
-	@if [ $(GOLANGCI_CURRENT_MAJOR) -lt $(GOLANGCI_MINIMUM_MAJOR) ]; then \
+	@if [ $(GOLANGCI_CURRENT_MAJOR) -gt $(GOLANGCI_MINIMUM_MAJOR) ]; then \
+		exit 0; \
+	elif [ $(GOLANGCI_CURRENT_MAJOR) -lt $(GOLANGCI_MINIMUM_MAJOR) ]; then \
 		echo $(GOLANCI_VERSION_ERRORMESSAGE) \
 		exit 1; \
 	elif [ $(GOLANGCI_CURRENT_MINOR) -lt $(GOLANGCI_MINIMUM_MINOR) ]; then \

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -93,7 +93,7 @@ func (h *PlaybookHandler) validPlaybook(w http.ResponseWriter, playbook *app.Pla
 		playbook.SignalAnyKeywords = app.ProcessSignalAnyKeywords(playbook.SignalAnyKeywords)
 	}
 
-	if playbook.BroadcastEnabled {
+	if playbook.BroadcastEnabled { //nolint
 		for _, channelID := range playbook.BroadcastChannelIDs {
 			channel, err := h.pluginAPI.Channel.Get(channelID)
 			if err != nil {

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -236,7 +236,7 @@ func (p *playbookStore) Create(playbook app.Playbook) (id string, err error) {
 			"DefaultCommanderID":                    rawPlaybook.DefaultOwnerID,
 			"DefaultCommanderEnabled":               rawPlaybook.DefaultOwnerEnabled,
 			"ConcatenatedBroadcastChannelIDs":       rawPlaybook.ConcatenatedBroadcastChannelIDs,
-			"BroadcastEnabled":                      rawPlaybook.BroadcastEnabled,
+			"BroadcastEnabled":                      rawPlaybook.BroadcastEnabled, //nolint
 			"ConcatenatedWebhookOnCreationURLs":     rawPlaybook.ConcatenatedWebhookOnCreationURLs,
 			"WebhookOnCreationEnabled":              rawPlaybook.WebhookOnCreationEnabled,
 			"MessageOnJoin":                         rawPlaybook.MessageOnJoin,
@@ -644,7 +644,7 @@ func (p *playbookStore) Update(playbook app.Playbook) (err error) {
 			"DefaultCommanderID":                    rawPlaybook.DefaultOwnerID,
 			"DefaultCommanderEnabled":               rawPlaybook.DefaultOwnerEnabled,
 			"ConcatenatedBroadcastChannelIDs":       rawPlaybook.ConcatenatedBroadcastChannelIDs,
-			"BroadcastEnabled":                      rawPlaybook.BroadcastEnabled,
+			"BroadcastEnabled":                      rawPlaybook.BroadcastEnabled, //nolint
 			"ConcatenatedWebhookOnCreationURLs":     rawPlaybook.ConcatenatedWebhookOnCreationURLs,
 			"WebhookOnCreationEnabled":              rawPlaybook.WebhookOnCreationEnabled,
 			"MessageOnJoin":                         rawPlaybook.MessageOnJoin,

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -450,7 +450,7 @@ func playbookProperties(playbook app.Playbook, userID string) map[string]interfa
 		"DefaultCommanderID":          playbook.DefaultOwnerID,
 		"DefaultCommanderEnabled":     playbook.DefaultOwnerEnabled,
 		"BroadcastChannelIDs":         playbook.BroadcastChannelIDs,
-		"BroadcastEnabled":            playbook.BroadcastEnabled,
+		"BroadcastEnabled":            playbook.BroadcastEnabled, //nolint
 		"NumWebhookOnCreationURLs":    len(playbook.WebhookOnCreationURLs),
 		"WebhookOnCreationEnabled":    playbook.WebhookOnCreationEnabled,
 		"SignalAnyKeywordsEnabled":    playbook.SignalAnyKeywordsEnabled,

--- a/server/telemetry/rudder_test.go
+++ b/server/telemetry/rudder_test.go
@@ -431,7 +431,7 @@ func TestPlaybookProperties(t *testing.T) {
 		"DefaultCommanderID":          dummyPlaybook.DefaultOwnerID,
 		"DefaultCommanderEnabled":     dummyPlaybook.DefaultOwnerEnabled,
 		"BroadcastChannelIDs":         dummyPlaybook.BroadcastChannelIDs,
-		"BroadcastEnabled":            dummyPlaybook.BroadcastEnabled,
+		"BroadcastEnabled":            dummyPlaybook.BroadcastEnabled, //nolint
 		"NumWebhookOnCreationURLs":    2,
 		"WebhookOnCreationEnabled":    dummyPlaybook.WebhookOnCreationEnabled,
 		"SignalAnyKeywordsEnabled":    dummyPlaybook.SignalAnyKeywordsEnabled,


### PR DESCRIPTION
#### Summary
Recover golangci linters: gosimple, unused and staticcheck.

At CI:
- Since cicleci image is forcing 1.45.2 version, a new step is added to force the tool to be udpated
- PR [sent to circleci](https://github.com/CircleCI-Public/cimg-go/pull/183) . If they accept this change, we can remove the additional step to replace the binary.

At Local dev env:
- force version check to 1.46.2 in `make check-style` to force everyone to update :) (Sorry if this makes some noise, but it's important to have the linters locally)

Changes in the codebase:
//nolint tag in the deprecated lines. VScode will still warn about it but we won't break CI.

#### Ticket Link
NOpe

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
