### PR TITLE
graphql mutations to add/remove participants to/from a run

### DIFF
--- a/server/api/graphql_run.go
+++ b/server/api/graphql_run.go
@@ -32,3 +32,59 @@ func (r *RunResolver) IsFavorite(ctx context.Context) (bool, error) {
 
 	return isFavorite, nil
 }
+
+// -----------------------------------------------------------------------------
+// Run mutations
+// -----------------------------------------------------------------------------
+
+func (r *RootResolver) AddRunParticipants(ctx context.Context, args struct {
+	RunID   string
+	UserIDs []string
+}) (string, error) {
+	c, err := getContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	userID := c.r.Header.Get("Mattermost-User-ID")
+
+	if err := c.permissions.RunView(userID, args.RunID); err != nil {
+		return "", errors.Wrap(err, "attempted to modify participants without permissions")
+	}
+
+	if err := c.playbookRunService.AddRunParticipants(args.RunID, args.UserIDs); err != nil {
+		return "", errors.Wrap(err, "failed to remove participant from run")
+	}
+
+	return "", nil
+}
+
+func (r *RootResolver) RemoveRunParticipant(ctx context.Context, args struct {
+	RunID  string
+	UserID string
+}) (string, error) {
+	c, err := getContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	userID := c.r.Header.Get("Mattermost-User-ID")
+
+	if err := c.permissions.RunView(userID, args.RunID); err != nil {
+		return "", errors.Wrap(err, "attempted to modify participants without permissions")
+	}
+
+	if err := c.playbookRunService.RemoveRunParticipant(args.RunID, args.UserID); err != nil {
+		return "", errors.Wrap(err, "failed to remove participant from run")
+	}
+
+	// Don't worry if the user could not be previously a follower
+	// Unfollow implementation is defensive about this.
+	if err := c.playbookRunService.Unfollow(args.RunID, args.UserID); err != nil {
+		return "", errors.Wrap(err, "failed to make participant to unfollow run")
+	}
+
+	if err := c.permissions.RunView(userID, args.RunID); err != nil {
+		return "", nil
+	}
+
+	return "", nil
+}

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -904,7 +904,7 @@ func (h *PlaybookRunHandler) leave(w http.ResponseWriter, r *http.Request) {
 	playbookRunID := mux.Vars(r)["id"]
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	if err := h.playbookRunService.Leave(playbookRunID, userID); err != nil {
+	if err := h.playbookRunService.RemoveRunParticipant(playbookRunID, userID); err != nil {
 		h.HandleError(w, err)
 		return
 	}

--- a/server/api/schema.graphqls
+++ b/server/api/schema.graphqls
@@ -20,14 +20,16 @@ type Query {
 type Mutation {
 	updatePlaybook(id: String!, updates: PlaybookUpdates!): String!
 
-	updateRun(id: String!, updates: RunUpdates!): String!
-
 	addMetric(playbookID: String!, title: String!, description: String!, type: String!, target: Int): String!
 	updateMetric(id: String!, title: String, description: String, target: Int): String!
 	deleteMetric(id: String!): String!
 
 	addPlaybookMember(playbookID: String!, userID: String!): String!
 	removePlaybookMember(playbookID: String!, userID: String!): String!
+
+	updateRun(id: String!, updates: RunUpdates!): String!
+	addRunParticipants(runID: String!, userIDs: [String!]!): String!
+	removeRunParticipant(runID: String!, userID: String!): String!
 }
 
 input PlaybookUpdates {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -743,8 +743,11 @@ type PlaybookRunService interface {
 	// RequestGetInvolved posts a join request message in the run's channel
 	RequestGetInvolved(playbookRunID, requesterID string) error
 
-	// Leave removes user from the run's participants&followers list
-	Leave(playbookRunID, requesterID string) error
+	// AddRunParticipants add users to the run's participants&followers list
+	AddRunParticipants(playbookRunID string, userIDs []string) error
+
+	// RemoveRunParticipant removes user from the run's participants&followers list
+	RemoveRunParticipant(playbookRunID, userID string) error
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2748,25 +2748,51 @@ func (s *PlaybookRunServiceImpl) RequestGetInvolved(playbookRunID, requesterID s
 	return nil
 }
 
-// Leave removes user from the run's participants&followers lists
-func (s *PlaybookRunServiceImpl) Leave(playbookRunID, requesterID string) error {
+// RemoveRunParticipant removes user from the run's participants&followers lists
+func (s *PlaybookRunServiceImpl) AddRunParticipants(playbookRunID string, userIDs []string) error {
+	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve playbook run")
+	}
+
+	// To be migrated to run participats store functions
+	// Once it's migrated, we might want to push run through websocket
+	for _, userID := range userIDs {
+		member, err := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, userID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get channel member")
+		}
+		if member == nil {
+			if _, err := s.api.AddChannelMember(playbookRun.ChannelID, userID); err != nil {
+				return errors.Wrap(err, "failed to add channel member")
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveRunParticipant removes user from the run's participants&followers lists
+func (s *PlaybookRunServiceImpl) RemoveRunParticipant(playbookRunID, userID string) error {
 	playbookRun, err := s.store.GetPlaybookRun(playbookRunID)
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve playbook run")
 	}
 
 	// Check if user is an owner
-	if playbookRun.OwnerUserID == requesterID {
+	if playbookRun.OwnerUserID == userID {
 		return errors.New("owner user can't leave the run")
 	}
 
+	// To be migrated to run participats store functions
+	// Once it's migrated, we might want to push run through websocket
+
 	// Check if user is not a member of the channel
-	member, _ := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, requesterID)
+	member, _ := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, userID)
 	if member == nil {
 		return errors.New("user is not a participant")
 	}
 
-	if err := s.api.DeleteChannelMember(playbookRun.ChannelID, requesterID); err != nil {
+	if err := s.api.DeleteChannelMember(playbookRun.ChannelID, userID); err != nil {
 		return errors.Wrap(err, "failed to remove channel member")
 	}
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
@@ -41,13 +41,14 @@ interface Props {
     role: Role;
     channel: Channel | undefined | null;
     hasAccessToChannel: boolean;
+    hasPermanentViewerAccess: boolean;
     onInfoClick: () => void;
     onTimelineClick: () => void;
     rhsSection: RHSContent | null;
     isFollowing: boolean;
 }
 
-export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAccessToChannel, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
+export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasPermanentViewerAccess, hasAccessToChannel, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const [showGetInvolvedConfirm, setShowGetInvolvedConfirm] = useState(false);
@@ -112,6 +113,7 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAcc
                 isFavoriteRun={isFavoriteRun}
                 isFollowing={isFollowing}
                 toggleFavorite={toggleFavorite}
+                hasPermanentViewerAccess={hasPermanentViewerAccess}
             />
             <StyledBadge status={BadgeType[playbookRun.current_status]}/>
             <HeaderButton

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -103,6 +103,7 @@ const PlaybookRunDetails = () => {
     const myUser = useSelector(getCurrentUser);
     const {options, selectOption, eventsFilter, resetFilters} = useFilter();
     const followState = useFollowers(metadata?.followers || []);
+    const hasPermanentViewerAccess = playbook?.public || playbook?.members.find((m) => m.user_id === myUser.id) !== undefined;
 
     const RHS = useRHS(playbookRun);
 
@@ -216,6 +217,7 @@ const PlaybookRunDetails = () => {
                         role={role}
                         channel={channel}
                         hasAccessToChannel={!channelFetchMetadata.isErrorCode(403)}
+                        hasPermanentViewerAccess={hasPermanentViewerAccess}
                         rhsSection={RHS.isOpen ? RHS.section : null}
                         isFollowing={followState.isFollowing}
                     />

--- a/webapp/src/graphql/generated_types.ts
+++ b/webapp/src/graphql/generated_types.ts
@@ -67,8 +67,10 @@ export type Mutation = {
     __typename?: 'Mutation';
     addMetric: Scalars['String'];
     addPlaybookMember: Scalars['String'];
+    addRunParticipants: Scalars['String'];
     deleteMetric: Scalars['String'];
     removePlaybookMember: Scalars['String'];
+    removeRunParticipant: Scalars['String'];
     updateMetric: Scalars['String'];
     updatePlaybook: Scalars['String'];
     updateRun: Scalars['String'];
@@ -87,12 +89,22 @@ export type MutationAddPlaybookMemberArgs = {
     userID: Scalars['String'];
 };
 
+export type MutationAddRunParticipantsArgs = {
+    runID: Scalars['String'];
+    userIDs: Array<Scalars['String']>;
+};
+
 export type MutationDeleteMetricArgs = {
     id: Scalars['String'];
 };
 
 export type MutationRemovePlaybookMemberArgs = {
     playbookID: Scalars['String'];
+    userID: Scalars['String'];
+};
+
+export type MutationRemoveRunParticipantArgs = {
+    runID: Scalars['String'];
     userID: Scalars['String'];
 };
 
@@ -280,6 +292,20 @@ export type UpdateRunMutationVariables = Exact<{
 }>;
 
 export type UpdateRunMutation = { __typename?: 'Mutation', updateRun: string };
+
+export type AddRunParticipantsMutationVariables = Exact<{
+    runID: Scalars['String'];
+    userIDs: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+export type AddRunParticipantsMutation = { __typename?: 'Mutation', addRunParticipants: string };
+
+export type RemoveRunParticipantMutationVariables = Exact<{
+    runID: Scalars['String'];
+    userID: Scalars['String'];
+}>;
+
+export type RemoveRunParticipantMutation = { __typename?: 'Mutation', removeRunParticipant: string };
 
 export const PlaybookDocument = gql`
     query Playbook($id: String!) {
@@ -550,6 +576,70 @@ export function useUpdateRunMutation(baseOptions?: Apollo.MutationHookOptions<Up
 export type UpdateRunMutationHookResult = ReturnType<typeof useUpdateRunMutation>;
 export type UpdateRunMutationResult = Apollo.MutationResult<UpdateRunMutation>;
 export type UpdateRunMutationOptions = Apollo.BaseMutationOptions<UpdateRunMutation, UpdateRunMutationVariables>;
+export const AddRunParticipantsDocument = gql`
+    mutation AddRunParticipants($runID: String!, $userIDs: [String!]!) {
+  addRunParticipants(runID: $runID, userIDs: $userIDs)
+}
+    `;
+export type AddRunParticipantsMutationFn = Apollo.MutationFunction<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>;
+
+/**
+ * __useAddRunParticipantsMutation__
+ *
+ * To run a mutation, you first call `useAddRunParticipantsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddRunParticipantsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addRunParticipantsMutation, { data, loading, error }] = useAddRunParticipantsMutation({
+ *   variables: {
+ *      runID: // value for 'runID'
+ *      userIDs: // value for 'userIDs'
+ *   },
+ * });
+ */
+export function useAddRunParticipantsMutation(baseOptions?: Apollo.MutationHookOptions<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>) {
+    const options = {...defaultOptions, ...baseOptions};
+    return Apollo.useMutation<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>(AddRunParticipantsDocument, options);
+}
+export type AddRunParticipantsMutationHookResult = ReturnType<typeof useAddRunParticipantsMutation>;
+export type AddRunParticipantsMutationResult = Apollo.MutationResult<AddRunParticipantsMutation>;
+export type AddRunParticipantsMutationOptions = Apollo.BaseMutationOptions<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>;
+export const RemoveRunParticipantDocument = gql`
+    mutation RemoveRunParticipant($runID: String!, $userID: String!) {
+  removeRunParticipant(runID: $runID, userID: $userID)
+}
+    `;
+export type RemoveRunParticipantMutationFn = Apollo.MutationFunction<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>;
+
+/**
+ * __useRemoveRunParticipantMutation__
+ *
+ * To run a mutation, you first call `useRemoveRunParticipantMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveRunParticipantMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeRunParticipantMutation, { data, loading, error }] = useRemoveRunParticipantMutation({
+ *   variables: {
+ *      runID: // value for 'runID'
+ *      userID: // value for 'userID'
+ *   },
+ * });
+ */
+export function useRemoveRunParticipantMutation(baseOptions?: Apollo.MutationHookOptions<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>) {
+    const options = {...defaultOptions, ...baseOptions};
+    return Apollo.useMutation<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>(RemoveRunParticipantDocument, options);
+}
+export type RemoveRunParticipantMutationHookResult = ReturnType<typeof useRemoveRunParticipantMutation>;
+export type RemoveRunParticipantMutationResult = Apollo.MutationResult<RemoveRunParticipantMutation>;
+export type RemoveRunParticipantMutationOptions = Apollo.BaseMutationOptions<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>;
 
 export interface PossibleTypesResultData {
     possibleTypes: {

--- a/webapp/src/graphql/hooks.ts
+++ b/webapp/src/graphql/hooks.ts
@@ -10,8 +10,10 @@ import {
     PlaybookUpdates,
     RunUpdates,
     useAddPlaybookMemberMutation,
+    useAddRunParticipantsMutation,
     usePlaybookQuery,
     useRemovePlaybookMemberMutation,
+    useRemoveRunParticipantMutation,
     useUpdatePlaybookMutation,
     useUpdateRunMutation,
 } from 'src/graphql/generated_types';
@@ -95,4 +97,42 @@ export const usePlaybookMembership = (playbookID?: string, userID?: string) => {
     }, [playbookID, userID, leavePlaybook]);
 
     return {join, leave};
+};
+
+export const useRunAddParticipants = (runID?: string, userIDs?: string[]) => {
+    const [addToRun] = useAddRunParticipantsMutation({
+        refetchQueries: [
+            PlaybookLhsDocument,
+        ],
+        variables: {
+            runID: runID || '',
+            userIDs: userIDs || [],
+        },
+    });
+
+    return useCallback(async () => {
+        if (!runID || !userIDs || userIDs?.length === 0) {
+            return;
+        }
+        await addToRun();
+    }, [runID, JSON.stringify(userIDs), addToRun]);
+};
+
+export const useRunRemoveParticipant = (runID?: string, userID?: string) => {
+    const [removeFromRun] = useRemoveRunParticipantMutation({
+        refetchQueries: [
+            PlaybookLhsDocument,
+        ],
+        variables: {
+            runID: runID || '',
+            userID: userID || '',
+        },
+    });
+
+    return useCallback(async () => {
+        if (!runID || !userID) {
+            return;
+        }
+        await removeFromRun();
+    }, [runID, userID, removeFromRun]);
 };

--- a/webapp/src/graphql/runs.graphql
+++ b/webapp/src/graphql/runs.graphql
@@ -1,3 +1,11 @@
 mutation UpdateRun($id: String!, $updates: RunUpdates!) {
   updateRun(id: $id, updates: $updates)
 }
+
+mutation AddRunParticipants($runID: String!, $userIDs: [String!]!) {
+	addRunParticipants(runID: $runID, userIDs: $userIDs)
+}
+
+mutation RemoveRunParticipant($runID: String!, $userID: String!) {
+	removeRunParticipant(runID: $runID, userID: $userID)
+}


### PR DESCRIPTION
#### Summary
Make new graphql mutations to work with current participate/leave flows (still rely on channel members).

#### Ticket Link
Fixes 


#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
