### PR TITLE
Set height for global header give feedback btn

### DIFF
--- a/webapp/src/components/global_header_right.tsx
+++ b/webapp/src/components/global_header_right.tsx
@@ -9,6 +9,7 @@ import GiveFeedbackButton from 'src/components/give_feedback_button';
 const GlobalHeaderGiveFeedbackButton = styled(GiveFeedbackButton)`
     padding: 0 5px;
     font-size: 11px;
+    height: 24px;
 `;
 
 const GlobalHeaderRight = () => {


### PR DESCRIPTION
## Summary
Set height for global header give feedback btn. Previously:

![image](https://user-images.githubusercontent.com/1023171/195353732-a332f538-7f29-4bd1-b149-4857147f6038.png)

Now:

<img width="218" alt="image" src="https://user-images.githubusercontent.com/1023171/195353824-c1118402-a607-4e11-917d-7c3f456bed60.png">

## Ticket Link
N/A