### PR TITLE
LHS: remove experimental checks (e.g. narrow-width runs/playbooks)

### DIFF
--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -7,7 +7,7 @@ import {Team} from '@mattermost/types/teams';
 import React, {useRef, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
-import styled, {css} from 'styled-components';
+import styled from 'styled-components';
 
 import {Redirect} from 'react-router-dom';
 
@@ -23,7 +23,6 @@ import {SortableColHeader} from 'src/components/sortable_col_header';
 import {BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
 import {
     useCanCreatePlaybooksOnAnyTeam,
-    useExperimentalFeaturesEnabled,
     usePlaybooksCrud,
     usePlaybooksRouting,
 } from 'src/hooks';
@@ -47,11 +46,7 @@ import useConfirmPlaybookArchiveModal from './archive_playbook_modal';
 import NoContentPage from './playbook_list_getting_started';
 import useConfirmPlaybookRestoreModal from './restore_playbook_modal';
 
-const ContainerMedium = styled.article<{$newLHSEnabled: boolean}>`
-    ${({$newLHSEnabled}) => !$newLHSEnabled && css`
-        margin: 0 auto;
-        max-width: 1160px;
-    `}
+const ContainerMedium = styled.article`
     padding: 0 20px;
     scroll-margin-top: 20px;
 `;
@@ -60,13 +55,9 @@ const PlaybookListContainer = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.9);
 `;
 
-const TableContainer = styled.div<{$newLHSEnabled: boolean;}>`
+const TableContainer = styled.div`
     overflow-x: hidden;
     overflow-x: clip;
-    ${({$newLHSEnabled}) => !$newLHSEnabled && css`
-        margin: 0 auto;
-        max-width: 1160px;
-    `}
 `;
 
 const CreatePlaybookHeader = styled(BackstageSubheader)`
@@ -143,8 +134,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
 
     const {view, edit} = usePlaybooksRouting<Playbook>({onGo: setSelectedPlaybook});
 
-    const newLHSEnabled = useExperimentalFeaturesEnabled();
-
     const hasPlaybooks = Boolean(playbooks?.length);
 
     if (props.firstTimeUserExperience && hasPlaybooks) {
@@ -208,7 +197,7 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
         };
 
         return (
-            <TableContainer $newLHSEnabled={newLHSEnabled}>
+            <TableContainer>
                 <Header
                     data-testid='titlePlaybook'
                     level={2}
@@ -336,7 +325,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                 <>
                     <ContainerMedium
                         ref={selectorRef}
-                        $newLHSEnabled={newLHSEnabled}
                     >
                         {props.firstTimeUserExperience || (!hasPlaybooks && !isFiltering) ? (
                             <AltCreatePlaybookHeader>

--- a/webapp/src/components/backstage/runs_page.tsx
+++ b/webapp/src/components/backstage/runs_page.tsx
@@ -3,7 +3,7 @@
 
 import React, {useEffect, useState} from 'react';
 
-import styled, {css} from 'styled-components';
+import styled from 'styled-components';
 
 import {Redirect} from 'react-router-dom';
 
@@ -17,7 +17,7 @@ import {clientHasPlaybooks, fetchPlaybookRuns} from 'src/client';
 
 import {BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
 
-import {useExperimentalFeaturesEnabled, useRunsList} from 'src/hooks';
+import {useRunsList} from 'src/hooks';
 
 import {pluginUrl} from 'src/browser_routing';
 
@@ -38,17 +38,12 @@ const defaultPlaybookFetchParams = {
         .map((opt) => opt.value),
 };
 
-const RunListContainer = styled.div<{$newLHSEnabled: boolean;}>`
+const RunListContainer = styled.div`
     flex: 1 1 auto;
-	${({$newLHSEnabled}) => !$newLHSEnabled && css`
-        margin: 0 auto;
-        max-width: 1160px;
-    `}
 `;
 
 const RunsPage = () => {
     const {formatMessage} = useIntl();
-    const newLHSEnabled = useExperimentalFeaturesEnabled();
     const [playbookRuns, totalCount, fetchParams, setFetchParams] = useRunsList(defaultPlaybookFetchParams);
     const [showNoPlaybookRuns, setShowNoPlaybookRuns] = useState<boolean | null>(null);
     const [noPlaybooks, setNoPlaybooks] = useState<boolean | null>(null);
@@ -80,7 +75,7 @@ const RunsPage = () => {
     }
 
     return (
-        <RunListContainer $newLHSEnabled={newLHSEnabled}>
+        <RunListContainer>
             <Header
                 data-testid='titlePlaybookRun'
                 level={2}


### PR DESCRIPTION
#### Summary
Removes final remaining experimental flag checks to restore full-width Playbooks List and Runs List.

#### Ticket Link
None

#### Checklist
<!-- Mark items as `Y` they are completed. `NA` items if they don't apply -->
Item | Y / N / NA [^1]
---|---
Telemetry updated? | N
Gated by experimental feature flag? | Not anymore
Unit/E2E tests updated? | N

[^1]: Yes / No / Not Applicable.