### PR TITLE
RHS: do not trigger inline edit if user is doing a text-selection

### DIFF
--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -24,9 +24,7 @@ interface DescriptionProps {
 const RHSAboutDescription = (props: DescriptionProps) => {
     const {formatMessage} = useIntl();
     const placeholder = formatMessage({defaultMessage: 'Add a run summary…'});
-
     const [editedValue, setEditedValue] = useState(props.value);
-
     const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
 
     const saveAndClose = () => {
@@ -46,9 +44,11 @@ const RHSAboutDescription = (props: DescriptionProps) => {
             <RenderedDescription
                 data-testid='rendered-description'
                 onClick={(event) => {
-                    // Enter edit mode only if the user is not clicking a link
+                    // Enter edit mode only if the user is not clicking a link and there's no selected text
                     const targetNode = event.target as Node;
-                    if (targetNode.nodeName !== 'A') {
+                    const selectedText = window.getSelection();
+                    const hasSelectedText = selectedText !== null && selectedText.toString() !== '';
+                    if (targetNode.nodeName !== 'A' && !hasSelectedText) {
                         props.setEditing(true);
                     }
                 }}

--- a/webapp/src/components/rhs/rhs_about_title.tsx
+++ b/webapp/src/components/rhs/rhs_about_title.tsx
@@ -62,7 +62,11 @@ const RHSAboutTitle = (props: Props) => {
     let onRenderedTitleClick = () => { /* do nothing */};
     if (permissionToChangeTitle) {
         onRenderedTitleClick = () => {
-            setEditing(true);
+            const selectedText = window.getSelection();
+            const hasSelectedText = selectedText !== null && selectedText.toString() !== '';
+            if (!hasSelectedText) {
+                setEditing(true);
+            }
         };
     }
 


### PR DESCRIPTION
#### Summary
Prevent users from accidentally enter into inline edit when they want to select the title or description in the channel RHS.

![CleanShot 2022-08-29 at 13 31 54](https://user-images.githubusercontent.com/4096774/187192024-07deb9e0-ddcb-468e-a240-99e369e7de8b.gif)

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-38717

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
