### PR TITLE
extract from redux event filters

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -12,7 +12,7 @@ import {getCurrentChannelId} from 'mattermost-webapp/packages/mattermost-redux/s
 
 import {PlaybookRun} from 'src/types/playbook_run';
 import {selectToggleRHS, canIPostUpdateForRun} from 'src/selectors';
-import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
+import {RHSState} from 'src/types/rhs';
 import {
     PLAYBOOK_RUN_CREATED,
     PLAYBOOK_RUN_UPDATED,
@@ -25,11 +25,9 @@ import {
     REMOVED_FROM_CHANNEL,
     RemovedFromChannel,
     SET_CLIENT_ID,
-    SET_PLAYBOOK_RUN_EVENTS_FILTER,
     SET_RHS_OPEN,
     SET_RHS_STATE,
     SetClientId,
-    SetPlaybookRunEventsFilter,
     SetRHSOpen,
     SetRHSState,
     SetTriggerId,
@@ -276,12 +274,6 @@ export const receivedTeamPlaybookRuns = (playbookRuns: PlaybookRun[]): ReceivedT
 export const removedFromPlaybookRunChannel = (channelId: string): RemovedFromChannel => ({
     type: REMOVED_FROM_CHANNEL,
     channelId,
-});
-
-export const setPlaybookRunEventsFilter = (playbookRunId: string, nextState: TimelineEventsFilter): SetPlaybookRunEventsFilter => ({
-    type: SET_PLAYBOOK_RUN_EVENTS_FILTER,
-    playbookRunId,
-    nextState,
 });
 
 export const actionSetGlobalSettings = (settings: GlobalSettings): ReceivedGlobalSettings => ({

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -82,9 +82,13 @@ const PlaybookRunDetails = () => {
     const [statusUpdates] = useRunStatusUpdates(playbookRunId, [playbookRun?.status_posts.length]);
     const channel = useChannel(playbookRun?.channel_id ?? '');
     const myUser = useSelector(getCurrentUser);
-    const {options, selectOption, eventsFilter} = useFilter();
+    const {options, selectOption, eventsFilter, resetFilters} = useFilter();
 
     const RHS = useRHS(playbookRun);
+
+    useUpdateEffect(() => {
+        resetFilters();
+    }, [playbookRunId]);
 
     useEffect(() => {
         const RHSUpdatesOpened = RHS.isOpen && RHS.section === RHSContent.RunStatusUpdates;
@@ -99,7 +103,6 @@ const PlaybookRunDetails = () => {
         if (!teamId) {
             return;
         }
-
         dispatch(selectTeam(teamId));
     }, [dispatch, playbookRun?.team_id]);
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -17,8 +17,8 @@ import {ErrorPageTypes} from 'src/constants';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {usePlaybookRunViewTelemetry} from 'src/hooks/telemetry';
 import {PlaybookRunViewTarget} from 'src/types/telemetry';
-
 import {useDefaultRedirectOnTeamChange} from 'src/components/backstage/main_body';
+import {useFilter} from 'src/components/backstage/playbook_runs/playbook_run/timeline_utils';
 
 import Summary from './summary';
 import {ParticipantStatusUpdate, ViewerStatusUpdate} from './status_update';
@@ -82,6 +82,7 @@ const PlaybookRunDetails = () => {
     const [statusUpdates] = useRunStatusUpdates(playbookRunId, [playbookRun?.status_posts.length]);
     const channel = useChannel(playbookRun?.channel_id ?? '');
     const myUser = useSelector(getCurrentUser);
+    const {options, selectOption, eventsFilter} = useFilter();
 
     const RHS = useRHS(playbookRun);
 
@@ -149,7 +150,10 @@ const PlaybookRunDetails = () => {
                 role={role}
                 channel={channel}
                 onViewParticipants={() => RHS.open(RHSContent.RunParticipants, formatMessage({defaultMessage: 'Participants'}), playbookRun.name, () => onViewInfo)}
-                onViewTimeline={() => RHS.open(RHSContent.RunTimeline, formatMessage({defaultMessage: 'Timeline'}), playbookRun.name, () => onViewInfo, false)}
+                onViewTimeline={() => {
+                    selectOption('all', true);
+                    RHS.open(RHSContent.RunTimeline, formatMessage({defaultMessage: 'Timeline'}), playbookRun.name, () => onViewInfo, false);
+                }}
             />
         );
         break;
@@ -166,6 +170,9 @@ const PlaybookRunDetails = () => {
             <RHSTimeline
                 playbookRun={playbookRun}
                 role={role}
+                options={options}
+                selectOption={selectOption}
+                eventsFilter={eventsFilter}
             />
         );
         break;

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
@@ -15,22 +15,26 @@ import {renderThumbVertical, renderTrackHorizontal, renderView} from '../../../r
 import TimelineEventItem from 'src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {clientRemoveTimelineEvent} from 'src/client';
-import MultiCheckbox from 'src/components/multi_checkbox';
+import MultiCheckbox, {CheckboxOption} from 'src/components/multi_checkbox';
 import {Role} from 'src/components/backstage/playbook_runs/shared';
-import {useTimelineEvents, useFilter} from 'src/components/backstage/playbook_runs/playbook_run/timeline_utils';
+import {useTimelineEvents} from 'src/components/backstage/playbook_runs/playbook_run/timeline_utils';
+import {TimelineEventsFilter} from 'src/types/rhs';
 
 interface Props {
     playbookRun: PlaybookRun;
     role: Role;
+    options: CheckboxOption[];
+    selectOption: (value: string, checked: boolean) => void;
+    eventsFilter: TimelineEventsFilter;
 }
 
-const RHSTimeline = ({playbookRun, role}: Props) => {
+const RHSTimeline = ({playbookRun, role, options, selectOption, eventsFilter}: Props) => {
     const {formatMessage} = useIntl();
     const channelNamesMap = useSelector(getChannelsNameMapInCurrentTeam);
     const team = useSelector((state: GlobalState) => getTeam(state, playbookRun.team_id));
 
-    const {options, selectOption} = useFilter(playbookRun);
-    const [filteredEvents] = useTimelineEvents(playbookRun);
+    // const {options, selectOption, eventsFilter} = useFilter(playbookRun);
+    const [filteredEvents] = useTimelineEvents(playbookRun, eventsFilter);
 
     return (
         <Container data-testid='timeline-view'>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
@@ -33,7 +33,6 @@ const RHSTimeline = ({playbookRun, role, options, selectOption, eventsFilter}: P
     const channelNamesMap = useSelector(getChannelsNameMapInCurrentTeam);
     const team = useSelector((state: GlobalState) => getTeam(state, playbookRun.team_id));
 
-    // const {options, selectOption, eventsFilter} = useFilter(playbookRun);
     const [filteredEvents] = useTimelineEvents(playbookRun, eventsFilter);
 
     return (

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/timeline_utils.ts
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/timeline_utils.ts
@@ -85,6 +85,8 @@ export const useFilter = () => {
     const {formatMessage} = useIntl();
     const [eventsFilter, setEventsFilter] = useState<TimelineEventsFilter>(TimelineEventsFilterDefault);
 
+    const resetFilters = () => setEventsFilter(TimelineEventsFilterDefault);
+
     const selectOption = (value: string, checked: boolean) => {
         if (eventsFilter.all && value !== 'all') {
             return;
@@ -142,5 +144,5 @@ export const useFilter = () => {
             disabled: eventsFilter.all,
         },
     ];
-    return {options, selectOption, eventsFilter};
+    return {options, selectOption, eventsFilter, resetFilters};
 };

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/timeline_utils.ts
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/timeline_utils.ts
@@ -13,25 +13,22 @@ import {getUser as getUserAction} from 'mattermost-redux/actions/users';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
 
-import {TimelineEvent, TimelineEventsFilter, TimelineEventType} from 'src/types/rhs';
-import {eventsFilterForPlaybookRun} from 'src/selectors';
+import {TimelineEvent, TimelineEventsFilter, TimelineEventType, TimelineEventsFilterDefault} from 'src/types/rhs';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {CheckboxOption} from 'src/components/multi_checkbox';
-import {setPlaybookRunEventsFilter} from 'src/actions';
 
-export const useTimelineEvents = (playbookRun: PlaybookRun, eventsFilterOverride?: TimelineEventsFilter) => {
+export const useTimelineEvents = (playbookRun: PlaybookRun, eventsFilter: TimelineEventsFilter) => {
     const dispatch = useDispatch();
     const displayPreference = useSelector(getTeammateNameDisplaySetting) || 'username';
     const [allEvents, setAllEvents] = useState<TimelineEvent[]>([]);
     const [filteredEvents, setFilteredEvents] = useState<TimelineEvent[]>([]);
-    const eventsFilter = useSelector((state: GlobalState) => eventsFilterForPlaybookRun(state, playbookRun.id));
     const getStateFn = useStore().getState;
     const getUserFn = (userId: string) => getUserAction(userId)(dispatch as DispatchFunc, getStateFn);
     const selectUser = useSelector((state: GlobalState) => (userId: string) => getUser(state, userId));
 
     useEffect(() => {
-        setFilteredEvents(allEvents.filter((e) => showEvent(e.event_type, eventsFilterOverride || eventsFilter)));
-    }, [eventsFilter, eventsFilterOverride, allEvents]);
+        setFilteredEvents(allEvents.filter((e) => showEvent(e.event_type, eventsFilter)));
+    }, [eventsFilter, allEvents]);
 
     useEffect(() => {
         const {
@@ -84,20 +81,18 @@ const showEvent = (eventType: string, filter: TimelineEventsFilter) => {
     return filterRecord[eventType] || (filterRecord[TimelineEventType.StatusUpdated] && statusUpdateTypes.includes(eventType as TimelineEventType));
 };
 
-export const useFilter = (playbookRun: PlaybookRun) => {
+export const useFilter = () => {
     const {formatMessage} = useIntl();
-    const dispatch = useDispatch();
-    const eventsFilter = useSelector((state: GlobalState) => eventsFilterForPlaybookRun(state, playbookRun.id));
+    const [eventsFilter, setEventsFilter] = useState<TimelineEventsFilter>(TimelineEventsFilterDefault);
 
     const selectOption = (value: string, checked: boolean) => {
         if (eventsFilter.all && value !== 'all') {
             return;
         }
-
-        dispatch(setPlaybookRunEventsFilter(playbookRun.id, {
+        setEventsFilter({
             ...eventsFilter,
             [value]: checked,
-        }));
+        });
     };
 
     const options = [
@@ -147,5 +142,5 @@ export const useFilter = (playbookRun: PlaybookRun) => {
             disabled: eventsFilter.all,
         },
     ];
-    return {options, selectOption};
+    return {options, selectOption, eventsFilter};
 };

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_retro.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_retro.tsx
@@ -1,26 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useState} from 'react';
-import {useDispatch, useSelector, useStore} from 'react-redux';
+import React from 'react';
 import styled from 'styled-components';
 import {useIntl} from 'react-intl';
-
-import {GlobalState} from '@mattermost/types/store';
-import {UserProfile} from '@mattermost/types/users';
-import {displayUsername} from 'mattermost-redux/utils/user_utils';
-import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-import {getUser as getUserAction} from 'mattermost-redux/actions/users';
-import {DispatchFunc} from 'mattermost-redux/types/actions';
-import {getUser} from 'mattermost-redux/selectors/entities/users';
 
 import Timeline from 'src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {Content, TabPageContainer, Title} from 'src/components/backstage/playbook_runs/shared';
-import MultiCheckbox, {CheckboxOption} from 'src/components/multi_checkbox';
-import {TimelineEvent, TimelineEventsFilter, TimelineEventType} from 'src/types/rhs';
-import {setPlaybookRunEventsFilter} from 'src/actions';
-import {eventsFilterForPlaybookRun} from 'src/selectors';
+import MultiCheckbox from 'src/components/multi_checkbox';
+import {useTimelineEvents, useFilter} from 'src/components/backstage/playbook_runs/playbook_run/timeline_utils';
 
 const Header = styled.div`
     display: flex;
@@ -63,118 +52,16 @@ const TextContainer = styled.span`
     display: flex;
 `;
 
-type IdToUserFn = (userId: string) => UserProfile;
-
 interface Props {
     playbookRun: PlaybookRun;
     deleteTimelineEvent: (id: string) => void;
 }
 
 const TimelineRetro = (props: Props) => {
-    const dispatch = useDispatch();
-    const displayPreference = useSelector<GlobalState, string | undefined>(getTeammateNameDisplaySetting) || 'username';
-    const [allEvents, setAllEvents] = useState<TimelineEvent[]>([]);
-    const [filteredEvents, setFilteredEvents] = useState<TimelineEvent[]>([]);
-    const eventsFilter = useSelector<GlobalState, TimelineEventsFilter>((state) => eventsFilterForPlaybookRun(state, props.playbookRun.id));
-    const getStateFn = useStore().getState;
-    const getUserFn = (userId: string) => getUserAction(userId)(dispatch as DispatchFunc, getStateFn);
-    const selectUser = useSelector<GlobalState, IdToUserFn>((state) => (userId: string) => getUser(state, userId));
     const {formatMessage} = useIntl();
 
-    useEffect(() => {
-        setFilteredEvents(allEvents.filter((e) => showEvent(e.event_type, eventsFilter)));
-    }, [eventsFilter, allEvents]);
-
-    useEffect(() => {
-        const {
-            status_posts: statuses,
-            timeline_events: events,
-        } = props.playbookRun;
-        const statusDeleteAtByPostId = statuses.reduce<{[id: string]: number}>((map, post) => {
-            if (post.delete_at !== 0) {
-                map[post.id] = post.delete_at;
-            }
-
-            return map;
-        }, {});
-        Promise.all(events.map(async (event) => {
-            let user = selectUser(event.subject_user_id) as UserProfile | undefined;
-
-            if (!user) {
-                const ret = await getUserFn(event.subject_user_id) as { data?: UserProfile, error?: any };
-                if (!ret.data) {
-                    return null;
-                }
-                user = ret.data;
-            }
-            return {
-                ...event,
-                status_delete_at: statusDeleteAtByPostId[event.post_id] ?? 0,
-                subject_display_name: displayUsername(user, displayPreference),
-            } as TimelineEvent;
-        })).then((eventArray) => {
-            setAllEvents(eventArray.filter((e) => e) as TimelineEvent[]);
-        });
-    }, [props.playbookRun.timeline_events, displayPreference, props.playbookRun.status_posts]);
-
-    const selectOption = (value: string, checked: boolean) => {
-        if (eventsFilter.all && value !== 'all') {
-            return;
-        }
-
-        dispatch(setPlaybookRunEventsFilter(props.playbookRun.id, {
-            ...eventsFilter,
-            [value]: checked,
-        }));
-    };
-
-    const filterOptions = [
-        {
-            display: formatMessage({defaultMessage: 'All events'}),
-            value: 'all',
-            selected: eventsFilter.all,
-            disabled: false,
-        },
-        {
-            value: 'divider',
-        } as CheckboxOption,
-        {
-            display: formatMessage({defaultMessage: 'Role changes'}),
-            value: TimelineEventType.OwnerChanged,
-            selected: eventsFilter.owner_changed,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: formatMessage({defaultMessage: 'Status updates'}),
-            value: TimelineEventType.StatusUpdated,
-            selected: eventsFilter.status_updated,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: formatMessage({defaultMessage: 'Saved messages'}),
-            value: TimelineEventType.EventFromPost,
-            selected: eventsFilter.event_from_post,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: formatMessage({defaultMessage: 'Task state changes'}),
-            value: TimelineEventType.TaskStateModified,
-            selected: eventsFilter.task_state_modified,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: formatMessage({defaultMessage: 'Task assignments'}),
-            value: TimelineEventType.AssigneeChanged,
-            selected: eventsFilter.assignee_changed,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: formatMessage({defaultMessage: 'Slash commands'}),
-            value: TimelineEventType.RanSlashCommand,
-            selected: eventsFilter.ran_slash_command,
-            disabled: eventsFilter.all,
-        },
-    ];
+    const {options, selectOption, eventsFilter} = useFilter();
+    const [filteredEvents] = useTimelineEvents(props.playbookRun, eventsFilter);
 
     return (
         <TabPageContainer>
@@ -182,7 +69,7 @@ const TimelineRetro = (props: Props) => {
                 <Title>{formatMessage({defaultMessage: 'Timeline'})}</Title>
                 <MultiCheckbox
                     dotMenuButton={FakeButton}
-                    options={filterOptions}
+                    options={options}
                     onselect={selectOption}
                     placement='bottom-end'
                     icon={
@@ -212,13 +99,3 @@ const TimelineRetro = (props: Props) => {
 
 export default TimelineRetro;
 
-const showEvent = (eventType: string, filter: TimelineEventsFilter) => {
-    if (filter.all) {
-        return true;
-    }
-    const filterRecord = filter as unknown as Record<string, boolean>;
-    return filterRecord[eventType] ||
-        (eventType === TimelineEventType.RunCreated && filterRecord[TimelineEventType.StatusUpdated]) ||
-        (eventType === TimelineEventType.RunFinished && filterRecord[TimelineEventType.StatusUpdated]) ||
-        (eventType === TimelineEventType.RunRestored && filterRecord[TimelineEventType.StatusUpdated]);
-};

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -7,7 +7,7 @@ import {Team} from '@mattermost/types/teams';
 import {Channel} from '@mattermost/types/channels';
 
 import {PlaybookRun} from 'src/types/playbook_run';
-import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
+import {RHSState} from 'src/types/rhs';
 import {
     RECEIVED_TOGGLE_RHS_ACTION,
     ReceivedToggleRHSAction,
@@ -25,8 +25,6 @@ import {
     PlaybookRunUpdated,
     PLAYBOOK_RUN_UPDATED,
     REMOVED_FROM_CHANNEL,
-    SetPlaybookRunEventsFilter,
-    SET_PLAYBOOK_RUN_EVENTS_FILTER,
     ReceivedGlobalSettings,
     RECEIVED_GLOBAL_SETTINGS,
     ShowPostMenuModal,
@@ -174,18 +172,6 @@ const myPlaybookRunsByTeam = (
     }
 };
 
-const eventsFilterByPlaybookRun = (state: Record<string, TimelineEventsFilter> = {}, action: SetPlaybookRunEventsFilter) => {
-    switch (action.type) {
-    case SET_PLAYBOOK_RUN_EVENTS_FILTER:
-        return {
-            ...state,
-            [action.playbookRunId]: action.nextState,
-        };
-    default:
-        return state;
-    }
-};
-
 const globalSettings = (state: GlobalSettings | null = null, action: ReceivedGlobalSettings) => {
     switch (action.type) {
     case RECEIVED_GLOBAL_SETTINGS:
@@ -312,7 +298,6 @@ const reducer = combineReducers({
     clientId,
     myPlaybookRunsByTeam,
     rhsState,
-    eventsFilterByPlaybookRun,
     globalSettings,
     postMenuModalVisibility,
     channelActionsModalVisibility,

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -27,7 +27,7 @@ import {Team} from 'mattermost-webapp/packages/mattermost-redux/src/types/teams'
 
 import {pluginId} from 'src/manifest';
 import {playbookRunIsActive, PlaybookRun} from 'src/types/playbook_run';
-import {RHSState, TimelineEventsFilter, TimelineEventsFilterDefault} from 'src/types/rhs';
+import {RHSState} from 'src/types/rhs';
 import {findLastUpdated} from 'src/utils';
 import {GlobalSettings} from 'src/types/settings';
 import {ChecklistItemsFilter, ChecklistItemsFilterDefault} from 'src/types/playbook';
@@ -159,10 +159,6 @@ export const myPlaybookRunsMap = (state: GlobalState) => {
 };
 
 export const currentRHSState = (state: GlobalState): RHSState => pluginState(state).rhsState;
-
-export const eventsFilterForPlaybookRun = (state: GlobalState, playbookRunId: string): TimelineEventsFilter => {
-    return pluginState(state).eventsFilterByPlaybookRun[playbookRunId] || TimelineEventsFilterDefault;
-};
 
 export const lastUpdatedByPlaybookRunId = createSelector(
     'lastUpdatedByPlaybookRunId',

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -4,7 +4,7 @@
 import Integrations from 'mattermost-redux/action_types/integrations';
 
 import {PlaybookRun} from 'src/types/playbook_run';
-import {RHSState, TimelineEventsFilter} from 'src/types/rhs';
+import {RHSState} from 'src/types/rhs';
 import {pluginId} from 'src/manifest';
 import {GlobalSettings} from 'src/types/settings';
 import {ChecklistItemsFilter} from 'src/types/playbook';
@@ -20,7 +20,6 @@ export const PLAYBOOK_RESTORED = pluginId + '_playbook_restored';
 export const RECEIVED_TEAM_PLAYBOOK_RUNS = pluginId + '_received_team_playbook_run_channels';
 export const REMOVED_FROM_CHANNEL = pluginId + '_removed_from_playbook_run_channel';
 export const SET_RHS_STATE = pluginId + '_set_rhs_state';
-export const SET_PLAYBOOK_RUN_EVENTS_FILTER = pluginId + '_set_playbook_run_events_filter';
 export const RECEIVED_GLOBAL_SETTINGS = pluginId + '_received_global_settings';
 export const SHOW_POST_MENU_MODAL = pluginId + '_show_post_menu_modal';
 export const HIDE_POST_MENU_MODAL = pluginId + '_hide_post_menu_modal';
@@ -93,12 +92,6 @@ export interface RemovedFromChannel {
 export interface SetRHSState {
     type: typeof SET_RHS_STATE;
     nextState: RHSState;
-}
-
-export interface SetPlaybookRunEventsFilter {
-    type: typeof SET_PLAYBOOK_RUN_EVENTS_FILTER;
-    playbookRunId: string;
-    nextState: TimelineEventsFilter;
 }
 
 export interface ReceivedGlobalSettings {

--- a/webapp/src/types/rhs.ts
+++ b/webapp/src/types/rhs.ts
@@ -56,7 +56,7 @@ export const TimelineEventsFilterDefault = {
     owner_changed: true,
     status_updated: true,
     event_from_post: true,
-    task_state_modified: false,
+    task_state_modified: true,
     assignee_changed: false,
     ran_slash_command: false,
     user_joined_left: false,


### PR DESCRIPTION
#### Summary
The main goal of this task is to be coherent when navigating from recent activity to RHS timeline. We were navigating from partial to complete information, having actually less events (due to filters)

To fix that, several actions have been addressed:
- extract feature from redux, the main component handles the filter state. if you reload the page, you lose the state and have the default.
- when navigating from recent activity "all" filter is automatically enabled 
- tasks events are visible by default
- if you change run in LHS, filters are reset

2/5 on the behavior. With this change, we keep the "all" filter after navigating through recent activity. We could, in addition to that, revert to previous filters if wanted (with some internal double state).

Note that a big part of this PR is fixing the code that is not being used anymore. Don't be scared about the removed code in the playbook_runs_backstage folder. I had to migrate it to be compliant with the redux removal.


![CleanShot 2022-07-21 at 15 56 29](https://user-images.githubusercontent.com/4096774/180231729-4f1520d2-7c23-4840-8d33-22ffc36f4a49.gif)

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45896

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
