### PR TITLE
e2e: Cypress 10.3 -> 10.6

### DIFF
--- a/tests-e2e/package-lock.json
+++ b/tests-e2e/package-lock.json
@@ -10,7 +10,7 @@
         "authenticator": "^1.1.5",
         "axios": "^0.21.1",
         "axios-retry": "^3.1.9",
-        "cypress": "^10.3.0",
+        "cypress": "^10.6.0",
         "cypress-multi-reporters": "^1.5.0",
         "cypress-plugin-tab": "^1.0.5",
         "cypress-terminal-report": "^4.1.1",
@@ -1541,9 +1541,9 @@
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "node_modules/cypress": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.0.tgz",
-      "integrity": "sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.6.0.tgz",
+      "integrity": "sha512-6sOpHjostp8gcLO34p6r/Ci342lBs8S5z9/eb3ZCQ22w2cIhMWGUoGKkosabPBfKcvRS9BE4UxybBtlIs8gTQA==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
@@ -7319,9 +7319,9 @@
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "cypress": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.0.tgz",
-      "integrity": "sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.6.0.tgz",
+      "integrity": "sha512-6sOpHjostp8gcLO34p6r/Ci342lBs8S5z9/eb3ZCQ22w2cIhMWGUoGKkosabPBfKcvRS9BE4UxybBtlIs8gTQA==",
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",

--- a/tests-e2e/package.json
+++ b/tests-e2e/package.json
@@ -5,7 +5,7 @@
     "authenticator": "^1.1.5",
     "axios": "^0.21.1",
     "axios-retry": "^3.1.9",
-    "cypress": "^10.3.0",
+    "cypress": "^10.6.0",
     "cypress-multi-reporters": "^1.5.0",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-terminal-report": "^4.1.1",


### PR DESCRIPTION
The new Cypress 10 runner has been locking up on me pretty frequently while working on tests. Saturn noticed the same but also tried `10.4` and said that it seemed much better, so :crossed_fingers:.