### PR TITLE
hide key metrics in rhs if retro is disabled

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
@@ -215,7 +215,7 @@ describe('runs > run details page > run info', () => {
             });
         });
 
-        describe('playbook with metrics', () => {
+        describe('playbook with metrics (enabled retro)', () => {
             let playbookWithMetrics;
             let runWithMetrics;
 
@@ -370,6 +370,74 @@ describe('runs > run details page > run info', () => {
                         });
                     });
                 });
+            });
+        });
+
+        describe('playbook with metrics (disabled retro)', () => {
+            let playbookWithMetrics;
+            let runWithMetrics;
+
+            before(() => {
+                // # Login as testUser
+                cy.apiLogin(testUser);
+
+                // # Create a public playbook with metrics
+                cy.apiCreatePlaybook({
+                    teamId: testTeam.id,
+                    title: 'Public Playbook with metrics',
+                    memberIDs: [],
+                    metrics: [
+                        {
+                            title: 'Integer',
+                            description: 'integer',
+                            type: 'metric_integer',
+                            target: 1,
+                        },
+                    ],
+                    retrospectiveEnabled: false,
+                }).then((playbook) => {
+                    playbookWithMetrics = playbook;
+                });
+            });
+
+            beforeEach(() => {
+                // # Size the viewport to show the RHS without covering posts.
+                cy.viewport('macbook-13');
+
+                // # Login as testUser
+                cy.apiLogin(testUser);
+
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: playbookWithMetrics.id,
+                    playbookRunName: 'the run name',
+                    ownerUserId: testUser.id,
+                }).then((playbookRun) => {
+                    runWithMetrics = playbookRun;
+
+                    // # Visit the playbook run
+                    cy.visit(`/playbooks/runs/${playbookRun.id}`);
+                });
+            });
+
+            const commonTests = () => {
+                it('key metrics is hidden', () => {
+                    getRHSSection('Key Metrics').should('not.exist');
+                });
+            };
+
+            describe('as participant', () => {
+                commonTests();
+            });
+
+            describe('as viewer', () => {
+                beforeEach(() => {
+                    cy.apiLogin(testViewerUser).then(() => {
+                        cy.visit(`/playbooks/runs/${runWithMetrics.id}`);
+                    });
+                });
+
+                commonTests();
             });
         });
     });

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
@@ -35,12 +35,14 @@ const RHSInfo = (props: Props) => {
                 editable={editable}
                 channel={props.channel}
             />
-            <RHSInfoMetrics
-                runID={props.run.id}
-                metricsData={props.run.metrics_data}
-                metricsConfig={props.playbook?.metrics}
-                editable={editable}
-            />
+            {props.run.retrospective_enabled ? (
+                <RHSInfoMetrics
+                    runID={props.run.id}
+                    metricsData={props.run.metrics_data}
+                    metricsConfig={props.playbook?.metrics}
+                    editable={editable}
+                />
+            ) : null}
             <RHSInfoActivity
                 run={props.run}
                 role={props.role}


### PR DESCRIPTION
#### Summary
Hide RHS key metrics section when retrospective is disabled.

![CleanShot 2022-08-01 at 18 24 20](https://user-images.githubusercontent.com/4096774/182197501-2d5a4f30-e39b-4cf0-a551-99cbd9a8add0.gif)


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46081

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
