### PR TITLE
MM-47028 Use version of React DOM provided by web app

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -117,6 +117,7 @@ let config = {
     },
     externals: {
         react: 'React',
+        'react-dom': 'ReactDOM',
         redux: 'Redux',
         luxon: 'Luxon',
         'react-redux': 'ReactRedux',


### PR DESCRIPTION
The crash in the ticket happens when the `CSSTransition` component from `react-transition-group` gets mounted as part of the `ToastBanner` component. We're not sure specifically why that crashes, but it has to do with the Playbooks plugin compiling in a React 16 version of React DOM which is run against web app's React 17.

As I mentioned in the channel, this fixes the case when the web app and plugin are both up to date, but it won't handle the old plugin/new server case since the old plugin will still have React DOM compiled into it.

One big thing thing that this doesn't include those is that Playbooks will still be developed against React 16, so unit tests will be run against React 16 and we won't get any dependency errors due to mismatched React versions. We got quite a few dependency errors when attempting to update it, and some of them appeared to be existing ones, so we left that out and filed [MM-47039](https://mattermost.atlassian.net/browse/MM-47039) to address that.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-47028

## Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
