### PR TITLE
reduce GraphQL error logs

### DIFF
--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -143,7 +143,13 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 	r.Header.Set("X-GQL-Operation", params.OperationName)
 
 	for _, err := range response.Errors {
-		c.logger.WithError(err).WithField("operation", params.OperationName).Error("Error executing request")
+		errLogger := c.logger.WithError(err).WithField("operation", params.OperationName)
+
+		if errors.Is(err, app.ErrNoPermissions) {
+			errLogger.Warn("Warning executing request")
+		} else {
+			errLogger.Error("Error executing request")
+		}
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {

--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -134,7 +134,7 @@ func (r *PlaybookRootResolver) UpdatePlaybook(ctx context.Context, args struct {
 	}
 
 	if err := c.permissions.PlaybookManageProperties(userID, currentPlaybook); err != nil {
-		return "", errors.Wrapf(err, "permissions check failed for playbook `%s`", args.ID)
+		return "", err
 	}
 
 	if currentPlaybook.DeleteAt != 0 {

--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -25,8 +25,7 @@ func (r *PlaybookRootResolver) Playbook(ctx context.Context, args struct {
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
 	if err := c.permissions.PlaybookView(userID, playbookID); err != nil {
-		c.logger.WithError(err).Warn("Not authorized")
-		return nil, errors.New("Not authorized")
+		return nil, err
 	}
 
 	playbook, err := c.playbookService.Get(playbookID)
@@ -53,8 +52,7 @@ func (r *PlaybookRootResolver) Playbooks(ctx context.Context, args struct {
 
 	if args.TeamID != "" {
 		if err := c.permissions.PlaybookList(userID, args.TeamID); err != nil {
-			c.logger.WithError(err).Warn("Not authorized")
-			return nil, errors.New("Not authorized")
+			return nil, err
 		}
 	}
 

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -22,8 +22,7 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
 	if err := c.permissions.RunView(userID, args.ID); err != nil {
-		c.logger.WithError(err).Warn("Not authorized")
-		return nil, errors.New("Not authorized")
+		return nil, err
 	}
 
 	run, err := c.playbookRunService.GetPlaybookRun(args.ID)

--- a/server/app/permissions_service.go
+++ b/server/app/permissions_service.go
@@ -97,7 +97,7 @@ func (p *PermissionsService) PlaybookCreate(userID string, playbook Playbook) er
 	// Check the user has permissions over all broadcast channels
 	for _, channelID := range playbook.BroadcastChannelIDs {
 		if !p.pluginAPI.User.HasPermissionToChannel(userID, channelID, model.PermissionCreatePost) {
-			return errors.Errorf("userID %s does not have permission to create posts in the channel %s", userID, channelID)
+			return errors.Errorf("user `%s` does not have permission to create posts in channel `%s`", userID, channelID)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (p *PermissionsService) PlaybookCreate(userID string, playbook Playbook) er
 	for _, userID := range playbook.InvitedUserIDs {
 		if !p.pluginAPI.User.HasPermissionToTeam(userID, playbook.TeamID, model.PermissionViewTeam) {
 			return errors.Errorf(
-				"invited user with ID %s does not have permission to playbook's team %s",
+				"invited user `%s` does not have permission to playbook's team `%s`",
 				userID,
 				playbook.TeamID,
 			)
@@ -121,7 +121,7 @@ func (p *PermissionsService) PlaybookCreate(userID string, playbook Playbook) er
 
 		if !group.AllowReference {
 			return errors.Errorf(
-				"group %s does not allow references",
+				"group `%s` does not allow references",
 				groupID,
 			)
 		}
@@ -137,7 +137,7 @@ func (p *PermissionsService) PlaybookCreate(userID string, playbook Playbook) er
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to create playbook", userID)
 }
 
 func (p *PermissionsService) PlaybookManageProperties(userID string, playbook Playbook) error {
@@ -150,7 +150,7 @@ func (p *PermissionsService) PlaybookManageProperties(userID string, playbook Pl
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have access to playbook `%s`", userID, playbook.ID)
 }
 
 // PlaybookodifyWithFixes checks both ManageProperties and ManageMembers permissions
@@ -279,7 +279,7 @@ func (p *PermissionsService) NoAddedBroadcastChannelsWithoutPermission(userID st
 			!p.pluginAPI.User.HasPermissionToChannel(userID, channelID, model.PermissionCreatePost) {
 			return errors.Wrapf(
 				ErrNoPermissions,
-				"userID %s does not have permission to create posts in the channel %s",
+				"user `%s` does not have permission to create posts in channel `%s`",
 				userID,
 				channelID,
 			)
@@ -299,7 +299,7 @@ func (p *PermissionsService) PlaybookManageMembers(userID string, playbook Playb
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to manage members for playbook `%s`", userID, playbook.ID)
 }
 
 func (p *PermissionsService) PlaybookManageRoles(userID string, playbook Playbook) error {
@@ -312,7 +312,7 @@ func (p *PermissionsService) PlaybookManageRoles(userID string, playbook Playboo
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to manage roles for playbook `%s`", userID, playbook.ID)
 }
 
 func (p *PermissionsService) PlaybookView(userID string, playbookID string) error {
@@ -330,13 +330,13 @@ func (p *PermissionsService) PlaybookList(userID, teamID string) error {
 		return nil
 	}
 
-	return errors.Wrapf(ErrNoPermissions, "userID `%s` is not on team `%s`", userID, teamID)
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to list playbooks for team `%s`", userID, teamID)
 }
 
 func (p *PermissionsService) PlaybookViewWithPlaybook(userID string, playbook Playbook) error {
 	noAccessErr := errors.Wrapf(
 		ErrNoPermissions,
-		"userID `%s` to access playbook `%s`",
+		"user `%s` to access playbook `%s`",
 		userID,
 		playbook.ID,
 	)
@@ -363,7 +363,7 @@ func (p *PermissionsService) PlaybookMakePrivate(userID string, playbook Playboo
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to make playbook `%s` private", userID, playbook.ID)
 }
 
 func (p *PermissionsService) PlaybookMakePublic(userID string, playbook Playbook) error {
@@ -371,7 +371,7 @@ func (p *PermissionsService) PlaybookMakePublic(userID string, playbook Playbook
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to make playbook `%s` public", userID, playbook.ID)
 }
 
 func (p *PermissionsService) RunCreate(userID string, playbook Playbook) error {
@@ -379,7 +379,7 @@ func (p *PermissionsService) RunCreate(userID string, playbook Playbook) error {
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to run playbook `%s`", userID, playbook.ID)
 }
 
 func (p *PermissionsService) RunManageProperties(userID, runID string) error {
@@ -402,7 +402,7 @@ func (p *PermissionsService) RunManageProperties(userID, runID string) error {
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to manage run `%s`", userID, runID)
 }
 
 func (p *PermissionsService) RunManagePropertiesByChannel(userID, channelID string) error {
@@ -450,7 +450,7 @@ func (p *PermissionsService) ChannelActionCreate(userID, channelID string) error
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to create actions for channel `%s`", userID, channelID)
 }
 
 func (p *PermissionsService) ChannelActionView(userID, channelID string) error {
@@ -458,7 +458,7 @@ func (p *PermissionsService) ChannelActionView(userID, channelID string) error {
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to view actions for channel `%s`", userID, channelID)
 }
 
 func (p *PermissionsService) ChannelActionUpdate(userID, channelID string) error {
@@ -466,7 +466,7 @@ func (p *PermissionsService) ChannelActionUpdate(userID, channelID string) error
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to update actions for channel `%s`", userID, channelID)
 }
 
 // IsSystemAdmin returns true if the userID is a system admin

--- a/server/app/permissions_service.go
+++ b/server/app/permissions_service.go
@@ -330,19 +330,20 @@ func (p *PermissionsService) PlaybookList(userID, teamID string) error {
 		return nil
 	}
 
-	return ErrNoPermissions
+	return errors.Wrapf(ErrNoPermissions, "userID `%s` is not on team `%s`", userID, teamID)
 }
 
 func (p *PermissionsService) PlaybookViewWithPlaybook(userID string, playbook Playbook) error {
 	noAccessErr := errors.Wrapf(
 		ErrNoPermissions,
-		"userID %s to access playbook",
+		"userID `%s` to access playbook `%s`",
 		userID,
+		playbook.ID,
 	)
 
 	// Playbooks are tied to teams. You must have permission to the team to have permission to the playbook.
 	if !p.canViewTeam(userID, playbook.TeamID) {
-		return errors.Wrap(noAccessErr, "no playbook access; no team view permission")
+		return errors.Wrapf(noAccessErr, "no playbook access; no team view permission for team `%s`", playbook.TeamID)
 	}
 
 	// If the playbook is public team access is enough to view


### PR DESCRIPTION
## Summary
I was seeing a rash of permission logs on community from the GraphQL endpoints, that essentially looked like these two logs:
```
{
  "timestamp": "2022-10-12 15:03:58.990 -03:00",
  "level": "warn",
  "msg": "Not authorized",
  "caller": "app/plugin_api.go:979",
  "plugin_id": "playbooks",
  "error": "does not have permissions\ngithub.com/mattermost/mattermost-plugin-playbooks/server/app.init\n\tgithub.com/mattermost/mattermost-plugin-playbooks/server/app/permissions_service.go:15\nruntime.doInit\n\truntime/proc.go:6321\nruntime.d
oInit\n\truntime/proc.go:6298\nruntime.doInit\n\truntime/proc.go:6298\nruntime.main\n\truntime/proc.go:233\nruntime.goexit\n\truntime/asm_arm64.s:1165",
  "request_id": "h4f5h3up7jfoi8saxikzpiypch",
  "plugin_caller": "github.com/mattermost/mattermost-plugin-playbooks/server/api/graphql_root_playbook.go:56"
}
{
  "timestamp": "2022-10-12 15:03:58.997 -03:00",
  "level": "error",
  "msg": "Error executing request",
  "caller": "app/plugin_api.go:976",
  "plugin_id": "playbooks",
  "request_id": "h4f5h3up7jfoi8saxikzpiypch",
  "error": "graphql: Not authorized",
  "operation": "PlaybookLHS",
  "plugin_caller": "github.com/mattermost/mattermost-plugin-playbooks/server/api/graphql.go:146"
}
```


This PR changes this into the single warning log:
```
{
  "timestamp": "2022-10-12 15:05:54.229 -03:00",
  "level": "warn",
  "msg": "Warning executing request",
  "caller": "app/plugin_api.go:979",
  "plugin_id": "playbooks",
  "request_id": "bk8gu5qa83noicwboo9yzgrmir",
  "error": "graphql: userID `ts3e4e98npggzkkj53s4t6cgrr` is not on team `abc`: does not have permissions",
  "operation": "PlaybookLHS",
  "plugin_caller": "github.com/mattermost/mattermost-plugin-playbooks/server/api/graphql.go:149"
}
```