### PR TITLE
e2e: Disable `Desktop App` initial landing prompt

### DIFF
--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -10,6 +10,18 @@ import {isMac} from '../utils';
 // Read more: https://on.cypress.io/custom-commands
 // ***********************************************************
 
+// Overwrite navigation functions to disable landing page
+// See https://github.com/mattermost/mattermost-webapp/pull/10653
+Cypress.Commands.overwrite('reload', (originalFn, forceReload, options) => {
+    localStorage.setItem('__landingPageSeen__', 'true');
+    originalFn(forceReload, options);
+});
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+    localStorage.setItem('__landingPageSeen__', 'true');
+    originalFn(url, options);
+});
+
 Cypress.Commands.add('logout', () => {
     cy.get('#logout').click({force: true});
 });


### PR DESCRIPTION
Prevents this new prompt from interfering with tests. 