### PR TITLE
channel displayname for RDP RHS  info

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
@@ -143,6 +143,9 @@ describe('runs > run details page > run info', () => {
             });
 
             it('click channel link navigates to run\'s channel', () => {
+                // * Assert channel name
+                getOverviewEntry('channel').contains('the run name');
+
                 // # Click on channel item
                 getOverviewEntry('channel').click();
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
@@ -8,6 +8,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {AccountPlusOutlineIcon, UpdateIcon, InformationOutlineIcon, LightningBoltOutlineIcon, StarOutlineIcon, StarIcon} from '@mattermost/compass-icons/components';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {joinChannel} from 'mattermost-redux/actions/channels';
+import {Channel} from '@mattermost/types/channels';
 
 import {PrimaryButton} from 'src/components/assets/buttons';
 import CopyLink from 'src/components/widgets/copy_link';
@@ -17,7 +18,7 @@ import {
     requestGetInvolved,
     telemetryEventForPlaybookRun,
 } from 'src/client';
-import {useChannel, useFavoriteRun} from 'src/hooks';
+import {useFavoriteRun} from 'src/hooks';
 import {PlaybookRun, Metadata as PlaybookRunMetadata} from 'src/types/playbook_run';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {Role, Badge, ExpandRight} from 'src/components/backstage/playbook_runs/shared';
@@ -37,17 +38,17 @@ interface Props {
     playbookRunMetadata: PlaybookRunMetadata | null;
     playbookRun: PlaybookRun;
     role: Role;
+    channel: Channel | undefined | null;
     onInfoClick: () => void;
     onTimelineClick: () => void;
     rhsSection: RHSContent | null;
 }
 
-export const RunHeader = ({playbookRun, playbookRunMetadata, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
+export const RunHeader = ({playbookRun, playbookRunMetadata, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const [showGetInvolvedConfirm, setShowGetInvolvedConfirm] = useState(false);
     const currentUserId = useSelector(getCurrentUserId);
-    const channel = useChannel(playbookRun.channel_id);
     const addToast = useToaster().add;
     const [isFavoriteRun, toggleFavorite] = useFavoriteRun(playbookRun.team_id, playbookRun.id);
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -10,7 +10,7 @@ import {useLocation, useRouteMatch, Redirect} from 'react-router-dom';
 import {selectTeam} from 'mattermost-webapp/packages/mattermost-redux/src/actions/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
-import {usePlaybook, useRun, useRunMetadata, useRunStatusUpdates, FetchState} from 'src/hooks';
+import {usePlaybook, useRun, useChannel, useRunMetadata, useRunStatusUpdates, FetchState} from 'src/hooks';
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 import {pluginErrorUrl} from 'src/browser_routing';
 import {ErrorPageTypes} from 'src/constants';
@@ -80,6 +80,7 @@ const PlaybookRunDetails = () => {
     const playbook = usePlaybook(playbookRun?.playbook_id);
     const [metadata, metadataResult] = useRunMetadata(playbookRunId);
     const [statusUpdates] = useRunStatusUpdates(playbookRunId, [playbookRun?.status_posts.length]);
+    const channel = useChannel(playbookRun?.channel_id ?? '');
     const myUser = useSelector(getCurrentUser);
 
     const RHS = useRHS(playbookRun);
@@ -146,6 +147,7 @@ const PlaybookRunDetails = () => {
                 playbook={playbook ?? undefined}
                 runMetadata={metadata ?? undefined}
                 role={role}
+                channel={channel}
                 onViewParticipants={() => RHS.open(RHSContent.RunParticipants, formatMessage({defaultMessage: 'Participants'}), playbookRun.name, () => onViewInfo)}
                 onViewTimeline={() => RHS.open(RHSContent.RunTimeline, formatMessage({defaultMessage: 'Timeline'}), playbookRun.name, () => onViewInfo, false)}
             />
@@ -184,6 +186,7 @@ const PlaybookRunDetails = () => {
                         onInfoClick={onInfoClick}
                         onTimelineClick={onTimelineClick}
                         role={role}
+                        channel={channel}
                         rhsSection={RHS.isOpen ? RHS.section : null}
                     />
                 </Header>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import {Channel} from '@mattermost/types/channels';
 
 import RHSInfoOverview from 'src/components/backstage/playbook_runs/playbook_run/rhs_info_overview';
 import RHSInfoMetrics from 'src/components/backstage/playbook_runs/playbook_run/rhs_info_metrics';
@@ -10,12 +11,12 @@ import RHSInfoActivity from 'src/components/backstage/playbook_runs/playbook_run
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 import {PlaybookRun, PlaybookRunStatus, Metadata} from 'src/types/playbook_run';
 import {PlaybookWithChecklist} from 'src/types/playbook';
-
 interface Props {
     run: PlaybookRun;
     playbook?: PlaybookWithChecklist;
     runMetadata?: Metadata;
     role: Role;
+    channel: Channel | undefined | null;
     onViewParticipants: () => void;
     onViewTimeline: () => void;
 }
@@ -32,6 +33,7 @@ const RHSInfo = (props: Props) => {
                 runMetadata={props.runMetadata}
                 onViewParticipants={props.onViewParticipants}
                 editable={editable}
+                channel={props.channel}
             />
             <RHSInfoMetrics
                 runID={props.run.id}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -6,6 +6,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {Link} from 'react-router-dom';
 import {useIntl} from 'react-intl';
 import styled, {css} from 'styled-components';
+import {Channel} from '@mattermost/types/channels';
 
 import {AccountOutlineIcon, AccountMultipleOutlineIcon, BookOutlineIcon, BullhornOutlineIcon, ProductChannelsIcon, OpenInNewIcon} from '@mattermost/compass-icons/components';
 import {addChannelMember} from 'mattermost-redux/actions/channels';
@@ -30,10 +31,11 @@ interface Props {
     run: PlaybookRun;
     runMetadata?: Metadata;
     editable: boolean;
+    channel: Channel | undefined | null;
     onViewParticipants: () => void;
 }
 
-const RHSInfoOverview = ({run, runMetadata, editable, onViewParticipants}: Props) => {
+const RHSInfoOverview = ({run, channel, runMetadata, editable, onViewParticipants}: Props) => {
     const {formatMessage} = useIntl();
     const playbook = usePlaybook(run.playbook_id);
     const addToast = useToaster().add;
@@ -137,16 +139,16 @@ const RHSInfoOverview = ({run, runMetadata, editable, onViewParticipants}: Props
                     setSelectedUser(null);
                 }}
             />}
-            {runMetadata && editable && (
+            {channel && runMetadata && editable && (
                 <Item
                     id='runinfo-channel'
                     icon={ProductChannelsIcon}
                     name={formatMessage({defaultMessage: 'Channel'})}
-                    onClick={() => navigateToUrl(`/${runMetadata.team_name}/channels/${runMetadata.channel_name}`)}
+                    onClick={() => navigateToUrl(`/${runMetadata.team_name}/channels/${channel.name}`)}
                 >
-                    <ItemLink to={`/${runMetadata.team_name}/channels/${runMetadata.channel_name}`}>
+                    <ItemLink to={`/${runMetadata.team_name}/channels/${channel.name}`}>
                         <ItemContent >
-                            {runMetadata.channel_name}
+                            {channel.display_name}
                             <OpenInNewIcon
                                 size={14}
                                 color={'var(--button-bg)'}


### PR DESCRIPTION
#### Summary
Use chanel displayname instead of channel name in the RHS info.
- move useChannel to playbookRun
- pass channel from playbookRun to RHSinfo and header (get involved) 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45856


#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
