### PR TITLE
[MM-44815] Duplicate task as next task instead of the last task

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1569,7 +1569,7 @@ func (s *PlaybookRunServiceImpl) DuplicateChecklistItem(playbookRunID, userID st
 	playbookRunToModify.Checklists[checklistNumber].Items = append(
 		playbookRunToModify.Checklists[checklistNumber].Items[:itemNumber+1],
 		playbookRunToModify.Checklists[checklistNumber].Items[itemNumber:]...)
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber] = checklistItem
+	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber+1] = checklistItem
 
 	if err = s.store.UpdatePlaybookRun(playbookRunToModify); err != nil {
 		return errors.Wrapf(err, "failed to update playbook run")

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1566,7 +1566,10 @@ func (s *PlaybookRunServiceImpl) DuplicateChecklistItem(playbookRunID, userID st
 	checklistItem := playbookRunToModify.Checklists[checklistNumber].Items[itemNumber]
 	checklistItem.ID = ""
 
-	playbookRunToModify.Checklists[checklistNumber].Items = append(playbookRunToModify.Checklists[checklistNumber].Items, checklistItem)
+	playbookRunToModify.Checklists[checklistNumber].Items = append(
+		playbookRunToModify.Checklists[checklistNumber].Items[:itemNumber+1],
+		playbookRunToModify.Checklists[checklistNumber].Items[itemNumber:]...)
+	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber] = checklistItem
 
 	if err = s.store.UpdatePlaybookRun(playbookRunToModify); err != nil {
 		return errors.Wrapf(err, "failed to update playbook run")

--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -56,7 +56,7 @@ const GenericChecklist = (props: Props) => {
     const onDuplicateChecklistItem = (index: number) => {
         const newChecklistItems = [...props.checklist.items];
         const duplicate = {...newChecklistItems[index]};
-        newChecklistItems.splice(index, 0, duplicate);
+        newChecklistItems.splice(index + 1, 0, duplicate);
         const newChecklist = {...props.checklist};
         newChecklist.items = newChecklistItems;
         props.onUpdateChecklist(newChecklist);

--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -56,7 +56,7 @@ const GenericChecklist = (props: Props) => {
     const onDuplicateChecklistItem = (index: number) => {
         const newChecklistItems = [...props.checklist.items];
         const duplicate = {...newChecklistItems[index]};
-        newChecklistItems.push(duplicate);
+        newChecklistItems.splice(index, 0, duplicate);
         const newChecklist = {...props.checklist};
         newChecklist.items = newChecklistItems;
         props.onUpdateChecklist(newChecklist);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

#### Summary
<!--
A description of what this pull request does
-->
Duplicates the item next to itself. The behaviour before this was to add to the end of the list.

#### Technical Description

Instead of a simple append towards the end of the list, this PR creates a new list which is a copy of all the items before and after the duplicated item and returns it after adding the item at the supposedly new position.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/20824

Otherwise, link the Jira ticket.
-->
Fixes: https://github.com/mattermost/mattermost-server/issues/20824

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~Telemetry updated~
- [ ] ~Gated by experimental feature flag~
- [ ] ~Unit tests updated~
