### PR TITLE
MM-47558: fix a crash re: status update posts

### DIFF
--- a/tests-e2e/cypress/integration/channels/post_type_components_spec.js
+++ b/tests-e2e/cypress/integration/channels/post_type_components_spec.js
@@ -1,0 +1,106 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('channels > post type components', () => {
+    let testTeam;
+    let testUser;
+    let testChannel;
+    let testPlaybookRun;
+
+    beforeEach(() => {
+        cy.apiInitSetup({promoteNewUserAsAdmin: true}).then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Create a public playbook
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Playbook',
+                memberIDs: [],
+                createPublicPlaybookRun: true,
+            }).then((playbook) => {
+                cy.apiRunPlaybook({
+                    teamId: testTeam.id,
+                    playbookId: playbook.id,
+                    playbookRunName: 'Test Run',
+                    ownerUserId: testUser.id,
+                }).then((playbookRun) => {
+                    testPlaybookRun = playbookRun;
+                });
+            });
+
+            cy.apiCreateChannel(
+                testTeam.id,
+                'other-channel',
+                'Other Channel',
+                'O'
+            ).then(({channel}) => {
+                testChannel = channel;
+            });
+        });
+    });
+
+    describe('update post (custom_run_update)', () => {
+        it('displays when permalinked in a different channel', () => {
+            // # Go to the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/test-run`);
+
+            // # Post a status update
+            cy.apiUpdateStatus({
+                playbookRunId: testPlaybookRun.id,
+                message: 'status update',
+                reminder: 60,
+            });
+
+            // Grab the post id
+            cy.getLastPostId().then((postId) => {
+                // # Go to the other channel
+                cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+
+                // # Post a permalink to the status update
+                cy.uiPostMessageQuickly(`${Cypress.config('baseUrl')}/${testTeam.name}/pl/${postId}`);
+
+                cy.getLastPost().then((element) => {
+                    // # Verify the expected message text
+                    cy.get(element).contains(`${testUser.username} posted an update for ${testPlaybookRun.name}`);
+                    cy.get(element).contains(`status update`);
+                });
+            });
+        });
+
+        it('displays when permalinked in a different channel, even if not a member of the original channel', () => {
+            // # Go to the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/test-run`);
+
+            // # Post a status update
+            cy.apiUpdateStatus({
+                playbookRunId: testPlaybookRun.id,
+                message: 'status update',
+                reminder: 60,
+            });
+
+            cy.getLastPostId().then((postId) => {
+                // # Leave the playbook run channel
+                cy.uiLeaveChannel();
+
+                // # Go to the other channel
+                cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+
+                // # Post a permalink to the status update
+                cy.uiPostMessageQuickly(`${Cypress.config('baseUrl')}/${testTeam.name}/pl/${postId}`);
+
+                cy.getLastPost().then((element) => {
+                    // # Verify the expected message text
+                    cy.get(element).contains(`${testUser.username} posted an update for ${testPlaybookRun.name}`);
+                    cy.get(element).contains(`status update`);
+                });
+            });
+        });
+    });
+});

--- a/tests-e2e/cypress/integration/channels/post_type_components_spec.js
+++ b/tests-e2e/cypress/integration/channels/post_type_components_spec.js
@@ -5,7 +5,6 @@
 // - [#] indicates a test step (e.g. # Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
-import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('channels > post type components', () => {
     let testTeam;
@@ -14,7 +13,7 @@ describe('channels > post type components', () => {
     let testPlaybookRun;
 
     beforeEach(() => {
-        cy.apiInitSetup({promoteNewUserAsAdmin: true}).then(({team, user}) => {
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true}).then(({team, user}) => {
             testTeam = team;
             testUser = user;
 
@@ -69,7 +68,7 @@ describe('channels > post type components', () => {
                 cy.getLastPost().then((element) => {
                     // # Verify the expected message text
                     cy.get(element).contains(`${testUser.username} posted an update for ${testPlaybookRun.name}`);
-                    cy.get(element).contains(`status update`);
+                    cy.get(element).contains('status update');
                 });
             });
         });
@@ -98,7 +97,7 @@ describe('channels > post type components', () => {
                 cy.getLastPost().then((element) => {
                     // # Verify the expected message text
                     cy.get(element).contains(`${testUser.username} posted an update for ${testPlaybookRun.name}`);
-                    cy.get(element).contains(`status update`);
+                    cy.get(element).contains('status update');
                 });
             });
         });

--- a/webapp/src/components/update_post.tsx
+++ b/webapp/src/components/update_post.tsx
@@ -55,7 +55,7 @@ export const UpdatePost = (props: Props) => {
     useViewTelemetry(PlaybookRunViewTarget.StatusUpdate, props.post.id, {
         post_id: props.post.id,
         playbook_id: currentRun?.playbook_id, // not always available
-        channel_type: channel.type,
+        channel_type: channel?.type, // not always available
         playbook_run_id: currentRun?.id, // not always available
     });
 


### PR DESCRIPTION
## Summary
If a status update is permalinked and posted into another channel, and a user views that permalink without being a member of the run channel, the application crashes due to an attempt to resolve channel metadata.

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-47558