### PR TITLE
e2e: Fix recent failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Mattermost Playbooks allows your team to create and run playbooks from within Ma
 In your `mattermost-server` configuration (`config/config.json`), set the following values:
 
 `ServiceSettings.EnableLocalMode: true`
+
 `PluginSettings.EnableUploads: true`
 
 and restart the server. Once done, the relevant `make` commands should be able to install builds. Those commands are:
 
 `make deploy` - builds and installs the plugin a single time
+
 `make watch` - continuously builds and installs when files change
 
 which are run from the repo root.

--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -133,7 +133,10 @@ describe('channels > rhs > header', () => {
                 });
             });
 
-            cy.findByText('Edit run summary').click({force: true});
+            cy.findByTestId('dropdownmenu').within(() => {
+                cy.get('span').should('have.length', 3);
+                cy.findByText('Edit run summary').click();
+            });
 
             // # type text in textarea
             cy.focused().should('be.visible').type('new summary{ctrl+enter}');

--- a/tests-e2e/cypress/integration/lhs_spec.js
+++ b/tests-e2e/cypress/integration/lhs_spec.js
@@ -181,7 +181,7 @@ describe('lhs', () => {
 
             // # The assertions here guard against the click() on 194
             // # happening on a detached element.
-            cy.assertBackstageRenderComplete(testUser.username);
+            cy.assertRunDetailsPageRenderComplete(testUser.username);
             cy.findByTestId('runinfo-following').should('be.visible').within(() => {
                 // # Verify follower icon
                 cy.findAllByTestId('profile-option', {exact: false}).should('have.length', 1);

--- a/tests-e2e/cypress/integration/lhs_spec.js
+++ b/tests-e2e/cypress/integration/lhs_spec.js
@@ -126,16 +126,12 @@ describe('lhs', () => {
 
                 // # Intercept these graphQL requests for wait()'s
                 // # that help ensure rendering has finished.
-                cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
-                    if (req.body?.operationName === 'PlaybookLHS') {
-                        req.alias = 'gqlUpdateLHS';
-                    }
-                });
+                cy.gqlInterceptQuery('PlaybookLHS');
             });
         });
 
         it('shows on click', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click dot menu
             cy.findByTestId('Runs')
@@ -148,7 +144,7 @@ describe('lhs', () => {
         });
 
         it('can copy link', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
             stubClipboard().as('clipboard');
 
             // # Click on Copy link menu item
@@ -159,18 +155,18 @@ describe('lhs', () => {
         });
 
         it('can favorite / unfavorite', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click on favorite menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Favorite').click().then(() => {
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
 
                 // * Verify the run is added to favorites
                 cy.findByTestId('Favorite').findByTestId(playbookRun.name).should('exist');
 
                 // # Click on unfavorite menu item
                 getRunDropdownItemByText('Favorite', playbookRun.name, 'Unfavorite').click().then(() => {
-                    cy.wait('@gqlUpdateLHS');
+                    cy.wait('@gqlPlaybookLHS');
 
                     // * Verify the run is removed from favorites
                     cy.findByTestId('Favorite').should('not.exist');
@@ -183,19 +179,18 @@ describe('lhs', () => {
 
             // # Visit the playbook run
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # The assertions here guard against the click() on 194
             // # happening on a detached element.
-            cy.findByTestId('assignee-profile-selector').should('contain', testUser.username);
-            cy.findByTestId('rhs-timeline').children().should('have.length', 3);
+            cy.assertBackstageRenderComplete(testUser.username);
             cy.findByTestId('runinfo-following').should('be.visible').within(() => {
-                // # Checking follower icons
+                // # Verify follower icon
                 cy.findAllByTestId('profile-option', {exact: false}).should('have.length', 1);
                 cy.findByTestId('rdp-rhs-follow-button').should('be.visible').click();
 
                 // # Verify icons update
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
                 cy.findAllByTestId('profile-option', {exact: false}).should('have.length', 2);
             });
 
@@ -206,7 +201,7 @@ describe('lhs', () => {
 
             // # Click on unfollow menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Unfollow').click().then(() => {
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
 
                 // * Verify that the run is removed lhs
                 cy.findByTestId('Runs').findByTestId(playbookRun.name).should('not.exist');
@@ -219,7 +214,7 @@ describe('lhs', () => {
 
             // # Visit the playbook run
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
@@ -230,7 +225,7 @@ describe('lhs', () => {
             // # Change the owner to testViewerUser
             cy.findByTestId('runinfo-owner').findByTestId('assignee-profile-selector').click();
             cy.get('.playbook-run-user-select').findByText('@' + testViewerUser.username).click();
-            cy.wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
@@ -265,17 +260,13 @@ describe('lhs', () => {
 
                     // # Intercept these graphQL requests for wait()'s
                     // # that help ensure rendering has finished.
-                    cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
-                        if (req.body?.operationName === 'PlaybookLHS') {
-                            req.alias = 'gqlUpdateLHS';
-                        }
-                    });
+                    cy.gqlInterceptQuery('PlaybookLHS');
                 });
             });
         });
 
         it('leave run, when on rdp of the same run', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
@@ -283,7 +274,7 @@ describe('lhs', () => {
             // # confirm modal
             cy.get('#confirmModal').should('be.visible').within(() => {
                 cy.get('#confirmModalButton').click();
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
             });
 
             // * Verify that user was redirected to the run list page
@@ -293,7 +284,7 @@ describe('lhs', () => {
         it('leave run, when not on rdp of the same run', () => {
             // # Visit playbooks list page
             cy.visit('/playbooks/playbooks');
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
@@ -301,7 +292,7 @@ describe('lhs', () => {
             // # confirm modal
             cy.get('#confirmModal').should('be.visible').within(() => {
                 cy.get('#confirmModalButton').click();
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
             });
 
             // * Verify that user was not redirected to the run list page
@@ -330,16 +321,12 @@ describe('lhs', () => {
 
                 // # Intercept these graphQL requests for wait()'s
                 // # that help ensure rendering has finished.
-                cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
-                    if (req.body?.operationName === 'PlaybookLHS') {
-                        req.alias = 'gqlUpdateLHS';
-                    }
-                });
+                cy.gqlInterceptQuery('PlaybookLHS');
             });
         });
 
         it('shows on click', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click dot menu
             cy.findByTestId('Playbooks')
@@ -352,7 +339,7 @@ describe('lhs', () => {
         });
 
         it('can copy link', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
             stubClipboard().as('clipboard');
 
             // # Click on Copy link menu item
@@ -365,18 +352,18 @@ describe('lhs', () => {
         });
 
         it('can favorite / unfavorite', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             // # Click on favorite menu item
             getRunDropdownItemByText('Playbooks', testPublicPlaybook.title, 'Favorite').click().then(() => {
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
 
                 // * Verify the playbook is added to favorites
                 cy.findByTestId('Favorite').findByTestId(testPublicPlaybook.title).should('exist');
 
                 // # Click on unfavorite menu item
                 getRunDropdownItemByText('Favorite', testPublicPlaybook.title, 'Unfavorite').click().then(() => {
-                    cy.wait('@gqlUpdateLHS');
+                    cy.wait('@gqlPlaybookLHS');
 
                     // * Verify the playbook is removed from favorites
                     cy.findByTestId('Playbooks').findByTestId(testPublicPlaybook.title).should('exist');
@@ -385,13 +372,13 @@ describe('lhs', () => {
         });
 
         it('can leave', () => {
-            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
 
             stubClipboard().as('clipboard');
 
             // # Click on Leave menu item
             getRunDropdownItemByText('Playbooks', testPublicPlaybook.title, 'Leave').click().then(() => {
-                cy.wait('@gqlUpdateLHS');
+                cy.wait('@gqlPlaybookLHS');
 
                 // * Verify the playbook is removed from the list
                 cy.findByTestId('Playbooks').findByTestId(testPublicPlaybook.title).should('not.exist');

--- a/tests-e2e/cypress/integration/lhs_spec.js
+++ b/tests-e2e/cypress/integration/lhs_spec.js
@@ -52,8 +52,14 @@ describe('lhs', () => {
     });
 
     const getRunDropdownItemByText = (groupName, runName, itemName) => {
-        cy.findByTestId(groupName).findByTestId(runName).findByTestId('menuButton').click();
-        return cy.findByTestId('dropdownmenu').findByText(itemName);
+        cy.findByTestId(groupName).should('exist')
+            .findByTestId(runName).should('exist')
+            .findByTestId('menuButton')
+            .click({force: true});
+        return cy.findByTestId('dropdownmenu')
+            .should('be.visible')
+            .findByText(itemName)
+            .should('be.visible');
     };
 
     describe('navigate', () => {
@@ -74,7 +80,9 @@ describe('lhs', () => {
 
                 // # Visit the playbook run
                 cy.visit('/playbooks/runs');
-                cy.wait(5000);
+                cy.findByTestId('lhs-navigation').within((() => {
+                    cy.contains(playbookRun.name).should('be.visible');
+                }));
             });
         });
 
@@ -85,7 +93,7 @@ describe('lhs', () => {
             // # Click on run at LHS
             cy.findByTestId('Runs').findByTestId(playbookRun.name).click();
 
-            // * assert  telemetry pageview
+            // * assert telemetry pageview
             cy.wait('@telemetry').then((interception) => {
                 expect(interception.request.body.name).to.eq('run_details');
                 expect(interception.request.body.type).to.eq('page');
@@ -116,20 +124,31 @@ describe('lhs', () => {
                 // # Visit the playbook run
                 cy.visit(`/playbooks/runs/${playbookRun.id}`);
 
-                // # LHS render takes a few seconds, wait for it
-                cy.wait(5000);
+                // # Intercept these graphQL requests for wait()'s
+                // # that help ensure rendering has finished.
+                cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
+                    if (req.body?.operationName === 'PlaybookLHS') {
+                        req.alias = 'gqlUpdateLHS';
+                    }
+                });
             });
         });
 
         it('shows on click', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+
             // # Click dot menu
-            cy.findByTestId('Runs').findByTestId(playbookRun.name).findByTestId('menuButton').click();
+            cy.findByTestId('Runs')
+                .findByTestId(playbookRun.name)
+                .findByTestId('menuButton')
+                .click({force: true});
 
             // * Assert context menu is opened
             cy.findByTestId('dropdownmenu').should('be.visible');
         });
 
         it('can copy link', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
             stubClipboard().as('clipboard');
 
             // # Click on Copy link menu item
@@ -140,44 +159,57 @@ describe('lhs', () => {
         });
 
         it('can favorite / unfavorite', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+
             // # Click on favorite menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Favorite').click().then(() => {
+                cy.wait('@gqlUpdateLHS');
+
                 // * Verify the run is added to favorites
                 cy.findByTestId('Favorite').findByTestId(playbookRun.name).should('exist');
 
                 // # Click on unfavorite menu item
                 getRunDropdownItemByText('Favorite', playbookRun.name, 'Unfavorite').click().then(() => {
+                    cy.wait('@gqlUpdateLHS');
+
                     // * Verify the run is removed from favorites
-                    cy.findByTestId('Runs').findByTestId(playbookRun.name).should('exist');
+                    cy.findByTestId('Favorite').should('not.exist');
                 });
             });
         });
 
         it('lhs refresh on follow/unfollow', () => {
-            cy.apiLogin(testViewerUser).then(() => {
-                // # Visit the playbook run
-                cy.visit(`/playbooks/runs/${playbookRun.id}`);
+            cy.apiLogin(testViewerUser);
 
-                // # Wait for load
-                cy.wait(1000);
+            // # Visit the playbook run
+            cy.visit(`/playbooks/runs/${playbookRun.id}`);
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
 
-                // # Follow the run
-                cy.findByTestId('rdp-rhs-follow-button').click();
+            // # The assertions here guard against the click() on 194
+            // # happening on a detached element.
+            cy.findByTestId('assignee-profile-selector').should('contain', testUser.username);
+            cy.findByTestId('rhs-timeline').children().should('have.length', 3);
+            cy.findByTestId('runinfo-following').should('be.visible').within(() => {
+                // # Checking follower icons
+                cy.findAllByTestId('profile-option', {exact: false}).should('have.length', 1);
+                cy.findByTestId('rdp-rhs-follow-button').should('be.visible').click();
 
-                // # Wait to lhs refresh
-                cy.wait(3000);
+                // # Verify icons update
+                cy.wait('@gqlUpdateLHS');
+                cy.findAllByTestId('profile-option', {exact: false}).should('have.length', 2);
+            });
 
-                // * Verify that the run was added to the lhs
-                cy.findByTestId('Runs').findByTestId(playbookRun.name).should('exist');
+            // * Verify that the run was added to the lhs
+            cy.findByTestId('lhs-navigation').within((() => {
+                cy.findByTestId(playbookRun.name).should('be.visible');
+            }));
 
-                // # Click on unfollow menu item
-                getRunDropdownItemByText('Runs', playbookRun.name, 'Unfollow').click().then(() => {
-                    // # Wait to lhs refresh
-                    cy.wait(3000);
+            // # Click on unfollow menu item
+            getRunDropdownItemByText('Runs', playbookRun.name, 'Unfollow').click().then(() => {
+                cy.wait('@gqlUpdateLHS');
 
-                    // * Verify that the run is removed lhs
-                    cy.findByTestId('Runs').findByTestId(playbookRun.name).should('not.exist');
-                });
+                // * Verify that the run is removed lhs
+                cy.findByTestId('Runs').findByTestId(playbookRun.name).should('not.exist');
             });
         });
 
@@ -187,11 +219,10 @@ describe('lhs', () => {
 
             // # Visit the playbook run
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
-            cy.wait(3000);
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
-            cy.wait(200);
 
             // * Verify that owner can't leave.
             cy.get('#confirmModal').should('not.exist');
@@ -199,7 +230,7 @@ describe('lhs', () => {
             // # Change the owner to testViewerUser
             cy.findByTestId('runinfo-owner').findByTestId('assignee-profile-selector').click();
             cy.get('.playbook-run-user-select').findByText('@' + testViewerUser.username).click();
-            cy.wait(500);
+            cy.wait('@gqlUpdateLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
@@ -232,19 +263,28 @@ describe('lhs', () => {
                     // # Visit the playbook run
                     cy.visit(`/playbooks/runs/${playbookRun.id}`);
 
-                    // # LHS render takes a few seconds, wait for it
-                    cy.wait(5000);
+                    // # Intercept these graphQL requests for wait()'s
+                    // # that help ensure rendering has finished.
+                    cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
+                        if (req.body?.operationName === 'PlaybookLHS') {
+                            req.alias = 'gqlUpdateLHS';
+                        }
+                    });
                 });
             });
         });
 
         it('leave run, when on rdp of the same run', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
-            cy.wait(200);
 
             // # confirm modal
-            cy.get('#confirmModal').get('#confirmModalButton').click();
+            cy.get('#confirmModal').should('be.visible').within(() => {
+                cy.get('#confirmModalButton').click();
+                cy.wait('@gqlUpdateLHS');
+            });
 
             // * Verify that user was redirected to the run list page
             cy.url().should('include', 'playbooks/runs?sort=');
@@ -253,14 +293,16 @@ describe('lhs', () => {
         it('leave run, when not on rdp of the same run', () => {
             // # Visit playbooks list page
             cy.visit('/playbooks/playbooks');
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
 
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
-            cy.wait(200);
 
             // # confirm modal
-            cy.get('#confirmModal').get('#confirmModalButton').click();
-            cy.wait(500);
+            cy.get('#confirmModal').should('be.visible').within(() => {
+                cy.get('#confirmModalButton').click();
+                cy.wait('@gqlUpdateLHS');
+            });
 
             // * Verify that user was not redirected to the run list page
             cy.url().should('not.include', 'playbooks/runs?sort=');
@@ -286,37 +328,56 @@ describe('lhs', () => {
                 // # Visit the playbooks page
                 cy.visit('/playbooks/playbooks');
 
-                // # LHS render takes a few seconds, wait for it
-                cy.wait(5000);
+                // # Intercept these graphQL requests for wait()'s
+                // # that help ensure rendering has finished.
+                cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
+                    if (req.body?.operationName === 'PlaybookLHS') {
+                        req.alias = 'gqlUpdateLHS';
+                    }
+                });
             });
         });
 
         it('shows on click', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+
             // # Click dot menu
-            cy.findByTestId('Playbooks').findByTestId(testPublicPlaybook.title).findByTestId('menuButton').click();
+            cy.findByTestId('Playbooks')
+                .findByTestId(testPublicPlaybook.title)
+                .findByTestId('menuButton')
+                .click({force: true});
 
             // * Assert context menu is opened
             cy.findByTestId('dropdownmenu').should('be.visible');
         });
 
         it('can copy link', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
             stubClipboard().as('clipboard');
 
             // # Click on Copy link menu item
             getRunDropdownItemByText('Playbooks', testPublicPlaybook.title, 'Copy link').click().then(() => {
                 // * Verify clipboard content
-                cy.get('@clipboard').its('contents').should('contain', `/playbooks/playbooks/${testPublicPlaybook.id}`);
+                cy.get('@clipboard')
+                    .its('contents')
+                    .should('contain', `/playbooks/playbooks/${testPublicPlaybook.id}`);
             });
         });
 
         it('can favorite / unfavorite', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+
             // # Click on favorite menu item
             getRunDropdownItemByText('Playbooks', testPublicPlaybook.title, 'Favorite').click().then(() => {
+                cy.wait('@gqlUpdateLHS');
+
                 // * Verify the playbook is added to favorites
                 cy.findByTestId('Favorite').findByTestId(testPublicPlaybook.title).should('exist');
 
                 // # Click on unfavorite menu item
                 getRunDropdownItemByText('Favorite', testPublicPlaybook.title, 'Unfavorite').click().then(() => {
+                    cy.wait('@gqlUpdateLHS');
+
                     // * Verify the playbook is removed from favorites
                     cy.findByTestId('Playbooks').findByTestId(testPublicPlaybook.title).should('exist');
                 });
@@ -324,10 +385,14 @@ describe('lhs', () => {
         });
 
         it('can leave', () => {
+            cy.wait('@gqlUpdateLHS').wait('@gqlUpdateLHS');
+
             stubClipboard().as('clipboard');
 
             // # Click on Leave menu item
             getRunDropdownItemByText('Playbooks', testPublicPlaybook.title, 'Leave').click().then(() => {
+                cy.wait('@gqlUpdateLHS');
+
                 // * Verify the playbook is removed from the list
                 cy.findByTestId('Playbooks').findByTestId(testPublicPlaybook.title).should('not.exist');
             });

--- a/tests-e2e/cypress/integration/lhs_spec.js
+++ b/tests-e2e/cypress/integration/lhs_spec.js
@@ -80,9 +80,7 @@ describe('lhs', () => {
 
                 // # Visit the playbook run
                 cy.visit('/playbooks/runs');
-                cy.findByTestId('lhs-navigation').within((() => {
-                    cy.contains(playbookRun.name).should('be.visible');
-                }));
+                cy.findByTestId('lhs-navigation').findByText(playbookRun.name).should('be.visible');
             });
         });
 
@@ -195,9 +193,7 @@ describe('lhs', () => {
             });
 
             // * Verify that the run was added to the lhs
-            cy.findByTestId('lhs-navigation').within((() => {
-                cy.findByTestId(playbookRun.name).should('be.visible');
-            }));
+            cy.findByTestId('lhs-navigation').findByText(playbookRun.name).should('exist');
 
             // # Click on unfollow menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Unfollow').click().then(() => {

--- a/tests-e2e/cypress/integration/runs/rdp_general_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_general_spec.js
@@ -66,7 +66,7 @@ describe('runs > run details page', () => {
         // # Visit the URL of a non-existing playbook run
         cy.visit(`/playbooks/runs/${testPlaybookRun.id}`);
 
-        // * assert  telemetry pageview
+        // * assert telemetry pageview
         cy.wait('@telemetry').then((interception) => {
             expect(interception.request.body.name).to.eq('run_details');
             expect(interception.request.body.type).to.eq('page');

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -145,6 +145,12 @@ describe('runs > run details page > header', () => {
 
                 // # Visit the playbook run
                 cy.visit(`/playbooks/runs/${playbookRun.id}`);
+
+                // # Intercept these graphQL requests for wait()'s
+                // # that help ensure rendering has finished.
+                cy.gqlInterceptQuery('PlaybookLHS');
+                cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                cy.assertBackstageRenderComplete(testUser.username);
             });
         });
 
@@ -428,7 +434,7 @@ describe('runs > run details page > header', () => {
 
                     // # Change the owner to testViewerUser
                     cy.apiChangePlaybookRunOwner(playbookRun.id, testViewerUser.id);
-                    cy.wait(500);
+                    cy.findByTestId('assignee-profile-selector').should('contain', testViewerUser.username);
 
                     // # Click on leave run
                     getDropdownItemByText('Leave and unfollow run').click();
@@ -473,6 +479,12 @@ describe('runs > run details page > header', () => {
                     // # Visit the playbook run
                     cy.visit(`/playbooks/runs/${playbookRun.id}`);
                 });
+
+                // # Intercept these graphQL requests for wait()'s
+                // # that help ensure rendering has finished.
+                cy.gqlInterceptQuery('PlaybookLHS');
+                cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                cy.assertBackstageRenderComplete(testUser.username);
             });
         });
 
@@ -480,31 +492,6 @@ describe('runs > run details page > header', () => {
             commonHeaderTests();
 
             describe('Favorite', () => {
-                beforeEach(() => {
-                    // # Login as testUser
-                    cy.apiLogin(testUser);
-
-                    const now = Date.now();
-                    playbookRunName = 'Playbook Run (' + now + ')';
-                    playbookRunChannelName = 'playbook-run-' + now;
-                    cy.apiRunPlaybook({
-                        teamId: testTeam.id,
-                        playbookId: testPublicPlaybookAndChannel.id,
-                        playbookRunName,
-                        ownerUserId: testUser.id,
-                    }).then((run) => {
-                        playbookRun = run;
-
-                        cy.apiLogin(testViewerUser).then(() => {
-                            // # Visit the playbook run
-                            cy.visit(`/playbooks/runs/${playbookRun.id}`);
-
-                            // # let the page render completely
-                            cy.wait(3000);
-                        });
-                    });
-                });
-
                 it('add and remove from LHS', () => {
                     // # Click fav icon
                     getHeader().getStyledComponent('StarButton').click();
@@ -530,9 +517,6 @@ describe('runs > run details page > header', () => {
                     // * Assert that component is rendered
                     getHeader().findByText('Participate').should('be.visible');
 
-                    // # Wait for useChannel
-                    cy.wait(500);
-
                     // * Click Participate button
                     getHeader().findByText('Participate').click();
 
@@ -556,9 +540,6 @@ describe('runs > run details page > header', () => {
                     // * Assert component is rendered
                     getHeader().findByText('Participate').should('be.visible');
 
-                    // # Wait for useChannel
-                    cy.wait(500);
-
                     // * Click start-participating button
                     getHeader().findByText('Participate').click();
 
@@ -568,11 +549,11 @@ describe('runs > run details page > header', () => {
                     // * Assert that modal is not shown
                     cy.get('#confirmModal').should('not.exist');
 
-                    // # Wait for ws event to be received
-                    cy.wait(500);
-
                     // * Verify run has been added to LHS
-                    cy.findByTestId('lhs-navigation').findByText(playbookRunName).should('exist');
+                    cy.findByTestId('lhs-navigation')
+                        .should('be.visible')
+                        .findByText(playbookRunName)
+                        .should('be.visible');
                 });
 
                 it('click button and confirm to when public channel', () => {
@@ -594,12 +575,11 @@ describe('runs > run details page > header', () => {
 
                         // # Visit the playbook run
                         cy.visit(`/playbooks/runs/${run.id}`);
+                        cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                        cy.assertBackstageRenderComplete(testUser.username);
 
                         // * Assert that component is rendered
                         getHeader().findByText('Participate').should('be.visible');
-
-                        // # Wait for useChannel
-                        cy.wait(500);
 
                         // # Click start-participating button
                         getHeader().findByText('Participate').click();
@@ -609,9 +589,6 @@ describe('runs > run details page > header', () => {
 
                         // * Assert that modal is not shown
                         cy.get('#confirmModal').should('not.exist');
-
-                        // # Wait for ws event to be received
-                        cy.wait(500);
 
                         // * Verify run has been added to LHS
                         cy.findByTestId('lhs-navigation').findByText(playbookRunName).should('exist');

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -150,7 +150,7 @@ describe('runs > run details page > header', () => {
                 // # that help ensure rendering has finished.
                 cy.gqlInterceptQuery('PlaybookLHS');
                 cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                cy.assertBackstageRenderComplete(testUser.username);
+                cy.assertRunDetailsPageRenderComplete(testUser.username);
             });
         });
 
@@ -484,7 +484,7 @@ describe('runs > run details page > header', () => {
                 // # that help ensure rendering has finished.
                 cy.gqlInterceptQuery('PlaybookLHS');
                 cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                cy.assertBackstageRenderComplete(testUser.username);
+                cy.assertRunDetailsPageRenderComplete(testUser.username);
             });
         });
 
@@ -576,7 +576,7 @@ describe('runs > run details page > header', () => {
                         // # Visit the playbook run
                         cy.visit(`/playbooks/runs/${run.id}`);
                         cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                        cy.assertBackstageRenderComplete(testUser.username);
+                        cy.assertRunDetailsPageRenderComplete(testUser.username);
 
                         // * Assert that component is rendered
                         getHeader().findByText('Participate').should('be.visible');

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -65,7 +65,7 @@ describe('runs > run details page > status update', () => {
             // # that help ensure rendering has finished.
             cy.gqlInterceptQuery('PlaybookLHS');
             cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-            cy.assertBackstageRenderComplete(testUser.username);
+            cy.assertRunDetailsPageRenderComplete(testUser.username);
         });
     });
 
@@ -141,7 +141,7 @@ describe('runs > run details page > status update', () => {
                     // # reload url
                     cy.visit(`/playbooks/runs/${testRun.id}`);
                     cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                    cy.assertBackstageRenderComplete(testUser.username, 4);
+                    cy.assertRunDetailsPageRenderComplete(testUser.username);
 
                     // # Click on kebab menu
                     cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();
@@ -202,7 +202,7 @@ describe('runs > run details page > status update', () => {
             cy.apiLogin(testViewerUser).then(() => {
                 cy.visit(`/playbooks/runs/${testRun.id}`);
                 cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                cy.assertBackstageRenderComplete(testUser.username);
+                cy.assertRunDetailsPageRenderComplete(testUser.username);
             });
         });
 
@@ -232,13 +232,13 @@ describe('runs > run details page > status update', () => {
             cy.apiLogin(testUser).then(() => {
                 cy.visit(`/playbooks/runs/${testRun.id}`);
                 cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                cy.assertBackstageRenderComplete(testUser.username);
+                cy.assertRunDetailsPageRenderComplete(testUser.username);
             });
 
             // # Click post update
-            cy.findByTestId('run-statusupdate-section').should('be.visible').within(() => {
-                cy.findByTestId('post-update-button').click();
-            });
+            cy.findByTestId('run-statusupdate-section')
+                .should('be.visible')
+                .findByTestId('post-update-button').click();
 
             // * Assert modal is opened
             cy.getStatusUpdateDialog().should('be.visible');
@@ -255,7 +255,7 @@ describe('runs > run details page > status update', () => {
             cy.apiLogin(testViewerUser).then(() => {
                 cy.visit(`/playbooks/runs/${testRun.id}`);
                 cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
-                cy.assertBackstageRenderComplete(testUser.username, 4);
+                cy.assertRunDetailsPageRenderComplete(testUser.username);
 
                 // * Check new due date
                 cy.findByTestId('update-due-date-text').contains('Update due');
@@ -268,9 +268,9 @@ describe('runs > run details page > status update', () => {
 
         it('requests an update and confirm', () => {
             // # Click on request update
-            cy.findByTestId('run-statusupdate-section').should('be.visible').within(() => {
-                cy.findByText('Request update...').click();
-            });
+            cy.findByTestId('run-statusupdate-section')
+                .should('be.visible')
+                .findByText('Request update...').click();
 
             // # Click on modal confirmation
             cy.get('#confirmModalButton').click();
@@ -286,9 +286,9 @@ describe('runs > run details page > status update', () => {
 
         it('requests an update and cancel', () => {
             // # Click post update
-            cy.findByTestId('run-statusupdate-section').should('be.visible').within(() => {
-                cy.findByText('Request update...').click();
-            });
+            cy.findByTestId('run-statusupdate-section')
+                .should('be.visible')
+                .findByText('Request update...').click();
 
             // # Click on modal confirmation
             cy.get('#cancelModalButton').click();

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -60,6 +60,9 @@ describe('runs > run details page > status update', () => {
 
             // # Visit the playbook run
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
+            cy.findByTestId('lhs-navigation').within((() => {
+                cy.contains(playbookRun.name).should('be.visible');
+            }));
         });
     });
 
@@ -150,8 +153,12 @@ describe('runs > run details page > status update', () => {
                 // # Click on kebab menu
                 cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();
 
-                // # Click on request update
-                cy.findByText('Request update...').click();
+                cy.findByTestId('dropdownmenu').within(($dropdown) => {
+                    cy.wrap($dropdown).children().should('have.length', 2);
+
+                    // # Click on request update
+                    cy.findByText('Request update...').click();
+                });
 
                 // # Click on modal confirmation
                 cy.get('#confirmModalButton').click();
@@ -166,9 +173,12 @@ describe('runs > run details page > status update', () => {
             it('requests and cancel', () => {
                 // # Click on kebab menu
                 cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();
+                cy.findByTestId('dropdownmenu').within(($dropdown) => {
+                    cy.wrap($dropdown).children().should('have.length', 2);
 
-                // # Click on request update
-                cy.findByTestId('dropdownmenu').findByText('Request update...').click();
+                    // # Click on request update
+                    cy.findByText('Request update...').click();
+                });
 
                 // # Click on modal confirmation
                 cy.get('#cancelModalButton').click();
@@ -217,7 +227,9 @@ describe('runs > run details page > status update', () => {
             });
 
             // # Click post update
-            cy.findByTestId('run-statusupdate-section').findByTestId('post-update-button').click();
+            cy.findByTestId('run-statusupdate-section').should('be.visible').within(() => {
+                cy.findByTestId('post-update-button').click();
+            });
 
             // * Assert modal is opened
             cy.getStatusUpdateDialog().should('be.visible');
@@ -245,7 +257,9 @@ describe('runs > run details page > status update', () => {
 
         it('requests an update and confirm', () => {
             // # Click on request update
-            cy.findByTestId('run-statusupdate-section').findByText('Request update...').click();
+            cy.findByTestId('run-statusupdate-section').should('be.visible').within(() => {
+                cy.findByText('Request update...').click();
+            });
 
             // # Click on modal confirmation
             cy.get('#confirmModalButton').click();
@@ -260,8 +274,10 @@ describe('runs > run details page > status update', () => {
         });
 
         it('requests an update and cancel', () => {
-            // # Click on request update
-            cy.findByTestId('run-statusupdate-section').findByText('Request update...').click();
+            // # Click post update
+            cy.findByTestId('run-statusupdate-section').should('be.visible').within(() => {
+                cy.findByText('Request update...').click();
+            });
 
             // # Click on modal confirmation
             cy.get('#cancelModalButton').click();

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -60,9 +60,12 @@ describe('runs > run details page > status update', () => {
 
             // # Visit the playbook run
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
-            cy.findByTestId('lhs-navigation').within((() => {
-                cy.contains(playbookRun.name).should('be.visible');
-            }));
+
+            // # Intercept these graphQL requests for wait()'s
+            // # that help ensure rendering has finished.
+            cy.gqlInterceptQuery('PlaybookLHS');
+            cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+            cy.assertBackstageRenderComplete(testUser.username);
         });
     });
 
@@ -137,6 +140,8 @@ describe('runs > run details page > status update', () => {
                 cy.apiFinishRun(testRun.id).then(() => {
                     // # reload url
                     cy.visit(`/playbooks/runs/${testRun.id}`);
+                    cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                    cy.assertBackstageRenderComplete(testUser.username, 4);
 
                     // # Click on kebab menu
                     cy.findByTestId('run-statusupdate-section').getStyledComponent('Kebab').click();
@@ -196,6 +201,8 @@ describe('runs > run details page > status update', () => {
         beforeEach(() => {
             cy.apiLogin(testViewerUser).then(() => {
                 cy.visit(`/playbooks/runs/${testRun.id}`);
+                cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                cy.assertBackstageRenderComplete(testUser.username);
             });
         });
 
@@ -224,6 +231,8 @@ describe('runs > run details page > status update', () => {
             // # Login as participant
             cy.apiLogin(testUser).then(() => {
                 cy.visit(`/playbooks/runs/${testRun.id}`);
+                cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                cy.assertBackstageRenderComplete(testUser.username);
             });
 
             // # Click post update
@@ -245,6 +254,8 @@ describe('runs > run details page > status update', () => {
 
             cy.apiLogin(testViewerUser).then(() => {
                 cy.visit(`/playbooks/runs/${testRun.id}`);
+                cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+                cy.assertBackstageRenderComplete(testUser.username, 4);
 
                 // * Check new due date
                 cy.findByTestId('update-due-date-text').contains('Update due');

--- a/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_statusupdate_spec.js
@@ -285,7 +285,7 @@ describe('runs > run details page > status update', () => {
         });
 
         it('requests an update and cancel', () => {
-            // # Click post update
+            // # Click request update
             cy.findByTestId('run-statusupdate-section')
                 .should('be.visible')
                 .findByText('Request update...').click();

--- a/tests-e2e/cypress/support/plugin/api_commands.js
+++ b/tests-e2e/cypress/support/plugin/api_commands.js
@@ -422,3 +422,11 @@ Cypress.Commands.add('apiUnfollowPlaybookRun', (playbookRunId) => {
         cy.wrap(response.body);
     });
 });
+
+Cypress.Commands.add('gqlInterceptQuery', (operationName) => {
+    cy.intercept('/plugins/playbooks/api/v0/query', (req) => {
+        if (req.body?.operationName === operationName) {
+            req.alias = `gql${operationName}`;
+        }
+    });
+});

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -300,7 +300,7 @@ Cypress.Commands.add('getFirstPostId', () => {
         .invoke('replace', 'post_', '');
 });
 
-Cypress.Commands.add('assertBackstageRenderComplete', (expectedRunOwner, expectedTimelineItems = 3) => {
+Cypress.Commands.add('assertRunDetailsPageRenderComplete', (expectedRunOwner) => {
     cy.findByTestId('assignee-profile-selector').should('contain', expectedRunOwner);
-    cy.findByTestId('rhs-timeline').children().should('have.length', expectedTimelineItems);
+    cy.findByTestId('rhs-timeline').children().should('not.be.empty');
 });

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -302,5 +302,6 @@ Cypress.Commands.add('getFirstPostId', () => {
 
 Cypress.Commands.add('assertRunDetailsPageRenderComplete', (expectedRunOwner) => {
     cy.findByTestId('assignee-profile-selector').should('contain', expectedRunOwner);
-    cy.findByTestId('rhs-timeline').children().should('not.be.empty');
+    cy.findAllByTestId('timeline-item', {exact: false}).should('have.length.of.at.least', 1);
+    cy.findAllByTestId('profile-option', {exact: false}).should('have.length.of.at.least', 1);
 });

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -299,3 +299,8 @@ Cypress.Commands.add('getFirstPostId', () => {
     cy.findAllByTestId('postView').first().should('have.attr', 'id').and('not.include', ':')
         .invoke('replace', 'post_', '');
 });
+
+Cypress.Commands.add('assertBackstageRenderComplete', (expectedRunOwner, expectedTimelineItems = 3) => {
+    cy.findByTestId('assignee-profile-selector').should('contain', expectedRunOwner);
+    cy.findByTestId('rhs-timeline').children().should('have.length', expectedTimelineItems);
+});


### PR DESCRIPTION
Failures from these specs were due to tests interacting with certain elements while the DOM was unstable. The fixes rely on more accurately describing expected page state (`should(...)`) and/or `wait()`ing on a common request responsible for most of the data used on the page, prior to the problematic interactions. 