### PR TITLE
Add channel scheme role support

### DIFF
--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -840,8 +840,11 @@ type PlaybookRunStore interface {
 	// if a user is member of more than one channel, it will be counted multiple times
 	GetParticipantsActiveTotal() (int64, error)
 
-	// GetSchemeRolesForChannel scheme role names for the channel
+	// GetSchemeRolesForChannel scheme role ids for the channel
 	GetSchemeRolesForChannel(channelID string) (string, string, string, error)
+
+	// GetSchemeRolesForTeam scheme role ids for the team
+	GetSchemeRolesForTeam(teamID string) (string, string, string, error)
 }
 
 // PlaybookRunTelemetry defines the methods that the PlaybookRunServiceImpl needs from the RudderTelemetry.

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -839,6 +839,9 @@ type PlaybookRunStore interface {
 	// (i.e. members of the playbook run channel when the run is active)
 	// if a user is member of more than one channel, it will be counted multiple times
 	GetParticipantsActiveTotal() (int64, error)
+
+	// GetSchemeRolesForChannel scheme role names for the channel
+	GetSchemeRolesForChannel(channelID string) (string, string, string, error)
 }
 
 // PlaybookRunTelemetry defines the methods that the PlaybookRunServiceImpl needs from the RudderTelemetry.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2280,7 +2280,14 @@ func (s *PlaybookRunServiceImpl) addPlaybookRunUsers(playbookRun *PlaybookRun, c
 		}
 	}
 
-	if _, err := s.pluginAPI.Channel.UpdateChannelMemberRoles(channel.Id, playbookRun.OwnerUserID, fmt.Sprintf("%s %s", model.ChannelAdminRoleId, model.ChannelUserRoleId)); err != nil {
+	_, userRoleID, adminRoleID, err := s.store.GetSchemeRolesForChannel(channel.Id)
+	if err != nil {
+		s.logger.Errorf("failed to get channel scheme roles; error: %s", err.Error())
+		userRoleID = model.ChannelAdminRoleId
+		adminRoleID = model.ChannelUserRoleId
+	}
+
+	if _, err := s.pluginAPI.Channel.UpdateChannelMemberRoles(channel.Id, playbookRun.OwnerUserID, fmt.Sprintf("%s %s", userRoleID, adminRoleID)); err != nil {
 		s.pluginAPI.Log.Warn("failed to promote owner to admin", "ChannelID", channel.Id, "OwnerUserID", playbookRun.OwnerUserID, "err", err.Error())
 	}
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2280,18 +2280,28 @@ func (s *PlaybookRunServiceImpl) addPlaybookRunUsers(playbookRun *PlaybookRun, c
 		}
 	}
 
-	_, userRoleID, adminRoleID, err := s.store.GetSchemeRolesForChannel(channel.Id)
-	if err != nil {
-		s.logger.Errorf("failed to get channel scheme roles; error: %s", err.Error())
-		userRoleID = model.ChannelAdminRoleId
-		adminRoleID = model.ChannelUserRoleId
-	}
+	_, userRoleID, adminRoleID := s.GetSchemeRolesForChannel(channel)
 
 	if _, err := s.pluginAPI.Channel.UpdateChannelMemberRoles(channel.Id, playbookRun.OwnerUserID, fmt.Sprintf("%s %s", userRoleID, adminRoleID)); err != nil {
 		s.pluginAPI.Log.Warn("failed to promote owner to admin", "ChannelID", channel.Id, "OwnerUserID", playbookRun.OwnerUserID, "err", err.Error())
 	}
 
 	return nil
