### PR TITLE
[MM-21265] Checkbox to show/hide skipped tasks

### DIFF
--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -336,7 +336,7 @@ const makeFilterOptions = (filter: ChecklistItemsFilter, name: string): Checkbox
         },
         {
             display: 'Show skipped tasks',
-            value: 'checked',
+            value: 'skipped',
             selected: filter.skipped,
             disabled: filter.all,
         },

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -88,6 +88,11 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props)
             return false;
         }
 
+        // "Show skipped tasks" is not checked, so if item is skipped, don't show it.
+        if (!checklistItemsFilter.skipped && checklistItem.state === ChecklistItemState.Skip) {
+            return false;
+        }
+
         // "Me" is not checked, so if assignee_id is me, don't show it.
         if (!checklistItemsFilter.me && checklistItem.assignee_id === myId) {
             return false;
@@ -327,6 +332,12 @@ const makeFilterOptions = (filter: ChecklistItemsFilter, name: string): Checkbox
             display: 'Show checked tasks',
             value: 'checked',
             selected: filter.checked,
+            disabled: filter.all,
+        },
+        {
+            display: 'Show skipped tasks',
+            value: 'checked',
+            selected: filter.skipped,
             disabled: filter.all,
         },
         {

--- a/webapp/src/types/playbook.ts
+++ b/webapp/src/types/playbook.ts
@@ -218,6 +218,7 @@ export const newChecklistItem = (title = '', description = '', command = '', sta
 export interface ChecklistItemsFilter extends Record<string, boolean> {
     all: boolean;
     checked: boolean;
+    skipped: boolean;
     me: boolean;
     unassigned: boolean;
     others: boolean;
@@ -227,6 +228,7 @@ export interface ChecklistItemsFilter extends Record<string, boolean> {
 export const ChecklistItemsFilterDefault: ChecklistItemsFilter = {
     all: false,
     checked: true,
+    skipped: true,
     me: true,
     unassigned: true,
     others: true,


### PR DESCRIPTION
## Summary

Introduce a Show skipped tasks, defaulting on, that allows the user to optionally hide those tasks when filtering the checklists. It has same persistence semantics as Show checked tasks, meaning not remembered after a page reload. New option is shown just below the existing Show checked tasks option below.

## Ticket Link

  Fixes: https://github.com/mattermost/mattermost-server/issues/21265


## Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
