### PR TITLE
remove unneeded team selector from import flow

### DIFF
--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -1,9 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
-import {GlobalState} from '@mattermost/types/store';
-import {Team} from '@mattermost/types/teams';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import React, {useRef, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
@@ -37,8 +35,6 @@ import {importFile} from 'src/client';
 import {pluginUrl} from 'src/browser_routing';
 
 import Header from '../widgets/header';
-
-import TeamSelector from '../team/team_selector';
 
 import CheckboxInput from './runs_list/checkbox_input';
 
@@ -117,10 +113,9 @@ const PlaybooksListFilters = styled.div`
 const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
     const {formatMessage} = useIntl();
     const canCreatePlaybooks = useCanCreatePlaybooksOnAnyTeam();
-    const teams = useSelector<GlobalState, Team[]>(getMyTeams);
+    const teamId = useSelector(getCurrentTeamId);
     const content = useRef<JSX.Element | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
-    const [importTargetTeam, setImportTargetTeam] = useState('');
     const selectorRef = useRef<HTMLDivElement>(null);
 
     const [
@@ -156,7 +151,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
             <PlaybookListRow
                 key={p.id}
                 playbook={p}
-                displayTeam={teams.length > 1}
                 onClick={() => view(p)}
                 onEdit={() => edit(p)}
                 onRestore={() => openConfirmRestoreModal({id: p.id, title: p.title})}
@@ -181,12 +175,6 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
         const importUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
             if (e.target.files && e.target.files[0]) {
                 const file = e.target.files[0];
-                let teamId = teams[0].id;
-
-                if (teams.length !== 1) {
-                    teamId = importTargetTeam;
-                }
-
                 const reader = new FileReader();
                 reader.onload = async (ev) => {
                     const {id} = await importFile(ev?.target?.result, teamId);
@@ -205,31 +193,15 @@ const PlaybookList = (props: {firstTimeUserExperience?: boolean}) => {
                     subtitle={formatMessage({defaultMessage: 'All the playbooks that you can access will show here'})}
                     right={(
                         <TitleActions>
-                            {teams.length > 1 && (
-                                <TeamSelector
-                                    placeholder={<ImportButton/>}
-                                    onlyPlaceholder={true}
-                                    enableEdit={true}
-                                    teams={teams}
-                                    onSelectedChange={(teamId: string) => {
-                                        setImportTargetTeam(teamId);
-                                        if (fileInputRef && fileInputRef.current) {
-                                            fileInputRef.current.click();
-                                        }
-                                    }}
-                                />
-                            )}
-                            {teams.length <= 1 && (
-                                <ImportButton
-                                    onClick={() => {
-                                        if (fileInputRef && fileInputRef.current) {
-                                            fileInputRef.current.click();
-                                        }
-                                    }}
-                                />
-                            )}
                             {canCreatePlaybooks && (
                                 <>
+                                    <ImportButton
+                                        onClick={() => {
+                                            if (fileInputRef && fileInputRef.current) {
+                                                fileInputRef.current.click();
+                                            }
+                                        }}
+                                    />
                                     <HorizontalSpacer size={12}/>
                                     <PlaybookModalButton/>
                                 </>

--- a/webapp/src/components/backstage/playbook_list_row.tsx
+++ b/webapp/src/components/backstage/playbook_list_row.tsx
@@ -24,7 +24,6 @@ import {InfoLine} from './styles';
 
 interface Props {
     playbook: Playbook
-    displayTeam: boolean
     onClick: () => void
     onEdit: () => void
     onArchive: () => void
@@ -101,10 +100,6 @@ const PlaybookListRow = (props: Props) => {
                 <ArchiveIcon className='icon icon-archive-outline'/>
             </Tooltip>
         ));
-    }
-
-    if (props.displayTeam) {
-        infos.push((<>{teamName}</>));
     }
 
     const [exportHref, exportFilename] = playbookExportProps(props.playbook);


### PR DESCRIPTION
#### Summary
This was a piece left over from #1327.

- [x] Remove: `playbook_list` Import flow team selector 
<img width="316" alt="CleanShot 2022-07-22 at 16 25 48@2x" src="https://user-images.githubusercontent.com/11724372/180571016-2a2d58ae-97e6-4326-9bac-7e5a0b57346f.png">

![CleanShot 2022-07-22 at 16 26 47](https://user-images.githubusercontent.com/11724372/180571042-3b1baed9-2668-431f-8f36-438551d51617.gif)

#### Ticket Link
None

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
