### PR TITLE
remove chevron in team name LHS

### DIFF
--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -59,7 +59,6 @@ const Sidebar = (props: SidebarProps) => {
                 >
                     <SidebarHeading>
                         <span className='title'>{team.display_name}</span>
-                        <i className='icon icon-chevron-down'/>
                     </SidebarHeading>
                 </OverlayTrigger>
                 {props.headerDropdown}


### PR DESCRIPTION
#### Summary
The chevron down next to the team name in the playbooks LHS looks like a clickable component.
The chevron has been removed until we add the actual dropdown.

|Before|After|
|--|---|
|![Screenshot 2022-08-01 at 18 33 33](https://user-images.githubusercontent.com/4096774/182198891-7934e4b1-63f5-4fd7-ba3e-61402b726052.png)|![Screenshot 2022-08-01 at 18 32 48](https://user-images.githubusercontent.com/4096774/182198803-f598bce1-e61f-4205-bfdc-98b497f7aa86.png)|





#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46076

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
