### PR TITLE
add hover background color to pbe broadcast channel selector

### DIFF
--- a/webapp/src/components/backstage/playbook_editor/outline/inputs/broadcast_channels_selector.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/inputs/broadcast_channels_selector.tsx
@@ -135,10 +135,10 @@ const BroadcastChannels = (props: Props) => {
 const selectStyles: StylesConfig<Channel, boolean> = {
     control: (provided) => ({...provided, minWidth: 240, margin: 8}),
     menu: () => ({boxShadow: 'none', width: '340px'}),
-    option: (provided) => {
+    option: (provided, state) => {
         return {
             ...provided,
-            backgroundColor: 'var(--center-channel-bg)',
+            backgroundColor: state.isFocused ? 'rgba(var(--button-bg-rgb), 0.08)' : 'var(--center-channel-bg)',
             color: 'unset',
         };
     },


### PR DESCRIPTION
#### Summary
Add missing hover effects to channel selector in playbook editor


![CleanShot 2022-08-29 at 12 42 02](https://user-images.githubusercontent.com/4096774/187183775-0078e124-a08c-4ded-8313-b41ad08d72a4.gif)

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-44808

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
