### PR TITLE
migrate fa icons to compass + fix pb assign owner clear

### DIFF
--- a/server/api/graphql_root.go
+++ b/server/api/graphql_root.go
@@ -241,8 +241,11 @@ func (r *RootResolver) UpdatePlaybook(ctx context.Context, args struct {
 
 	addToSetmap(setmap, "InviteUsersEnabled", args.Updates.InviteUsersEnabled)
 	if args.Updates.DefaultOwnerID != nil {
-		if !c.pluginAPI.User.HasPermissionToTeam(*args.Updates.DefaultOwnerID, currentPlaybook.TeamID, model.PermissionViewTeam) {
-			return "", errors.Wrap(app.ErrNoPermissions, "default owner can't view team")
+		// Do not check permissions if we want to unset the DefaultOwnerID
+		if *args.Updates.DefaultOwnerID != "" {
+			if !c.pluginAPI.User.HasPermissionToTeam(*args.Updates.DefaultOwnerID, currentPlaybook.TeamID, model.PermissionViewTeam) {
+				return "", errors.Wrap(app.ErrNoPermissions, "default owner can't view team")
+			}
 		}
 		addToSetmap(setmap, "DefaultCommanderID", args.Updates.DefaultOwnerID)
 	}

--- a/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
@@ -3,13 +3,10 @@
 
 import React from 'react';
 
-import styled from 'styled-components';
-
 import {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {FormattedMessage} from 'react-intl';
 
-import Profile from 'src/components/profile/profile';
 import {
     AutomationHeader,
     AutomationTitle,
@@ -49,96 +46,5 @@ export const AutoAssignOwner = (props: Props) => {
                 />
             </SelectorWrapper>
         </AutomationHeader>
-    );
-};
-
-interface UserRowProps {
-    isEnabled: boolean;
-}
-
-const UserRow = styled.div<UserRowProps>`
-    margin: 12px 0 0 auto;
-
-    padding: 0;
-
-    display: flex;
-    flex-direction: row;
-`;
-
-const Cross = styled.i`
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 50%;
-
-    color: var(--button-bg);
-    // Filling the transparent X in the icon: this sets a background gradient,
-    // which is effectively a circle with color --button-color that fills only
-    // 50% of the background, transparent outside of it. If we simply add a
-    // background color, the icon is misplaced and a weird border appears at the bottom
-    background-image: radial-gradient(circle, var(--button-color) 50%, rgba(0, 0, 0, 0) 50%);
-
-    visibility: hidden;
-`;
-
-const UserPic = styled.div`
-    .PlaybookRunProfile {
-        flex-direction: column;
-
-        .name {
-            display: none;
-            position: absolute;
-            bottom: -24px;
-            margin-left: auto;
-        }
-    }
-
-    :not(:first-child) {
-        margin-left: -16px;
-    }
-
-    position: relative;
-    transition: transform .4s;
-
-    :hover {
-        z-index: 1;
-        transform: translateY(-8px);
-
-        ${Cross} {
-            visibility: visible;
-        }
-
-        .name {
-            display: block;
-        }
-    }
-
-    && img {
-        // We need both background-color and border color to imitate the color in the background
-        background-color: var(--center-channel-bg);
-        border: 2px solid rgba(var(--center-channel-color-rgb), 0.04);
-    }
-
-`;
-
-interface UserProps {
-    userIds: string[];
-    onRemoveUser: (userId: string) => void;
-    isEnabled: boolean;
-}
-
-const Users = (props: UserProps) => {
-    return (
-        <UserRow isEnabled={props.isEnabled}>
-            {props.userIds.map((userId: string) => (
-                <UserPic key={userId}>
-                    <Profile userId={userId}/>
-                    <Cross
-                        className='fa fa-times-circle'
-                        onClick={() => props.onRemoveUser(userId)}
-                    />
-                </UserPic>
-            ))}
-        </UserRow>
     );
 };

--- a/webapp/src/components/widgets/show_more.tsx
+++ b/webapp/src/components/widgets/show_more.tsx
@@ -2,12 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React, {useState, useRef, useEffect} from 'react';
-
 import {useSelector} from 'react-redux';
-
 import styled, {css} from 'styled-components';
-
 import {FormattedMessage} from 'react-intl';
+
+import {ChevronDownIcon, ChevronUpIcon} from '@mattermost/compass-icons/components';
 
 import {getIsRhsExpanded} from 'src/selectors';
 
@@ -82,7 +81,7 @@ const ShowMoreButton = styled.button`
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.1);
     border-radius: 2px;
 
-    display: inline-block;
+    display: inline-flex;
     flex-shrink: 0;
     font-size: 13px;
     font-weight: bold;
@@ -93,17 +92,6 @@ const ShowMoreButton = styled.button`
     background: var(--center-channel-bg);
     color: var(--link-color);
 
-    .fa {
-        font-size: 1.4em;
-        font-weight: bold;
-        margin-right: 5px;
-        position: relative;
-        top: 2px;
-
-        &.fa-angle-up {
-            top: 1px;
-        }
-    }
 
     &:focus {
         outline: none;
@@ -193,10 +181,10 @@ const ShowMore = (props: Props) => {
         );
     }
 
-    let showIcon = 'fa fa-angle-up';
+    let showIcon = <ChevronUpIcon color={'currentColor'}/>;
     let showText = <FormattedMessage defaultMessage='Show less'/>;
     if (isCollapsed) {
-        showIcon = 'fa fa-angle-down';
+        showIcon = <ChevronDownIcon color={'currentColor'}/>;
         showText = <FormattedMessage defaultMessage='Show more'/>;
     }
 
@@ -214,7 +202,7 @@ const ShowMore = (props: Props) => {
                 <ShowMoreContainer isCollapsed={isCollapsed}>
                     <ShowMoreLine/>
                     <ShowMoreButton onClick={toggleCollapsed}>
-                        <span className={showIcon}/>
+                        {showIcon}
                         {showText}
                     </ShowMoreButton>
                     <ShowMoreLine/>


### PR DESCRIPTION
#### Summary
Migrate font-awesome to compass icons:

If merged after https://github.com/mattermost/mattermost-plugin-playbooks/pull/1460, currentColor prop can be removed.

```
src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx:137:                        className='fa fa-times-circle'
src/components/widgets/show_more.tsx:103:        &.fa-angle-up {
src/components/widgets/show_more.tsx:196:    let showIcon = 'fa fa-angle-up';
src/components/widgets/show_more.tsx:199:        showIcon = 'fa fa-angle-down';
```

Opportunistic bugfix in playbook editor. It was not possible to clear the default owner in actions PBE.

**not migrated**
we need a spinner alternative and for system stats I'd do it all at once in mattermost-webapp
```
src/index.tsx:215:                        icon: 'fa-book', // font-awesome-4.7.0 handler
src/index.tsx:221:                        icon: 'fa-list-alt', // font-awesome-4.7.0 handler
src/components/assets/icons/spinner.tsx:12:    <i className={classNames('fa fa-pulse fa-spinner', props.className)}/>
```

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46687 (except spinner and system stats)
Fixes https://mattermost.atlassian.net/browse/MM-46830

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
