### PR TITLE
remove retrospective telemetry and duplicated requests in rdp

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -97,9 +97,8 @@ const PlaybookRunDetails = () => {
     usePlaybookRunViewTelemetry(PlaybookRunViewTarget.Details, playbookRun?.id);
 
     // we must force metadata refetch when participants change (leave&unfollow)
-    const [metadata, metadataResult] = useRunMetadata(playbookRunId, [JSON.stringify(playbookRun?.participant_ids)]);
-
-    const [statusUpdates] = useRunStatusUpdates(playbookRunId, [playbookRun?.status_posts.length]);
+    const [metadata, metadataResult] = useRunMetadata(playbookRun?.id, [JSON.stringify(playbookRun?.participant_ids)]);
+    const [statusUpdates] = useRunStatusUpdates(playbookRun?.id, [playbookRun?.status_posts.length]);
     const [channel, channelFetchMetadata] = useChannel(playbookRun?.channel_id ?? '');
     const myUser = useSelector(getCurrentUser);
     const {options, selectOption, eventsFilter, resetFilters} = useFilter();

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/retrospective.tsx
@@ -16,8 +16,6 @@ import Report from '../playbook_run_backstage/retrospective/report';
 import ConfirmModalLight from 'src/components/widgets/confirmation_modal_light';
 import {TertiaryButton} from 'src/components/assets/buttons';
 import {PAST_TIME_SPEC} from 'src/components/time_spec';
-import {usePlaybookRunViewTelemetry} from 'src/hooks/telemetry';
-import {PlaybookRunViewTarget} from 'src/types/telemetry';
 
 interface Props {
     id: string;
@@ -36,8 +34,6 @@ const Retrospective = ({
     role,
     focusMetricId,
 }: Props) => {
-    usePlaybookRunViewTelemetry(PlaybookRunViewTarget.Retrospective, playbookRun.id);
-
     const allowRetrospectiveAccess = useAllowRetrospectiveAccess();
     const {formatMessage} = useIntl();
     const [showConfirmation, setShowConfirmation] = useState(false);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info.tsx
@@ -42,6 +42,7 @@ const RHSInfo = (props: Props) => {
                 editable={editable}
                 channel={props.channel}
                 followState={props.followState}
+                playbook={props.playbook}
             />
             {props.run.retrospective_enabled ? (
                 <RHSInfoMetrics

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -23,8 +23,9 @@ import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import {followPlaybookRun, unfollowPlaybookRun, setOwner as clientSetOwner} from 'src/client';
 import {pluginUrl} from 'src/browser_routing';
-import {usePlaybook, useFormattedUsername} from 'src/hooks';
+import {useFormattedUsername} from 'src/hooks';
 import {PlaybookRun, Metadata} from 'src/types/playbook_run';
+import {PlaybookWithChecklist} from 'src/types/playbook';
 import {CompassIcon} from 'src/types/compass';
 
 import {FollowState} from './rhs_info';
@@ -72,12 +73,12 @@ interface Props {
     editable: boolean;
     channel: Channel | undefined | null;
     followState: FollowState;
+    playbook?: PlaybookWithChecklist;
     onViewParticipants: () => void;
 }
 
-const RHSInfoOverview = ({run, channel, runMetadata, followState, editable, onViewParticipants}: Props) => {
+const RHSInfoOverview = ({run, channel, runMetadata, followState, editable, playbook, onViewParticipants}: Props) => {
     const {formatMessage} = useIntl();
-    const [playbook] = usePlaybook(run.playbook_id);
     const addToast = useToaster().add;
     const [showAddToChannel, setShowAddToChannel] = useState(false);
     const [selectedUser, setSelectedUser] = useState<UserProfile | null>(null);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run_backstage/retrospective/retrospective.tsx
@@ -15,8 +15,7 @@ import {Container, Content, Left, Right, Title} from 'src/components/backstage/p
 import UpgradeBanner from 'src/components/upgrade_banner';
 import {AdminNotificationType} from 'src/constants';
 
-import {useAllowPlaybookAndRunMetrics, useAllowRetrospectiveAccess, usePlaybookRunViewTelemetry} from 'src/hooks';
-import {PlaybookRunViewTarget} from 'src/types/telemetry';
+import {useAllowPlaybookAndRunMetrics, useAllowRetrospectiveAccess} from 'src/hooks';
 import {PlaybookRun, RunMetricData} from 'src/types/playbook_run';
 import {Metric} from 'src/types/playbook';
 
@@ -44,8 +43,6 @@ interface Props {
 }
 
 export const Retrospective = (props: Props) => {
-    usePlaybookRunViewTelemetry(PlaybookRunViewTarget.Retrospective, props.playbookRun.id);
-
     const allowRetrospectiveAccess = useAllowRetrospectiveAccess();
     const {formatMessage} = useIntl();
     const [showConfirmation, setShowConfirmation] = useState(false);

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -394,7 +394,7 @@ export function useRun(runId: string, teamId?: string, channelId?: string) {
  * @param id identifier of the run to fetch metadata
  * @returns data and fetchState in a array tuple
  */
-export function useRunMetadata(id: PlaybookRun['id'], deps: DependencyList = []) {
+export function useRunMetadata(id: PlaybookRun['id'] | undefined, deps: DependencyList = []) {
     return useThing(id, fetchPlaybookRunMetadata, noopSelector, deps);
 }
 
@@ -404,7 +404,7 @@ export function useRunMetadata(id: PlaybookRun['id'], deps: DependencyList = [])
  * @param deps Array of additional deps whose change will invoke again fetch
  * @returns data and fetchState in a array tuple
  */
-export function useRunStatusUpdates(id: PlaybookRun['id'], deps: DependencyList = []) {
+export function useRunStatusUpdates(id: PlaybookRun['id'] | undefined, deps: DependencyList = []) {
     return useThing(id, fetchPlaybookRunStatusUpdates, noopSelector, deps);
 }
 


### PR DESCRIPTION
#### Summary
Retrospective view telemetry is being triggered inside the run details page and shouldn't be triggered (already included, was part of old tab navigation).

Status updates and Run metadata were fetched twice when switching Runs in LHS due to permutations in the useEffect deps while new run is being processed.

Playbook hook removed from RHS, and passed as a prop from the main component to avoid duplicate fetch. 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46400
- https://mattermost.atlassian.net/browse/MM-46399

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
