### PR TITLE
Collapse categories

### DIFF
--- a/server/api/categories.go
+++ b/server/api/categories.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/bot"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -42,6 +43,7 @@ func NewCategoryHandler(router *mux.Router, api *pluginapi.Client, logger bot.Lo
 	categoryRouter := categoriesRouter.PathPrefix("/{id:[A-Za-z0-9]+}").Subrouter()
 	categoryRouter.HandleFunc("", handler.updateMyCategory).Methods(http.MethodPut)
 	categoryRouter.HandleFunc("", handler.deleteMyCategory).Methods(http.MethodDelete)
+	categoryRouter.HandleFunc("/collapse", handler.collapseMyCategory).Methods(http.MethodPost)
 
 	return handler
 }
@@ -146,6 +148,50 @@ func (h *CategoryHandler) updateMyCategory(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := h.categoryService.Update(category); err != nil {
+		h.HandleError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *CategoryHandler) collapseMyCategory(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	categoryID := vars["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var collapsed bool
+	if err := json.NewDecoder(r.Body).Decode(&collapsed); err != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode collapsed", err)
+		return
+	}
+
+	// verify if category belongs to the user
+	existingCategory, err := h.categoryService.Get(categoryID)
+	if err != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Can't get category", err)
+		return
+	}
+
+	if existingCategory.DeleteAt != 0 {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Category deleted", nil)
+		return
+	}
+
+	if existingCategory.UserID != userID {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "UserID mismatch", nil)
+		return
+	}
+
+	if existingCategory.Collapsed == collapsed {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Collapsed state is not changed", nil)
+		return
+	}
+
+	patchedCategory := existingCategory
+	patchedCategory.Collapsed = collapsed
+	patchedCategory.UpdateAt = model.GetMillis()
+
+	if err := h.categoryService.Update(patchedCategory); err != nil {
 		h.HandleError(w, err)
 		return
 	}

--- a/server/sqlstore/category.go
+++ b/server/sqlstore/category.go
@@ -164,6 +164,7 @@ func (c *categoryStore) Update(category app.Category) error {
 		Update("IR_Category").
 		Set("Name", category.Name).
 		Set("UpdateAt", category.UpdateAt).
+		Set("Collapsed", category.Collapsed).
 		Where(sq.Eq{"ID": category.ID})); err != nil {
 		return errors.Wrapf(err, "failed to update category with id '%s'", category.ID)
 	}

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -778,6 +778,14 @@ export const fetchMyCategories = async (teamID: string): Promise<Category[]> => 
     return data;
 };
 
