### PR TITLE
add portal-false to dotmenu in pbe manage members

### DIFF
--- a/webapp/src/components/backstage/select_users_below.tsx
+++ b/webapp/src/components/backstage/select_users_below.tsx
@@ -175,6 +175,7 @@ const UserLine = (props: UserLineProps) => {
             <DotMenu
                 placement='bottom-end'
                 dotMenuButton={MemberButton}
+                portal={false}
                 icon={
                     <IconWrapper>
                         {roleDisplayText(props.member.roles)}


### PR DESCRIPTION
#### Summary
add a portal=false (thanks @gbochora) in PBE members modal to recover the dropdown

manually tested, created task to [add e2e](https://mattermost.atlassian.net/browse/MM-46970)

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46969

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
