### PR TITLE
graphql mutations to add/remove participants to/from a run

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -884,6 +884,7 @@ func (h *PlaybookRunHandler) requestUpdate(w http.ResponseWriter, r *http.Reques
 }
 
 // requestGetInvolved handles the request of a user who does not participate actively in a run
+// and can not join directly (need to ask others who have permissions to add them)
 func (h *PlaybookRunHandler) requestGetInvolved(w http.ResponseWriter, r *http.Request) {
 	playbookRunID := mux.Vars(r)["id"]
 	userID := r.Header.Get("Mattermost-User-ID")
@@ -900,11 +901,12 @@ func (h *PlaybookRunHandler) requestGetInvolved(w http.ResponseWriter, r *http.R
 }
 
 // leave handles the POST request /runs/{id}/leave endpoint, caller user will be removed from participants.
+// @deprecated use GraphQL removeRunParticipant mutation instead
 func (h *PlaybookRunHandler) leave(w http.ResponseWriter, r *http.Request) {
 	playbookRunID := mux.Vars(r)["id"]
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	if err := h.playbookRunService.Leave(playbookRunID, userID); err != nil {
+	if err := h.playbookRunService.RemoveRunParticipant(playbookRunID, userID); err != nil {
 		h.HandleError(w, err)
 		return
 	}

--- a/server/api/schema.graphqls
+++ b/server/api/schema.graphqls
@@ -29,7 +29,7 @@ type Mutation {
 
 	updateRun(id: String!, updates: RunUpdates!): String!
 	addRunParticipants(runID: String!, userIDs: [String!]!): String!
-	removeRunParticipant(runID: String!, userID: String!): String!
+	removeRunParticipants(runID: String!, userIDs: [String!]!): String!
 }
 
 input PlaybookUpdates {

--- a/server/api/schema.graphqls
+++ b/server/api/schema.graphqls
@@ -20,14 +20,16 @@ type Query {
 type Mutation {
 	updatePlaybook(id: String!, updates: PlaybookUpdates!): String!
 
-	updateRun(id: String!, updates: RunUpdates!): String!
-
 	addMetric(playbookID: String!, title: String!, description: String!, type: String!, target: Int): String!
 	updateMetric(id: String!, title: String, description: String, target: Int): String!
 	deleteMetric(id: String!): String!
 
 	addPlaybookMember(playbookID: String!, userID: String!): String!
 	removePlaybookMember(playbookID: String!, userID: String!): String!
+
+	updateRun(id: String!, updates: RunUpdates!): String!
+	addRunParticipants(runID: String!, userIDs: [String!]!): String!
+	removeRunParticipant(runID: String!, userID: String!): String!
 }
 
 input PlaybookUpdates {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -743,8 +743,11 @@ type PlaybookRunService interface {
 	// RequestGetInvolved posts a join request message in the run's channel
 	RequestGetInvolved(playbookRunID, requesterID string) error
 
-	// Leave removes user from the run's participants&followers list
-	Leave(playbookRunID, requesterID string) error
+	// AddRunParticipants add users to the run's participants&followers list
+	AddRunParticipants(playbookRunID string, userIDs []string) error
+
+	// RemoveRunParticipant removes user from the run's participants&followers list
+	RemoveRunParticipant(playbookRunID, userID string) error
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2758,6 +2758,7 @@ func (s *PlaybookRunServiceImpl) AddRunParticipants(playbookRunID string, userID
 
 	// To be migrated to run participats store functions
 	// Once it's migrated, we might want to push run through websocket
+	// (since we still rely on redux, not apollo cache)
 	for _, userID := range userIDs {
 		member, err := s.pluginAPI.Channel.GetMember(playbookRun.ChannelID, userID)
 		if member != nil {

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -329,6 +329,7 @@
   "XXbWAU": "Select this to automatically receive updates when this playbook is run.",
   "Xgxruo": "Skip checklist",
   "XmUdvV": "All the statistics you need",
+  "XnICdK": "It wasn't possible to join the run",
   "XpDetT": "Opt out of these tips.",
   "Xx0WZV": "Send message",
   "Y4MU/9": "Select <strong>Start a test run</strong> to see it in action.",

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
@@ -17,7 +17,7 @@ import {PlaybookRun, playbookRunIsActive} from 'src/types/playbook_run';
 import DotMenu, {DropdownMenuItem} from 'src/components/dot_menu';
 import {SemiBoldHeading} from 'src/styles/headings';
 import {copyToClipboard} from 'src/utils';
-import {useRunRemoveParticipant} from 'src/graphql/hooks';
+import {useRunRemoveParticipants} from 'src/graphql/hooks';
 import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
 import {useAllowChannelExport, useExportLogAvailable} from 'src/hooks';
 import UpgradeModal from 'src/components/backstage/upgrade_modal';
@@ -141,7 +141,7 @@ const useLeaveRun = (hasPermanentViewerAccess: boolean, playbookRun: PlaybookRun
     const currentUserId = useSelector(getCurrentUserId);
     const addToast = useToaster().add;
     const [showLeaveRunConfirm, setLeaveRunConfirm] = useState(false);
-    const leaveRun = useRunRemoveParticipant(playbookRun.id, currentUserId);
+    const leaveRun = useRunRemoveParticipants(playbookRun.id, [currentUserId]);
 
     const onLeaveRun = async () => {
         leaveRun()

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
@@ -7,7 +7,6 @@ import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import {AccountPlusOutlineIcon, TimelineTextOutlineIcon, InformationOutlineIcon, LightningBoltOutlineIcon, StarOutlineIcon, StarIcon} from '@mattermost/compass-icons/components';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {joinChannel} from 'mattermost-redux/actions/channels';
 import {Channel} from '@mattermost/types/channels';
 
 import {PrimaryButton} from 'src/components/assets/buttons';
@@ -15,10 +14,11 @@ import CopyLink from 'src/components/widgets/copy_link';
 import {showRunActionsModal} from 'src/actions';
 import {
     getSiteUrl,
-    requestGetInvolved,
     telemetryEventForPlaybookRun,
+    requestGetInvolved,
 } from 'src/client';
 import {useFavoriteRun} from 'src/hooks';
+import {useRunAddParticipants} from 'src/graphql/hooks';
 import {PlaybookRun, Metadata as PlaybookRunMetadata} from 'src/types/playbook_run';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {Role, Badge, ExpandRight} from 'src/components/backstage/playbook_runs/shared';
@@ -30,7 +30,6 @@ import {ToastType, useToaster} from '../../toast_banner';
 import {RHSContent} from 'src/components/backstage/playbook_runs/playbook_run/rhs';
 
 import {StarButton} from '../../playbook_editor/playbook_editor';
-import {useLHSRefresh} from '../../lhs_navigation';
 
 import {ContextMenu} from './context_menu';
 import HeaderButton from './header_button';
@@ -41,13 +40,14 @@ interface Props {
     role: Role;
     channel: Channel | undefined | null;
     hasAccessToChannel: boolean;
+    hasPermanentViewerAccess: boolean;
     onInfoClick: () => void;
     onTimelineClick: () => void;
     rhsSection: RHSContent | null;
     isFollowing: boolean;
 }
 
-export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAccessToChannel, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
+export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasPermanentViewerAccess, hasAccessToChannel, channel, role, onInfoClick, onTimelineClick, rhsSection}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const [showGetInvolvedConfirm, setShowGetInvolvedConfirm] = useState(false);
@@ -55,9 +55,10 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAcc
 
     const addToast = useToaster().add;
     const [isFavoriteRun, toggleFavorite] = useFavoriteRun(playbookRun.team_id, playbookRun.id);
-    const refreshLHS = useLHSRefresh();
 
-    const onGetInvolved = async () => {
+    const joinRun = useRunAddParticipants(playbookRun.id, [currentUserId]);
+
+    const onParticipate = async () => {
         if (role === Role.Participant || !playbookRunMetadata) {
             return;
         }
@@ -65,28 +66,30 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAcc
         setShowGetInvolvedConfirm(true);
     };
 
-    const onConfirmGetInvolved = async () => {
+    const onConfirmParticipate = async () => {
         if (role === Role.Participant || !playbookRunMetadata) {
             return;
         }
+        if (!channel) {
+            addToast(formatMessage({defaultMessage: 'Your request wasn\'t successful.'}), ToastType.Failure);
+            return;
+        }
+
+        // TODO: remove channel eval when participants are full-related to run
         if (!hasAccessToChannel) {
-            const response = await requestGetInvolved(playbookRun.id);
-            if (response?.error) {
-                addToast(formatMessage({defaultMessage: 'Your request to join the run was unsuccessful. '}), ToastType.Failure);
-            } else {
-                addToast(formatMessage({defaultMessage: 'Your request has been sent to the run channel. '}), ToastType.Success);
-            }
+            requestGetInvolved(playbookRun.id)
+                .then(() => addToast(formatMessage({defaultMessage: 'Your request has been sent to the run channel.'}), ToastType.Success))
+                .catch(() => addToast(formatMessage({defaultMessage: 'Your request to join the run was unsuccessful.'}), ToastType.Failure));
             return;
         } else if (!channel) {
             addToast(formatMessage({defaultMessage: 'Your request wasn\'t successful.'}), ToastType.Failure);
             return;
         }
 
-        // if channel is not null, join the channel
-        await dispatch(joinChannel(currentUserId, playbookRun.team_id, playbookRun.channel_id, playbookRunMetadata.channel_name));
+        joinRun()
+            .then(() => addToast(formatMessage({defaultMessage: 'You\'ve joined this run.'}), ToastType.Success))
+            .catch(() => addToast(formatMessage({defaultMessage: 'It wasn\'t possible to join the run'}), ToastType.Failure));
         telemetryEventForPlaybookRun(playbookRun.id, PlaybookRunEventTarget.GetInvolvedJoin);
-        refreshLHS();
-        addToast(formatMessage({defaultMessage: 'You\'ve joined this run.'}), ToastType.Success);
     };
 
     const confirmGetInvolvedMessage = () => {
@@ -112,6 +115,7 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAcc
                 isFavoriteRun={isFavoriteRun}
                 isFollowing={isFollowing}
                 toggleFavorite={toggleFavorite}
+                hasPermanentViewerAccess={hasPermanentViewerAccess}
             />
             <StyledBadge status={BadgeType[playbookRun.current_status]}/>
             <HeaderButton
@@ -145,7 +149,7 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAcc
                 data-testid={'rhs-header-button-info'}
             />
             {role === Role.Viewer &&
-                <GetInvolved onClick={onGetInvolved}>
+                <GetInvolved onClick={onParticipate}>
                     <GetInvolvedIcon color={'var(--button-color)'}/>
                     {formatMessage({defaultMessage: 'Participate'})}
                 </GetInvolved>
@@ -160,7 +164,7 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasAcc
                 message={confirmGetInvolvedMessage()}
                 confirmButtonText={formatMessage({defaultMessage: 'Confirm'})}
                 onConfirm={() => {
-                    onConfirmGetInvolved();
+                    onConfirmParticipate();
                     setShowGetInvolvedConfirm(false);
                 }}
                 onCancel={() => setShowGetInvolvedConfirm(false)}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
@@ -70,10 +70,6 @@ export const RunHeader = ({playbookRun, playbookRunMetadata, isFollowing, hasPer
         if (role === Role.Participant || !playbookRunMetadata) {
             return;
         }
-        if (!channel) {
-            addToast(formatMessage({defaultMessage: 'Your request wasn\'t successful.'}), ToastType.Failure);
-            return;
-        }
 
         // TODO: remove channel eval when participants are full-related to run
         if (!hasAccessToChannel) {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/playbook_run.tsx
@@ -103,6 +103,7 @@ const PlaybookRunDetails = () => {
     const myUser = useSelector(getCurrentUser);
     const {options, selectOption, eventsFilter, resetFilters} = useFilter();
     const followState = useFollowers(metadata?.followers || []);
+    const hasPermanentViewerAccess = playbook?.public || playbook?.members.find((m) => m.user_id === myUser.id) !== undefined;
 
     const RHS = useRHS(playbookRun);
 
@@ -216,6 +217,7 @@ const PlaybookRunDetails = () => {
                         role={role}
                         channel={channel}
                         hasAccessToChannel={!channelFetchMetadata.isErrorCode(403)}
+                        hasPermanentViewerAccess={hasPermanentViewerAccess}
                         rhsSection={RHS.isOpen ? RHS.section : null}
                         isFollowing={followState.isFollowing}
                     />

--- a/webapp/src/graphql/generated_types.ts
+++ b/webapp/src/graphql/generated_types.ts
@@ -67,8 +67,10 @@ export type Mutation = {
     __typename?: 'Mutation';
     addMetric: Scalars['String'];
     addPlaybookMember: Scalars['String'];
+    addRunParticipants: Scalars['String'];
     deleteMetric: Scalars['String'];
     removePlaybookMember: Scalars['String'];
+    removeRunParticipant: Scalars['String'];
     updateMetric: Scalars['String'];
     updatePlaybook: Scalars['String'];
     updateRun: Scalars['String'];
@@ -87,12 +89,22 @@ export type MutationAddPlaybookMemberArgs = {
     userID: Scalars['String'];
 };
 
+export type MutationAddRunParticipantsArgs = {
+    runID: Scalars['String'];
+    userIDs: Array<Scalars['String']>;
+};
+
 export type MutationDeleteMetricArgs = {
     id: Scalars['String'];
 };
 
 export type MutationRemovePlaybookMemberArgs = {
     playbookID: Scalars['String'];
+    userID: Scalars['String'];
+};
+
+export type MutationRemoveRunParticipantArgs = {
+    runID: Scalars['String'];
     userID: Scalars['String'];
 };
 
@@ -280,6 +292,20 @@ export type UpdateRunMutationVariables = Exact<{
 }>;
 
 export type UpdateRunMutation = { __typename?: 'Mutation', updateRun: string };
+
+export type AddRunParticipantsMutationVariables = Exact<{
+    runID: Scalars['String'];
+    userIDs: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+export type AddRunParticipantsMutation = { __typename?: 'Mutation', addRunParticipants: string };
+
+export type RemoveRunParticipantMutationVariables = Exact<{
+    runID: Scalars['String'];
+    userID: Scalars['String'];
+}>;
+
+export type RemoveRunParticipantMutation = { __typename?: 'Mutation', removeRunParticipant: string };
 
 export const PlaybookDocument = gql`
     query Playbook($id: String!) {
@@ -550,6 +576,70 @@ export function useUpdateRunMutation(baseOptions?: Apollo.MutationHookOptions<Up
 export type UpdateRunMutationHookResult = ReturnType<typeof useUpdateRunMutation>;
 export type UpdateRunMutationResult = Apollo.MutationResult<UpdateRunMutation>;
 export type UpdateRunMutationOptions = Apollo.BaseMutationOptions<UpdateRunMutation, UpdateRunMutationVariables>;
+export const AddRunParticipantsDocument = gql`
+    mutation AddRunParticipants($runID: String!, $userIDs: [String!]!) {
+  addRunParticipants(runID: $runID, userIDs: $userIDs)
+}
+    `;
+export type AddRunParticipantsMutationFn = Apollo.MutationFunction<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>;
+
+/**
+ * __useAddRunParticipantsMutation__
+ *
+ * To run a mutation, you first call `useAddRunParticipantsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddRunParticipantsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addRunParticipantsMutation, { data, loading, error }] = useAddRunParticipantsMutation({
+ *   variables: {
+ *      runID: // value for 'runID'
+ *      userIDs: // value for 'userIDs'
+ *   },
+ * });
+ */
+export function useAddRunParticipantsMutation(baseOptions?: Apollo.MutationHookOptions<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>) {
+    const options = {...defaultOptions, ...baseOptions};
+    return Apollo.useMutation<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>(AddRunParticipantsDocument, options);
+}
+export type AddRunParticipantsMutationHookResult = ReturnType<typeof useAddRunParticipantsMutation>;
+export type AddRunParticipantsMutationResult = Apollo.MutationResult<AddRunParticipantsMutation>;
+export type AddRunParticipantsMutationOptions = Apollo.BaseMutationOptions<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>;
+export const RemoveRunParticipantDocument = gql`
+    mutation RemoveRunParticipant($runID: String!, $userID: String!) {
+  removeRunParticipant(runID: $runID, userID: $userID)
+}
+    `;
+export type RemoveRunParticipantMutationFn = Apollo.MutationFunction<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>;
+
+/**
+ * __useRemoveRunParticipantMutation__
+ *
+ * To run a mutation, you first call `useRemoveRunParticipantMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveRunParticipantMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeRunParticipantMutation, { data, loading, error }] = useRemoveRunParticipantMutation({
+ *   variables: {
+ *      runID: // value for 'runID'
+ *      userID: // value for 'userID'
+ *   },
+ * });
+ */
+export function useRemoveRunParticipantMutation(baseOptions?: Apollo.MutationHookOptions<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>) {
+    const options = {...defaultOptions, ...baseOptions};
+    return Apollo.useMutation<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>(RemoveRunParticipantDocument, options);
+}
+export type RemoveRunParticipantMutationHookResult = ReturnType<typeof useRemoveRunParticipantMutation>;
+export type RemoveRunParticipantMutationResult = Apollo.MutationResult<RemoveRunParticipantMutation>;
+export type RemoveRunParticipantMutationOptions = Apollo.BaseMutationOptions<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>;
 
 export interface PossibleTypesResultData {
     possibleTypes: {

--- a/webapp/src/graphql/generated_types.ts
+++ b/webapp/src/graphql/generated_types.ts
@@ -70,7 +70,7 @@ export type Mutation = {
     addRunParticipants: Scalars['String'];
     deleteMetric: Scalars['String'];
     removePlaybookMember: Scalars['String'];
-    removeRunParticipant: Scalars['String'];
+    removeRunParticipants: Scalars['String'];
     updateMetric: Scalars['String'];
     updatePlaybook: Scalars['String'];
     updateRun: Scalars['String'];
@@ -103,9 +103,9 @@ export type MutationRemovePlaybookMemberArgs = {
     userID: Scalars['String'];
 };
 
-export type MutationRemoveRunParticipantArgs = {
+export type MutationRemoveRunParticipantsArgs = {
     runID: Scalars['String'];
-    userID: Scalars['String'];
+    userIDs: Array<Scalars['String']>;
 };
 
 export type MutationUpdateMetricArgs = {
@@ -300,12 +300,12 @@ export type AddRunParticipantsMutationVariables = Exact<{
 
 export type AddRunParticipantsMutation = { __typename?: 'Mutation', addRunParticipants: string };
 
-export type RemoveRunParticipantMutationVariables = Exact<{
+export type RemoveRunParticipantsMutationVariables = Exact<{
     runID: Scalars['String'];
-    userID: Scalars['String'];
+    userIDs: Array<Scalars['String']> | Scalars['String'];
 }>;
 
-export type RemoveRunParticipantMutation = { __typename?: 'Mutation', removeRunParticipant: string };
+export type RemoveRunParticipantsMutation = { __typename?: 'Mutation', removeRunParticipants: string };
 
 export const PlaybookDocument = gql`
     query Playbook($id: String!) {
@@ -608,38 +608,38 @@ export function useAddRunParticipantsMutation(baseOptions?: Apollo.MutationHookO
 export type AddRunParticipantsMutationHookResult = ReturnType<typeof useAddRunParticipantsMutation>;
 export type AddRunParticipantsMutationResult = Apollo.MutationResult<AddRunParticipantsMutation>;
 export type AddRunParticipantsMutationOptions = Apollo.BaseMutationOptions<AddRunParticipantsMutation, AddRunParticipantsMutationVariables>;
-export const RemoveRunParticipantDocument = gql`
-    mutation RemoveRunParticipant($runID: String!, $userID: String!) {
-  removeRunParticipant(runID: $runID, userID: $userID)
+export const RemoveRunParticipantsDocument = gql`
+    mutation RemoveRunParticipants($runID: String!, $userIDs: [String!]!) {
+  removeRunParticipants(runID: $runID, userIDs: $userIDs)
 }
     `;
-export type RemoveRunParticipantMutationFn = Apollo.MutationFunction<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>;
+export type RemoveRunParticipantsMutationFn = Apollo.MutationFunction<RemoveRunParticipantsMutation, RemoveRunParticipantsMutationVariables>;
 
 /**
- * __useRemoveRunParticipantMutation__
+ * __useRemoveRunParticipantsMutation__
  *
- * To run a mutation, you first call `useRemoveRunParticipantMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useRemoveRunParticipantMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useRemoveRunParticipantsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveRunParticipantsMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [removeRunParticipantMutation, { data, loading, error }] = useRemoveRunParticipantMutation({
+ * const [removeRunParticipantsMutation, { data, loading, error }] = useRemoveRunParticipantsMutation({
  *   variables: {
  *      runID: // value for 'runID'
- *      userID: // value for 'userID'
+ *      userIDs: // value for 'userIDs'
  *   },
  * });
  */
-export function useRemoveRunParticipantMutation(baseOptions?: Apollo.MutationHookOptions<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>) {
+export function useRemoveRunParticipantsMutation(baseOptions?: Apollo.MutationHookOptions<RemoveRunParticipantsMutation, RemoveRunParticipantsMutationVariables>) {
     const options = {...defaultOptions, ...baseOptions};
-    return Apollo.useMutation<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>(RemoveRunParticipantDocument, options);
+    return Apollo.useMutation<RemoveRunParticipantsMutation, RemoveRunParticipantsMutationVariables>(RemoveRunParticipantsDocument, options);
 }
-export type RemoveRunParticipantMutationHookResult = ReturnType<typeof useRemoveRunParticipantMutation>;
-export type RemoveRunParticipantMutationResult = Apollo.MutationResult<RemoveRunParticipantMutation>;
-export type RemoveRunParticipantMutationOptions = Apollo.BaseMutationOptions<RemoveRunParticipantMutation, RemoveRunParticipantMutationVariables>;
+export type RemoveRunParticipantsMutationHookResult = ReturnType<typeof useRemoveRunParticipantsMutation>;
+export type RemoveRunParticipantsMutationResult = Apollo.MutationResult<RemoveRunParticipantsMutation>;
+export type RemoveRunParticipantsMutationOptions = Apollo.BaseMutationOptions<RemoveRunParticipantsMutation, RemoveRunParticipantsMutationVariables>;
 
 export interface PossibleTypesResultData {
     possibleTypes: {

--- a/webapp/src/graphql/hooks.ts
+++ b/webapp/src/graphql/hooks.ts
@@ -10,8 +10,10 @@ import {
     PlaybookUpdates,
     RunUpdates,
     useAddPlaybookMemberMutation,
+    useAddRunParticipantsMutation,
     usePlaybookQuery,
     useRemovePlaybookMemberMutation,
+    useRemoveRunParticipantMutation,
     useUpdatePlaybookMutation,
     useUpdateRunMutation,
 } from 'src/graphql/generated_types';
@@ -95,4 +97,42 @@ export const usePlaybookMembership = (playbookID?: string, userID?: string) => {
     }, [playbookID, userID, leavePlaybook]);
 
     return {join, leave};
+};
+
+export const useRunAddParticipants = (runID?: string, userIDs?: string[]) => {
+    const [addToRun] = useAddRunParticipantsMutation({
+        refetchQueries: [
+            PlaybookLhsDocument,
+        ],
+        variables: {
+            runID: runID || '',
+            userIDs: userIDs || [],
+        },
+    });
+
+    return useCallback(async () => {
+        if (!runID || !userIDs || userIDs?.length === 0) {
+            return;
+        }
+        await addToRun();
+    }, [runID, JSON.stringify(userIDs), addToRun]);
+};
+
+export const useRunRemoveParticipant = (runID?: string, userID?: string) => {
+    const [removeFromRun] = useRemoveRunParticipantMutation({
+        refetchQueries: [
+            PlaybookLhsDocument,
+        ],
+        variables: {
+            runID: runID || '',
+            userID: userID || '',
+        },
+    });
+
+    return useCallback(async () => {
+        if (!runID || !userID) {
+            return;
+        }
+        await removeFromRun();
+    }, [runID, userID, removeFromRun]);
 };

--- a/webapp/src/graphql/hooks.ts
+++ b/webapp/src/graphql/hooks.ts
@@ -13,7 +13,7 @@ import {
     useAddRunParticipantsMutation,
     usePlaybookQuery,
     useRemovePlaybookMemberMutation,
-    useRemoveRunParticipantMutation,
+    useRemoveRunParticipantsMutation,
     useUpdatePlaybookMutation,
     useUpdateRunMutation,
 } from 'src/graphql/generated_types';
@@ -118,21 +118,21 @@ export const useRunAddParticipants = (runID?: string, userIDs?: string[]) => {
     }, [runID, JSON.stringify(userIDs), addToRun]);
 };
 
-export const useRunRemoveParticipant = (runID?: string, userID?: string) => {
-    const [removeFromRun] = useRemoveRunParticipantMutation({
+export const useRunRemoveParticipants = (runID?: string, userIDs?: string[]) => {
+    const [removeFromRun] = useRemoveRunParticipantsMutation({
         refetchQueries: [
             PlaybookLhsDocument,
         ],
         variables: {
             runID: runID || '',
-            userID: userID || '',
+            userIDs: userIDs || [],
         },
     });
 
     return useCallback(async () => {
-        if (!runID || !userID) {
+        if (!runID || !userIDs || userIDs?.length === 0) {
             return;
         }
         await removeFromRun();
-    }, [runID, userID, removeFromRun]);
+    }, [runID, JSON.stringify(userIDs), removeFromRun]);
 };

--- a/webapp/src/graphql/runs.graphql
+++ b/webapp/src/graphql/runs.graphql
@@ -6,6 +6,6 @@ mutation AddRunParticipants($runID: String!, $userIDs: [String!]!) {
 	addRunParticipants(runID: $runID, userIDs: $userIDs)
 }
 
-mutation RemoveRunParticipant($runID: String!, $userID: String!) {
-	removeRunParticipant(runID: $runID, userID: $userID)
+mutation RemoveRunParticipants($runID: String!, $userIDs: [String!]!) {
+	removeRunParticipants(runID: $runID, userIDs: $userIDs)
 }

--- a/webapp/src/graphql/runs.graphql
+++ b/webapp/src/graphql/runs.graphql
@@ -1,3 +1,11 @@
 mutation UpdateRun($id: String!, $updates: RunUpdates!) {
   updateRun(id: $id, updates: $updates)
 }
+
+mutation AddRunParticipants($runID: String!, $userIDs: [String!]!) {
+	addRunParticipants(runID: $runID, userIDs: $userIDs)
+}
+
+mutation RemoveRunParticipant($runID: String!, $userID: String!) {
+	removeRunParticipant(runID: $runID, userID: $userID)
+}


### PR DESCRIPTION
#### Summary
This PR introduces the new graphql run mutations but internally relies on channel members. Code will be simplified a lot after connecting to the actual run-participants service/store implementation (https://github.com/mattermost/mattermost-plugin-playbooks/pull/1412).

This could be merged as is, but I'd be more inclined to do it after https://github.com/mattermost/mattermost-plugin-playbooks/pull/1412 and some little refactor.

#### Ticket Link
Fixes (partially) https://github.com/mattermost/mattermost-plugin-playbooks/issues/1402


#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
