### PR TITLE
fix memory issue when looking at nil posts

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -817,6 +817,7 @@ func (h *PlaybookRunHandler) getStatusUpdates(w http.ResponseWriter, r *http.Req
 		post, err := h.pluginAPI.Post.GetPost(p.ID)
 		if err != nil {
 			h.log.Warnf("statusUpdates: can not retrieve post %s: %v ", p.ID, err)
+			continue
 		}
 
 		// Given the fact that we are bypassing some permissions,


### PR DESCRIPTION
#### Summary
Fix memory issue. nil posts due to retrieval error were still being used.

A simple continue clause fix that.  


```
Jul 18, 2022 @ 10:39:09.667 | Received HTTP request
  | Jul 18, 2022 @ 10:39:09.653 | Plugin failed to ServeHTTP, RPC call failed

  | Jul 18, 2022 @ 10:39:09.572 | Received HTTP request

  | Jul 18, 2022 @ 10:39:09.487 | Received HTTP request

  | Jul 18, 2022 @ 10:39:09.048 | Plugin failed to ServeHTTP, RPC call failed

  | Jul 18, 2022 @ 10:39:09.048 | plugin process exited

  | Jul 18, 2022 @ 10:39:09.044 | created by net/rpc.(*Server).ServeCodec

  | Jul 18, 2022 @ 10:39:09.044 | Plugin failed to ServeHTTP, RPC call failed

  | Jul 18, 2022 @ 10:39:09.044 | net/rpc/server.go:478 +0x3fe

  | Jul 18, 2022 @ 10:39:09.044 | net/rpc/server.go:381 +0x226

  | Jul 18, 2022 @ 10:39:09.044 | net/rpc.(*service).call(0xc0004a4040, 0xc0000345a0?, 0x0?, 0xc0001aa090, 0xc000159080, 0xc0003c2f48?, {0xebe0a0?, 0xc0005aea40?, 0xb2b1e6?}, {0xecbaa0, ...}, ...)

  | Jul 18, 2022 @ 10:39:09.043 | reflect/value.go:339 +0xbf

  | Jul 18, 2022 @ 10:39:09.043 | reflect/value.go:556 +0x845

  | Jul 18, 2022 @ 10:39:09.043 | reflect.Value.Call({0xc000127140?, 0xc000124f68?, 0xc0003c2e88?}, {0xc0003c2ef8, 0x3, 0x3})

  | Jul 18, 2022 @ 10:39:09.042 | reflect.Value.call({0xc000127140?, 0xc000124f68?, 0x13?}, {0x1090e99, 0x4}, {0xc000349ef8, 0x3, 0x3?})

  | Jul 18, 2022 @ 10:39:09.040 | net/http.HandlerFunc.ServeHTTP(0xc000582500?, {0x129c460?, 0xc000677f50?}, 0xc0003fafc8?)

  | Jul 18, 2022 @ 10:39:09.040 | net/http/server.go:2084 +0x2f

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-server/v6@v6.0.0-20220512052723-ea98f9f4a9dc/plugin/client_rpc.go:456 +0x379

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-server/v6/plugin.(*hooksRPCServer).ServeHTTP(0xc00034e200, 0xc0005aea40, 0x1?)

  | Jul 18, 2022 @ 10:39:09.040 | github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf

  | Jul 18, 2022 @ 10:39:09.040 | net/http/server.go:2084 +0x2f

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/api.MattermostAuthorizationRequired.func1({0x129c460, 0xc000677f50}, 0xc000582600)

  | Jul 18, 2022 @ 10:39:09.040 | net/http/server.go:2084 +0x2f

  | Jul 18, 2022 @ 10:39:09.040 | main.(*Plugin).getErrorCounterHandler.func1.1({0x129c460?, 0xc000677f50}, 0x12?)

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/api/playbook_runs.go:824 +0x463

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/api.(*PlaybookRunHandler).getStatusUpdates(0xc000158e80, {0x129cc40, 0xc0008b53b0}, 0xc000582600)

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/api/api.go:49

  | Jul 18, 2022 @ 10:39:09.040 | net/http.HandlerFunc.ServeHTTP(0xc000b00d80?, {0x129c460?, 0xc000677f50?}, 0xee8140?)

  | Jul 18, 2022 @ 10:39:09.040 | net/http.HandlerFunc.ServeHTTP(0xc000b00e70?, {0x129cc40?, 0xc0008b53b0?}, 0x1?)

  | Jul 18, 2022 @ 10:39:09.040 | goroutine 980 [running]:

  | Jul 18, 2022 @ 10:39:09.040 |  

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/plugin.go:85 +0x34

  | Jul 18, 2022 @ 10:39:09.040 | main.(*Plugin).ServeHTTP(0x791ca8986170?, 0x102c500?, {0x129c460?, 0xc000677f50?}, 0x3?)

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/api.(*Handler).ServeHTTP(...)

  | Jul 18, 2022 @ 10:39:09.040 | github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000dccc0, {0x129c460, 0xc000677f50}, 0xc000582400)

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/api/api.go:95 +0x75

  | Jul 18, 2022 @ 10:39:09.040 | github.com/mattermost/mattermost-plugin-playbooks/server/plugin.go:393 +0xa9

  | Jul 18, 2022 @ 10:39:09.040 | [signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0xdf8f83]

  | Jul 18, 2022 @ 10:39:09.040 | panic: runtime error: invalid memory address or nil pointer dereference

  | Jul 18, 2022 @ 10:39:09.034 | statusUpdates: can not retrieve post 1qaxkj4ix7gsi8j3efxiq1qd6o: not found
``` 


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45799

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated
