### PR TITLE
prevent long commands to get to the edge in checklist

### DIFF
--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -472,6 +472,7 @@ const Row = styled.div`
 
     margin-left: 35px;
     margin-top: 8px;
+    margin-right: 10px;
 `;
 
 const ItemContainer = styled.div<{editing: boolean, $disabled: boolean, hoverMenuItemOpen: boolean}>`


### PR DESCRIPTION

#### Summary
Long commands use all space until the edge of the checklist, add a margin-right to prevent it.

|before|after|
|--------|----------|
|![Screenshot 2022-07-20 at 12 33 26](https://user-images.githubusercontent.com/4096774/179962817-a6390a02-d770-4fbf-9c5d-714d2e8716e7.png)|![Screenshot 2022-07-20 at 12 35 16](https://user-images.githubusercontent.com/4096774/179962765-e99bf274-c8da-416e-96ec-48d81829b3c9.png) |
|![Screenshot 2022-07-20 at 12 33 06](https://user-images.githubusercontent.com/4096774/179963083-4acfc148-9624-4529-8aa5-0431801dead0.png)| ![Screenshot 2022-07-20 at 12 32 07](https://user-images.githubusercontent.com/4096774/179963118-332f191c-c706-49ac-bb4f-922984921538.png) |




#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45727

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
