### PR TITLE
share follower state between rhs and main + leave-run copies accuracy

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
@@ -29,14 +29,15 @@ interface Props {
     playbookRun: PlaybookRun;
     role: Role;
     isFavoriteRun: boolean;
+    isFollowing: boolean;
     toggleFavorite: () => void;
 }
 
-export const ContextMenu = ({playbookRun, role, isFavoriteRun, toggleFavorite}: Props) => {
+export const ContextMenu = ({playbookRun, role, isFavoriteRun, isFollowing, toggleFavorite}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const {add: addToast} = useToaster();
-    const {leaveRunConfirmModal, showLeaveRunConfirm} = useLeaveRun(playbookRun);
+    const {leaveRunConfirmModal, showLeaveRunConfirm} = useLeaveRun(playbookRun, isFollowing);
     const exportAvailable = useExportLogAvailable();
     const allowChannelExport = useAllowChannelExport();
     const [showModal, setShowModal] = useState(false);
@@ -114,7 +115,10 @@ export const ContextMenu = ({playbookRun, role, isFavoriteRun, toggleFavorite}: 
                         <Separator/>
                         <StyledDropdownMenuItemRed onClick={showLeaveRunConfirm}>
                             <CloseIcon size={18}/>
-                            <FormattedMessage defaultMessage='Leave and unfollow run'/>
+                            <FormattedMessage
+                                defaultMessage='Leave {isFollowing, select, true { and unfollow } other {}}run'
+                                values={{isFollowing}}
+                            />
                         </StyledDropdownMenuItemRed>
                     </>
                 }
@@ -129,7 +133,7 @@ export const ContextMenu = ({playbookRun, role, isFavoriteRun, toggleFavorite}: 
     );
 };
 
-const useLeaveRun = (playbookRun: PlaybookRun) => {
+const useLeaveRun = (playbookRun: PlaybookRun, isFollowing: boolean) => {
     const {formatMessage} = useIntl();
     const currentUserId = useSelector(getCurrentUserId);
     const addToast = useToaster().add;
@@ -149,8 +153,8 @@ const useLeaveRun = (playbookRun: PlaybookRun) => {
     const leaveRunConfirmModal = (
         <ConfirmModal
             show={showLeaveRunConfirm}
-            title={formatMessage({defaultMessage: 'Confirm leave and unfollow'})}
-            message={formatMessage({defaultMessage: 'When you leave and unfollow a run, it\'s removed from the left-hand sidebar. You can find it again by viewing all runs.'})}
+            title={formatMessage({defaultMessage: 'Confirm leave{isFollowing, select, true { and unfollow} other {}}'}, {isFollowing})}
+            message={formatMessage({defaultMessage: 'When you leave{isFollowing, select, true { and unfollow a run} other { a run}}, it\'s removed from the left-hand sidebar. You can find it again by viewing all runs.'}, {isFollowing})}
             confirmButtonText={formatMessage({defaultMessage: 'Leave and unfollow'})}
             onConfirm={() => {
                 onLeaveRun();

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
@@ -42,9 +42,10 @@ interface Props {
     onInfoClick: () => void;
     onTimelineClick: () => void;
     rhsSection: RHSContent | null;
+    isFollowing: boolean;
 }
 
-export const RunHeader = ({playbookRun, playbookRunMetadata, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
+export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const [showGetInvolvedConfirm, setShowGetInvolvedConfirm] = useState(false);
@@ -105,6 +106,7 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, channel, role, onIn
                 playbookRun={playbookRun}
                 role={role}
                 isFavoriteRun={isFavoriteRun}
+                isFollowing={isFollowing}
                 toggleFavorite={toggleFavorite}
             />
             <StyledBadge status={BadgeType[playbookRun.current_status]}/>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
@@ -17,8 +17,16 @@ interface Props {
     runMetadata?: Metadata;
     role: Role;
     channel: Channel | undefined | null;
+    followState: FollowState;
     onViewParticipants: () => void;
     onViewTimeline: () => void;
+}
+
+export interface FollowState {
+    isFollowing: boolean;
+    followers: string[];
+    setIsFollowing: (isFollowing: boolean) => void;
+    setFollowers: (followers: string[]) => void;
 }
 
 const RHSInfo = (props: Props) => {
@@ -34,6 +42,7 @@ const RHSInfo = (props: Props) => {
                 onViewParticipants={props.onViewParticipants}
                 editable={editable}
                 channel={props.channel}
+                followState={props.followState}
             />
             <RHSInfoMetrics
                 runID={props.run.id}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Link} from 'react-router-dom';
 import {useIntl} from 'react-intl';
@@ -27,21 +27,63 @@ import {usePlaybook, useFormattedUsername} from 'src/hooks';
 import {PlaybookRun, Metadata} from 'src/types/playbook_run';
 import {CompassIcon} from 'src/types/compass';
 
+import {FollowState} from './rhs_info';
+
+export const useFollow = (runID: string, followState: FollowState) => {
+    const {formatMessage} = useIntl();
+    const addToast = useToaster().add;
+    const {isFollowing, followers, setIsFollowing, setFollowers} = followState;
+    const currentUser = useSelector(getCurrentUser);
+
+    const toggleFollow = () => {
+        const action = isFollowing ? unfollowPlaybookRun : followPlaybookRun;
+        action(runID)
+            .then(() => {
+                const newFollowers = isFollowing ? followers.filter((userId) => userId !== currentUser.id) : [...followers, currentUser.id];
+                setIsFollowing(!isFollowing);
+                setFollowers(newFollowers);
+            })
+            .catch(() => {
+                setIsFollowing(isFollowing);
+                addToast(formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}), ToastType.Failure);
+            });
+    };
+
+    const FollowingButton = () => {
+        if (isFollowing) {
+            return (
+                <UnfollowButton onClick={toggleFollow}>
+                    {formatMessage({defaultMessage: 'Following'})}
+                </UnfollowButton>
+            );
+        }
+
+        return (
+            <FollowButton onClick={toggleFollow}>
+                {formatMessage({defaultMessage: 'Follow'})}
+            </FollowButton>
+        );
+    };
+
+    return FollowingButton;
+};
+
 interface Props {
     run: PlaybookRun;
     runMetadata?: Metadata;
     editable: boolean;
     channel: Channel | undefined | null;
+    followState: FollowState;
     onViewParticipants: () => void;
 }
 
-const RHSInfoOverview = ({run, channel, runMetadata, editable, onViewParticipants}: Props) => {
+const RHSInfoOverview = ({run, channel, runMetadata, followState, editable, onViewParticipants}: Props) => {
     const {formatMessage} = useIntl();
     const playbook = usePlaybook(run.playbook_id);
     const addToast = useToaster().add;
     const [showAddToChannel, setShowAddToChannel] = useState(false);
     const [selectedUser, setSelectedUser] = useState<UserProfile | null>(null);
-    const [FollowingButton, followers] = useFollowing(run.id, runMetadata?.followers || []);
+    const FollowingButton = useFollow(run.id, followState);
 
     const setOwner = async (userID: string) => {
         try {
@@ -122,7 +164,7 @@ const RHSInfoOverview = ({run, channel, runMetadata, editable, onViewParticipant
                 <FollowersWrapper>
                     <FollowingButton/>
                     <Following
-                        userIds={followers}
+                        userIds={followState.followers}
                         maxUsers={4}
                     />
                 </FollowersWrapper>
@@ -199,51 +241,6 @@ const AddToChannelModal = ({user, channelId, setOwner, show, onHide}: AddToChann
             onCancel={onHide}
         />
     );
-};
-
-const useFollowing = (runID: string, metadataFollowers: string[]) => {
-    const {formatMessage} = useIntl();
-    const addToast = useToaster().add;
-    const currentUser = useSelector(getCurrentUser);
-    const [followers, setFollowers] = useState(metadataFollowers);
-    const [isFollowing, setIsFollowing] = useState(followers.includes(currentUser.id));
-
-    useEffect(() => {
-        setFollowers(metadataFollowers);
-        setIsFollowing(metadataFollowers.includes(currentUser.id));
-    }, [currentUser.id, JSON.stringify(metadataFollowers)]);
-
-    const toggleFollow = () => {
-        const action = isFollowing ? unfollowPlaybookRun : followPlaybookRun;
-        action(runID)
-            .then(() => {
-                const newFollowers = isFollowing ? followers.filter((userId) => userId !== currentUser.id) : [...followers, currentUser.id];
-                setIsFollowing(!isFollowing);
-                setFollowers(newFollowers);
-            })
-            .catch(() => {
-                setIsFollowing(isFollowing);
-                addToast(formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}), ToastType.Failure);
-            });
-    };
-
-    const FollowingButton = () => {
-        if (isFollowing) {
-            return (
-                <UnfollowButton onClick={toggleFollow}>
-                    {formatMessage({defaultMessage: 'Following'})}
-                </UnfollowButton>
-            );
-        }
-
-        return (
-            <FollowButton onClick={toggleFollow}>
-                {formatMessage({defaultMessage: 'Follow'})}
-            </FollowButton>
-        );
-    };
-
-    return [FollowingButton, followers] as const;
 };
 
 interface ItemProps {


### PR DESCRIPTION
#### Summary
Make leave-run aware of the current follower state to set the copies to leave-run or leave-and-unfollow. 

Follower state is not handled at redux, it had to be moved to parent component so we can share it between RHS-Info (where the follow/unfollow button is) and header/context-menu

Telemetry for page view moved from RHS to actual page (no effect in metrics but I wasn't the right palce).

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46085

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated
