### PR TITLE
[MM-42886] Introduce weekly digest

### DIFF
--- a/server/api/bot.go
+++ b/server/api/bot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/bot"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/config"
+	"github.com/mattermost/mattermost-plugin-playbooks/server/timeutils"
 	"github.com/mattermost/mattermost-server/v6/model"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -180,6 +181,10 @@ func (h *BotHandler) promptForFeedback(c *Context, w http.ResponseWriter, r *htt
 	w.WriteHeader(http.StatusOK)
 }
 
+type DigestSenderParams struct {
+	isWeekly bool
+}
+
 // connect handles the GET /bot/connect endpoint (a notification sent when the client wakes up or reconnects)
 func (h *BotHandler) connect(c *Context, w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
@@ -202,25 +207,39 @@ func (h *BotHandler) connect(c *Context, w http.ResponseWriter, r *http.Request)
 	offset, _ := strconv.Atoi(r.Header.Get("X-Timezone-Offset"))
 	timezone = time.FixedZone("local", offset*60*60)
 
-	// DM message if it's the next day and been more than an hour since the last post
-	// Hat tip to Github plugin for the logic.
-	now := model.GetMillis()
-	nt := time.Unix(now/1000, 0).In(timezone)
-	lt := time.Unix(info.LastDailyTodoDMAt/1000, 0).In(timezone)
-	if nt.Sub(lt).Hours() >= 1 && (nt.Day() != lt.Day() || nt.Month() != lt.Month() || nt.Year() != lt.Year()) {
+	sendRegularDigest := h.createDigestSender(c, w, userID, &info)
+
+	// we want to first try a weekly digest
+	// if we have already sent it this week, try with a daily one
+	currentTime := timeutils.GetCurrentUnixTime(timezone)
+	if app.ShouldSendWeeklyDigestMessage(info, timezone, currentTime) {
+		sendRegularDigest(DigestSenderParams{isWeekly: true})
+	} else if app.ShouldSendDailyDigestMessage(info, timezone, currentTime) {
+		sendRegularDigest(DigestSenderParams{isWeekly: false})
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *BotHandler) createDigestSender(c *Context, w http.ResponseWriter, userID string, userInfo *app.UserInfo) func(DigestSenderParams) {
+	return func(params DigestSenderParams) {
+		now := model.GetMillis()
 		// record that we're sending a DM now (this will prevent us trying over and over on every
 		// response if there's a failure later)
-		info.LastDailyTodoDMAt = now
-		if err = h.userInfoStore.Upsert(info); err != nil {
+		userInfo.LastDailyTodoDMAt = now
+		if err := h.userInfoStore.Upsert(*userInfo); err != nil {
 			h.HandleError(w, c.logger, err)
 			return
 		}
 
-		if err = h.playbookRunService.DMTodoDigestToUser(userID, false); err != nil {
-			h.HandleError(w, c.logger, errors.Wrapf(err, "failed to DMTodoDigest to userID '%s'", userID))
+		regulartity := "daily"
+		if params.isWeekly {
+			regulartity = "weekly"
+		}
+
+		if err := h.playbookRunService.DMTodoDigestToUser(userID, params.isWeekly); err != nil {
+			h.HandleError(w, c.logger, errors.Wrapf(err, "failed to send '%s' DMTodoDigest to userID '%s'", regulartity, userID))
 			return
 		}
 	}
-
-	w.WriteHeader(http.StatusOK)
 }

--- a/server/app/regular_digest_service.go
+++ b/server/app/regular_digest_service.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-playbooks/server/timeutils"
+)
+
+func ShouldSendWeeklyDigestMessage(userInfo UserInfo, timezone *time.Location, currentTime time.Time) bool {
+	lastSentTime := timeutils.GetUnixTimeForTimezone(userInfo.LastDailyTodoDMAt, timezone)
+
+	currentYear, currentWeek := currentTime.ISOWeek()
+	lastSentYear, lastSentWeek := lastSentTime.ISOWeek()
+	isFirstLoginOfTheWeek := currentYear != lastSentYear || currentWeek != lastSentWeek
+
+	return ShouldSendDailyDigestMessage(userInfo, timezone, currentTime) && isFirstLoginOfTheWeek
+}
+
+func ShouldSendDailyDigestMessage(userInfo UserInfo, timezone *time.Location, currentTime time.Time) bool {
+	// DM message if it's the next day and been more than an hour since the last post
+	// Hat tip to Github plugin for the logic.
+	lastSentTime := timeutils.GetUnixTimeForTimezone(userInfo.LastDailyTodoDMAt, timezone)
+
+	isMoreThanOneHourPassed := currentTime.Sub(lastSentTime).Hours() >= 1
+
+	isDifferentDay := currentTime.Day() != lastSentTime.Day() ||
+		currentTime.Month() != lastSentTime.Month() ||
+		currentTime.Year() != lastSentTime.Year()
+
+	return isMoreThanOneHourPassed && isDifferentDay
+}

--- a/server/app/regular_digest_service_test.go
+++ b/server/app/regular_digest_service_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldSendWeeklyDigestMessage(t *testing.T) {
+	now, ok := time.Parse("2006-01-02", "2022-10-08")
+	if ok != nil {
+		t.Error("Could not parse current time")
+	}
+
+	type args struct {
+		userInfo    UserInfo
+		timezone    *time.Location
+		currentTime time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Should not send a weekly digest if we have already sent a digest this week",
+			args: args{
+				userInfo: UserInfo{
+					ID:                "testUser",
+					LastDailyTodoDMAt: now.AddDate(0, 0, -1).UnixMilli(),
+					DigestNotificationSettings: DigestNotificationSettings{
+						DisableDailyDigest: false,
+					},
+				},
+				timezone:    time.FixedZone("local", 0),
+				currentTime: now,
+			},
+			want: false,
+		},
+		{
+			name: "Should send a weekly digest if we have not sent a digest this week",
+			args: args{
+				userInfo: UserInfo{
+					ID:                "testUser",
+					LastDailyTodoDMAt: now.AddDate(0, 0, -6).UnixMilli(),
+					DigestNotificationSettings: DigestNotificationSettings{
+						DisableDailyDigest: false,
+					},
+				},
+				timezone:    time.FixedZone("local", 0),
+				currentTime: now,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldSendWeeklyDigestMessage(tt.args.userInfo, tt.args.timezone, tt.args.currentTime); got != tt.want {
+				t.Errorf("ShouldSendWeeklyDigestMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldSendDailyDigestMessage(t *testing.T) {
+	now, ok := time.Parse("Jan 2, 2006 at 3:04pm", "Oct 8, 2022 at 3:04pm")
+	lateNow, lateOk := time.Parse("Jan 2, 2006 at 3:04pm", "Oct 8, 2022 at 12:10am")
+	if ok != nil || lateOk != nil {
+		t.Error("Could not parse current time")
+	}
+
+	type args struct {
+		userInfo    UserInfo
+		timezone    *time.Location
+		currentTime time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Should not send a daily digest if we have already sent a digest today",
+			args: args{
+				userInfo: UserInfo{
+					ID:                "testUser",
+					LastDailyTodoDMAt: now.Add(-((time.Hour * 1) + (time.Minute * 2))).UnixMilli(),
+					DigestNotificationSettings: DigestNotificationSettings{
+						DisableDailyDigest: false,
+					},
+				},
+				timezone:    time.FixedZone("local", 0),
+				currentTime: now,
+			},
+			want: false,
+		},
+		{
+			name: "Should send a daily digest if we have not sent a digest today",
+			args: args{
+				userInfo: UserInfo{
+					ID:                "testUser",
+					LastDailyTodoDMAt: now.Add(-(time.Hour * 25)).UnixMilli(),
+					DigestNotificationSettings: DigestNotificationSettings{
+						DisableDailyDigest: false,
+					},
+				},
+				timezone:    time.FixedZone("local", 0),
+				currentTime: now,
+			},
+			want: true,
+		},
+		{
+			name: "Should not send a daily digest if we have sent one within the last hour",
+			args: args{
+				userInfo: UserInfo{
+					ID:                "testUser",
+					LastDailyTodoDMAt: lateNow.Add(-(time.Minute * 40)).UnixMilli(),
+					DigestNotificationSettings: DigestNotificationSettings{
+						DisableDailyDigest: false,
+					},
+				},
+				timezone:    time.FixedZone("local", 0),
+				currentTime: lateNow,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldSendDailyDigestMessage(tt.args.userInfo, tt.args.timezone, tt.args.currentTime); got != tt.want {
+				t.Errorf("ShouldSendDailyDigestMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/timeutils/timeutils.go
+++ b/server/timeutils/timeutils.go
@@ -69,3 +69,11 @@ func GetDaysDiff(start, end time.Time) int {
 	}
 	return days
 }
+
+func GetUnixTimeForTimezone(currentTime int64, timezone *time.Location) time.Time {
+	return time.Unix(currentTime/1000, 0).In(timezone)
+}
+
+func GetCurrentUnixTime(timezone *time.Location) time.Time {
+	return GetUnixTimeForTimezone(model.GetMillis(), timezone)
+}


### PR DESCRIPTION
## Summary

Introduces a weekly digest, similar to the daily one. 
Extracted functions that decide whether a daily/weekly digest should be sent.
Currently users would receive weekly digest if the daily digest is enabled.

What's left:
- [ ] Introduce a enable/disable weekly digest flag
- [ ] The above flag should default to the current daily digest setting
- [ ] Add a feature flag, as this is a user-facing feature and includes refactoring
- [ ] Add more tests for corner cases around sending daily/weekly digests

## Ticket Link
[Weekly Digest](https://github.com/mattermost/mattermost-server/issues/20825)

## Checklist
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [x] Unit tests updated
