### PR TITLE
[MM-46382] Make convert to private playbook more prominent

### DIFF
--- a/webapp/src/components/backstage/convert_private_playbook_modal.tsx
+++ b/webapp/src/components/backstage/convert_private_playbook_modal.tsx
@@ -4,7 +4,13 @@ import {useIntl} from 'react-intl';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {useEditPlaybook} from 'src/hooks';
 
-const useConfirmPlaybookConvertPrivateModal = (playbookId: string, refetch: () => void) => {
+type ConfirmPlaybookConvertPrivateReturn = [React.ReactNode, (show: boolean) => void];
+type Props = {
+    playbookId: string,
+    refetch?: () => void | undefined,
+}
+
+const useConfirmPlaybookConvertPrivateModal = ({playbookId, refetch}: Props): ConfirmPlaybookConvertPrivateReturn => {
     const {formatMessage} = useIntl();
     const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
     const [playbook, updatePlaybook] = useEditPlaybook(playbookId, refetch);

--- a/webapp/src/components/backstage/convert_private_playbook_modal.tsx
+++ b/webapp/src/components/backstage/convert_private_playbook_modal.tsx
@@ -1,0 +1,30 @@
+import React, {useState} from 'react';
+import {useIntl} from 'react-intl';
+
+import ConfirmModal from 'src/components/widgets/confirmation_modal';
+import {useEditPlaybook} from 'src/hooks';
+
+const useConfirmPlaybookConvertPrivateModal = (playbookId: string, refetch: () => void) => {
+    const {formatMessage} = useIntl();
+    const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
+    const [playbook, updatePlaybook] = useEditPlaybook(playbookId, refetch);
+
+    const modal = (
+        <ConfirmModal
+            show={showMakePrivateConfirm}
+            title={formatMessage({defaultMessage: 'Convert to Private playbook'})}
+            message={formatMessage({defaultMessage: 'When you convert to a private playbook, membership and run history is preserved. This change is permanent and cannot be undone. Are you sure you want to convert {playbookTitle} to a private playbook?'}, {playbookTitle: playbook?.title})}
+            confirmButtonText={formatMessage({defaultMessage: 'Confirm'})}
+            onConfirm={() => {
+                if (playbookId) {
+                    updatePlaybook({public: false});
+                }
+                setShowMakePrivateConfirm(false);
+            }}
+            onCancel={() => setShowMakePrivateConfirm(false)}
+        />
+    );
+    return [modal, setShowMakePrivateConfirm];
+};
+
+export default useConfirmPlaybookConvertPrivateModal;

--- a/webapp/src/components/backstage/convert_private_playbook_modal.tsx
+++ b/webapp/src/components/backstage/convert_private_playbook_modal.tsx
@@ -3,14 +3,16 @@ import {useIntl} from 'react-intl';
 
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {useEditPlaybook} from 'src/hooks';
+import {PlaybookWithChecklist} from 'src/types/playbook';
 
 type ConfirmPlaybookConvertPrivateReturn = [React.ReactNode, (show: boolean) => void];
 type Props = {
     playbookId: string,
     refetch?: () => void | undefined,
+    updater?: (update: Partial<PlaybookWithChecklist>) => void,
 }
 
-const useConfirmPlaybookConvertPrivateModal = ({playbookId, refetch}: Props): ConfirmPlaybookConvertPrivateReturn => {
+const useConfirmPlaybookConvertPrivateModal = ({playbookId, refetch, updater}: Props): ConfirmPlaybookConvertPrivateReturn => {
     const {formatMessage} = useIntl();
     const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
     const [playbook, updatePlaybook] = useEditPlaybook(playbookId, refetch);
@@ -22,7 +24,9 @@ const useConfirmPlaybookConvertPrivateModal = ({playbookId, refetch}: Props): Co
             message={formatMessage({defaultMessage: 'When you convert to a private playbook, membership and run history is preserved. This change is permanent and cannot be undone. Are you sure you want to convert {playbookTitle} to a private playbook?'}, {playbookTitle: playbook?.title})}
             confirmButtonText={formatMessage({defaultMessage: 'Confirm'})}
             onConfirm={() => {
-                if (playbookId) {
+                if (playbookId && updater) {
+                    updater({public: false});
+                } else if (playbookId) {
                     updatePlaybook({public: false});
                 }
                 setShowMakePrivateConfirm(false);

--- a/webapp/src/components/backstage/playbook_access_modal.tsx
+++ b/webapp/src/components/backstage/playbook_access_modal.tsx
@@ -12,12 +12,12 @@ import GenericModal from 'src/components/widgets/generic_modal';
 import {AdminNotificationType, PROFILE_CHUNK_SIZE} from 'src/constants';
 import {useEditPlaybook, useHasPlaybookPermission, useAllowMakePlaybookPrivate} from 'src/hooks';
 import {Playbook, PlaybookMember, PlaybookWithChecklist} from 'src/types/playbook';
-import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import {PlaybookPermissionGeneral, PlaybookRole} from 'src/types/permissions';
 
 import SelectUsersBelow from './select_users_below';
 import UpgradeModal from './upgrade_modal';
+import useConfirmPlaybookConvertPrivateModal from './convert_private_playbook_modal';
 
 const ID = 'playbooks_access';
 
@@ -77,7 +77,7 @@ const PlaybookAccessModal = ({
     const licenseToMakePrivate = useAllowMakePlaybookPrivate();
 
     const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-    const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
+    const [confirmConvertPrivateModal, setShowMakePrivateConfirm] = useConfirmPlaybookConvertPrivateModal({playbookId, refetch, updater: updatePlaybook});
 
     const onChange = (update: Partial<PlaybookWithChecklist>) => {
         if (playbook) {
@@ -116,12 +116,6 @@ const PlaybookAccessModal = ({
         member.roles = roles;
         onChange({
             members: [...playbook.members.slice(0, idx), ...playbook.members.slice(idx + 1), member],
-        });
-    };
-
-    const modifyPublic = (pub: boolean) => {
-        onChange({
-            public: pub,
         });
     };
 
@@ -187,17 +181,7 @@ const PlaybookAccessModal = ({
                 </>
                 }
             </SizedGenericModal>
-            <ConfirmModal
-                show={showMakePrivateConfirm}
-                title={formatMessage({defaultMessage: 'Convert to Private playbook'})}
-                message={formatMessage({defaultMessage: 'When you convert to a private playbook, membership and run history is preserved. This change is permanent and cannot be undone. Are you sure you want to convert {playbookTitle} to a private playbook?'}, {playbookTitle: playbook?.title})}
-                confirmButtonText={formatMessage({defaultMessage: 'Confirm'})}
-                onConfirm={() => {
-                    modifyPublic(false);
-                    setShowMakePrivateConfirm(false);
-                }}
-                onCancel={() => setShowMakePrivateConfirm(false)}
-            />
+            {confirmConvertPrivateModal}
             <UpgradeModal
                 messageType={AdminNotificationType.PLAYBOOK_GRANULAR_ACCESS}
                 show={showUpgradeModal}

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -373,7 +373,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
         }
     });
     const [confirmRestoreModal, openConfirmRestoreModal] = useConfirmPlaybookRestoreModal((playbookId: string) => restorePlaybook(playbookId));
-    const [confirmConvertPrivateModal, showConfirmConvertPrivateModal] = useConfirmPlaybookConvertPrivateModal(playbook.id, refetch);
+    const [confirmConvertPrivateModal] = useConfirmPlaybookConvertPrivateModal({playbookId: playbook.id, refetch});
 
     const {add: addToast} = useToaster();
 
@@ -385,7 +385,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
     const permissionForDuplicate = useHasTeamPermission(playbook.team_id, 'playbook_public_create');
     const permissionToMakePrivate = useHasPlaybookPermission(PlaybookPermissionGeneral.Convert, playbook);
     const licenseToMakePrivate = useAllowMakePlaybookPrivate();
-    const isEligibleToMakePrivate = currentUserMember && permissionToMakePrivate && licenseToMakePrivate;
+    const isEligibleToMakePrivate = currentUserMember && playbook.public && permissionToMakePrivate && licenseToMakePrivate;
 
     const {leave} = usePlaybookMembership(playbook.id, currentUserId);
 

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -373,7 +373,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
         }
     });
     const [confirmRestoreModal, openConfirmRestoreModal] = useConfirmPlaybookRestoreModal((playbookId: string) => restorePlaybook(playbookId));
-    const [confirmConvertPrivateModal] = useConfirmPlaybookConvertPrivateModal({playbookId: playbook.id, refetch});
+    const [confirmConvertPrivateModal, setShowMakePrivateConfirm] = useConfirmPlaybookConvertPrivateModal({playbookId: playbook.id, refetch});
 
     const {add: addToast} = useToaster();
 
@@ -451,6 +451,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
                         css={`${iconSplitStyling}`}
                         onClick={() => {
                             telemetryEventForPlaybook(playbook.id, 'playbook_makeprivate');
+                            setShowMakePrivateConfirm(true);
                         }}
                     >
                         <FormattedMessage defaultMessage='Convert to private playbook'/>

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -19,6 +19,7 @@ import {
     LinkVariantIcon,
     RestoreIcon,
     PlayOutlineIcon,
+    LockOutlineIcon,
 } from '@mattermost/compass-icons/components';
 
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
@@ -454,6 +455,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
                             setShowMakePrivateConfirm(true);
                         }}
                     >
+                        <LockOutlineIcon size={18}/>
                         <FormattedMessage defaultMessage='Convert to private playbook'/>
                     </DropdownMenuItemStyled>
                 )

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import styled, {css} from 'styled-components';
-import React, {PropsWithChildren, useEffect, useMemo} from 'react';
+import React, {PropsWithChildren, useEffect, useMemo, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Link} from 'react-router-dom';
 
@@ -33,7 +33,7 @@ import {FormattedMessage, FormattedNumber, useIntl} from 'react-intl';
 import {createGlobalState} from 'react-use';
 
 import {pluginUrl, navigateToPluginUrl} from 'src/browser_routing';
-import {PlaybookPermissionsMember, useHasPlaybookPermission, useHasTeamPermission} from 'src/hooks';
+import {PlaybookPermissionsMember, useAllowMakePlaybookPrivate, useEditPlaybook, useHasPlaybookPermission, useHasTeamPermission} from 'src/hooks';
 import {useToaster} from '../toast_banner';
 
 import {
@@ -61,6 +61,7 @@ import {usePlaybookMembership, useUpdatePlaybook} from 'src/graphql/hooks';
 import {StyledDropdownMenuItem} from '../shared';
 import {copyToClipboard} from 'src/utils';
 import {useLHSRefresh} from '../lhs_navigation';
+import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 type ControlProps = {
     playbook: {
@@ -381,6 +382,11 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
     const currentUserMember = useMemo(() => playbook?.members.find(({user_id}) => user_id === currentUserId), [playbook?.members, currentUserId]);
 
     const permissionForDuplicate = useHasTeamPermission(playbook.team_id, 'playbook_public_create');
+    const permissionToMakePrivate = useHasPlaybookPermission(PlaybookPermissionGeneral.Convert, playbook);
+    const licenseToMakePrivate = useAllowMakePlaybookPrivate();
+    const isEligibleToMakePrivate = currentUserMember && permissionToMakePrivate && licenseToMakePrivate;
+    const [showMakePrivateConfirm, setShowMakePrivateConfirm] = useState(false);
+    const [_, updatePlaybook] = useEditPlaybook(playbook.id, refetch);
 
     const {leave} = usePlaybookMembership(playbook.id, currentUserId);
 
@@ -440,6 +446,19 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
                     <ExportVariantIcon size={18}/>
                     <FormattedMessage defaultMessage='Export'/>
                 </DropdownMenuItemStyled>
+                {isEligibleToMakePrivate && (
+                    <DropdownMenuItemStyled
+                        role={'button'}
+                        css={`${iconSplitStyling}`}
+                        onClick={() => {
+                            telemetryEventForPlaybook(playbook.id, 'playbook_makeprivate');
+                            setShowMakePrivateConfirm(true);
+                        }}
+                    >
+                        <FormattedMessage defaultMessage='Convert to private playbook'/>
+                    </DropdownMenuItemStyled>
+                )
+                }
                 {currentUserMember && (
                     <>
                         <div className='MenuGroup menu-divider'/>
@@ -475,6 +494,19 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
             </DotMenu>
             {confirmArchiveModal}
             {confirmRestoreModal}
+            <ConfirmModal
+                show={showMakePrivateConfirm}
+                title={formatMessage({defaultMessage: 'Convert to Private playbook'})}
+                message={formatMessage({defaultMessage: 'When you convert to a private playbook, membership and run history is preserved. This change is permanent and cannot be undone. Are you sure you want to convert {playbookTitle} to a private playbook?'}, {playbookTitle: playbook?.title})}
+                confirmButtonText={formatMessage({defaultMessage: 'Confirm'})}
+                onConfirm={() => {
+                    if (playbook) {
+                        updatePlaybook({public: false});
+                    }
+                    setShowMakePrivateConfirm(false);
+                }}
+                onCancel={() => setShowMakePrivateConfirm(false)}
+            />
         </>
     );
 };


### PR DESCRIPTION
## Summary

- Add convert to playbook private menu in the dropdown
- Create custom hook for converting playbook private 
- Apply custom hook for playbook access modal for converting private

## Ticket Link

Fixes: https://github.com/mattermost/mattermost-server/issues/21184
JIRA: https://mattermost.atlassian.net/browse/MM-46382

## Checklist
- [x] Telemetry updated
- [x] Unit tests updated(everything except formatted_duration.test.tsx because of i18n issue)