+export const setCategoryCollapsed = async (categoryID: string, collapsed: boolean) => {
+    try {
+        return await doPost(`${apiUrl}/my_categories/${categoryID}/collapse`, collapsed);
+    } catch (error) {
+        return {error};
+    }
+};
+
 export const doGet = async <TData = any>(url: string) => {
     const {data} = await doFetchWithResponse<TData>(url, {method: 'get'});
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -780,7 +780,7 @@ export const fetchMyCategories = async (teamID: string): Promise<Category[]> => 
 
 export const setCategoryCollapsed = async (categoryID: string, collapsed: boolean) => {
     try {
-        return await doPost(`${apiUrl}/my_categories/${categoryID}/collapse`, collapsed);
+        return await doPut(`${apiUrl}/my_categories/${categoryID}/collapse`, collapsed);
     } catch (error) {
         return {error};
     }

--- a/webapp/src/components/sidebar/group.tsx
+++ b/webapp/src/components/sidebar/group.tsx
@@ -1,23 +1,37 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, {useState} from 'react';
+import styled, {css} from 'styled-components';
+
+import {setCategoryCollapsed} from 'src/client';
 
 import {SidebarGroup} from './sidebar';
 import ItemComponent from './item';
+import {PlaybooksCategoryName, RunsCategoryName} from './playbooks_sidebar';
 
 interface GroupProps {
     group: SidebarGroup;
-    onClick: () => void;
 }
 
 const Group = (props: GroupProps) => {
+    const [collapsed, setCollapsed] = useState(props.group.collapsed);
+
     return (
         <GroupContainer>
             <Header>
                 <HeaderButton
                     aria-label={props.group.display_name}
-                    onClick={props.onClick}
+                    onClick={() => {
+                        // Currently Runs category and Playbooks category are automatically generated and
+                        // not saved in the DB. So we can't yet save the collapse state for these categories.
+                        if (props.group.id !== RunsCategoryName && props.group.id !== PlaybooksCategoryName) {
+                            setCategoryCollapsed(props.group.id, !collapsed);
+                        }
+                        setCollapsed(!collapsed);
+                    }}
                 >
-                    <i className='icon icon-chevron-down'/>
+                    <Chevron
+                        className='icon icon-chevron-down'
+                        isCollapsed={collapsed}
+                    />
                     <HeaderName>
                         {props.group.display_name}
                     </HeaderName>
@@ -34,7 +48,7 @@ const Group = (props: GroupProps) => {
                             className={item.className}
                             display_name={item.display_name}
                             icon={item.icon}
-                            isCollapsed={props.group.collapsed}
+                            isCollapsed={collapsed}
                             itemMenu={item.itemMenu}
                             link={item.link}
                         />
@@ -47,6 +61,15 @@ const Group = (props: GroupProps) => {
 };
 
 export default Group;
+
+const Chevron = styled.i<{isCollapsed?: boolean}>`
+    ${(props) => props.isCollapsed && css`
+        -webkit-transform: rotate(-90deg);
+        -ms-transform: rotate(-90deg);
+        transform: rotate(-90deg);
+        transition: transform 0.15s ease-out; /* should match collapse animation speed */
+    `};
+`;
 
 const GroupContainer = styled.div`
     box-sizing: border-box;

--- a/webapp/src/components/sidebar/item.tsx
+++ b/webapp/src/components/sidebar/item.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {NavLink} from 'react-router-dom';
 
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 interface ItemProps {
     icon: React.ReactNode;
@@ -16,7 +16,7 @@ interface ItemProps {
 
 const Item = (props: ItemProps) => {
     return (
-        <ItemContainer>
+        <ItemContainer isCollapsed={props.isCollapsed}>
             <StyledNavLink
                 className={props.className}
                 id={`sidebarItem_${props.id}`}
@@ -55,7 +55,7 @@ export const Icon = styled.div`
     color: rgba(var(--sidebar-text-rgb), 0.72);
 `;
 
-export const ItemContainer = styled.li`
+export const ItemContainer = styled.li<{isCollapsed?: boolean}>`
     display: flex;
     overflow: hidden;
     height: 32px;
@@ -65,6 +65,10 @@ export const ItemContainer = styled.li`
     opacity: 1;
     transition: height 0.18s ease;
     visibility: visible;
+
+    ${(props) => props.isCollapsed && css`
+        height: 0px;
+    `};
 `;
 
 export const StyledNavLink = styled(NavLink)`

--- a/webapp/src/components/sidebar/playbooks_sidebar.tsx
+++ b/webapp/src/components/sidebar/playbooks_sidebar.tsx
@@ -15,6 +15,9 @@ import Sidebar, {GroupItem, SidebarGroup} from './sidebar';
 import CreatePlaybookDropdown from './create_playbook_dropdown';
 import {ItemContainer, StyledNavLink, ItemDisplayLabel} from './item';
 
+export const RunsCategoryName = 'runsCategory';
+export const PlaybooksCategoryName = 'playbooksCategory';
+
 const PlaybooksSidebar = () => {
     const teamID = useSelector(getCurrentTeamId);
     const categories = useCategories(teamID);
@@ -53,9 +56,9 @@ const PlaybooksSidebar = () => {
 
     const addViewAllsToGroups = (groups: SidebarGroup[]) => {
         for (let i = 0; i < groups.length; i++) {
-            if (groups[i].id === 'runsCategory') {
+            if (groups[i].id === RunsCategoryName) {
                 groups[i].afterGroup = viewAllRuns();
-            } else if (groups[i].id === 'playbooksCategory') {
+            } else if (groups[i].id === PlaybooksCategoryName) {
                 groups[i].afterGroup = viewAllPlaybooks();
             }
         }
@@ -105,7 +108,6 @@ const PlaybooksSidebar = () => {
         <Sidebar
             groups={groups}
             headerDropdown={<CreatePlaybookDropdown team_id={teamID}/>}
-            onGroupClick={() => {/*empty*/}}
             team_id={teamID}
         />
     );

--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -35,7 +35,6 @@ export interface SidebarGroup {
 interface SidebarProps {
     team_id: string;
     groups: Array<SidebarGroup>;
-    onGroupClick: (groupId: string) => void;
     headerDropdown: React.ReactNode;
 }
 
@@ -82,9 +81,6 @@ const Sidebar = (props: SidebarProps) => {
                         <Group
                             key={group.id}
                             group={group}
-                            onClick={() => {
-                                props.onGroupClick(group.id);
-                            }}
                         />
                     );
                 })}


### PR DESCRIPTION


#### Summary
This PR will support collapsing categories. 
Currently we do not save `RUNS` and `Playbooks` categories in the DB(we generate them), so this PR does not add the possibility to save collapsed state for those 2 categories. For other categories everything works fine.

If you collapse `RUNS` or `PLAYBOOKS` and refresh they will appear expanded. If this is not usable, I'll add the collapsed state for those too.

https://user-images.githubusercontent.com/2340127/180065696-ac0f76d2-7a46-450e-8d91-dfc39b893c41.mp4


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
