### PR TITLE
prevent request-update from execute when run is finished

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -114,6 +114,22 @@ describe('runs > run details page > status update', () => {
         });
 
         describe('request an update', () => {
+            it('is disabled if the run is finished', () => {
+                cy.apiFinishRun(testRun.id).then(() => {
+                    // # reload url
+                    cy.visit(`/playbooks/runs/${testRun.id}`);
+
+                    // # Click on kebab menu
+                    cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();
+
+                    // # Click on request update
+                    cy.findByText('Request update...').click();
+
+                    // # Click on modal confirmation
+                    cy.get('#confirmModalButton').should('not.exist');
+                });
+            });
+
             it('requests and confirm', () => {
                 // # Click on kebab menu
                 cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -125,7 +125,7 @@ describe('runs > run details page > status update', () => {
                     // # Click on request update
                     cy.findByText('Request update...').click();
 
-                    // # Click on modal confirmation
+                    // * Assert modal is not opened
                     cy.get('#confirmModalButton').should('not.exist');
                 });
             });

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -251,8 +251,8 @@ export const ParticipantStatusUpdate = ({id, playbookRun, openRHS}: ParticipantP
                                 {openRHSText}
                             </DropdownItem>
                             <DropdownItem
-                                onClick={showRequestUpdateConfirm}
-                                disabled={false}
+                                onClick={playbookRun.current_status === PlaybookRunStatus.Finished ? undefined : showRequestUpdateConfirm}
+                                disabled={playbookRun.current_status === PlaybookRunStatus.Finished}
                             >
                                 {formatMessage({defaultMessage: 'Request update...'})}
                             </DropdownItem>


### PR DESCRIPTION
#### Summary
Prevent participants from requesting updates once the run is finished

![CleanShot 2022-08-01 at 11 42 47](https://user-images.githubusercontent.com/4096774/182121056-a906dfff-d4e6-4b70-ad08-7139247b8b6a.gif)


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46073

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
