### PR TITLE
prevent users from saving invalid webhooks

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -175,6 +175,31 @@ describe('runs > run details page > header', () => {
                         saveRunActionsModal();
                     });
 
+                    it('can not save an invalid form', () => {
+                        // * Verify that the run actions modal is shown when clicking on the button
+                        openRunActionsModal();
+
+                        cy.findByRole('dialog', {name: /Run Actions/i}).within(() => {
+                            // # click on webhooks toggle
+                            cy.findByText('Send outgoing webhook').click();
+
+                            // # Type an invalid webhook URL
+                            cy.getStyledComponent('TextArea').clear().type('invalidurl');
+
+                            // # Click outside textarea
+                            cy.findByText('Run Actions').click();
+
+                            // * Assert the error message is displayed
+                            cy.findByText('Invalid webhook URLs').should('be.visible');
+
+                            // # Click save
+                            cy.findByTestId('modal-confirm-button').click();
+
+                            // * Assert that modal is still open
+                            cy.findByText('Run Actions').should('be.visible');
+                        });
+                    });
+
                     it('honours the settings from the playbook', () => {
                         cy.apiCreateChannel(
                             testTeam.id,

--- a/webapp/src/components/actions_modal.tsx
+++ b/webapp/src/components/actions_modal.tsx
@@ -23,6 +23,7 @@ interface Props {
     onSave: () => void;
     children: React.ReactNode;
     adjustTop?: number;
+    isValid: boolean;
 }
 
 const ActionsModal = (props: Props) => {
@@ -43,6 +44,17 @@ const ActionsModal = (props: Props) => {
         </Header>
     );
 
+    // We want to show the confirm button but disabled when is invalid
+    const onHandleConfirm = () => {
+        if (!props.editable) {
+            return null;
+        }
+        if (!props.isValid) {
+            return () => null;
+        }
+        return props.onSave;
+    };
+
     return (
         <StyledModal
             id={props.id}
@@ -51,10 +63,11 @@ const ActionsModal = (props: Props) => {
             onHide={props.onHide}
             onExited={() => {/* do nothing else after the modal has exited */}}
             handleCancel={props.editable ? props.onHide : null}
-            handleConfirm={props.editable ? props.onSave : null}
+            handleConfirm={onHandleConfirm()}
             confirmButtonText={formatMessage({defaultMessage: 'Save'})}
             cancelButtonText={formatMessage({defaultMessage: 'Cancel'})}
             isConfirmDisabled={!props.editable}
+            confirmButtonClassName={props.isValid ? '' : 'disabled'}
             isConfirmDestructive={false}
             autoCloseOnCancelButton={true}
             autoCloseOnConfirmButton={false}
@@ -107,6 +120,11 @@ const ModalFooter = styled(DefaultFooterContainer)`
         margin-top: -24px;
 
         background: rgba(var(--center-channel-color-rgb), 0.08);
+    }
+
+    .disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
     }
 `;
 

--- a/webapp/src/components/channel_actions_modal.tsx
+++ b/webapp/src/components/channel_actions_modal.tsx
@@ -151,6 +151,7 @@ const ChannelActionsModal = () => {
             editable={editable}
             onSave={onSave}
             adjustTop={350}
+            isValid={true}
         >
             <TriggersContainer>
                 <Trigger

--- a/webapp/src/components/patterned_text_area.tsx
+++ b/webapp/src/components/patterned_text_area.tsx
@@ -13,6 +13,7 @@ interface Props {
     pattern: string;
     delimiter?: string;
     onChange?: (updatedInput: string) => void;
+    onValidationChange?: (isValid: boolean) => void;
     onBlur?: (updatedInput: string) => void;
     maxLength?: number;
     rows?: number;
@@ -25,6 +26,8 @@ const PatternedTextArea = (props: Props) => {
     const [invalid, setInvalid] = useState<boolean>(false);
     const [errorText, setErrorText] = useState<string>(props.errorText);
     const [value, setValue] = useState(props.input);
+
+    props.onValidationChange?.(!invalid);
 
     useUpdateEffect(() => {
         setValue(props.input);
@@ -108,7 +111,7 @@ const TextArea = styled.textarea<TextAreaProps>`
     width: 100%;
 
     background-color: ${(props) => (props.disabled ? 'rgba(var(--center-channel-bg-rgb), 0.16)' : 'var(--center-channel-bg)')};
-    color: var(--center-channel-color);
+    color: ${(props) => (props.disabled ? 'rgba(var(--center-channel-color-rgb), 0.64)' : 'var(--center-channel-color);')};
     border-radius: 4px;
     border: none;
     box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);

--- a/webapp/src/components/run_actions_modal.tsx
+++ b/webapp/src/components/run_actions_modal.tsx
@@ -33,6 +33,7 @@ const RunActionsModal = ({playbookRun, readOnly}: Props) => {
 
     const [channelIds, setChannelIds] = useState(playbookRun.broadcast_channel_ids);
     const [webhooks, setWebhooks] = useState(playbookRun.webhook_on_status_update_urls);
+    const [isValid, setIsValid] = useState<boolean>(true);
 
     const onHide = () => {
         dispatch(hideRunActionsModal());
@@ -65,6 +66,7 @@ const RunActionsModal = ({playbookRun, readOnly}: Props) => {
             editable={!readOnly}
             onSave={onSave}
             adjustTop={260}
+            isValid={isValid}
         >
             <TriggersContainer>
                 <Trigger
@@ -103,6 +105,7 @@ const RunActionsModal = ({playbookRun, readOnly}: Props) => {
                                 maxRows={64}
                                 maxErrorText={formatMessage({defaultMessage: 'Invalid entry: the maximum number of webhooks allowed is 64'})}
                                 resize={'vertical'}
+                                onValidationChange={(valid) => setIsValid(valid)}
                             />
                             <HelpText>
                                 {formatMessage({defaultMessage: 'Please enter one webhook per line'})}


### PR DESCRIPTION
#### Summary
Prevent webhooks from being saved at "Run actions modal" when they are invalid. The save button handler is removed temporarily (until content is valid) and the style changed (less opacity). I considered that approach better than just hiding the save button (which is a bit unexpected).

![CleanShot 2022-08-02 at 10 56 50](https://user-images.githubusercontent.com/4096774/182335335-e2264181-9662-4d96-8644-fe2c41b30c9a.gif)



Disabled text color for webhooks (when they are non-editable).


![CleanShot 2022-08-02 at 10 58 13](https://user-images.githubusercontent.com/4096774/182335504-f64c542d-f380-4031-86a4-0fce0c2a786f.png)


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45959
Fixes https://mattermost.atlassian.net/browse/MM-45958

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
