### PR TITLE
datetime selector: set custom error text

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -200,6 +200,7 @@
   "KXVV4+": "Welcome to the playbook preview page!",
   "KeO51o": "Channel",
   "KiXNvz": "Run",
+  "KjNfA8": "Invalid time duration",
   "KzHQCQ": "There are no finished runs matching those filters.",
   "L6k6aT": "…or start with a template",
   "LDYFkN": "Duration (in dd:hh:mm)",

--- a/webapp/src/components/datetime_parsing.test.ts
+++ b/webapp/src/components/datetime_parsing.test.ts
@@ -2,7 +2,7 @@ import {Duration, DurationObjectUnits, Settings} from 'luxon';
 
 import range from 'lodash/range';
 
-import {durationFromQuery} from './datetime_parsing';
+import {durationFromQuery, parse, Mode} from './datetime_parsing';
 
 describe('durationFromQuery', () => {
     const locales = [
@@ -33,6 +33,7 @@ describe('durationFromQuery', () => {
     ];
 
     test.each([
+
         ...range(1, 60).map((n) => ({seconds: n})),
         ...range(1, 60).map((n) => ({minutes: n})),
         ...range(1, 24).map((n) => ({hours: n})),
@@ -77,3 +78,10 @@ describe('durationFromQuery', () => {
     });
 });
 
+// Failing test to reproduce https://mattermost.atlassian.net/browse/MM-44810
+describe.skip('parse', () => {
+    it('Mode.DurationValue', () => {
+        const duration = parse('en', '1 month', Mode.DurationValue);
+        expect(duration?.milliseconds).toEqual(2592000000); // 30 days
+    });
+});

--- a/webapp/src/components/datetime_selector.tsx
+++ b/webapp/src/components/datetime_selector.tsx
@@ -150,6 +150,7 @@ export const DateTimeSelector = ({
                 options={options}
                 placeholder={mode === Mode.DateTimeValue ? formatMessage({defaultMessage: 'Specify date/time (“in 4 hours”, “May 1”...)'}) : formatMessage({defaultMessage: 'Specify duration ("8 hours", "3 days"...)'})}
                 styles={selectStyles}
+                noOptionsMessage={() => <InvalidLabel>{formatMessage({defaultMessage: 'Invalid time duration'})}</InvalidLabel>}
                 onChange={onSelectedChange}
                 classNamePrefix='playbook-run-user-select' // TODO debt: rename
                 className='playbook-run-user-select' // TODO debt: rename
@@ -225,4 +226,8 @@ const Right = styled.div`
     flex-grow: 1;
     display: flex;
     justify-content: flex-end;
+`;
+
+const InvalidLabel = styled.span`
+    color: var(--error-text);
 `;

--- a/webapp/src/components/formatted_duration.test.tsx
+++ b/webapp/src/components/formatted_duration.test.tsx
@@ -39,6 +39,8 @@ describe('formatDuration', () => {
         [{days: 99, hours: 10, minutes: 45}, '99d, 10h, 45m', '99 days, 10 hours, 45 minutes'],
         [{weeks: 6}, '42d', '42 days'],
         [{weeks: 2, days: 6, minutes: 12}, '20d, 12m', '20 days, 12 minutes'],
+        [{months: 1}, '30d', '30 days'],
+        [{months: 2}, '60d', '60 days'],
         [{years: 2, days: 6, minutes: 12}, '2y, 6d, 12m', '2 years, 6 days, 12 minutes'],
     ])('should format %p as %p and %p', (durationObj, expectedNarrow, expectedLong) => {
         const duration = Duration.fromObject(durationObj);


### PR DESCRIPTION
#### Summary
Add a custom text&style for errors to datetime_selector.

![CleanShot 2022-08-30 at 12 37 29](https://user-images.githubusercontent.com/4096774/187416099-4bcf9aaa-5515-4170-a003-04f1130ff00e.gif)


Additionally, I added a failing test (skipped) for the case `1 month` parse. [parse duration lib](https://github.com/jkroso/parse-duration/blob/master/index.js#L46) take a month as the real number of days 365.25/12 instead of the standard 30 days (as luxon does). Will follow up on that case in a future PR. 

#### Ticket Link
Fixes (partially) https://mattermost.atlassian.net/browse/MM-44810
[More context](https://community.mattermost.com/core/pl/mbqcs4dctiy95fhts6gxhaskcr)

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
