### PR TITLE
[MM-45662] Fix context dropdown closing when clicked

### DIFF
--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -124,6 +124,9 @@ describe('runs > run details page > header', () => {
                 // * Verify clipboard content
                 cy.get('@clipboard').its('contents').should('contain', `/playbooks/runs/${playbookRun.id}`);
             });
+
+            // * Verify context menu is opened
+            cy.findByTestId('run-header-section').findByTestId('dropdownmenu').should('be.visible');
         });
     };
 

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -124,9 +124,6 @@ describe('runs > run details page > header', () => {
                 // * Verify clipboard content
                 cy.get('@clipboard').its('contents').should('contain', `/playbooks/runs/${playbookRun.id}`);
             });
-
-            // * Verify context menu is opened
-            cy.findByTestId('run-header-section').findByTestId('dropdownmenu').should('be.visible');
         });
     };
 

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -66,6 +66,7 @@ type DotMenuProps = {
     className?: string;
     isActive?: boolean;
     onOpenChange?: (isOpen: boolean) => void;
+    isMultiCheckbox?: boolean;
 };
 
 type DropdownProps = Omit<ComponentProps<typeof Dropdown>, 'target' | 'children'>;
@@ -77,6 +78,7 @@ const DotMenu = ({
     className,
     disabled,
     isActive,
+    isMultiCheckbox,
     dotMenuButton: MenuButton = DotMenuButton,
     dropdownMenu: Menu = DropdownMenu,
     onOpenChange,
@@ -127,7 +129,10 @@ const DotMenu = ({
         >
             <Menu
                 data-testid='dropdownmenu'
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    !isMultiCheckbox ? setOpen(false) : null;
+                }}
             >
                 {children}
             </Menu>

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -66,7 +66,7 @@ type DotMenuProps = {
     className?: string;
     isActive?: boolean;
     onOpenChange?: (isOpen: boolean) => void;
-    isMultiCheckbox?: boolean;
+    closeOnClick?: boolean;
 };
 
 type DropdownProps = Omit<ComponentProps<typeof Dropdown>, 'target' | 'children'>;
@@ -78,7 +78,7 @@ const DotMenu = ({
     className,
     disabled,
     isActive,
-    isMultiCheckbox,
+    closeOnClick = true,
     dotMenuButton: MenuButton = DotMenuButton,
     dropdownMenu: Menu = DropdownMenu,
     onOpenChange,
@@ -131,7 +131,9 @@ const DotMenu = ({
                 data-testid='dropdownmenu'
                 onClick={(e) => {
                     e.stopPropagation();
-                    return isMultiCheckbox ? null : setOpen(false);
+                    if (closeOnClick) {
+                        setOpen(false);
+                    }
                 }}
             >
                 {children}

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -127,10 +127,7 @@ const DotMenu = ({
         >
             <Menu
                 data-testid='dropdownmenu'
-                onClick={(e) => {
-                    e.stopPropagation();
-                    setOpen(false);
-                }}
+                onClick={(e) => e.stopPropagation()}
             >
                 {children}
             </Menu>

--- a/webapp/src/components/dot_menu.tsx
+++ b/webapp/src/components/dot_menu.tsx
@@ -131,7 +131,7 @@ const DotMenu = ({
                 data-testid='dropdownmenu'
                 onClick={(e) => {
                     e.stopPropagation();
-                    !isMultiCheckbox ? setOpen(false) : null;
+                    return isMultiCheckbox ? null : setOpen(false);
                 }}
             >
                 {children}

--- a/webapp/src/components/multi_checkbox.tsx
+++ b/webapp/src/components/multi_checkbox.tsx
@@ -72,6 +72,7 @@ const MultiCheckbox = (props: Props) => {
             placement={props.placement}
             dotMenuButton={props.dotMenuButton}
             isActive={isFilterActive}
+            isMultiCheckbox={true}
             icon={
                 props.icon ??
                 <IconWrapper>

--- a/webapp/src/components/multi_checkbox.tsx
+++ b/webapp/src/components/multi_checkbox.tsx
@@ -72,7 +72,7 @@ const MultiCheckbox = (props: Props) => {
             placement={props.placement}
             dotMenuButton={props.dotMenuButton}
             isActive={isFilterActive}
-            isMultiCheckbox={true}
+            closeOnClick={false}
             icon={
                 props.icon ??
                 <IconWrapper>


### PR DESCRIPTION
#### Summary
Resolved task filter context dropdown closing when checked and unchecked.

Now context dropdown is closed only when clicking on parent element, clicking outside the menu, or if dropdown parent appears on hover then hovering outside of the element.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/20821

#### Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
