### PR TITLE
RDP RHS info: remove onclick events and keep regular a elements

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_retrospective_spec.js
@@ -172,7 +172,7 @@ describe('runs > run details page', () => {
                 editAndPublishRetro();
 
                 // # Switch to the run channel
-                cy.findByTestId('runinfo-channel').click();
+                cy.findByTestId('runinfo-channel-link').click();
 
                 // * Verify the modified retro text is posted
                 cy.getStyledComponent('CustomPostContent').should('exist').contains('Edited retrospective.');

--- a/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_rhs_runinfo_spec.js
@@ -68,7 +68,7 @@ describe('runs > run details page > run info', () => {
         const commonTests = () => {
             it('Playbook entry links to the playbook', () => {
                 // # Click on the Playbook entry
-                getOverviewEntry('playbook').click();
+                getOverviewEntry('playbook').within(() => cy.getStyledComponent('ItemLink').click());
 
                 // * Verify the we're in the right playbook page
                 cy.url().should('include', '/playbooks/playbooks');
@@ -147,7 +147,7 @@ describe('runs > run details page > run info', () => {
                 getOverviewEntry('channel').contains('the run name');
 
                 // # Click on channel item
-                getOverviewEntry('channel').click();
+                getOverviewEntry('channel').within(() => cy.getStyledComponent('ItemLink').click());
 
                 // * Assert we navigated correctly
                 cy.url().should('include', `${testTeam.name}/channels/the-run-name`);
@@ -162,7 +162,7 @@ describe('runs > run details page > run info', () => {
                     getOverviewEntry('channel').contains('the run name');
 
                     // # Click on channel item
-                    getOverviewEntry('channel').click();
+                    getOverviewEntry('channel').within(() => cy.getStyledComponent('ItemLink').click());
 
                     // * Assert we navigated correctly
                     cy.url().should('include', `${testTeam.name}/channels/the-run-name`);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -22,7 +22,7 @@ import {Section, SectionHeader} from 'src/components/backstage/playbook_runs/pla
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import {followPlaybookRun, unfollowPlaybookRun, setOwner as clientSetOwner} from 'src/client';
-import {navigateToUrl, pluginUrl} from 'src/browser_routing';
+import {pluginUrl} from 'src/browser_routing';
 import {usePlaybook, useFormattedUsername} from 'src/hooks';
 import {PlaybookRun, Metadata} from 'src/types/playbook_run';
 import {CompassIcon} from 'src/types/compass';
@@ -124,7 +124,6 @@ const RHSInfoOverview = ({run, channel, runMetadata, followState, editable, onVi
                 id='runinfo-playbook'
                 icon={BookOutlineIcon}
                 name={formatMessage({defaultMessage: 'Playbook'})}
-                onClick={() => navigateToUrl(pluginUrl(`/playbooks/${run.playbook_id}`))}
             >
                 {playbook && <ItemLink to={pluginUrl(`/playbooks/${run.playbook_id}`)}>{playbook.title}</ItemLink>}
             </Item>
@@ -183,7 +182,6 @@ const RHSInfoOverview = ({run, channel, runMetadata, followState, editable, onVi
                     id='runinfo-channel'
                     icon={ProductChannelsIcon}
                     name={formatMessage({defaultMessage: 'Channel'})}
-                    onClick={() => navigateToUrl(`/${runMetadata.team_name}/channels/${channel.name}`)}
                 >
                     <ItemLink to={`/${runMetadata.team_name}/channels/${channel.name}`}>
                         <ItemContent >

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -183,7 +183,10 @@ const RHSInfoOverview = ({run, channel, runMetadata, followState, editable, onVi
                     icon={ProductChannelsIcon}
                     name={formatMessage({defaultMessage: 'Channel'})}
                 >
-                    <ItemLink to={`/${runMetadata.team_name}/channels/${channel.name}`}>
+                    <ItemLink
+                        to={`/${runMetadata.team_name}/channels/${channel.name}`}
+                        data-testid='runinfo-channel-link'
+                    >
                         <ItemContent >
                             {channel.display_name}
                             <OpenInNewIcon


### PR DESCRIPTION
#### Summary
Remove onclick handlers in the items that are pure links in RHS overview at Run Details Page.
That make the cmd+click works natively due to the inner `<a>`. We lose the click handler for the whole row, but it's not critical since the links at the right part catch naturally all the clicks.

Done for playbook and channel links.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45960

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
