### PR TITLE
add telemetry testing to post_udpate + rely on post internal props

### DIFF
--- a/webapp/src/components/update_post.tsx
+++ b/webapp/src/components/update_post.tsx
@@ -54,9 +54,8 @@ export const UpdatePost = (props: Props) => {
     const runName = props.post.props.runName ?? '';
     useViewTelemetry(PlaybookRunViewTarget.StatusUpdate, props.post.id, {
         post_id: props.post.id,
-        playbook_id: currentRun?.playbook_id, // not always available
-        channel_type: channel?.type, // not always available
-        playbook_run_id: currentRun?.id, // not always available
+        channel_type: channel?.type || '', // not always available
+        playbook_run_id: props.post.props.playbookRunId || '',
     });
 
     return (


### PR DESCRIPTION
## Summary

Follow up https://github.com/mattermost/mattermost-plugin-playbooks/pull/1515

- Send empty string when some extra props are undefined
- avoid relying on selectors whose triggers are not ready 
- add telemetry for 3 cases of post_udpate render (run channel + permalink scenarios)

## Ticket Link
No

## Checklist
- [X] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
