### PR TITLE
Mm 44497 playbook refresh issues

### DIFF
--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -148,15 +148,15 @@ func (r *PlaybookRootResolver) UpdatePlaybook(ctx context.Context, args struct {
 	addToSetmap(setmap, "Description", args.Updates.Description)
 	if args.Updates.Public != nil {
 		if *args.Updates.Public {
-			if err := c.permissions.PlaybookMakePrivate(userID, currentPlaybook); err != nil {
-				return "", errors.Wrap(err, "attempted to make playbook private without permissions")
-			}
-		} else {
 			if err := c.permissions.PlaybookMakePublic(userID, currentPlaybook); err != nil {
 				return "", errors.Wrap(err, "attempted to make playbook public without permissions")
 			}
+		} else {
+			if err := c.permissions.PlaybookMakePrivate(userID, currentPlaybook); err != nil {
+				return "", errors.Wrap(err, "attempted to make playbook private without permissions")
+			}
 		}
-		if c.licenceChecker.PlaybookAllowed(*args.Updates.Public) {
+		if !c.licenceChecker.PlaybookAllowed(*args.Updates.Public) {
 			return "", errors.Wrapf(app.ErrLicensedFeature, "the playbook is not valid with the current license")
 		}
 		addToSetmap(setmap, "Public", args.Updates.Public)

--- a/tests-e2e/cypress/integration/playbooks/access_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/access_spec.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('playbooks > edit', () => {
+    let testTeam;
+    let testUser;
+    let testUser2;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Create a second test user in this team
+            cy.apiCreateUser().then((payload) => {
+                testUser2 = payload.user;
+                cy.apiAddUserToTeam(testTeam.id, payload.user.id);
+            });
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    describe('rdp information refresh', () => {
+        let testPlaybook;
+
+        beforeEach(() => {
+            // # Create a playbook
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Playbook (' + Date.now() + ')',
+                userId: testUser.id,
+                public: true,
+            }).then((playbook) => {
+                testPlaybook = playbook;
+
+                // Navigate to the playbook page
+                cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
+            });
+        });
+
+        it('add / remove a member', () => {
+            // # Open playbook access modal
+            cy.findByTestId('playbook-members').click();
+
+            // # Add a new member
+            cy.findByTestId('add-people-input').type(testUser2.username);
+            cy.wait(2000);
+            cy.findByTestId('add-people-input').get('body').tab({force: true});
+
+            // * Verify that user was added
+            cy.findByTestId('members-list').findByText(testUser2.username).should('exist');
+
+            // # Close playbook access modal
+            cy.get('.close > [aria-hidden="true"]').click();
+
+            // * Verify members number
+            cy.findByTestId('playbook-members').findByText('2').should('exist');
+
+            // # Open playbook access modal
+            cy.findByTestId('playbook-members').click();
+
+            // # Open dropdown and remove user
+            cy.findByText('Playbook Member').click();
+            cy.findByTestId('dropdownmenu').findByText('Remove').click();
+
+            // * Verify that user was removed
+            cy.findByTestId('members-list').findByText(testUser2.username).should('not.exist');
+
+            // # Close playbook access modal
+            cy.get('.close > [aria-hidden="true"]').click();
+
+            // * Verify members number
+            cy.findByTestId('playbook-members').findByText('1').should('exist');
+        });
+
+        it('change to private', () => {
+            // # Open playbook access modal
+            cy.findByTestId('playbook-members').click();
+
+            // # Click on convert to private
+            cy.findByText('Convert to private playbook').click();
+
+            // * Check that confirm modal is open
+            cy.get('#confirmModal').should('be.visible');
+
+            // # Confirm convert to private
+            cy.get('#confirmModal').get('#confirmModalButton').click();
+
+            // * Verify that playbook is private
+            cy.findByText('Convert to private playbook').should('not.exist');
+
+            // # Close playbook access modal
+            cy.get('.close > [aria-hidden="true"]').click();
+
+            // * Verify lock icon is visible
+            cy.findByTestId('playbook-editor-header').get('.icon-lock-outline').should('be.visible');
+        });
+    });
+});

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -68,7 +68,7 @@ import {
 } from 'src/types/actions';
 import {clientExecuteCommand} from 'src/client';
 import {GlobalSettings} from 'src/types/settings';
-import {ChecklistItemsFilter, PlaybookWithChecklist} from 'src/types/playbook';
+import {ChecklistItemsFilter} from 'src/types/playbook';
 import {modals} from 'src/webapp_globals';
 import {makeModalDefinition as makeUpdateRunStatusModalDefinition} from 'src/components/modals/update_run_status_modal';
 import {makePlaybookAccessModalDefinition} from 'src/components/backstage/playbook_access_modal';
@@ -133,10 +133,10 @@ export function openUpdateRunStatusModal(
 
 export function displayEditPlaybookAccessModal(
     playbookId: string,
-    onPlaybookChange?: React.Dispatch<React.SetStateAction<PlaybookWithChecklist | undefined>>,
+    refetch?: () => void,
 ) {
     return async (dispatch: Dispatch<AnyAction>) => {
-        dispatch(modals.openModal(makePlaybookAccessModalDefinition({playbookId, onPlaybookChange})));
+        dispatch(modals.openModal(makePlaybookAccessModalDefinition({playbookId, refetch})));
     };
 }
 

--- a/webapp/src/components/backstage/playbook_access_modal.tsx
+++ b/webapp/src/components/backstage/playbook_access_modal.tsx
@@ -23,7 +23,7 @@ const ID = 'playbooks_access';
 
 type Props = {
     playbookId: string
-    onPlaybookChange?: React.Dispatch<React.SetStateAction<PlaybookWithChecklist | undefined>>
+    refetch?: () => void
 } & Partial<ComponentProps<typeof GenericModal>>;
 
 export const makePlaybookAccessModalDefinition = (props: Props) => ({
@@ -66,12 +66,12 @@ const BlueArrow = styled.i`
 
 const PlaybookAccessModal = ({
     playbookId,
-    onPlaybookChange,
+    refetch,
     ...modalProps
 }: Props) => {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
-    const [playbook, updatePlaybook] = useEditPlaybook(playbookId);
+    const [playbook, updatePlaybook] = useEditPlaybook(playbookId, refetch);
     const team = useSelector<GlobalState, Team>((state) => getTeam(state, playbook?.team_id || ''));
     const permissionToMakePrivate = useHasPlaybookPermission(PlaybookPermissionGeneral.Convert, playbook);
     const licenseToMakePrivate = useAllowMakePlaybookPrivate();
@@ -83,7 +83,6 @@ const PlaybookAccessModal = ({
         if (playbook) {
             const updatedPlaybook: PlaybookWithChecklist = {...playbook, ...update};
             updatePlaybook(updatedPlaybook);
-            onPlaybookChange?.(updatedPlaybook);
         }
     };
 

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -128,7 +128,10 @@ export const Back = styled((props: StyledProps) => {
 export const Members = (props: {playbookId: string, numMembers: number, refetch: () => void}) => {
     const dispatch = useDispatch();
     return (
-        <ButtonIconStyled onClick={() => dispatch(displayEditPlaybookAccessModal(props.playbookId, props.refetch))}>
+        <ButtonIconStyled
+            data-testid={'playbook-members'}
+            onClick={() => dispatch(displayEditPlaybookAccessModal(props.playbookId, props.refetch))}
+        >
             <i className={'icon icon-account-multiple-outline'}/>
             <FormattedNumber value={props.numMembers}/>
         </ButtonIconStyled>

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -125,10 +125,10 @@ export const Back = styled((props: StyledProps) => {
 
 `;
 
-export const Members = (props: {playbookId: string, numMembers: number}) => {
+export const Members = (props: {playbookId: string, numMembers: number, refetch: () => void}) => {
     const dispatch = useDispatch();
     return (
-        <ButtonIconStyled onClick={() => dispatch(displayEditPlaybookAccessModal(props.playbookId))}>
+        <ButtonIconStyled onClick={() => dispatch(displayEditPlaybookAccessModal(props.playbookId, props.refetch))}>
             <i className={'icon icon-account-multiple-outline'}/>
             <FormattedNumber value={props.numMembers}/>
         </ButtonIconStyled>
@@ -400,7 +400,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
                 {currentUserMember && (
                     <>
                         <DropdownMenuItem
-                            onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id))}
+                            onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id, refetch))}
                         >
                             <AccountMultipleOutlineIcon size={18}/>
                             <FormattedMessage defaultMessage='Manage access'/>

--- a/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
+++ b/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
@@ -175,6 +175,7 @@ const PlaybookEditor = () => {
                             <Controls.Members
                                 playbookId={playbook.id}
                                 numMembers={playbook.members.length}
+                                refetch={refetch}
                             />
                             <Controls.AutoFollowToggle playbook={playbook}/>
                             <Controls.RunPlaybook playbook={playbook}/>

--- a/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
+++ b/webapp/src/components/backstage/playbook_editor/playbook_editor.tsx
@@ -214,7 +214,7 @@ const PlaybookEditor = () => {
                     `}
                 >
                     {(edit) => (
-                        <Heading>
+                        <Heading data-testid={'playbook-editor-header'}>
                             <Controls.CopyPlaybook playbook={playbook}/>
                             <Controls.TitleMenu
                                 playbook={playbook}

--- a/webapp/src/components/backstage/playbooks/playbook.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook.tsx
@@ -254,7 +254,7 @@ const Playbook = () => {
                         }
                     >
                         <DropdownMenuItem
-                            onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id, setPlaybook))}
+                            onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id))}
                         >
                             <FormattedMessage defaultMessage='Manage access'/>
                         </DropdownMenuItem>
@@ -287,7 +287,7 @@ const Playbook = () => {
                         }
                     </DotMenu>
                     <MembersIcon
-                        onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id, setPlaybook))}
+                        onClick={() => dispatch(displayEditPlaybookAccessModal(playbook.id))}
                     >
                         <i className={'icon icon-account-multiple-outline'}/>
                         {playbook.members.length}

--- a/webapp/src/components/backstage/select_users_below.tsx
+++ b/webapp/src/components/backstage/select_users_below.tsx
@@ -92,9 +92,9 @@ const SelectUsersBelow = (props: SelectUsersBelowProps) => {
     });
 
     return (
-        <Container>
+        <Container data-testid='members-list'>
             {permissionToEditMembers &&
-            <ProfileAutocompleteContainer>
+            <ProfileAutocompleteContainer data-testid={'add-people-input'}>
                 <ProfileAutocomplete
                     onAddUser={handleAddUser}
                     userIds={props.members.map((val: PlaybookMember) => val.user_id)}

--- a/webapp/src/hooks/crud.ts
+++ b/webapp/src/hooks/crud.ts
@@ -41,7 +41,7 @@ export function usePlaybook(id: Playbook['id'] | undefined) {
 
 type EditPlaybookReturn = [PlaybookWithChecklist | undefined, (update: Partial<PlaybookWithChecklist>) => void]
 
-export function useEditPlaybook(id: Playbook['id']): EditPlaybookReturn {
+export function useEditPlaybook(id: Playbook['id'], callback?: () => void): EditPlaybookReturn {
     const [playbook, setPlaybook] = useState<PlaybookWithChecklist | undefined>();
     useEffect(() => {
         clientFetchPlaybook(id).then(setPlaybook);
@@ -51,7 +51,13 @@ export function useEditPlaybook(id: Playbook['id']): EditPlaybookReturn {
         if (playbook) {
             const updatedPlaybook: PlaybookWithChecklist = {...playbook, ...update};
             setPlaybook(updatedPlaybook);
-            savePlaybook(updatedPlaybook);
+            const save = async () => {
+                savePlaybook(updatedPlaybook).then(() => {
+                    callback?.();
+                });
+            };
+
+            save();
         }
     };
 


### PR DESCRIPTION
#### Summary
- After adding/removing a playbook member, the member's number indicator did not update on the PDP.
- After converting the playbook to private, the PDP header didn't show a lock icon.

This PR fixes both issues.

https://user-images.githubusercontent.com/4368372/190228953-399f5c0d-38c1-4053-afbd-8395667471c2.mp4


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44497
https://mattermost.atlassian.net/browse/MM-41083
https://mattermost.atlassian.net/browse/MM-44506

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
