### PR TITLE
Fix a setState after unmount

### DIFF
--- a/webapp/src/components/widgets/text_with_tooltip_when_ellipsis.tsx
+++ b/webapp/src/components/widgets/text_with_tooltip_when_ellipsis.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {MutableRefObject, useCallback, useEffect, useRef, useState} from 'react';
+import React, {MutableRefObject, useMemo, useRef, useState, useEffect} from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {debounce} from 'debounce';
 
@@ -19,7 +19,7 @@ const TextWithTooltipWhenEllipsis = (props: Props) => {
     const ref = useRef<HTMLElement|null>(null);
     const [showTooltip, setShowTooltip] = useState(false);
 
-    const resizeListener = useCallback(debounce(() => {
+    const resizeListener = useMemo(() => debounce(() => {
         const parentWidth = (props.parentRef?.current && props.parentRef.current.offsetWidth) || 0;
         if (ref?.current && ref.current.offsetWidth > parentWidth) {
             setShowTooltip(true);
@@ -40,6 +40,9 @@ const TextWithTooltipWhenEllipsis = (props: Props) => {
     useEffect(() => {
         resizeListener();
     });
+
+    // Clean up the debounce handler on unmount.
+    useEffect(() => resizeListener.clear);
 
     const text = (
         <span


### PR DESCRIPTION
## Summary
Ensure debounce is cleaned up on unmount to avoid it running asynchronously after the tooltip component has been unmounted:

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1023171/191834388-7add8a94-58b5-4894-b5b9-44dabc6a01a7.png">

## Ticket Link
N/A