### PR TITLE
avoid requiring permission for leaving a playbook

### DIFF
--- a/server/api/graphql_root.go
+++ b/server/api/graphql_root.go
@@ -432,9 +432,11 @@ func (r *RootResolver) RemovePlaybookMember(ctx context.Context, args struct {
 	if currentPlaybook.DeleteAt != 0 {
 		return "", errors.New("archived playbooks can not be modified")
 	}
-
-	if err := c.permissions.PlaybookManageMembers(userID, currentPlaybook); err != nil {
-		return "", errors.Wrap(err, "attempted to modify members without permissions")
+	// do not require manageMembers permission if the user want to leave playbook
+	if userID != args.UserID {
+		if err := c.permissions.PlaybookManageMembers(userID, currentPlaybook); err != nil {
+			return "", errors.Wrap(err, "attempted to modify members without permissions")
+		}
 	}
 
 	if err := c.playbookStore.RemovePlaybookMember(args.PlaybookID, args.UserID); err != nil {


### PR DESCRIPTION
#### Summary
Prevent users without permissions from not being able to leave the playbook


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46552

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
