### PR TITLE
move participant request-update cases behind professional license

### DIFF
--- a/tests-e2e/cypress/integration/channels/slash_command/test_spec.js
+++ b/tests-e2e/cypress/integration/channels/slash_command/test_spec.js
@@ -169,7 +169,7 @@ describe('channels > slash command > test', () => {
                 // # Login as sysadmin.
                 cy.apiAdminLogin();
 
-                // # Set EnableTesting to false.
+                // # Set EnableTesting to true.
                 cy.apiUpdateConfig({
                     ServiceSettings: {
                         EnableTesting: true

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -138,10 +138,10 @@ describe('runs > run details page > status update', () => {
                     // # Click on kebab menu
                     cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();
 
-                    // # Click on request update
-                    cy.findByText('Request update...').click();
+                    // # click on request update option (force because is disabled)
+                    cy.findByText('Request update...').click({force: true});
 
-                    // * Assert modal is not opened
+                    // * assert modal is not opened
                     cy.get('#confirmModalButton').should('not.exist');
                 });
             });

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -19,13 +19,6 @@ describe('runs > run details page > status update', () => {
             testTeam = team;
             testUser = user;
 
-            // # Set EnableTesting to true.
-            cy.apiUpdateConfig({
-                ServiceSettings: {
-                    EnableTesting: true
-                },
-            });
-
             // Create another user in the same team
             cy.apiCreateUser().then(({user: viewer}) => {
                 testViewerUser = viewer;

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -19,6 +19,13 @@ describe('runs > run details page > status update', () => {
             testTeam = team;
             testUser = user;
 
+            // # Set EnableTesting to true.
+            cy.apiUpdateConfig({
+                ServiceSettings: {
+                    EnableTesting: true
+                },
+            });
+
             // Create another user in the same team
             cy.apiCreateUser().then(({user: viewer}) => {
                 testViewerUser = viewer;

--- a/tests-e2e/cypress/support/api/preference.js
+++ b/tests-e2e/cypress/support/api/preference.js
@@ -298,6 +298,12 @@ Cypress.Commands.add('apiDisableTutorials', (userId) => {
         },
         {
             user_id: userId,
+            category: 'crt_thread_pane_step',
+            name: userId,
+            value: '999',
+        },
+        {
+            user_id: userId,
             category: 'playbook_preview',
             name: userId,
             value: '999',

--- a/tests-e2e/cypress/support/api/preference.js
+++ b/tests-e2e/cypress/support/api/preference.js
@@ -319,6 +319,12 @@ Cypress.Commands.add('apiDisableTutorials', (userId) => {
             category: 'actions_menu',
             name: 'actions_menu_tutorial_state',
             value: '{"actions_menu_modal_viewed":true}'
+        },
+        {
+            user_id: userId,
+            category: 'insights',
+            name: 'insights_tutorial_state',
+            value: '{"insights_modal_viewed":true}'
         }
     ];
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -431,16 +431,16 @@ const useRequestUpdateUpgrade = () => {
                 )}
             >
                 {type === 'dotmenu' ? (
-                    <DropdownItem
+                    <DotMenuItem
                         disabled={disabled}
                         onClick={() => setShowUpgradeModal(true)}
                     >
                         {formatMessage({defaultMessage: 'Request update...'})}
                         <KeyVariantCircleIcon
                             color={'var(--online-indicator)'}
-                            size={16}
+                            size={20}
                         />
-                    </DropdownItem>
+                    </DotMenuItem>
                 ) : (
                     <UpgradeTertiaryButton
                         css={commonCss}
@@ -463,3 +463,9 @@ const ViewAllUpdates = styled.div`
     width: fit-content;
 `;
 
+const DotMenuItem = styled(DropdownItem)`
+    display: flex;
+    svg {
+        margin-left: 5px;
+    }
+`;

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -6,6 +6,7 @@ import {useDispatch} from 'react-redux';
 import styled from 'styled-components';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {DateTime} from 'luxon';
+import {KeyVariantCircleIcon} from '@mattermost/compass-icons/components';
 
 import {AdminNotificationType} from 'src/constants';
 import UpgradeModal from 'src/components/backstage/upgrade_modal';
@@ -118,6 +119,7 @@ export const ViewerStatusUpdate = ({id, playbookRun, openRHS, lastStatusUpdate}:
     const fiveSeconds = 5000;
     const now = useNow(fiveSeconds);
     const {RequestUpdateConfirmModal, showRequestUpdateConfirm} = useRequestUpdate(playbookRun.id);
+    const {UpgradeLicenseModal, RequestUpdateButton} = useRequestUpdateUpgrade();
 
     if (!playbookRun.status_update_enabled) {
         return null;
@@ -166,7 +168,11 @@ export const ViewerStatusUpdate = ({id, playbookRun, openRHS, lastStatusUpdate}:
                         {dueInfo.time}
                     </DueDateViewer>
                     {playbookRun.current_status === PlaybookRunStatus.InProgress ? (
-                        <RequestUpdateButton onClick={showRequestUpdateConfirm}/>
+                        <RequestUpdateButton
+                            onClick={showRequestUpdateConfirm}
+                            type={'button'}
+                            disabled={false}
+                        />
                     ) : null}
                 </RightWrapper>
             </Header>
@@ -177,6 +183,7 @@ export const ViewerStatusUpdate = ({id, playbookRun, openRHS, lastStatusUpdate}:
                 {openRHSText}
             </ViewAllUpdates> : null}
             {RequestUpdateConfirmModal}
+            {UpgradeLicenseModal}
         </Container>
     );
 };
@@ -191,6 +198,7 @@ export const ParticipantStatusUpdate = ({id, playbookRun, openRHS}: ParticipantP
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
     const {RequestUpdateConfirmModal, showRequestUpdateConfirm} = useRequestUpdate(playbookRun.id);
+    const {UpgradeLicenseModal, RequestUpdateButton} = useRequestUpdateUpgrade();
     const fiveSeconds = 5000;
     const now = useNow(fiveSeconds);
 
@@ -250,12 +258,17 @@ export const ParticipantStatusUpdate = ({id, playbookRun, openRHS}: ParticipantP
                             >
                                 {openRHSText}
                             </DropdownItem>
-                            <DropdownItem
+                            <RequestUpdateButton
+                                onClick={playbookRun.current_status === PlaybookRunStatus.Finished ? undefined : showRequestUpdateConfirm}
+                                disabled={playbookRun.current_status === PlaybookRunStatus.Finished}
+                                type={'dotmenu'}
+                            />
+                            {/* <DropdownItem
                                 onClick={playbookRun.current_status === PlaybookRunStatus.Finished ? undefined : showRequestUpdateConfirm}
                                 disabled={playbookRun.current_status === PlaybookRunStatus.Finished}
                             >
                                 {formatMessage({defaultMessage: 'Request update...'})}
-                            </DropdownItem>
+                            </DropdownItem> */}
                         </DotMenu>
                     </Kebab>
                 </RightWrapper>
@@ -264,6 +277,7 @@ export const ParticipantStatusUpdate = ({id, playbookRun, openRHS}: ParticipantP
                 {formatMessage({defaultMessage: 'View all updates'})}
             </ViewAllUpdates> : null}
             {RequestUpdateConfirmModal}
+            {UpgradeLicenseModal}
         </Container>
     );
 };
@@ -364,7 +378,7 @@ const PostUpdateButton = styled(TertiaryButton)`
     padding: 0 48px;
 `;
 
-const RequestUpdateButton = ({onClick}: {onClick: () => void}) => {
+const useRequestUpdateUpgrade = () => {
     const {formatMessage} = useIntl();
     const [showUpgradeModal, setShowUpgradeModal] = useState(false);
     const requestUpdateAllowed = useAllowRequestUpdate();
@@ -381,18 +395,36 @@ const RequestUpdateButton = ({onClick}: {onClick: () => void}) => {
         children: formatMessage({defaultMessage: 'Request update...'}),
     };
 
+    const UpgradeLicenseModal = (
+        <UpgradeModal
+            messageType={AdminNotificationType.REQUEST_UPDATE}
+            show={showUpgradeModal}
+            onHide={() => setShowUpgradeModal(false)}
+        />
+    );
+
     if (requestUpdateAllowed) {
-        return (
-            <TertiaryButton
-                css={commonCss}
-                onClick={onClick}
-                {...commonProps}
-            />
-        );
+        const RequestUpdateButton = ({type, onClick, disabled = false}: {disabled: boolean, type: 'dotmenu' | 'button', onClick?: () => void}) => {
+            return type === 'dotmenu' ? (
+                <DropdownItem
+                    disabled={disabled}
+                    onClick={onClick}
+                >
+                    {formatMessage({defaultMessage: 'Request update...'})}
+                </DropdownItem>
+            ) : (
+                <TertiaryButton
+                    css={commonCss}
+                    onClick={onClick}
+                    {...commonProps}
+                />
+            );
+        };
+        return {UpgradeLicenseModal, RequestUpdateButton};
     }
 
-    return (
-        <>
+    const RequestUpdateButton = ({type, onClick, disabled = false}: {disabled: boolean, type: 'dotmenu' | 'button', onClick?: () => void}) => {
+        return (<>
             <Tooltip
                 id={'request-update-button-tooltip'}
                 placement={'bottom'}
@@ -404,19 +436,28 @@ const RequestUpdateButton = ({onClick}: {onClick: () => void}) => {
                     }
                 )}
             >
-                <UpgradeTertiaryButton
-                    css={commonCss}
-                    onClick={() => setShowUpgradeModal(true)}
-                    {...commonProps}
-                />
+                {type === 'dotmenu' ? (
+                    <DropdownItem
+                        disabled={disabled}
+                        onClick={() => setShowUpgradeModal(true)}
+                    >
+                        {formatMessage({defaultMessage: 'Request update...'})}
+                        <KeyVariantCircleIcon
+                            color={'var(--online-indicator)'}
+                            size={16}
+                        />
+                    </DropdownItem>
+                ) : (
+                    <UpgradeTertiaryButton
+                        css={commonCss}
+                        onClick={() => setShowUpgradeModal(true)}
+                        {...commonProps}
+                    />
+                )}
             </Tooltip>
-            <UpgradeModal
-                messageType={AdminNotificationType.REQUEST_UPDATE}
-                show={showUpgradeModal}
-                onHide={() => setShowUpgradeModal(false)}
-            />
-        </>
-    );
+        </>);
+    };
+    return {UpgradeLicenseModal, RequestUpdateButton};
 };
 
 const ViewAllUpdates = styled.div`
@@ -425,6 +466,6 @@ const ViewAllUpdates = styled.div`
     cursor: pointer;
     color: var(--button-bg);
     font-weight: 600;
-    width: fit-content;    
+    width: fit-content;
 `;
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -263,12 +263,6 @@ export const ParticipantStatusUpdate = ({id, playbookRun, openRHS}: ParticipantP
                                 disabled={playbookRun.current_status === PlaybookRunStatus.Finished}
                                 type={'dotmenu'}
                             />
-                            {/* <DropdownItem
-                                onClick={playbookRun.current_status === PlaybookRunStatus.Finished ? undefined : showRequestUpdateConfirm}
-                                disabled={playbookRun.current_status === PlaybookRunStatus.Finished}
-                            >
-                                {formatMessage({defaultMessage: 'Request update...'})}
-                            </DropdownItem> */}
                         </DotMenu>
                     </Kebab>
                 </RightWrapper>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -466,6 +466,6 @@ const ViewAllUpdates = styled.div`
 const DotMenuItem = styled(DropdownItem)`
     display: flex;
     svg {
-        margin-left: 5px;
+        margin-left: 16px;
     }
 `;


### PR DESCRIPTION
## Summary

Move request update behind a professional license. It was already done for viewers, this PR cover the participants flow.
Code has been refactored a bit from `RequestUpdateButton` component to `useRequestUpdateUpgrade` hook to share upgrade flow/state among button/dotmenu item (viewer and participant triggers).


https://user-images.githubusercontent.com/4096774/193002562-903373b0-a96c-45e2-a2bd-9f26bf7516a0.mp4



## Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46984

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
