### PR TITLE
PBE: remove negative letter spacing and set wider min-width for context menu

### DIFF
--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -462,10 +462,10 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
 
 const DropdownMenuItem = styled(DropdownMenuItemBase)`
     ${iconSplitStyling};
+    min-width: 220px;
 `;
 
 export const TitleMenu = styled(TitleMenuImpl)`
-
 `;
 
 const buttonCommon = css`

--- a/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
+++ b/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
@@ -290,7 +290,6 @@ const PlaybookEditor = () => {
 
 const titleCommon = css`
     ${SemiBoldHeading}
-    letter-spacing: -0.01em;
     font-size: 16px;
     line-height: 24px;
     color: var(--center-channel-color);
@@ -363,7 +362,6 @@ const titleMenuOverrides = css`
 
 const Heading = styled.h1`
     ${SemiBoldHeading}
-    letter-spacing: -0.01em;
     font-size: 32px;
     line-height: 40px;
     color: var(--center-channel-color);
@@ -381,7 +379,6 @@ const Heading = styled.h1`
 
 const Title = styled.h1`
     ${SemiBoldHeading}
-    letter-spacing: -0.01em;
     font-size: 16px;
     line-height: 24px;
     color: var(--center-channel-color);
@@ -496,7 +493,7 @@ const Editor = styled.main<{$headingVisible: boolean}>`
     ${Sections} {
         margin: 5rem 1.5rem;
         grid-area: content;
-        
+
         ${HorizontalBG} {
             /* sticky checklist header */
             top: var(--bar-height);


### PR DESCRIPTION
#### Summary
Removed negative letter-spacing on titles&context menu at PBE 
Set a 220px min width for dropdown options
 

|before|after|
|--------|-----|
|![Screenshot 2022-08-29 at 14 06 47](https://user-images.githubusercontent.com/4096774/187198260-9875bb02-82f7-4ac0-85c7-696ca2f0e4d3.png)|![Screenshot 2022-08-29 at 14 05 25](https://user-images.githubusercontent.com/4096774/187198288-db8bc8d7-8516-4b22-90dd-2d2ac612e4b1.png)|


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45656

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
