### PR TITLE
Show due date on finished tasks without late warning style

### DIFF
--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -199,12 +199,8 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
     };
 
     const renderDueDate = (): null | React.ReactNode => {
-        const isTaskOpenOrInProgress = props.checklistItem.state === ChecklistItemState.Open || props.checklistItem.state === ChecklistItemState.InProgress;
+        const isTaskFinishedOrSkipped = props.checklistItem.state === ChecklistItemState.Closed || props.checklistItem.state === ChecklistItemState.Skip;
 
-        // if task is done hide due date info
-        if (!isTaskOpenOrInProgress) {
-            return null;
-        }
         if (buttonsFormat !== ButtonsFormat.Long && (!dueDate && !isEditing)) {
             return null;
         }
@@ -213,6 +209,7 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             <DueDateButton
                 editable={!props.disabled}
                 date={dueDate}
+                ignoreOverdue={isTaskFinishedOrSkipped}
                 mode={props.playbookRunId ? Mode.DateTimeValue : Mode.DurationValue}
                 onSelectedChange={onDueDateChange}
                 placement={'bottom-start'}

--- a/webapp/src/components/checklist_item/duedate.tsx
+++ b/webapp/src/components/checklist_item/duedate.tsx
@@ -24,6 +24,7 @@ interface Props {
     date?: number;
     mode: Mode.DateTimeValue | Mode.DurationValue;
     editable: boolean;
+    ignoreOverdue?: boolean;
 
     onSelectedChange: (value?: DateTimeOption | undefined | null) => void;
     placement: Placement;
@@ -136,6 +137,7 @@ export const DueDateHoverMenuButton = ({
 export const DueDateButton = ({
     date,
     mode,
+    ignoreOverdue,
     ...props
 }: Props) => {
     const {formatMessage} = useIntl();
@@ -180,8 +182,8 @@ export const DueDateButton = ({
         />
     );
 
-    const dueSoon = mode === Mode.DateTimeValue && isDueSoon(date);
-    const overdue = mode === Mode.DateTimeValue && isOverdue(date);
+    const dueSoon = !ignoreOverdue && mode === Mode.DateTimeValue && isDueSoon(date);
+    const overdue = !ignoreOverdue && mode === Mode.DateTimeValue && isOverdue(date);
     const label = mode === Mode.DateTimeValue ? buttonLabelForDateTime(date) : buttonLabelForDuration(date);
 
     const dueDateButton = (


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
After this PR, we will show a due date on finished/skipped tasks without a `late` warning. In such a way, finished tasks will not attract attention, and users can still quickly edit a due date. 

https://user-images.githubusercontent.com/4368372/182888081-af5319d4-f62a-4dc7-9223-d78d418b3316.mp4


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46015

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [ ] Unit tests updated
