### PR TITLE
Honour MetricsSettings.Enable

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -265,7 +265,6 @@ func (p *Plugin) OnActivate() error {
 
 	enableMetrics := p.API.GetConfig().MetricsSettings.Enable
 	if enableMetrics != nil && *enableMetrics {
-
 		// run metrics server to expose data
 		p.runMetricsServer()
 		// run metrics updater recurring task

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -263,12 +263,17 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrapf(err, "failed register commands")
 	}
 
-	// run metrics server to expose data
-	p.runMetricsServer()
-	// run metrics updater recurring task
-	p.runMetricsUpdaterTask(playbookStore, playbookRunStore, updateMetricsTaskFrequency)
-	// set error counter middleware handler
-	p.handler.APIRouter.Use(p.getErrorCounterHandler())
+	enableMetrics := p.API.GetConfig().MetricsSettings.Enable
+	if enableMetrics != nil && *enableMetrics {
+		p.pluginAPI.Log.Error("Metrics server could not be started", "Error", err)
+
+		// run metrics server to expose data
+		p.runMetricsServer()
+		// run metrics updater recurring task
+		p.runMetricsUpdaterTask(playbookStore, playbookRunStore, updateMetricsTaskFrequency)
+		// set error counter middleware handler
+		p.handler.APIRouter.Use(p.getErrorCounterHandler())
+	}
 
 	// prevent a recursive OnConfigurationChange
 	go func() {
@@ -332,6 +337,8 @@ func (p *Plugin) newMetricsInstance() *metrics.Metrics {
 }
 
 func (p *Plugin) runMetricsServer() {
+	p.pluginAPI.Log.Info("Starting Playbooks metrics server", "port", metricsExposePort)
+
 	metricServer := metrics.NewMetricsServer(metricsExposePort, p.metricsService, &p.pluginAPI.Log)
 	// Run server to expose metrics
 	go func() {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -265,7 +265,6 @@ func (p *Plugin) OnActivate() error {
 
 	enableMetrics := p.API.GetConfig().MetricsSettings.Enable
 	if enableMetrics != nil && *enableMetrics {
-		p.pluginAPI.Log.Error("Metrics server could not be started", "Error", err)
 
 		// run metrics server to expose data
 		p.runMetricsServer()


### PR DESCRIPTION
#### Summary
Honour `MetricsSettings.Enable` to at least allow turning off prometheus metrics if undesired. A more holistic, upcoming change will integrate plugin metrics directly with the server to avoid even opening a separate port.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-plugin-playbooks/issues/1359