+}
+
+func (s *PlaybookRunServiceImpl) GetSchemeRolesForChannel(channel *model.Channel) (string, string, string) {
+	// get channel roles
+	if guestRole, userRole, adminRole, err := s.store.GetSchemeRolesForChannel(channel.Id); err == nil {
+		return guestRole, userRole, adminRole
+	}
+
+	// get team roles if channel roles are not available
+	if guestRole, userRole, adminRole, err := s.store.GetSchemeRolesForTeam(channel.TeamId); err == nil {
+		return guestRole, userRole, adminRole
+	}
+
+	// return default roles
+	return model.ChannelGuestRoleId, model.ChannelUserRoleId, model.ChannelAdminRoleId
 }
 
 func (s *PlaybookRunServiceImpl) newFinishPlaybookRunDialog(outstanding int) *model.Dialog {

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -1291,7 +1291,7 @@ func (s *playbookRunStore) GetParticipantsActiveTotal() (int64, error) {
 	return count, nil
 }
 
-// GetSchemeRolesForChannel scheme role names for the channel
+// GetSchemeRolesForChannel scheme role ids for the channel
 func (s *playbookRunStore) GetSchemeRolesForChannel(channelID string) (string, string, string, error) {
 	query := s.queryBuilder.
 		Select("COALESCE(s.DefaultChannelGuestRole, 'channel_guest') DefaultChannelGuestRole",
@@ -1300,6 +1300,22 @@ func (s *playbookRunStore) GetSchemeRolesForChannel(channelID string) (string, s
 		From("Schemes as s").
 		Join("Channels AS c ON (c.SchemeId = s.Id)").
 		Where(sq.Eq{"c.Id": channelID})
+
+	var scheme model.Scheme
+	err := s.store.getBuilder(s.store.db, &scheme, query)
+
+	return scheme.DefaultChannelGuestRole, scheme.DefaultChannelUserRole, scheme.DefaultChannelAdminRole, err
+}
+
+// GetSchemeRolesForTeam scheme role ids for the team
+func (s *playbookRunStore) GetSchemeRolesForTeam(teamID string) (string, string, string, error) {
+	query := s.queryBuilder.
+		Select("COALESCE(s.DefaultChannelGuestRole, 'channel_guest') DefaultChannelGuestRole",
+			"COALESCE(s.DefaultChannelUserRole, 'channel_user') DefaultChannelUserRole",
+			"COALESCE(s.DefaultChannelAdminRole, 'channel_admin') DefaultChannelAdminRole").
+		From("Schemes as s").
+		Join("Teams AS t ON (t.SchemeId = s.Id)").
+		Where(sq.Eq{"t.Id": teamID})
 
 	var scheme model.Scheme
 	err := s.store.getBuilder(s.store.db, &scheme, query)

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -1291,6 +1291,22 @@ func (s *playbookRunStore) GetParticipantsActiveTotal() (int64, error) {
 	return count, nil
 }
 
+// GetSchemeRolesForChannel scheme role names for the channel
+func (s *playbookRunStore) GetSchemeRolesForChannel(channelID string) (string, string, string, error) {
+	query := s.queryBuilder.
+		Select("COALESCE(s.DefaultChannelGuestRole, 'channel_guest') DefaultChannelGuestRole",
+			"COALESCE(s.DefaultChannelUserRole, 'channel_user') DefaultChannelUserRole",
+			"COALESCE(s.DefaultChannelAdminRole, 'channel_admin') DefaultChannelAdminRole").
+		From("Schemes as s").
+		Join("Channels AS c ON (c.SchemeId = s.Id)").
+		Where(sq.Eq{"c.Id": channelID})
+
+	var scheme model.Scheme
+	err := s.store.getBuilder(s.store.db, &scheme, query)
+
+	return scheme.DefaultChannelGuestRole, scheme.DefaultChannelUserRole, scheme.DefaultChannelAdminRole, err
+}
+
 // updateRunMetrics updates run metrics values.
 func (s *playbookRunStore) updateRunMetrics(q queryExecer, playbookRun app.PlaybookRun) error {
 	if len(playbookRun.MetricsData) == 0 {

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/guregu/null.v4"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/mock/gomock"
 	"github.com/jmoiron/sqlx"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
@@ -1189,6 +1190,62 @@ func setupPlaybookRunStore(t *testing.T, db *sqlx.DB) app.PlaybookRunStore {
 	logger, sqlStore := setupSQLStore(t, db)
 
 	return NewPlaybookRunStore(pluginAPIClient, logger, sqlStore)
+}
+
+func TestGetSchemeRolesForChannel(t *testing.T) {
+	for _, driverName := range driverNames {
+		db := setupTestDB(t, driverName)
+		playbookRunStore := setupPlaybookRunStore(t, db)
+		_, store := setupSQLStore(t, db)
+
+		t.Run("channel with no scheme", func(t *testing.T) {
+			_, err := store.execBuilder(store.db, sq.
+				Insert("Schemes").
+				SetMap(map[string]interface{}{
+					"ID":                      "scheme_0",
+					"DefaultChannelGuestRole": "guest0",
+					"DefaultChannelUserRole":  "user0",
+					"DefaultChannelAdminRole": "admin0",
+				}))
+			require.NoError(t, err)
+
+			_, err = store.execBuilder(store.db, sq.
+				Insert("Channels").
+				SetMap(map[string]interface{}{
+					"ID": "channel_0",
+				}))
+			require.NoError(t, err)
+
+			_, _, _, err = playbookRunStore.GetSchemeRolesForChannel("channel_0")
+			require.Error(t, err)
+		})
+
+		t.Run("channel with scheme", func(t *testing.T) {
+			_, err := store.execBuilder(store.db, sq.
+				Insert("Schemes").
+				SetMap(map[string]interface{}{
+					"ID":                      "scheme_1",
+					"DefaultChannelGuestRole": nil,
+					"DefaultChannelUserRole":  "user1",
+					"DefaultChannelAdminRole": "admin1",
+				}))
+			require.NoError(t, err)
+
+			_, err = store.execBuilder(store.db, sq.
+				Insert("Channels").
+				SetMap(map[string]interface{}{
+					"ID":       "channel_1",
+					"SchemeId": "scheme_1",
+				}))
+			require.NoError(t, err)
+
+			guest, user, admin, err := playbookRunStore.GetSchemeRolesForChannel("channel_1")
+			require.NoError(t, err)
+			require.Equal(t, guest, model.ChannelGuestRoleId)
+			require.Equal(t, user, "user1")
+			require.Equal(t, admin, "admin1")
+		})
+	}
 }
 
 // PlaybookRunBuilder is a utility to build playbook runs with a default base.

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -15891,7 +15891,6 @@
       "name": "@mattermost/webapp",
       "version": "5.36.0-0",
       "resolved": "git+ssh://git@github.com/mattermost/mattermost-webapp.git#c00fde021889aaddfcd3afa5ce18254756fc4185",
-      "integrity": "sha512-uBL3cO278tHi4lQV2fO1ytDKbRuFJ50o9OV3Z8CoCE3xd6CK1cLcF5XXylsYllK4aqmk7p/1GY9NZ3gOo5B5Lg==",
       "workspaces": [
         "packages/client",
         "packages/types"
@@ -34795,7 +34794,6 @@
     },
     "mattermost-webapp": {
       "version": "git+ssh://git@github.com/mattermost/mattermost-webapp.git#c00fde021889aaddfcd3afa5ce18254756fc4185",
-      "integrity": "sha512-uBL3cO278tHi4lQV2fO1ytDKbRuFJ50o9OV3Z8CoCE3xd6CK1cLcF5XXylsYllK4aqmk7p/1GY9NZ3gOo5B5Lg==",
       "from": "mattermost-webapp@github:mattermost/mattermost-webapp#c00fde021889aaddfcd3afa5ce18254756fc4185",
       "requires": {
         "@floating-ui/react-dom": "0.7.1",


### PR DESCRIPTION
#### Summary
Before: we passed default role values to update a user channel role, which didn't work in cases when the channel had schema-managed roles. 
After: If the channel has scheme-managed roles, we retrieve them from the database and pass them to the `UpdateChannelMemberRoles`. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39387

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
