### PR TITLE
feat: in DotMenu, use Dropdown's better floating-ui logic

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -305,8 +305,8 @@ describe('channels > rhs > checklist', () => {
                 cy.findAllByTestId('checklistHeader').eq(0).within(() => {
                     cy.findByTitle('More').click();
                 });
-                cy.findByRole('button', {name: 'Rename checklist'}).click();
             });
+            cy.findByRole('button', {name: 'Rename checklist'}).click();
 
             // # Type the new title and click the confirm button
             cy.findByTestId('checklist-title-input').type(newTitle);

--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -130,9 +130,9 @@ describe('channels > rhs > header', () => {
             cy.get('#rhsContainer').within(() => {
                 cy.findByTestId('buttons-row').invoke('show').within(() => {
                     cy.findAllByRole('button').eq(1).click();
-                    cy.findByText('Edit run summary').click({force: true});
                 });
             });
+            cy.findByText('Edit run summary').click({force: true});
 
             // # type text in textarea
             cy.get('#rhsContainer').findByTestId('textarea-description').should('be.visible').type('new summary{ctrl+enter}');

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -76,7 +76,7 @@ describe('runs > run details page > header', () => {
 
     const getDropdownItemByText = (text) => {
         cy.findByTestId('run-header-section').find('h1').click();
-        return cy.findByTestId('run-header-section').findByTestId('dropdownmenu').findByText(text);
+        return cy.findByTestId('dropdownmenu').findByText(text);
     };
 
     const commonHeaderTests = () => {
@@ -114,7 +114,7 @@ describe('runs > run details page > header', () => {
             cy.findByTestId('run-header-section').find('h1').click();
 
             // * Assert context menu is opened
-            cy.findByTestId('run-header-section').findByTestId('dropdownmenu').should('be.visible');
+            cy.findByTestId('dropdownmenu').should('be.visible');
         });
 
         it('can copy link', () => {

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -351,6 +351,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
                 dotMenuButton={TitleButton}
                 className={className}
                 placement='bottom-start'
+                focusManager={{returnFocus: false}}
                 icon={
                     <>
                         {children}

--- a/webapp/src/components/backstage/playbook_editor/outline/inputs/webhooks_input.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/inputs/webhooks_input.tsx
@@ -70,7 +70,7 @@ export const WebhooksInput = (props: Props) => {
             isOpen={isOpen}
             onOpenChange={setOpen}
             target={target}
-            initialFocus={props.webhooksDisabled ? -1 : undefined}
+            focusManager={{initialFocus: props.webhooksDisabled ? -1 : undefined}}
         >
             <SelectorWrapper>
                 <TextArea

--- a/webapp/src/components/checklist_item/hover_menu.tsx
+++ b/webapp/src/components/checklist_item/hover_menu.tsx
@@ -87,6 +87,8 @@ const ChecklistItemHoverMenu = (props: Props) => {
                 dotMenuButton={DotMenuButton}
                 dropdownMenu={StyledDropdownMenu}
                 placement='bottom-end'
+                onOpenChange={props.onItemOpenChange}
+                focusManager={{returnFocus: false}}
                 title={formatMessage({defaultMessage: 'More'})}
             >
                 <StyledDropdownMenuItem

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -4,6 +4,8 @@
 import React, {useState, ComponentProps} from 'react';
 import styled, {css} from 'styled-components';
 
+import {useUpdateEffect} from 'react-use';
+
 import Tooltip from 'src/components/widgets/tooltip';
 import {useUniqueId} from 'src/utils';
 
@@ -61,8 +63,10 @@ type DotMenuProps = {
     className?: string;
     disabled?: boolean;
     isActive?: boolean;
+    onOpenChange?: (isOpen: boolean) => void;
     dotMenuButton?: typeof DotMenuButton | typeof PrimaryButton;
     dropdownMenu?: typeof DropdownMenu;
+
 };
 
 type DropdownProps = Omit<ComponentProps<typeof Dropdown>, 'target' | 'children'>;
@@ -76,12 +80,16 @@ const DotMenu = ({
     isActive,
     dotMenuButton: MenuButton = DotMenuButton,
     dropdownMenu: Menu = DropdownMenu,
+    onOpenChange,
     ...props
 }: DotMenuProps & DropdownProps) => {
     const [isOpen, setOpen] = useState(false);
     const toggleOpen = () => {
         setOpen(!isOpen);
     };
+    useUpdateEffect(() => {
+        onOpenChange?.(isOpen);
+    }, [isOpen]);
 
     const button = (
 

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -4,12 +4,13 @@
 import React, {useState} from 'react';
 import styled, {css} from 'styled-components';
 
-import {useFloating, offset, flip, shift, autoUpdate, Placement} from '@floating-ui/react-dom-interactions';
+import {offset, Placement} from '@floating-ui/react-dom-interactions';
 
-import {useKeyPress, useClickOutsideRef} from 'src/hooks';
-import {PrimaryButton} from 'src/components/assets/buttons';
 import Tooltip from 'src/components/widgets/tooltip';
 import {useUniqueId} from 'src/utils';
+
+import Dropdown from './dropdown';
+import {PrimaryButton} from './assets/buttons';
 
 export const DotMenuButton = styled.div<{isActive: boolean}>`
     display: inline-flex;
@@ -30,16 +31,12 @@ export const DotMenuButton = styled.div<{isActive: boolean}>`
     }
 `;
 
-const DropdownMenuWrapper = styled.div`
-    position: relative;
-`;
-
 export const DropdownMenu = styled.div`
     display: flex;
     flex-direction: column;
 
     width: max-content;
-    min-width: 160px;
+    min-width: 16rem;
     text-align: left;
     list-style: none;
 
@@ -73,34 +70,19 @@ interface DotMenuProps {
 }
 
 const DotMenu = (props: DotMenuProps) => {
-    const {strategy, x, y, reference, floating, refs} = useFloating<HTMLElement>({
-        placement: props.placement ?? 'bottom',
-        middleware: [offset(props.offset ?? 2), flip(), shift()],
-        whileElementsMounted: autoUpdate,
-    });
+    const MenuButton = props.dotMenuButton ?? DotMenuButton;
+    const Menu = props.dropdownMenu ?? DropdownMenu;
 
     const [isOpen, setOpen] = useState(false);
     const toggleOpen = () => {
         setOpen(!isOpen);
     };
 
-    useClickOutsideRef(refs.reference, () => {
-        setOpen(false);
-    });
-
-    useKeyPress('Escape', () => {
-        setOpen(false);
-    });
-
-    const MenuButton = props.dotMenuButton ?? DotMenuButton;
-    const Menu = props.dropdownMenu ?? DropdownMenu;
-
-    return (
+    const button = (
 
         // @ts-ignore
         <MenuButton
             title={props.title}
-            ref={reference}
             isActive={(props.isActive ?? false) || isOpen}
             onClick={(e: MouseEvent) => {
                 e.stopPropagation();
@@ -120,27 +102,21 @@ const DotMenu = (props: DotMenuProps) => {
             data-testid={'menuButton' + props.title}
         >
             {props.icon}
-            <DropdownMenuWrapper>
-                {
-                    isOpen &&
-                    <Menu
-                        ref={floating}
-                        style={{
-                            position: strategy,
-                            top: y ?? '',
-                            left: x ?? '',
-                        }}
-                        data-testid='dropdownmenu'
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            setOpen(false);
-                        }}
-                    >
-                        {props.children}
-                    </Menu>
-                }
-            </DropdownMenuWrapper>
         </MenuButton>
+    );
+
+    return (
+        <Dropdown
+            isOpen={isOpen}
+            onOpenChange={setOpen}
+            placement={props.placement}
+            offset={props.offset}
+            target={button}
+        >
+            <Menu data-testid='dropdownmenu'>
+                {props.children}
+            </Menu>
+        </Dropdown>
     );
 };
 

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -1,10 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState} from 'react';
+import React, {useState, ComponentProps} from 'react';
 import styled, {css} from 'styled-components';
-
-import {offset, Placement} from '@floating-ui/react-dom-interactions';
 
 import Tooltip from 'src/components/widgets/tooltip';
 import {useUniqueId} from 'src/utils';
@@ -56,23 +54,30 @@ export const DropdownMenu = styled.div`
     z-index: 12;
 `;
 
-interface DotMenuProps {
+type DotMenuProps = {
     children: React.ReactNode;
     icon: JSX.Element;
+    title?: string;
+    className?: string;
+    disabled?: boolean;
+    isActive?: boolean;
     dotMenuButton?: typeof DotMenuButton | typeof PrimaryButton;
     dropdownMenu?: typeof DropdownMenu;
-    placement?: Placement;
-    offset?: Parameters<typeof offset>[0];
-    title?: string;
-    disabled?: boolean;
-    className?: string;
-    isActive?: boolean;
-}
+};
 
-const DotMenu = (props: DotMenuProps) => {
-    const MenuButton = props.dotMenuButton ?? DotMenuButton;
-    const Menu = props.dropdownMenu ?? DropdownMenu;
+type DropdownProps = Omit<ComponentProps<typeof Dropdown>, 'target' | 'children'>;
 
+const DotMenu = ({
+    children,
+    icon,
+    title,
+    className,
+    disabled,
+    isActive,
+    dotMenuButton: MenuButton = DotMenuButton,
+    dropdownMenu: Menu = DropdownMenu,
+    ...props
+}: DotMenuProps & DropdownProps) => {
     const [isOpen, setOpen] = useState(false);
     const toggleOpen = () => {
         setOpen(!isOpen);
@@ -82,8 +87,8 @@ const DotMenu = (props: DotMenuProps) => {
 
         // @ts-ignore
         <MenuButton
-            title={props.title}
-            isActive={(props.isActive ?? false) || isOpen}
+            title={title}
+            isActive={(isActive ?? false) || isOpen}
             onClick={(e: MouseEvent) => {
                 e.stopPropagation();
                 toggleOpen();
@@ -96,25 +101,30 @@ const DotMenu = (props: DotMenuProps) => {
                 }
             }}
             tabIndex={0}
-            className={props.className}
+            className={className}
             role={'button'}
-            disabled={props.disabled || false}
-            data-testid={'menuButton' + props.title}
+            disabled={disabled ?? false}
+            data-testid={'menuButton' + title}
         >
-            {props.icon}
+            {icon}
         </MenuButton>
     );
 
     return (
         <Dropdown
+            {...props}
             isOpen={isOpen}
             onOpenChange={setOpen}
-            placement={props.placement}
-            offset={props.offset}
             target={button}
         >
-            <Menu data-testid='dropdownmenu'>
-                {props.children}
+            <Menu
+                data-testid='dropdownmenu'
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen(false);
+                }}
+            >
+                {children}
             </Menu>
         </Dropdown>
     );

--- a/webapp/src/components/dropdown.tsx
+++ b/webapp/src/components/dropdown.tsx
@@ -88,35 +88,33 @@ const Dropdown = (props: DropdownProps) => {
         useDismiss(context),
     ]);
 
-    const MaybePortal = (props.portal ?? true) ? FloatingPortal : React.Fragment;
+    const MaybePortal = (props.portal ?? true) ? FloatingPortal : React.Fragment; // 🤷
 
     return (
         <>
             {cloneElement(props.target, getReferenceProps({ref: reference, ...props.target.props}))}
             <MaybePortal>
                 {open && (
-                    <>
-                        <FloatingFocusManager
-                            context={context}
-                            initialFocus={props.initialFocus}
+                    <FloatingFocusManager
+                        context={context}
+                        initialFocus={props.initialFocus}
+                    >
+                        <FloatingContainer
+                            {...getFloatingProps({
+                                ref: floating,
+                                style: {
+                                    position: strategy,
+                                    top: y ?? 0,
+                                    left: x ?? 0,
+                                },
+                            })}
+                            css={`
+                                ${props.containerStyles};
+                            `}
                         >
-                            <FloatingContainer
-                                {...getFloatingProps({
-                                    ref: floating,
-                                    style: {
-                                        position: strategy,
-                                        top: y ?? 0,
-                                        left: x ?? 0,
-                                    },
-                                })}
-                                css={`
-                                    ${props.containerStyles};
-                                `}
-                            >
-                                {props.children}
-                            </FloatingContainer>
-                        </FloatingFocusManager>
-                    </>
+                            {props.children}
+                        </FloatingContainer>
+                    </FloatingFocusManager>
                 )}
             </MaybePortal>
         </>

--- a/webapp/src/components/dropdown.tsx
+++ b/webapp/src/components/dropdown.tsx
@@ -54,6 +54,7 @@ type DropdownProps = {
     flip?: Parameters<typeof flip>[0];
     shift?: Parameters<typeof shift>[0];
     initialFocus?: number;
+    manageFocus?: boolean;
     portal?: boolean;
     containerStyles?: ReturnType<typeof css>;
 } & ({
@@ -90,32 +91,40 @@ const Dropdown = (props: DropdownProps) => {
 
     const MaybePortal = (props.portal ?? true) ? FloatingPortal : React.Fragment; // 🤷
 
+    let content = (
+        <FloatingContainer
+            {...getFloatingProps({
+                ref: floating,
+                style: {
+                    position: strategy,
+                    top: y ?? 0,
+                    left: x ?? 0,
+                },
+            })}
+            css={`
+                ${props.containerStyles};
+            `}
+        >
+            {props.children}
+        </FloatingContainer>
+    );
+
+    if (props.manageFocus ?? true) {
+        content = (
+            <FloatingFocusManager
+                context={context}
+                initialFocus={props.initialFocus}
+            >
+                {content}
+            </FloatingFocusManager>
+        );
+    }
+
     return (
         <>
             {cloneElement(props.target, getReferenceProps({ref: reference, ...props.target.props}))}
             <MaybePortal>
-                {open && (
-                    <FloatingFocusManager
-                        context={context}
-                        initialFocus={props.initialFocus}
-                    >
-                        <FloatingContainer
-                            {...getFloatingProps({
-                                ref: floating,
-                                style: {
-                                    position: strategy,
-                                    top: y ?? 0,
-                                    left: x ?? 0,
-                                },
-                            })}
-                            css={`
-                                ${props.containerStyles};
-                            `}
-                        >
-                            {props.children}
-                        </FloatingContainer>
-                    </FloatingFocusManager>
-                )}
+                {open && content}
             </MaybePortal>
         </>
     );

--- a/webapp/src/components/dropdown.tsx
+++ b/webapp/src/components/dropdown.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {cloneElement, useState} from 'react';
+import React, {cloneElement, useState, ComponentProps} from 'react';
 import styled, {css} from 'styled-components';
 
 import {
@@ -53,8 +53,7 @@ type DropdownProps = {
     offset?: Parameters<typeof offset>[0];
     flip?: Parameters<typeof flip>[0];
     shift?: Parameters<typeof shift>[0];
-    initialFocus?: number;
-    manageFocus?: boolean;
+    focusManager?: boolean | Omit<ComponentProps<typeof FloatingFocusManager>, 'context' | 'children'>;
     portal?: boolean;
     containerStyles?: ReturnType<typeof css>;
 } & ({
@@ -109,11 +108,11 @@ const Dropdown = (props: DropdownProps) => {
         </FloatingContainer>
     );
 
-    if (props.manageFocus ?? true) {
+    if (props.focusManager ?? true) {
         content = (
             <FloatingFocusManager
+                {...typeof props.focusManager === 'boolean' ? false : props.focusManager}
                 context={context}
-                initialFocus={props.initialFocus}
             >
                 {content}
             </FloatingFocusManager>

--- a/webapp/src/components/dropdown.tsx
+++ b/webapp/src/components/dropdown.tsx
@@ -20,7 +20,7 @@ import {
 } from '@floating-ui/react-dom-interactions';
 
 const FloatingContainer = styled.div`
-    min-width: 20rem;
+    min-width: 16rem;
 	z-index: 50;
 
 	.PlaybookRunProfileButton {

--- a/webapp/src/components/rhs/rhs_about_buttons.tsx
+++ b/webapp/src/components/rhs/rhs_about_buttons.tsx
@@ -51,6 +51,8 @@ const RHSAboutButtons = (props: Props) => {
                 dotMenuButton={StyledDotMenuButton}
                 data-testid='run-dot-menu'
                 title={formatMessage({defaultMessage: 'More'})}
+                portal={false}
+                manageFocus={false}
             >
                 <StyledDropdownMenuItem
                     onClick={() => {

--- a/webapp/src/components/rhs/rhs_about_buttons.tsx
+++ b/webapp/src/components/rhs/rhs_about_buttons.tsx
@@ -52,7 +52,7 @@ const RHSAboutButtons = (props: Props) => {
                 data-testid='run-dot-menu'
                 title={formatMessage({defaultMessage: 'More'})}
                 portal={false}
-                manageFocus={false}
+                focusManager={{returnFocus: false}}
             >
                 <StyledDropdownMenuItem
                     onClick={() => {


### PR DESCRIPTION
#### Summary

This PR drops `DotMenu`s separate `useFloating` and switches to instead wrap `Dropdown` and  take advantage of its better capabilities. Notably, it portals by default and has focus management. A few `DotMenu`s needed to opt-out of certain behaviors (e.g. portaling or returning focus to the reference element) to maintain existing UX patterns—click-to-edit, hover menus, etc. 

Background:
When we did #1300, `Dropdown` got `useFloating` and `useInteractions`, whereas `DotMenu` ended up with just `useFloating`

#### Ticket Link

- https://mattermost.atlassian.net/browse/MM-44826

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
