### PR TITLE
add postid info to timeline event when requesting an update

### DIFF
--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -1199,6 +1199,8 @@ func TestRequestUpdate(t *testing.T) {
 		lastEvent := privateRun.TimelineEvents[len(privateRun.TimelineEvents)-1]
 		assert.Equal(t, client.StatusUpdateRequested, lastEvent.EventType)
 		assert.Equal(t, e.RegularUser2.Id, lastEvent.SubjectUserID)
+		assert.Equal(t, e.RegularUser2.Id, lastEvent.CreatorUserID)
+		assert.NotZero(t, lastEvent.PostID)
 		assert.Equal(t, "@playbooksuser2 requested a status update", lastEvent.Summary)
 	})
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2689,18 +2689,21 @@ func (s *PlaybookRunServiceImpl) RequestUpdate(playbookRunID, requesterID string
 	data := map[string]interface{}{
 		"Name": requesterUser.Username,
 	}
-	if _, err = s.poster.PostMessage(playbookRun.ChannelID, T("app.user.run.request_update", data)); err != nil {
+
+	post, err := s.poster.PostMessage(playbookRun.ChannelID, T("app.user.run.request_update", data))
+	if err != nil {
 		return errors.Wrap(err, "failed to post to channel")
 	}
 
 	// create timeline event
-	eventTime := model.GetMillis()
 	event := &TimelineEvent{
 		PlaybookRunID: playbookRunID,
-		CreateAt:      eventTime,
-		EventAt:       eventTime,
+		CreateAt:      post.CreateAt,
+		EventAt:       post.CreateAt,
 		EventType:     StatusUpdateRequested,
+		PostID:        post.Id,
 		SubjectUserID: requesterID,
+		CreatorUserID: requesterID,
 		Summary:       fmt.Sprintf("@%s requested a status update", requesterUser.Username),
 	}
 


### PR DESCRIPTION
#### Summary
We create an event for run timeline when a status update is requested. We want to additionally link the post sent to the channel so we can navigate from timeline to channel (just participants).

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45851

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
