### PR TITLE
Update run participants table and related queries.

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -904,7 +904,7 @@ func (h *PlaybookRunHandler) leave(w http.ResponseWriter, r *http.Request) {
 	playbookRunID := mux.Vars(r)["id"]
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	if err := h.playbookRunService.Leave(playbookRunID, userID); err != nil {
+	if err := h.playbookRunService.RemoveParticipants(playbookRunID, userID); err != nil {
 		h.HandleError(w, err)
 		return
 	}

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -904,7 +904,7 @@ func (h *PlaybookRunHandler) leave(w http.ResponseWriter, r *http.Request) {
 	playbookRunID := mux.Vars(r)["id"]
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	if err := h.playbookRunService.RemoveParticipants(playbookRunID, userID); err != nil {
+	if err := h.playbookRunService.RemoveParticipants(playbookRunID, []string{userID}); err != nil {
 		h.HandleError(w, err)
 		return
 	}

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -172,8 +172,6 @@ func TestRunCreation(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, run)
-		// assert some data has been injected
-		assert.Len(t, run.ParticipantIDs, 1)
 	})
 
 	t.Run("create valid run without playbook", func(t *testing.T) {

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -1264,8 +1263,6 @@ func TestLeave(t *testing.T) {
 	})
 
 	t.Run("join and leave run", func(t *testing.T) {
-		fmt.Println(e.BasicRun.ParticipantIDs)
-
 		// Join
 		_, _, err := e.ServerAdminClient.AddChannelMember(e.BasicRun.ChannelID, e.RegularUser2.Id)
 		require.NoError(t, err)

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -1272,6 +1272,9 @@ func TestLeave(t *testing.T) {
 		_, _, err := e.ServerAdminClient.AddChannelMember(e.BasicRun.ChannelID, e.RegularUser2.Id)
 		require.NoError(t, err)
 
+		// 'Has' plugin events are asyncronous so we must wait
+		time.Sleep(time.Second)
+
 		// Assert is participant and follower
 		run, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), e.BasicRun.ID)
 		require.NoError(t, err)
@@ -1284,6 +1287,9 @@ func TestLeave(t *testing.T) {
 		// Leave
 		err = e.PlaybooksClient2.PlaybookRuns.Leave(context.Background(), e.BasicRun.ID)
 		assert.NoError(t, err)
+
+		// 'Has' plugin events are asyncronous so we must wait
+		time.Sleep(time.Second)
 
 		// Assert is not participant and follower anymore
 		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), e.BasicRun.ID)

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -743,10 +743,10 @@ type PlaybookRunService interface {
 	// RequestGetInvolved posts a join request message in the run's channel
 	RequestGetInvolved(playbookRunID, requesterID string) error
 
-	// RemoveParticipants removes user from the run's participants
+	// RemoveParticipants removes users from the run's participants
 	RemoveParticipants(playbookRunID string, userIDs []string) error
 
-	// AddParticipants adds a user to the participants list
+	// AddParticipants adds users to the participants list
 	AddParticipants(playbookRunID string, userIDs []string) error
 }
 
@@ -843,10 +843,10 @@ type PlaybookRunStore interface {
 	// if a user is member of more than one channel, it will be counted multiple times
 	GetParticipantsActiveTotal() (int64, error)
 
-	// AddParticipants adds a particpant to the run
+	// AddParticipants adds particpants to the run
 	AddParticipants(playbookRunID string, userIDs []string) error
 
-	// RemoveParticipants removes a participant from the run
+	// RemoveParticipants removes participants from the run
 	RemoveParticipants(playbookRunID string, userIDs []string) error
 }
 

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -743,8 +743,11 @@ type PlaybookRunService interface {
 	// RequestGetInvolved posts a join request message in the run's channel
 	RequestGetInvolved(playbookRunID, requesterID string) error
 
-	// Leave removes user from the run's participants&followers list
+	// Leave removes user from the run's participants
 	Leave(playbookRunID, requesterID string) error
+
+	// Participate adds a user to the participants list
+	Participate(playbookRunID, userID string) error
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.
@@ -839,6 +842,12 @@ type PlaybookRunStore interface {
 	// (i.e. members of the playbook run channel when the run is active)
 	// if a user is member of more than one channel, it will be counted multiple times
 	GetParticipantsActiveTotal() (int64, error)
+
+	// AddParticipant adds a particpant to the run
+	AddParticipant(playbookRunID, userID string) error
+
+	// RemoveParticipant removes a participant from the run
+	RemoveParticipant(playbookRunID, userID string) error
 }
 
 // PlaybookRunTelemetry defines the methods that the PlaybookRunServiceImpl needs from the RudderTelemetry.

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -743,11 +743,11 @@ type PlaybookRunService interface {
 	// RequestGetInvolved posts a join request message in the run's channel
 	RequestGetInvolved(playbookRunID, requesterID string) error
 
-	// Leave removes user from the run's participants
-	Leave(playbookRunID, requesterID string) error
+	// RemoveParticipants removes user from the run's participants
+	RemoveParticipants(playbookRunID, userID string) error
 
-	// Participate adds a user to the participants list
-	Participate(playbookRunID, userID string) error
+	// AddParticipants adds a user to the participants list
+	AddParticipants(playbookRunID, userID string) error
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -744,10 +744,10 @@ type PlaybookRunService interface {
 	RequestGetInvolved(playbookRunID, requesterID string) error
 
 	// RemoveParticipants removes user from the run's participants
-	RemoveParticipants(playbookRunID, userID string) error
+	RemoveParticipants(playbookRunID string, userIDs []string) error
 
 	// AddParticipants adds a user to the participants list
-	AddParticipants(playbookRunID, userID string) error
+	AddParticipants(playbookRunID string, userIDs []string) error
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.
@@ -843,11 +843,11 @@ type PlaybookRunStore interface {
 	// if a user is member of more than one channel, it will be counted multiple times
 	GetParticipantsActiveTotal() (int64, error)
 
-	// AddParticipant adds a particpant to the run
-	AddParticipant(playbookRunID, userID string) error
+	// AddParticipants adds a particpant to the run
+	AddParticipants(playbookRunID string, userIDs []string) error
 
-	// RemoveParticipant removes a participant from the run
-	RemoveParticipant(playbookRunID, userID string) error
+	// RemoveParticipants removes a participant from the run
+	RemoveParticipants(playbookRunID string, userIDs []string) error
 }
 
 // PlaybookRunTelemetry defines the methods that the PlaybookRunServiceImpl needs from the RudderTelemetry.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2142,7 +2142,7 @@ func (s *PlaybookRunServiceImpl) addChannelJoinTimelineEvent(user *model.User, c
 	}
 
 	if _, err := s.store.CreateTimelineEvent(event); err != nil {
-		errors.Wrap(err, "failed to create timeline event")
+		return errors.Wrap(err, "failed to create timeline event")
 	}
 
 	return nil

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2108,7 +2108,7 @@ func (s *PlaybookRunServiceImpl) UserHasJoinedChannel(userID, channelID, actorID
 
 	// Automaticly participate if you join the channel
 	// To be removed when separating members and participants is complete.
-	if err := s.Participate(playbookRunID, user.Id); err != nil {
+	if err := s.AddParticipants(playbookRunID, user.Id); err != nil {
 		s.logger.Errorf("faied to add participant that joined channel for run '%s', user '%s'; error: %s", playbookRunID, user.Id, err.Error())
 	}
 
@@ -2189,7 +2189,7 @@ func (s *PlaybookRunServiceImpl) UserHasLeftChannel(userID, channelID, actorID s
 
 	// Automaticly leave if you leave the channel
 	// To be removed when separating members and participants is complete.
-	if err := s.Leave(playbookRunID, user.Id); err != nil {
+	if err := s.RemoveParticipants(playbookRunID, user.Id); err != nil {
 		s.logger.Errorf("faied to remove participant that left channel for run '%s', user '%s'; error: %s", playbookRunID, user.Id, err.Error())
 	}
 
@@ -2764,7 +2764,7 @@ func (s *PlaybookRunServiceImpl) RequestGetInvolved(playbookRunID, requesterID s
 }
 
 // Leave removes user from the run's participants
-func (s *PlaybookRunServiceImpl) Leave(playbookRunID, userID string) error {
+func (s *PlaybookRunServiceImpl) RemoveParticipants(playbookRunID, userID string) error {
 	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve playbook run")
@@ -2797,7 +2797,7 @@ func (s *PlaybookRunServiceImpl) leaveActions(playbookRun *PlaybookRun, userID s
 	}
 }
 
-func (s *PlaybookRunServiceImpl) Participate(playbookRunID, userID string) error {
+func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID, userID string) error {
 	if err := s.store.AddParticipant(playbookRunID, userID); err != nil {
 		return errors.Wrapf(err, "user `%s` failed to participate the run `%s`", userID, playbookRunID)
 	}

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2748,7 +2748,7 @@ func (s *PlaybookRunServiceImpl) RequestGetInvolved(playbookRunID, requesterID s
 	return nil
 }
 
-// Leave removes user from the run's participants&followers lists
+// Leave removes user from the run's participants
 func (s *PlaybookRunServiceImpl) Leave(playbookRunID, requesterID string) error {
 	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
 	if err != nil {
@@ -2768,6 +2768,14 @@ func (s *PlaybookRunServiceImpl) Leave(playbookRunID, requesterID string) error 
 
 	if err := s.api.DeleteChannelMember(playbookRun.ChannelID, requesterID); err != nil {
 		return errors.Wrap(err, "failed to remove channel member")
+	}
+
+	return nil
+}
+
+func (s *PlaybookRunServiceImpl) Participate(playbookRunID, userID string) error {
+	if err := s.store.AddParticipant(playbookRunID, userID); err != nil {
+		return errors.Wrapf(err, "user `%s` failed to participate the run `%s`", userID, playbookRunID)
 	}
 
 	return nil

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2098,14 +2098,32 @@ func (s *PlaybookRunServiceImpl) UserHasJoinedChannel(userID, channelID, actorID
 		return
 	}
 
+	_ = s.addChannelJoinTimelineEvent(user, channel, actorID, playbookRunID, userID)
+
+	if !user.IsBot {
+		if err := s.Follow(playbookRunID, user.Id); err != nil {
+			s.logger.Errorf("user `%s` was not able to follow the run `%s`; error: %s", user.Id, playbookRunID, err.Error())
+		}
+	}
+
+	// Automaticly participate if you join the channel
+	// To be removed when separating members and participants is complete.
+	if err := s.Participate(playbookRunID, user.Id); err != nil {
+		s.logger.Errorf("faied to add participant that joined channel for run '%s', user '%s'; error: %s", playbookRunID, user.Id, err.Error())
+	}
+
+	_ = s.sendPlaybookRunToClient(playbookRunID)
+}
+
+func (s *PlaybookRunServiceImpl) addChannelJoinTimelineEvent(user *model.User, channel *model.Channel, actorID string, playbookRunID string, userID string) error {
 	title := fmt.Sprintf("@%s joined the channel", user.Username)
 
 	summary := fmt.Sprintf("@%s joined ~%s", user.Username, channel.Name)
 	if actorID != "" {
-		actor, err2 := s.pluginAPI.User.Get(actorID)
-		if err2 != nil {
-			s.logger.Errorf("failed to resolve user for userID '%s'; error: %s", actorID, err2.Error())
-			return
+		actor, err := s.pluginAPI.User.Get(actorID)
+		if err != nil {
+			s.logger.Errorf("failed to resolve user for userID '%s'; error: %s", actorID, err.Error())
+			return err
 		}
 
 		summary = fmt.Sprintf("@%s added @%s to ~%s", actor.Username, user.Username, channel.Name)
@@ -2122,24 +2140,11 @@ func (s *PlaybookRunServiceImpl) UserHasJoinedChannel(userID, channelID, actorID
 		CreatorUserID: actorID,
 	}
 
-	if _, err = s.store.CreateTimelineEvent(event); err != nil {
+	if _, err := s.store.CreateTimelineEvent(event); err != nil {
 		s.logger.Errorf("failed to create timeline event; error: %s", err.Error())
+		return err
 	}
-
-	_ = s.sendPlaybookRunToClient(playbookRunID)
-
-	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
-	if err != nil {
-		return
-	}
-
-	if user.IsBot {
-		return
-	}
-
-	if err := s.Follow(playbookRun.ID, userID); err != nil {
-		s.logger.Errorf("user `%s` was not able to follow the run `%s`; error: %s", userID, playbookRun.ID, err.Error())
-	}
+	return nil
 }
 
 func (s *PlaybookRunServiceImpl) UpdateDescription(playbookRunID, description string) error {
@@ -2163,7 +2168,6 @@ func (s *PlaybookRunServiceImpl) UpdateDescription(playbookRunID, description st
 // was removed from the channel by actorID.
 func (s *PlaybookRunServiceImpl) UserHasLeftChannel(userID, channelID, actorID string) {
 	playbookRunID, err := s.store.GetPlaybookRunIDForChannel(channelID)
-
 	if err != nil {
 		// This is not a playbook run channel
 		return
@@ -2181,14 +2185,26 @@ func (s *PlaybookRunServiceImpl) UserHasLeftChannel(userID, channelID, actorID s
 		return
 	}
 
+	_ = s.addChannelLeaveTimelineEvent(user, channel, actorID, playbookRunID, userID)
+
+	// Automaticly leave if you leave the channel
+	// To be removed when separating members and participants is complete.
+	if err := s.Leave(playbookRunID, user.Id); err != nil {
+		s.logger.Errorf("faied to remove participant that left channel for run '%s', user '%s'; error: %s", playbookRunID, user.Id, err.Error())
+	}
+
+	_ = s.sendPlaybookRunToClient(playbookRunID)
+}
+
+func (s *PlaybookRunServiceImpl) addChannelLeaveTimelineEvent(user *model.User, channel *model.Channel, actorID string, playbookRunID string, userID string) error {
 	title := fmt.Sprintf("@%s left the channel", user.Username)
 
 	summary := fmt.Sprintf("@%s left ~%s", user.Username, channel.Name)
 	if actorID != "" {
-		actor, err2 := s.pluginAPI.User.Get(actorID)
-		if err2 != nil {
-			s.logger.Errorf("failed to resolve user for userID '%s'; error: %s", actorID, err2.Error())
-			return
+		actor, err := s.pluginAPI.User.Get(actorID)
+		if err != nil {
+			s.logger.Errorf("failed to resolve user for userID '%s'; error: %s", actorID, err.Error())
+			return err
 		}
 
 		summary = fmt.Sprintf("@%s removed @%s from ~%s", actor.Username, user.Username, channel.Name)
@@ -2205,11 +2221,10 @@ func (s *PlaybookRunServiceImpl) UserHasLeftChannel(userID, channelID, actorID s
 		CreatorUserID: actorID,
 	}
 
-	if _, err = s.store.CreateTimelineEvent(event); err != nil {
+	if _, err := s.store.CreateTimelineEvent(event); err != nil {
 		s.logger.Errorf("failed to create timeline event; error: %s", err.Error())
 	}
-
-	_ = s.sendPlaybookRunToClient(playbookRunID)
+	return nil
 }
 
 func (s *PlaybookRunServiceImpl) hasPermissionToModifyPlaybookRun(playbookRun *PlaybookRun, userID string) bool {
@@ -2749,28 +2764,37 @@ func (s *PlaybookRunServiceImpl) RequestGetInvolved(playbookRunID, requesterID s
 }
 
 // Leave removes user from the run's participants
-func (s *PlaybookRunServiceImpl) Leave(playbookRunID, requesterID string) error {
+func (s *PlaybookRunServiceImpl) Leave(playbookRunID, userID string) error {
 	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve playbook run")
 	}
 
 	// Check if user is an owner
-	if playbookRun.OwnerUserID == requesterID {
+	if playbookRun.OwnerUserID == userID {
 		return errors.New("owner user can't leave the run")
 	}
 
-	// Check if user is not a member of the channel
-	member, _ := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, requesterID)
-	if member == nil {
-		return errors.New("user is not a participant")
+	if err := s.store.RemoveParticipant(playbookRunID, userID); err != nil {
+		return errors.Wrapf(err, "user `%s` failed to remove participation in run `%s`", userID, playbookRunID)
 	}
 
-	if err := s.api.DeleteChannelMember(playbookRun.ChannelID, requesterID); err != nil {
-		return errors.Wrap(err, "failed to remove channel member")
-	}
+	s.leaveActions(playbookRun, userID)
 
 	return nil
+}
+
+func (s *PlaybookRunServiceImpl) leaveActions(playbookRun *PlaybookRun, userID string) {
+	// Don't do anything if the user not a channel member
+	member, _ := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, userID)
+	if member == nil {
+		return
+	}
+
+	// To be added to the UI as an optional action
+	if err := s.api.DeleteChannelMember(playbookRun.ChannelID, userID); err != nil {
+		s.logger.Errorf("failed to remove user from linked channel, userID '%s'; error: %s", userID, err.Error())
+	}
 }
 
 func (s *PlaybookRunServiceImpl) Participate(playbookRunID, userID string) error {
@@ -2778,7 +2802,27 @@ func (s *PlaybookRunServiceImpl) Participate(playbookRunID, userID string) error
 		return errors.Wrapf(err, "user `%s` failed to participate the run `%s`", userID, playbookRunID)
 	}
 
+	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve playbook run")
+	}
+
+	s.participateActions(playbookRun, userID)
+
 	return nil
+}
+
+func (s *PlaybookRunServiceImpl) participateActions(playbookRun *PlaybookRun, userID string) {
+	// Don't do anything if the user is a channel member
+	member, _ := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, userID)
+	if member != nil {
+		return
+	}
+
+	// To be added to the UI as an optional action
+	if _, err := s.api.AddChannelMember(playbookRun.ChannelID, userID); err != nil {
+		s.logger.Errorf("failed to add user to linked channel, userID '%s'; error: %s", userID, err.Error())
+	}
 }
 
 func (s *PlaybookRunServiceImpl) postMessageToThreadAndSaveRootID(playbookRunID, channelID string, post *model.Post) error {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2190,7 +2190,7 @@ func (s *PlaybookRunServiceImpl) UserHasLeftChannel(userID, channelID, actorID s
 		s.logger.Errorf("%w", err)
 	}
 
-	// Automaticly leave if you leave the channel
+	// Automatically leave run if you leave the channel
 	// To be removed when separating members and participants is complete.
 	if err := s.RemoveParticipants(playbookRunID, []string{user.Id}); err != nil {
 		s.logger.Errorf("faied to remove participant that left channel for run '%s', user '%s'; error: %s", playbookRunID, user.Id, err.Error())

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -2139,9 +2139,15 @@ var migrations = []Migration{
 				if err := addColumnToMySQLTable(e, "IR_Run_Participants", "IsParticipant", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column SummaryModifiedAt to table IR_Incident")
 				}
+				if _, err := e.Exec(`ALTER TABLE IR_Run_Participants ALTER IsFollower SET DEFAULT FALSE`); err != nil {
+					return errors.Wrapf(err, "failed to set new column default for IsFollower")
+				}
 			} else {
 				if err := addColumnToPGTable(e, "IR_Run_Participants", "IsParticipant", "BOOLEAN DEFAULT FALSE"); err != nil {
 					return errors.Wrapf(err, "failed adding column SummaryModifiedAt to table IR_Incident")
+				}
+				if _, err := e.Exec(`ALTER TABLE IR_Run_Participants ALTER COLUMN IsFollower SET DEFAULT FALSE`); err != nil {
+					return errors.Wrapf(err, "failed to set new column default for IsFollower")
 				}
 			}
 

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -2131,4 +2131,21 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.56.0"),
+		toVersion:   semver.MustParse("0.57.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if e.DriverName() == model.DatabaseDriverMysql {
+				if err := addColumnToMySQLTable(e, "IR_Run_Participants", "IsParticipant", "BOOLEAN DEFAULT FALSE"); err != nil {
+					return errors.Wrapf(err, "failed adding column SummaryModifiedAt to table IR_Incident")
+				}
+			} else {
+				if err := addColumnToPGTable(e, "IR_Run_Participants", "IsParticipant", "BOOLEAN DEFAULT FALSE"); err != nil {
+					return errors.Wrapf(err, "failed adding column SummaryModifiedAt to table IR_Incident")
+				}
+			}
+
+			return nil
+		},
+	},
 }

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -1157,27 +1157,27 @@ func (s *playbookRunStore) GetOverdueUpdateRuns(userID string) ([]app.RunLink, e
 }
 
 func (s *playbookRunStore) Follow(playbookRunID, userID string) error {
-	return s.followHelper(playbookRunID, userID, true)
+	return s.updateFollowing(playbookRunID, userID, true)
 }
 
 func (s *playbookRunStore) Unfollow(playbookRunID, userID string) error {
-	return s.followHelper(playbookRunID, userID, false)
+	return s.updateFollowing(playbookRunID, userID, false)
 }
 
-func (s *playbookRunStore) followHelper(playbookRunID, userID string, value bool) error {
+func (s *playbookRunStore) updateFollowing(playbookRunID, userID string, isFollowing bool) error {
 	var err error
 	if s.store.db.DriverName() == model.DatabaseDriverMysql {
 		_, err = s.store.execBuilder(s.store.db, sq.
 			Insert("IR_Run_Participants").
 			Columns("IncidentID", "UserID", "IsFollower").
-			Values(playbookRunID, userID, value).
-			Suffix("ON DUPLICATE KEY UPDATE IsFollower = ?", value))
+			Values(playbookRunID, userID, isFollowing).
+			Suffix("ON DUPLICATE KEY UPDATE IsFollower = ?", isFollowing))
 	} else {
 		_, err = s.store.execBuilder(s.store.db, sq.
 			Insert("IR_Run_Participants").
 			Columns("IncidentID", "UserID", "IsFollower").
-			Values(playbookRunID, userID, value).
-			Suffix("ON CONFLICT (IncidentID,UserID) DO UPDATE SET IsFollower = ?", value))
+			Values(playbookRunID, userID, isFollowing).
+			Suffix("ON CONFLICT (IncidentID,UserID) DO UPDATE SET IsFollower = ?", isFollowing))
 	}
 
 	if err != nil {
@@ -1347,6 +1347,37 @@ func (s *playbookRunStore) updateRunMetrics(q queryExecer, playbookRun app.Playb
 			return errors.Wrapf(err, "failed to upsert metric value '%s'", m.MetricConfigID)
 		}
 	}
+	return nil
+}
+
+func (s *playbookRunStore) AddParticipant(playbookRunID, userID string) error {
+	return s.updateParticipating(playbookRunID, userID, true)
+}
+
+func (s *playbookRunStore) RemoveParticipant(playbookRunID, userID string) error {
+	return s.updateParticipating(playbookRunID, userID, false)
+}
+
+func (s *playbookRunStore) updateParticipating(playbookRunID, userID string, isParticipating bool) error {
+	var err error
+	if s.store.db.DriverName() == model.DatabaseDriverMysql {
+		_, err = s.store.execBuilder(s.store.db, sq.
+			Insert("IR_Run_Participants").
+			Columns("IncidentID", "UserID", "IsParticipant").
+			Values(playbookRunID, userID, isParticipating).
+			Suffix("ON DUPLICATE KEY UPDATE IsParticipant = ?", isParticipating))
+	} else {
+		_, err = s.store.execBuilder(s.store.db, sq.
+			Insert("IR_Run_Participants").
+			Columns("IncidentID", "UserID", "IsFollower").
+			Values(playbookRunID, userID, isParticipating).
+			Suffix("ON CONFLICT (IncidentID,UserID) DO UPDATE SET IsParticipant = ?", isParticipating))
+	}
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to upsert participant '%s' for run '%s'", userID, playbookRunID)
+	}
+
 	return nil
 }
 

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -158,21 +158,23 @@ func NewPlaybookRunStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQ
 	// the user is not a member of the channel they won't have permissions to get the user list
 	participantsCol := `
         COALESCE(
-			(SELECT string_agg(cm.UserId, ',')
+			(SELECT string_agg(rp.UserId, ',')
 				FROM IR_Incident as i2
-					JOIN ChannelMembers as cm on cm.ChannelId = i2.ChannelId
+					JOIN IR_Run_Participants as rp on rp.IncidentID = i2.ID
 				WHERE i2.Id = i.Id
-				AND cm.UserId NOT IN (SELECT UserId FROM Bots)
+				AND rp.IsParticipant = true
+				AND rp.UserId NOT IN (SELECT UserId FROM Bots)
 			), ''
         ) AS ConcatenatedParticipantIDs`
 	if sqlStore.db.DriverName() == model.DatabaseDriverMysql {
 		participantsCol = `
         COALESCE(
-			(SELECT group_concat(cm.UserId separator ',')
+			(SELECT group_concat(rp.UserId separator ',')
 				FROM IR_Incident as i2
-					JOIN ChannelMembers as cm on cm.ChannelId = i2.ChannelId
+					JOIN IR_Run_Participants as rp on rp.IncidentID = i2.ID
 				WHERE i2.Id = i.Id
-				AND cm.UserId NOT IN (SELECT UserId FROM Bots)
+				AND rp.IsParticipant = true
+				AND rp.UserId NOT IN (SELECT UserId FROM Bots)
 			), ''
         ) AS ConcatenatedParticipantIDs`
 	}
@@ -279,9 +281,10 @@ func (s *playbookRunStore) GetPlaybookRuns(requesterInfo app.RequesterInfo, opti
 		membershipClause := s.queryBuilder.
 			Select("1").
 			Prefix("EXISTS(").
-			From("ChannelMembers AS cm").
-			Where("cm.ChannelId = i.ChannelID").
-			Where(sq.Eq{"cm.UserId": strings.ToLower(options.ParticipantID)}).
+			From("IR_Run_Participants AS p").
+			Where("p.IncidentID = i.ID").
+			Where("p.IsParticipant = true").
+			Where(sq.Eq{"p.UserID": strings.ToLower(options.ParticipantID)}).
 			Suffix(")")
 
 		queryForResults = queryForResults.Where(membershipClause)
@@ -289,20 +292,20 @@ func (s *playbookRunStore) GetPlaybookRuns(requesterInfo app.RequesterInfo, opti
 	}
 
 	if options.ParticipantOrFollowerID != "" {
-		userIDFilter := strings.ToLower(options.ParticipantOrFollowerID)
-		followerFilterExpr := sq.Expr(`EXISTS(SELECT 1
-			FROM IR_Run_Participants as rp
-			WHERE rp.IncidentID = i.ID
-			AND rp.UserID = ?
-			AND rp.IsFollower = TRUE)`, userIDFilter)
-		participantFilterExpr := sq.Expr(`EXISTS(SELECT 1
-			FROM ChannelMembers AS cm
-			WHERE cm.ChannelId = i.ChannelID
-			AND cm.UserId = ?)`, userIDFilter)
-		myRunsClause := sq.Or{followerFilterExpr, participantFilterExpr}
+		participantOrFollower := s.queryBuilder.
+			Select("1").
+			Prefix("EXISTS(").
+			From("IR_Run_Participants AS p").
+			Where("p.IncidentID = i.ID").
+			Where(sq.Or{
+				sq.Eq{"p.IsParticipant": true},
+				sq.Eq{"p.IsFollower": true},
+			}).
+			Where(sq.Eq{"p.UserID": strings.ToLower(options.ParticipantOrFollowerID)}).
+			Suffix(")")
 
-		queryForResults = queryForResults.Where(myRunsClause)
-		queryForTotal = queryForTotal.Where(myRunsClause)
+		queryForResults = queryForResults.Where(participantOrFollower)
+		queryForTotal = queryForTotal.Where(participantOrFollower)
 	}
 
 	if options.PlaybookID != "" {
@@ -929,26 +932,30 @@ func (s *playbookRunStore) buildPermissionsExpr(info app.RequesterInfo) sq.Sqliz
 		return nil
 	}
 
-	// Guests must be channel members
+	// Guests must be participants
 	if info.IsGuest {
 		return sq.Expr(`
 			  EXISTS(SELECT 1
-						 FROM ChannelMembers as cm
-						 WHERE cm.ChannelId = i.ChannelID
-						   AND cm.UserId = ?)
+						 FROM IR_Run_Participants as rp
+						 WHERE rp.IncidentID = i.ID
+						   AND rp.UserId = ?
+						   AND rp.IsParticipant = true
+					   )
 		`, info.UserID)
 	}
 
-	// 1. Is the user a channel member? If so, they have permission to view the run.
+	// 1. Is the user a participant of the run?
 	// 2. Is the playbook open to everyone on the team, or is the user a member of the playbook?
 	//    If so, they have permission to view the run.
 	return sq.Expr(`
         ((
 			EXISTS (
                     SELECT 1
-						FROM ChannelMembers as cm
-						WHERE cm.ChannelId = i.ChannelId
-						  AND cm.UserId = ?)
+						FROM IR_Run_Participants as rp
+						WHERE rp.IncidentID = i.ID
+						  AND rp.UserId = ?
+						  AND rp.IsParticipant = true
+					  )
 			) OR (
 				(SELECT Public
 					FROM IR_Playbook
@@ -1085,9 +1092,10 @@ func (s *playbookRunStore) GetParticipatingRuns(userID string) ([]app.RunLink, e
 	membershipClause := s.queryBuilder.
 		Select("1").
 		Prefix("EXISTS(").
-		From("ChannelMembers AS cm").
-		Where("cm.ChannelId = i.ChannelID").
-		Where(sq.Eq{"cm.UserId": userID}).
+		From("IR_Run_Participants AS rp").
+		Where("rp.IncidentID = i.ID").
+		Where(sq.Eq{"rp.UserId": userID}).
+		Where(sq.Eq{"rp.IsParticipant": true}).
 		Suffix(")")
 
 	query := s.store.builder.
@@ -1110,14 +1118,15 @@ func (s *playbookRunStore) GetParticipatingRuns(userID string) ([]app.RunLink, e
 
 // GetOverdueUpdateRuns returns runs owned by userID and that have overdue status updates.
 func (s *playbookRunStore) GetOverdueUpdateRuns(userID string) ([]app.RunLink, error) {
-	// only notify if the user is a current member of the run's channel
-	// in other words: don't notify the commander of an overdue run if they have left the run's channel
+	// only notify if the user is still a participant
+	// in other words: don't notify the commander of an overdue run if they have left the run
 	membershipClause := s.queryBuilder.
 		Select("1").
 		Prefix("EXISTS(").
-		From("ChannelMembers AS cm").
-		Where("cm.ChannelId = i.ChannelID").
-		Where(sq.Eq{"cm.UserId": userID}).
+		From("IR_Run_Participants AS rp").
+		Where("rp.IncidentID = i.ID").
+		Where(sq.Eq{"rp.UserId": userID}).
+		Where(sq.Eq{"rp.IsParticipant": true}).
 		Suffix(")")
 
 	query := s.store.builder.
@@ -1272,17 +1281,17 @@ func (s *playbookRunStore) GetFollowersActiveTotal() (int64, error) {
 }
 
 // GetParticipantsActiveTotal returns number of active participants
-// (i.e. members of the playbook run channel when the run is active)
-// if a user is member of more than one channel, it will be counted multiple times
+// if a user is a participant in more than one run they will be counted multiple times
 func (s *playbookRunStore) GetParticipantsActiveTotal() (int64, error) {
 	var count int64
 
 	query := s.store.builder.
 		Select("COUNT(*)").
-		From("ChannelMembers as cm").
-		Join("IR_Incident AS i ON i.ChannelId = cm.ChannelId").
+		From("IR_Run_Participants as rp").
+		Join("IR_Incident AS i ON i.ID = rp.IncidentID").
 		Where(sq.Eq{"i.CurrentStatus": app.StatusInProgress}).
-		Where(sq.Expr("cm.UserId NOT IN (SELECT UserId FROM Bots)"))
+		Where(sq.Eq{"rp.IsParticipant": true}).
+		Where(sq.Expr("rp.UserId NOT IN (SELECT UserId FROM Bots)"))
 
 	if err := s.store.getBuilder(s.store.db, &count, query); err != nil {
 		return 0, errors.Wrap(err, "failed to count active participants")

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -669,7 +669,6 @@ func TestTasksAndRunsDigest(t *testing.T) {
 		channel05 := model.Channel{Id: model.NewId(), Type: "O", Name: "channel-05"}
 		channel06 := model.Channel{Id: model.NewId(), Type: "O", Name: "channel-06"}
 		channels := []model.Channel{channel01, channel02, channel03, channel04, channel05, channel06}
-		addUsersToChannels(t, store, []userInfo{testUser}, []string{channel01.Id, channel02.Id, channel03.Id, channel04.Id, channel06.Id})
 
 		// three assigned tasks for inc01, and an overdue update
 		inc01 := *NewBuilder(nil).
@@ -755,9 +754,12 @@ func TestTasksAndRunsDigest(t *testing.T) {
 		playbookRuns := []app.PlaybookRun{inc01, inc02, inc03, inc04, inc05, inc06}
 
 		for i := range playbookRuns {
-			_, err := playbookRunStore.CreatePlaybookRun(&playbookRuns[i])
+			created, err := playbookRunStore.CreatePlaybookRun(&playbookRuns[i])
+			playbookRuns[i] = *created
 			require.NoError(t, err)
 		}
+
+		addUsersToRuns(t, store, []userInfo{testUser}, []string{playbookRuns[0].ID, playbookRuns[1].ID, playbookRuns[2].ID, playbookRuns[3].ID, playbookRuns[5].ID})
 
 		createChannels(t, store, channels)
 
@@ -1096,7 +1098,7 @@ func TestGetParticipantsActiveTotal(t *testing.T) {
 			returned, err := playbookRunStore.CreatePlaybookRun(run)
 			require.NoError(t, err)
 			if len(participants) > 0 {
-				addUsersToChannels(t, store, participants, []string{run.ChannelID})
+				addUsersToRuns(t, store, participants, []string{returned.ID})
 			}
 
 			createPlaybookRunChannel(t, store, returned)

--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -94,11 +94,12 @@ func (s *StatsStore) TotalPlaybookRuns() (int, error) {
 
 func (s *StatsStore) TotalActiveParticipants(filters *StatsFilters) int {
 	query := s.store.builder.
-		Select("COUNT(DISTINCT cm.UserId)").
-		From("ChannelMembers as cm").
-		Join("IR_Incident AS i ON i.ChannelId = cm.ChannelId").
+		Select("COUNT(DISTINCT rp.UserId)").
+		From("IR_Run_Participants as rp").
+		Join("IR_Incident AS i ON i.ID = rp.IncidentID").
 		Where("i.EndAt = 0").
-		Where(sq.Expr("cm.UserId NOT IN (SELECT UserId FROM Bots)"))
+		Where("rp.IsParticipant = true").
+		Where(sq.Expr("rp.UserId NOT IN (SELECT UserId FROM Bots)"))
 
 	query = applyFilters(query, filters)
 

--- a/server/sqlstore/stats_test.go
+++ b/server/sqlstore/stats_test.go
@@ -104,10 +104,6 @@ func TestTotalInProgressPlaybookRuns(t *testing.T) {
 		addUsersToTeam(t, store, []userInfo{lucy, bob, john, jane, notInvolved, phil, quincy, bot1, bot2}, team1id)
 		addUsersToTeam(t, store, []userInfo{lucy, bob, john, jane, notInvolved, phil, quincy, bot1, bot2}, team2id)
 		createChannels(t, store, []model.Channel{channel01, channel02, channel03, channel04, channel05, channel06, channel07, channel08, channel09})
-		addUsersToChannels(t, store, []userInfo{bob, lucy, phil, bot1, bot2}, []string{channel01.Id, channel02.Id, channel03.Id, channel04.Id, channel06.Id, channel07.Id, channel08.Id, channel09.Id})
-		addUsersToChannels(t, store, []userInfo{bob, quincy}, []string{channel05.Id})
-		addUsersToChannels(t, store, []userInfo{john}, []string{channel01.Id})
-		addUsersToChannels(t, store, []userInfo{jane}, []string{channel01.Id, channel02.Id})
 		makeAdmin(t, store, bob)
 
 		inc01 := *NewBuilder(nil).
@@ -194,9 +190,15 @@ func TestTotalInProgressPlaybookRuns(t *testing.T) {
 		playbookRuns := []app.PlaybookRun{inc01, inc02, inc03, inc04, inc05, inc06, inc07, inc08, inc09}
 
 		for i := range playbookRuns {
-			_, err := playbookRunStore.CreatePlaybookRun(&playbookRuns[i])
+			created, err := playbookRunStore.CreatePlaybookRun(&playbookRuns[i])
 			require.NoError(t, err)
+			playbookRuns[i] = *created
 		}
+
+		addUsersToRuns(t, store, []userInfo{bob, lucy, phil}, []string{playbookRuns[0].ID, playbookRuns[1].ID, playbookRuns[2].ID, playbookRuns[3].ID, playbookRuns[5].ID, playbookRuns[6].ID, playbookRuns[7].ID, playbookRuns[8].ID})
+		addUsersToRuns(t, store, []userInfo{bob, quincy}, []string{playbookRuns[4].ID})
+		addUsersToRuns(t, store, []userInfo{john}, []string{playbookRuns[0].ID})
+		addUsersToRuns(t, store, []userInfo{jane}, []string{playbookRuns[0].ID, playbookRuns[1].ID})
 
 		t.Run(driverName+" Active Participants - team1", func(t *testing.T) {
 			result := statsStore.TotalActiveParticipants(&StatsFilters{
@@ -348,9 +350,6 @@ func TestTotalPlaybookRuns(t *testing.T) {
 		addUsersToTeam(t, store, []userInfo{lucy, bob, john, bot2}, team1id)
 		addUsersToTeam(t, store, []userInfo{lucy, bob, bot1, bot2}, team2id)
 		createChannels(t, store, []model.Channel{chanOpen01, chanOpen02, chanOpen03, chanPrivate01, chanPrivate02, chanPrivate03, chanPrivate04, chanPrivate05, chanPrivate06})
-		addUsersToChannels(t, store, []userInfo{bob, lucy, bot1, bot2}, []string{chanOpen01.Id, chanOpen02.Id, chanOpen03.Id, chanPrivate01.Id, chanPrivate03.Id, chanPrivate04.Id, chanPrivate05.Id, chanPrivate06.Id})
-		addUsersToChannels(t, store, []userInfo{bob}, []string{chanPrivate02.Id})
-		addUsersToChannels(t, store, []userInfo{john}, []string{chanOpen01.Id})
 		makeAdmin(t, store, bob)
 
 		// create run with different statuses, channels, teams and playbooks
@@ -411,9 +410,14 @@ func TestTotalPlaybookRuns(t *testing.T) {
 		playbookRuns := []app.PlaybookRun{run01, run02, run03, run04, run05, run06}
 
 		for i := range playbookRuns {
-			_, err := playbookRunStore.CreatePlaybookRun(&playbookRuns[i])
+			created, err := playbookRunStore.CreatePlaybookRun(&playbookRuns[i])
+			playbookRuns[i] = *created
 			require.NoError(t, err)
 		}
+
+		addUsersToRuns(t, store, []userInfo{bob, lucy, bot1, bot2}, []string{playbookRuns[0].ID, playbookRuns[1].ID, playbookRuns[2].ID, playbookRuns[3].ID, playbookRuns[5].ID})
+		addUsersToRuns(t, store, []userInfo{bob}, []string{playbookRuns[4].ID})
+		addUsersToRuns(t, store, []userInfo{john}, []string{playbookRuns[0].ID})
 
 		t.Run(driverName+" TotalPlaybookRuns", func(t *testing.T) {
 			result, err := statsStore.TotalPlaybookRuns()

--- a/server/sqlstore/support_for_test.go
+++ b/server/sqlstore/support_for_test.go
@@ -712,6 +712,21 @@ func addUsersToChannels(t *testing.T, store *SQLStore, users []userInfo, channel
 	require.NoError(t, err)
 }
 
+func addUsersToRuns(t *testing.T, store *SQLStore, users []userInfo, runIDs []string) {
+	t.Helper()
+
+	insertBuilder := store.builder.Insert("IR_Run_Participants").Columns("IncidentID", "UserId", "IsParticipant", "IsFollower")
+
+	for _, u := range users {
+		for _, runID := range runIDs {
+			insertBuilder = insertBuilder.Values(runID, u.ID, true, false)
+		}
+	}
+
+	_, err := store.execBuilder(store.db, insertBuilder)
+	require.NoError(t, err)
+}
+
 func createChannels(t testing.TB, store *SQLStore, channels []model.Channel) {
 	t.Helper()
 


### PR DESCRIPTION
#### Summary
Adding participants to the `IR_Run_Participants` table. Modifying the queries to pull from the updated list.
Note that there is currently no way to actually become a participant from the UI.

Also adding automatic adding and removing of participants/members as this was required to fix tests.

Commits are logical if you want to review incrementally.  


#### Ticket Link
Fixes #1399
Fixes #1401 
