### PR TITLE
recover channel and all timeline by default

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
@@ -152,6 +152,22 @@ describe('runs > run details page > run info', () => {
                 // * Assert we navigated correctly
                 cy.url().should('include', `${testTeam.name}/channels/the-run-name`);
             });
+
+            it('channel is still there when the run is finished', () => {
+                cy.apiFinishRun(testRun.id).then(() => {
+                    // # Reload page
+                    cy.reload();
+
+                    // * Assert channel name
+                    getOverviewEntry('channel').contains('the run name');
+
+                    // # Click on channel item
+                    getOverviewEntry('channel').click();
+
+                    // * Assert we navigated correctly
+                    cy.url().should('include', `${testTeam.name}/channels/the-run-name`);
+                });
+            });
         });
 
         describe('as viewer', () => {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -155,10 +155,7 @@ const PlaybookRunDetails = () => {
                 role={role}
                 channel={channel}
                 onViewParticipants={() => RHS.open(RHSContent.RunParticipants, formatMessage({defaultMessage: 'Participants'}), playbookRun.name, () => onViewInfo)}
-                onViewTimeline={() => {
-                    selectOption('all', true);
-                    RHS.open(RHSContent.RunTimeline, formatMessage({defaultMessage: 'Timeline'}), playbookRun.name, () => onViewInfo, false);
-                }}
+                onViewTimeline={() => RHS.open(RHSContent.RunTimeline, formatMessage({defaultMessage: 'Timeline'}), playbookRun.name, () => onViewInfo, false)}
             />
         );
         break;

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_activity.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_activity.tsx
@@ -15,22 +15,12 @@ import {Role} from 'src/components/backstage/playbook_runs/shared';
 import {PlaybookRun} from 'src/types/playbook_run';
 import TimelineEventItem from 'src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/timeline_event_item';
 import {ItemList} from 'src/components/backstage/playbook_runs/playbook_run/rhs_timeline';
+import {TimelineEventsFilterDefault} from 'src/types/rhs';
 import {clientRemoveTimelineEvent} from 'src/client';
 
 import {useTimelineEvents} from './timeline_utils';
 
 const SHOWED_EVENTS = 5;
-
-const fixedFilters = {
-    all: true,
-    owner_changed: false,
-    status_updated: false,
-    event_from_post: false,
-    task_state_modified: false,
-    assignee_changed: false,
-    ran_slash_command: false,
-    user_joined_left: false,
-};
 
 interface Props {
     run: PlaybookRun;
@@ -40,7 +30,7 @@ interface Props {
 
 const RHSInfoActivity = ({run, role, onViewTimeline}: Props) => {
     const {formatMessage} = useIntl();
-    const [filteredEvents] = useTimelineEvents(run, fixedFilters);
+    const [filteredEvents] = useTimelineEvents(run, TimelineEventsFilterDefault);
     const channelNamesMap = useSelector(getChannelsNameMapInCurrentTeam);
     const team = useSelector((state: GlobalState) => getTeam(state, run.team_id));
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -138,7 +138,7 @@ const RHSInfoOverview = ({run, channel, runMetadata, editable, onViewParticipant
                     setSelectedUser(null);
                 }}
             />}
-            {channel && runMetadata && editable && (
+            {channel && runMetadata && (
                 <Item
                     id='runinfo-channel'
                     icon={ProductChannelsIcon}

--- a/webapp/src/types/rhs.ts
+++ b/webapp/src/types/rhs.ts
@@ -53,7 +53,7 @@ export interface TimelineEventsFilter {
 }
 
 export const TimelineEventsFilterDefault = {
-    all: false,
+    all: true,
     owner_changed: true,
     status_updated: true,
     event_from_post: true,


### PR DESCRIPTION
#### Summary
Don't remove the channel from RHS when the run is finished (only when you don't have permission to join)

Keep all events at timeline enabled by default (no matter the navigation). Filters are kept on the playbook_run state (instead of rhs_timeline) to avoid resetting them if close/reopen rhs.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46119
Fixes https://mattermost.atlassian.net/browse/MM-46123

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated
