### PR TITLE
Read only view, channel members who are not participants

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -441,6 +441,7 @@
   "q/Qo8l": "Private playbooks are only available in Mattermost Enterprise",
   "q48ca7": "Give feedback about Playbooks.",
   "q6f8x9": "Change since last update",
+  "qDxsQH": "Become a participant to interact with this run",
   "qGlwfc": "Start run",
   "qyJtWy": "Show less",
   "rDvvQs": "{completed, number} / {total, number} done",

--- a/webapp/src/components/backstage/follow_button.tsx
+++ b/webapp/src/components/backstage/follow_button.tsx
@@ -14,7 +14,8 @@ import {
     telemetryEvent,
 } from 'src/client';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
-import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 import Tooltip from 'src/components/widgets/tooltip';
 import {useLHSRefresh} from 'src/components/backstage/lhs_navigation';
 
@@ -69,7 +70,10 @@ export const FollowUnfollowButton = ({runID, followState, trigger}: Props) => {
                 });
             })
             .catch(() => {
-                addToast(formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}), ToastType.Failure);
+                addToast({
+                    content: formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}),
+                    toastStyle: ToastStyle.Failure,
+                });
             });
     };
 

--- a/webapp/src/components/backstage/import_playbook.tsx
+++ b/webapp/src/components/backstage/import_playbook.tsx
@@ -5,7 +5,8 @@ import React, {useRef} from 'react';
 import {useIntl} from 'react-intl';
 
 import {importFile} from 'src/client';
-import {useToaster, ToastType} from 'src/components/backstage/toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 
 export const useImportPlaybook = (teamId: string, cb: (id: string) => void) => {
     const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -20,7 +21,10 @@ export const useImportPlaybook = (teamId: string, cb: (id: string) => void) => {
             reader.onload = async (ev) => {
                 importFile(ev?.target?.result, teamId)
                     .then(({id}) => cb(id))
-                    .catch(() => addToast(formatMessage({defaultMessage: 'The playbook import has failed. Please check that JSON is valid and try again.'}), ToastType.Failure));
+                    .catch(() => addToast({
+                        content: formatMessage({defaultMessage: 'The playbook import has failed. Please check that JSON is valid and try again.'}),
+                        toastStyle: ToastStyle.Failure,
+                    }));
                 e.target.value = '';
             };
             reader.readAsArrayBuffer(file);

--- a/webapp/src/components/backstage/lhs_run_dot_menu.tsx
+++ b/webapp/src/components/backstage/lhs_run_dot_menu.tsx
@@ -9,7 +9,8 @@ import {getCurrentUser} from 'mattermost-webapp/packages/mattermost-redux/src/se
 
 import {followPlaybookRun, unfollowPlaybookRun, telemetryEvent} from 'src/client';
 import DotMenu from 'src/components/dot_menu';
-import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 import {Role, Separator} from 'src/components/backstage/playbook_runs/shared';
 import {useUpdateRun} from 'src/graphql/hooks';
 import {useRunFollowers} from 'src/hooks';
@@ -61,7 +62,10 @@ export const LHSRunDotMenu = ({playbookRunId, isFavorite, ownerUserId, participa
                 });
             })
             .catch(() => {
-                addToast(formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}), ToastType.Failure);
+                addToast({
+                    content: formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}),
+                    toastStyle: ToastStyle.Failure,
+                });
             });
     };
 

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -326,7 +326,7 @@ export const CopyPlaybookLinkMenuItem = (props: {playbookId: string}) => {
         <StyledDropdownMenuItem
             onClick={() => {
                 copyToClipboard(getSiteUrl() + '/playbooks/playbooks/' + props.playbookId);
-                addToast(formatMessage({defaultMessage: 'Copied!'}));
+                addToast({content: formatMessage({defaultMessage: 'Copied!'})});
             }}
         >
             <LinkVariantIcon size={18}/>
@@ -421,7 +421,7 @@ const TitleMenuImpl = ({playbook, children, className, editTitle, refetch}: Titl
                     onClick={async () => {
                         const newID = await clientDuplicatePlaybook(playbook.id);
                         navigateToPluginUrl(`/playbooks/${newID}/outline`);
-                        addToast(formatMessage({defaultMessage: 'Successfully duplicated playbook'}));
+                        addToast({content: formatMessage({defaultMessage: 'Successfully duplicated playbook'})});
                         telemetryEventForPlaybook(playbook.id, 'playbook_duplicate_clicked_in_playbook');
                     }}
                     disabled={!permissionForDuplicate}

--- a/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
@@ -103,7 +103,6 @@ const Outline = ({playbook, refetch}: Props) => {
             >
                 <ChecklistList
                     playbook={playbook}
-                    enableFinishRun={false}
                     isReadOnly={false}
                     checklistsCollapseState={checklistCollapseState}
                     onChecklistCollapsedStateChange={onChecklistCollapsedStateChange}

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/context_menu.tsx
@@ -16,7 +16,8 @@ import DotMenu from 'src/components/dot_menu';
 import {SemiBoldHeading} from 'src/styles/headings';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
 import {useRunMembership} from 'src/graphql/hooks';
-import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 import UpgradeModal from 'src/components/backstage/upgrade_modal';
 import {AdminNotificationType} from 'src/constants';
 import {Role, Separator} from 'src/components/backstage/playbook_runs/shared';
@@ -105,14 +106,20 @@ export const useLeaveRun = (hasPermanentViewerAccess: boolean, playbookRunId: st
         removeFromRun()
             .then(() => {
                 refreshLHS();
-                addToast(formatMessage({defaultMessage: "You've left the run."}), ToastType.Success);
+                addToast({
+                    content: formatMessage({defaultMessage: "You've left the run."}),
+                    toastStyle: ToastStyle.Success,
+                });
 
                 const sameRunRDP = window.location.href.includes('runs/' + playbookRunId);
                 telemetryEvent(PlaybookRunEventTarget.Leave, {playbookrun_id: playbookRunId, from: trigger});
                 if (!hasPermanentViewerAccess && sameRunRDP) {
                     navigateToUrl(pluginUrl(''));
                 }
-            }).catch(() => addToast(formatMessage({defaultMessage: "It wasn't possible to leave the run."}), ToastType.Failure));
+            }).catch(() => addToast({
+                content: formatMessage({defaultMessage: "It wasn't possible to leave the run."}),
+                toastStyle: ToastStyle.Failure,
+            }));
     };
     const leaveRunConfirmModal = (
         <ConfirmModal
@@ -133,7 +140,10 @@ export const useLeaveRun = (hasPermanentViewerAccess: boolean, playbookRunId: st
         leaveRunConfirmModal,
         showLeaveRunConfirm: () => {
             if (currentUserId === ownerUserId) {
-                addToast(formatMessage({defaultMessage: 'Assign a new owner before you leave the run.'}), ToastType.Failure);
+                addToast({
+                    content: formatMessage({defaultMessage: 'Assign a new owner before you leave the run.'}),
+                    toastStyle: ToastStyle.Failure,
+                });
                 return;
             }
             setLeaveRunConfirm(true);

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/controls.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/controls.tsx
@@ -44,7 +44,7 @@ export const CopyRunLinkMenuItem = (props: {playbookRunId: string}) => {
         <StyledDropdownMenuItem
             onClick={() => {
                 copyToClipboard(getSiteUrl() + '/playbooks/runs/' + props.playbookRunId);
-                addToast(formatMessage({defaultMessage: 'Copied!'}));
+                addToast({content: formatMessage({defaultMessage: 'Copied!'})});
             }}
         >
             <LinkVariantIcon size={18}/>

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/header.tsx
@@ -1,27 +1,28 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import styled from 'styled-components';
+import {AccountPlusOutlineIcon, InformationOutlineIcon, LightningBoltOutlineIcon, StarIcon, StarOutlineIcon, TimelineTextOutlineIcon} from '@mattermost/compass-icons/components';
 import React from 'react';
 import {useIntl} from 'react-intl';
 import {useDispatch} from 'react-redux';
-import {AccountPlusOutlineIcon, TimelineTextOutlineIcon, InformationOutlineIcon, LightningBoltOutlineIcon, StarOutlineIcon, StarIcon} from '@mattermost/compass-icons/components';
 
-import {PrimaryButton} from 'src/components/assets/buttons';
-import CopyLink from 'src/components/widgets/copy_link';
+import styled from 'styled-components';
+
 import {showRunActionsModal} from 'src/actions';
 import {
     getSiteUrl,
 } from 'src/client';
-import {useParticipateInRun, useFavoriteRun} from 'src/hooks';
-import {PlaybookRun, Metadata as PlaybookRunMetadata} from 'src/types/playbook_run';
-import {Role, Badge, ExpandRight} from 'src/components/backstage/playbook_runs/shared';
-import RunActionsModal from 'src/components/run_actions_modal';
-import {BadgeType} from 'src/components/backstage/status_badge';
-import {RHSContent} from 'src/components/backstage/playbook_runs/playbook_run/rhs';
+import {PrimaryButton} from 'src/components/assets/buttons';
 import {StarButton} from 'src/components/backstage/playbook_editor/playbook_editor';
-import {ContextMenu} from 'src/components/backstage/playbook_runs/playbook_run/context_menu';
 import HeaderButton from 'src/components/backstage/playbook_runs/playbook_run//header_button';
+import {ContextMenu} from 'src/components/backstage/playbook_runs/playbook_run/context_menu';
+import {RHSContent} from 'src/components/backstage/playbook_runs/playbook_run/rhs';
+import {Badge, ExpandRight, Role} from 'src/components/backstage/playbook_runs/shared';
+import {BadgeType} from 'src/components/backstage/status_badge';
+import RunActionsModal from 'src/components/run_actions_modal';
+import CopyLink from 'src/components/widgets/copy_link';
+import {useFavoriteRun, useParticipateInRun} from 'src/hooks';
+import {Metadata as PlaybookRunMetadata, PlaybookRun} from 'src/types/playbook_run';
 
 interface Props {
     playbookRunMetadata: PlaybookRunMetadata | null;

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -22,14 +22,15 @@ import {addChannelMember} from 'mattermost-redux/actions/channels';
 import {UserProfile} from '@mattermost/types/users';
 
 import {TertiaryButton} from 'src/components/assets/buttons';
-import {useToaster, ToastType} from 'src/components/backstage/toast_banner';
 import FollowButton from 'src/components/backstage/follow_button';
+import {Role} from 'src/components/backstage/playbook_runs/shared';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 import Following from 'src/components/backstage/playbook_runs/playbook_run/following';
 import AssignTo, {AssignToContainer} from 'src/components/checklist_item/assign_to';
 import {UserList} from 'src/components/rhs/rhs_participants';
 import {Section, SectionHeader} from 'src/components/backstage/playbook_runs/playbook_run/rhs_info_styles';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
-import {Role} from 'src/components/backstage/playbook_runs/shared';
 import {requestJoinChannel, setOwner as clientSetOwner} from 'src/client';
 import {pluginUrl} from 'src/browser_routing';
 import {useFormattedUsername} from 'src/hooks';
@@ -48,9 +49,15 @@ const useRequestJoinChannel = (playbookRunId: string) => {
     const requestJoin = async () => {
         const response = await requestJoinChannel(playbookRunId);
         if (response?.error) {
-            addToast(formatMessage({defaultMessage: 'The join channel request was unsuccessful.'}), ToastType.Failure);
+            addToast({
+                content: formatMessage({defaultMessage: 'The join channel request was unsuccessful.'}),
+                toastStyle: ToastStyle.Failure,
+            });
         } else {
-            addToast(formatMessage({defaultMessage: 'Your request was sent to the run channel.'}), ToastType.Success);
+            addToast({
+                content: formatMessage({defaultMessage: 'Your request was sent to the run channel.'}),
+                toastStyle: ToastStyle.Success,
+            });
         }
     };
     const RequestJoinModal = (
@@ -109,12 +116,18 @@ const RHSInfoOverview = ({run, role, channel, runMetadata, followState, editable
                     message = formatMessage({defaultMessage: 'It was not possible to change the owner'});
                 }
 
-                addToast(message, ToastType.Failure);
+                addToast({
+                    content: message,
+                    toastStyle: ToastStyle.Failure,
+                });
             } else {
                 refreshLHS();
             }
         } catch (error) {
-            addToast(formatMessage({defaultMessage: 'It was not possible to change the owner'}), ToastType.Failure);
+            addToast({
+                content: formatMessage({defaultMessage: 'It was not possible to change the owner'}),
+                toastStyle: ToastStyle.Failure,
+            });
         }
     };
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -26,7 +26,9 @@ import {HamburgerButton} from 'src/components/assets/icons/three_dots_icon';
 import Tooltip from 'src/components/widgets/tooltip';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
 
-import {ToastType, useToaster} from '../../toast_banner';
+import {useToaster} from '../../toast_banner';
+
+import {ToastStyle} from '../../toast';
 
 import StatusUpdateCard from './update_card';
 import {RHSContent} from './rhs';
@@ -87,9 +89,15 @@ const useRequestUpdate = (playbookRunId: string) => {
     const requestStatusUpdate = async () => {
         const response = await requestUpdate(playbookRunId);
         if (response?.error) {
-            addToast(formatMessage({defaultMessage: 'The update request was unsuccessful.'}), ToastType.Failure);
+            addToast({
+                content: formatMessage({defaultMessage: 'The update request was unsuccessful.'}),
+                toastStyle: ToastStyle.Failure,
+            });
         } else {
-            addToast(formatMessage({defaultMessage: 'Your request was sent to the run channel. '}), ToastType.Success);
+            addToast({
+                content: formatMessage({defaultMessage: 'Your request was sent to the run channel. '}),
+                toastStyle: ToastStyle.Success,
+            });
         }
     };
     const RequestUpdateConfirmModal = (

--- a/webapp/src/components/backstage/runs_list/row.tsx
+++ b/webapp/src/components/backstage/runs_list/row.tsx
@@ -27,7 +27,8 @@ import {
     followPlaybookRun,
 } from 'src/client';
 import {InfoLine} from '../styles';
-import {ToastType, useToaster} from '../toast_banner';
+import {useToaster} from '../toast_banner';
+import {ToastStyle} from '../toast';
 
 const SmallText = styled.div`
     font-weight: 400;
@@ -194,7 +195,10 @@ const FollowPlaybookRun = ({id}: {id: string}) => {
             })
             .catch(() => {
                 setIsFollowing(isFollowing);
-                addToast(formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}), ToastType.Failure);
+                addToast({
+                    content: formatMessage({defaultMessage: 'It was not possible to {isFollowing, select, true {unfollow} other {follow}} the run'}, {isFollowing}),
+                    toastStyle: ToastStyle.Failure,
+                });
             });
     };
 

--- a/webapp/src/components/backstage/toast.tsx
+++ b/webapp/src/components/backstage/toast.tsx
@@ -105,6 +105,7 @@ const StyledIcon = styled.i`
 `;
 
 const StyledClose = styled.i`
+    cursor: pointer;
     color: var(--center-channel-bg-56);
 `;
 
@@ -117,4 +118,5 @@ const StyledButton = styled.button`
     border: none;
     font-size: 12px;
     line-height: 16px;
+    font-weight: 600;
 `;

--- a/webapp/src/components/backstage/toast.tsx
+++ b/webapp/src/components/backstage/toast.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export enum ToastStyle {
+    Success = 'success',
+    Failure = 'failure',
+    Informational = 'inform',
+}
+
+export interface ToastProps {
+    content: string;
+    toastStyle?: ToastStyle;
+    iconName?: string;
+    buttonName?: string;
+    buttonCallback?: () => void;
+    closeCallback?: () => void;
+}
+
+export const Toast = (props: ToastProps) => {
+    let iconName = props.iconName;
+    if (!iconName) {
+        switch (props.toastStyle) {
+        case ToastStyle.Success:
+            iconName = 'check';
+            break;
+        case ToastStyle.Failure:
+            iconName = 'alert-outline';
+            break;
+        default:
+            iconName = 'information-outline';
+        }
+    }
+    return (
+        <StyledToast
+            toastStyle={props.toastStyle ?? ToastStyle.Success}
+        >
+            <StyledIcon className={`icon icon-${iconName}`}/>
+            <StyledText>{props.content}</StyledText>
+            {props.buttonName &&
+                <StyledButton
+                    onClick={props.buttonCallback}
+                >
+                    {props.buttonName}
+                </StyledButton>
+            }
+            <StyledClose
+                className={'icon icon-close'}
+                onClick={props.closeCallback}
+            />
+        </StyledToast >
+    );
+};
+
+const StyledToast = styled.div<{toastStyle: ToastStyle}>`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 4px 4px 4px 12px;
+    margin: 4px;
+    height: 48px;
+
+    background: ${({toastStyle}) => (toastStyle === ToastStyle.Failure ? 'var(--dnd-indicator)' : 'var(--center-channel-color)')};
+    color: ${({toastStyle}) => (toastStyle === ToastStyle.Failure ? 'var(--center-channel-color)' : 'var(--center-channel-bg)')};
+
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+
+    &.fade-enter {
+        transform: translateY(80px);
+    }
+
+    &.fade-enter-active {
+        transform: translateY(0);
+        transition: 0.5s cubic-bezier(0.44, 0.13, 0.42, 1.43);
+    }
+
+    &.fade-exit {
+        transform: translateY(0);
+    }
+
+    &.fade-exit-active {
+        transform: translateY(280px);
+        transition: transform 0.75s cubic-bezier(0.59, -0.23, 0.42, 1.43);
+    }
+`;
+
+const StyledText = styled.div`
+    font-family: Open Sans;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 16px;
+
+    display: flex;
+    align-items: center;
+    text-align: left;
+
+    margin: 0px 8px;
+    color: var(--center-channel-bg);
+`;
+
+const StyledIcon = styled.i`
+    color: var(--center-channel-bg);
+`;
+
+const StyledClose = styled.i`
+    color: var(--center-channel-bg-56);
+`;
+
+const StyledButton = styled.button`
+    background: rgba(var(--center-channel-bg-rgb), 0.12);
+    color: var(--center-channel-bg);
+    border-radius: 4px;
+    padding: 8px 16px;
+    margin: 8px;
+    border: none;
+    font-size: 12px;
+    line-height: 16px;
+`;

--- a/webapp/src/components/backstage/toast_banner.tsx
+++ b/webapp/src/components/backstage/toast_banner.tsx
@@ -63,8 +63,6 @@ export const ToastProvider = (props: Props) => {
         setToasts((ts) => ts.filter((t: ToastOptionsWithID) => t.id !== id));
     };
 
-    const onDismiss = (id: number) => () => remove(id);
-
     return (
         <Ctx.Provider value={{add, remove}}>
             {props.children}
@@ -80,7 +78,7 @@ export const ToastProvider = (props: Props) => {
                                 <Toast
                                     {...options}
                                     closeCallback={() => {
-                                        onDismiss(options.id);
+                                        remove(options.id);
                                         options.closeCallback?.();
                                     }}
                                 />

--- a/webapp/src/components/backstage/toast_banner.tsx
+++ b/webapp/src/components/backstage/toast_banner.tsx
@@ -32,7 +32,7 @@ interface ToastOptionsWithID extends ToastOptions {
 }
 
 interface ToastFuncs {
-    add: (options: ToastOptions) => void;
+    add: (options: ToastOptions) => number;
     remove: (id: number) => void;
 }
 
@@ -45,7 +45,7 @@ export const ToastProvider = (props: Props) => {
 
         setToasts((ts) => [...ts, {id, ...options}]);
         if (duration <= 0) {
-            return;
+            return id;
         }
 
         window.setTimeout(() => {
@@ -57,6 +57,8 @@ export const ToastProvider = (props: Props) => {
                 return [...ts.slice(0, index), ...ts.slice(index + 1)];
             });
         }, duration);
+
+        return id;
     };
 
     const remove = (id: number) => {
@@ -73,7 +75,7 @@ export const ToastProvider = (props: Props) => {
                             <CSSTransition
                                 key={options.id}
                                 classNames='fade'
-                                timeout={2000}
+                                timeout={500}
                             >
                                 <Toast
                                     {...options}

--- a/webapp/src/components/backstage/toast_banner.tsx
+++ b/webapp/src/components/backstage/toast_banner.tsx
@@ -1,65 +1,13 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
-import {CSSTransition, TransitionGroup} from 'react-transition-group';
+import {TransitionGroup, CSSTransition} from 'react-transition-group';
+
+import {Toast, ToastProps} from './toast';
 
 const Ctx = React.createContext({} as ToastFuncs);
 
 const DEFAULT_DURATION = 3000;
 let toastCount = 0;
-
-export enum ToastType {
-    Success = 'success',
-    Failure = 'failure',
-}
-
-const StyledToast = styled.div<{toastType: ToastType}>`
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    padding: 4px 4px 4px 12px;
-    margin: 4px;
-    height: 40px;
-
-    background: ${({toastType}) => (toastType === ToastType.Failure ? 'var(--dnd-indicator)' : 'var(--center-channel-color)')};
-    color: ${({toastType}) => (toastType === ToastType.Failure ? 'var(--center-channel-color)' : 'var(--center-channel-bg)')};
-
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.12);
-    border-radius: 4px;
-
-    &.fade-enter {
-        transform: translateY(80px);
-    }
-
-    &.fade-enter-active {
-        transform: translateY(0);
-        transition: 0.5s cubic-bezier(0.44, 0.13, 0.42, 1.43);
-    }
-
-    &.fade-exit {
-        transform: translateY(0);
-    }
-
-    &.fade-exit-active {
-        transform: translateY(280px);
-        transition: transform 0.75s cubic-bezier(0.59, -0.23, 0.42, 1.43);
-    }
-`;
-
-const StyledText = styled.div<{toastType: ToastType}>`
-    font-family: Open Sans;
-    font-style: normal;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 20px;
-
-    display: flex;
-    align-items: center;
-    text-align: center;
-
-    margin: 0px 8px;
-    color: var(--center-channel-bg);
-`;
 
 const ToastContainer = styled.div`
     position: fixed;
@@ -67,42 +15,39 @@ const ToastContainer = styled.div`
     bottom: 36px;
     transform: translate(-50%);
     z-index: 1;
+    width: max-content;
+    max-width: 95%;
 `;
-
-const StyledIcon = styled.i`
-    color: var(--center-channel-bg);
-`;
-
-const StyledClose = styled.i`
-    color: var(--center-channel-bg-56);
-`;
-
-interface Toast {
-    id: number;
-    content: string;
-    duration: number;
-    toastType: ToastType;
-}
 
 interface Props {
     children: React.ReactNode;
 }
 
+interface ToastOptions extends ToastProps {
+    duration?: number;
+}
+
+interface ToastOptionsWithID extends ToastOptions {
+    id: number
+}
+
 interface ToastFuncs {
-    add: (content: string, toastType?: ToastType, duration?: number) => void;
+    add: (options: ToastOptions) => void;
     remove: (id: number) => void;
 }
 
 export const ToastProvider = (props: Props) => {
-    const [toasts, setToasts] = useState<Toast[]>([]);
+    const [toasts, setToasts] = useState<ToastOptionsWithID[]>([]);
 
-    const add = (content: string, toastType: ToastType = ToastType.Success, duration: number = DEFAULT_DURATION) => {
+    const add = (options: ToastOptions) => {
         const id = toastCount++;
-        const toast = {id, content, duration, toastType};
-        setToasts((ts) => [...ts, toast]);
+        const duration = options.duration ?? DEFAULT_DURATION;
+
+        setToasts((ts) => [...ts, {id, ...options}]);
         if (duration <= 0) {
             return;
         }
+
         window.setTimeout(() => {
             setToasts((ts) => {
                 const index = ts.findIndex((t) => t.id === id);
@@ -115,7 +60,7 @@ export const ToastProvider = (props: Props) => {
     };
 
     const remove = (id: number) => {
-        setToasts((ts) => ts.filter((t: Toast) => t.id !== id));
+        setToasts((ts) => ts.filter((t: ToastOptionsWithID) => t.id !== id));
     };
 
     const onDismiss = (id: number) => () => remove(id);
@@ -125,42 +70,26 @@ export const ToastProvider = (props: Props) => {
             {props.children}
             <TransitionGroup component={ToastContainer}>
                 {
-                    toasts.map(({content, id, toastType, ...rest}) => {
-                        let iconName;
-                        switch (toastType) {
-                        case ToastType.Success:
-                            iconName = 'check';
-                            break;
-                        case ToastType.Failure:
-                            iconName = 'alert-outline';
-                            break;
-                        default:
-                            iconName = 'information-ouline';
-                        }
-
+                    toasts.map((options: ToastOptionsWithID) => {
                         return (
                             <CSSTransition
-                                key={id}
+                                key={options.id}
                                 classNames='fade'
                                 timeout={2000}
                             >
-                                <StyledToast
-                                    toastType={toastType}
-                                    {...rest}
-                                >
-                                    <StyledIcon className={`icon icon-${iconName}`}/>
-                                    <StyledText toastType={toastType}>{content}</StyledText>
-                                    <StyledClose
-                                        className={'icon icon-close'}
-                                        onClick={onDismiss(id)}
-                                    />
-                                </StyledToast >
+                                <Toast
+                                    {...options}
+                                    closeCallback={() => {
+                                        onDismiss(options.id);
+                                        options.closeCallback?.();
+                                    }}
+                                />
                             </CSSTransition>
                         );
                     })
                 }
             </TransitionGroup>
-        </Ctx.Provider >
+        </Ctx.Provider>
     );
 };
 

--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -9,7 +9,6 @@ import {Droppable, DroppableProvided} from 'react-beautiful-dnd';
 
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
-import {PlaybookRun} from 'src/types/playbook_run';
 import {
     Checklist,
     ChecklistItem,
@@ -17,13 +16,15 @@ import {
 } from 'src/types/playbook';
 import DraggableChecklistItem from 'src/components/checklist_item/checklist_item_draggable';
 import {ButtonsFormat as ItemButtonsFormat} from 'src/components/checklist_item/checklist_item';
+import {PlaybookRun} from 'src/types/playbook_run';
 
 // disable all react-beautiful-dnd development warnings
 // @ts-ignore
 window['__react-beautiful-dnd-disable-dev-warnings'] = true;
 
 interface Props {
-    playbookRun?: PlaybookRun;
+    id: string
+    playbookRun?: PlaybookRun
     disabled: boolean;
     checklist: Checklist;
     checklistIndex: number;
@@ -70,7 +71,7 @@ const GenericChecklist = (props: Props) => {
         props.onUpdateChecklist(newChecklist);
     };
 
-    const keys = generateKeys(props.checklist.items.map((item) => props.playbookRun?.id + item.title));
+    const keys = generateKeys(props.checklist.items.map((item) => props.id + item.title));
 
     return (
         <Droppable

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -40,6 +40,7 @@ interface Props {
     profileButtonClass?: string;
     onlyPlaceholder?: boolean;
     enableEdit: boolean;
+    onEditDisabledClick?: () => void
     isClearable?: boolean;
     customControl?: (props: ControlProps<Option, boolean>) => React.ReactElement;
     controlledOpenToggle?: boolean;
@@ -228,7 +229,7 @@ export default function ProfileSelector(props: Props) {
     const targetWrapped = (
         <div
             data-testid={props.testId}
-            onClick={props.enableEdit ? toggleOpen : () => null}
+            onClick={props.enableEdit ? toggleOpen : props.onEditDisabledClick}
             className={props.className}
         >
             {target}

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -125,6 +125,7 @@ const RHSAbout = (props: Props) => {
                         collapsed={collapsed}
                         toggleCollapsed={toggleCollapsed}
                         editSummary={editSummary}
+                        readOnly={props.readOnly}
                     />
                 </ButtonsRow>
                 <RHSAboutTitle
@@ -152,7 +153,8 @@ const RHSAbout = (props: Props) => {
                                     placeholder={formatMessage({defaultMessage: 'Assign the owner role'})}
                                     placeholderButtonClass={'NoAssignee-button'}
                                     profileButtonClass={'Assigned-button'}
-                                    enableEdit={!isFinished}
+                                    enableEdit={!isFinished && !props.readOnly}
+                                    onEditDisabledClick={props.onReadOnlyInteract}
                                     getUsers={fetchUsers}
                                     getUsersInTeam={fetchUsersInTeam}
                                     onSelectedChange={onSelectedProfileChange}
@@ -172,6 +174,8 @@ const RHSAbout = (props: Props) => {
                 }
                 {props.playbookRun.status_update_enabled && (
                     <RHSPostUpdate
+                        readOnly={props.readOnly}
+                        onReadOnlyInteract={props.onReadOnlyInteract}
                         collapsed={collapsed}
                         playbookRun={props.playbookRun}
                         updatesExist={props.playbookRun.status_posts.length !== 0}

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -32,6 +32,8 @@ import {messageHtmlToComponent, formatText} from 'src/webapp_globals';
 
 interface Props {
     playbookRun: PlaybookRun;
+    readOnly?: boolean;
+    onReadOnlyInteract?: () => void
 }
 
 const RHSAbout = (props: Props) => {
@@ -138,6 +140,8 @@ const RHSAbout = (props: Props) => {
                             onEdit={onDescriptionEdit}
                             editing={editingSummary}
                             setEditing={setEditingSummary}
+                            readOnly={props.readOnly}
+                            onReadOnlyInteract={props.onReadOnlyInteract}
                         />
                         <Row>
                             <OwnerSection>

--- a/webapp/src/components/rhs/rhs_about_buttons.tsx
+++ b/webapp/src/components/rhs/rhs_about_buttons.tsx
@@ -19,6 +19,7 @@ interface Props {
     collapsed: boolean;
     toggleCollapsed: () => void;
     editSummary: () => void;
+    readOnly?: boolean;
 }
 
 const RHSAboutButtons = (props: Props) => {
@@ -52,17 +53,21 @@ const RHSAboutButtons = (props: Props) => {
                 portal={false}
                 focusManager={{returnFocus: false}}
             >
-                <StyledDropdownMenuItem
-                    onClick={() => {
-                        props.editSummary();
-                    }}
-                >
-                    <IconWrapper>
-                        <PencilOutlineIcon size={20}/>
-                    </IconWrapper>
-                    <FormattedMessage defaultMessage='Edit run summary'/>
-                </StyledDropdownMenuItem>
-                <Separator/>
+                {!props.readOnly &&
+                <>
+                    <StyledDropdownMenuItem
+                        onClick={() => {
+                            props.editSummary();
+                        }}
+                    >
+                        <IconWrapper>
+                            <PencilOutlineIcon size={20}/>
+                        </IconWrapper>
+                        <FormattedMessage defaultMessage='Edit run summary'/>
+                    </StyledDropdownMenuItem>
+                    <Separator/>
+                </>
+                }
                 <StyledDropdownMenuItem onClick={() => navigateToPluginUrl(overviewURL)}>
                     <IconWrapper>
                         <PlayOutlineIcon size={22}/>

--- a/webapp/src/components/rhs/rhs_about_description.tsx
+++ b/webapp/src/components/rhs/rhs_about_description.tsx
@@ -19,6 +19,8 @@ interface DescriptionProps {
     onEdit: (value: string) => void;
     editing: boolean;
     setEditing: (editing: boolean) => void;
+    readOnly?: boolean;
+    onReadOnlyInteract?: () => void;
 }
 
 const RHSAboutDescription = (props: DescriptionProps) => {
@@ -45,10 +47,15 @@ const RHSAboutDescription = (props: DescriptionProps) => {
                 data-testid='rendered-description'
                 onClick={(event) => {
                     // Enter edit mode only if the user is not clicking a link and there's no selected text
+                    // and we are not in read only mode
                     const targetNode = event.target as Node;
                     const selectedText = window.getSelection();
                     const hasSelectedText = selectedText !== null && selectedText.toString() !== '';
                     if (targetNode.nodeName !== 'A' && !hasSelectedText) {
+                        if (props.readOnly) {
+                            props.onReadOnlyInteract?.();
+                            return;
+                        }
                         props.setEditing(true);
                     }
                 }}

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -52,6 +52,7 @@ interface Props {
     parentContainer: ChecklistParent;
     id?: string;
     viewerMode: boolean;
+    onViewerModeInteract?: () => void
 }
 
 export enum ChecklistParent {
@@ -96,7 +97,7 @@ const notFinishedTasks = (checklists: Checklist[]) => {
     return count;
 };
 
-const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props) => {
+const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode, onViewerModeInteract}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const channelId = useSelector(getCurrentChannelId);
@@ -271,7 +272,15 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props)
             />
             {
                 active && parentContainer === ChecklistParent.RHS && playbookRun &&
-                <FinishButton onClick={() => dispatch(finishRun(playbookRun?.team_id || ''))}>
+                <FinishButton
+                    onClick={() => {
+                        if (viewerMode && onViewerModeInteract) {
+                            onViewerModeInteract();
+                        } else {
+                            dispatch(finishRun(playbookRun?.team_id || ''));
+                        }
+                    }}
+                >
                     {formatMessage({defaultMessage: 'Finish run'})}
                 </FinishButton>
             }

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useState} from 'react';
-import {useIntl} from 'react-intl';
+import {useIntl, FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import styled from 'styled-components';
 
@@ -13,12 +13,13 @@ import {displayUsername} from 'mattermost-redux/utils/user_utils';
 import {DateTime} from 'luxon';
 import {GlobalState} from 'mattermost-webapp/types/store';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
 import {
     setAllChecklistsCollapsedState,
     setChecklistCollapsedState,
     setChecklistItemsFilter,
     setEveryChecklistCollapsedStateChange,
+    finishRun,
 } from 'src/actions';
 import {
     Checklist,
@@ -41,6 +42,10 @@ import {SemiBoldHeading} from 'src/styles/headings';
 import ChecklistList from 'src/components/checklist/checklist_list';
 import {AnchorLinkTitle} from '../backstage/playbook_runs/shared';
 import {ButtonsFormat as ItemButtonsFormat} from 'src/components/checklist_item/checklist_item';
+import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
+import TutorialTourTip, {useMeasurePunchouts, useShowTutorialStep} from 'src/components/tutorial/tutorial_tour_tip';
+import {RunDetailsTutorialSteps, TutorialTourCategories} from 'src/components/tutorial/tours';
+import GiveFeedbackButton from 'src/components/give_feedback_button';
 
 interface Props {
     playbookRun: PlaybookRun;
@@ -53,6 +58,43 @@ export enum ChecklistParent {
     RHS = 'rhs',
     RunDetails = 'run_details',
 }
+
+const StyledTertiaryButton = styled(TertiaryButton)`
+    display: inline-block;
+    margin: 12px 0;
+`;
+
+const StyledPrimaryButton = styled(PrimaryButton)`
+    display: inline-block;
+    margin: 12px 0;
+`;
+
+const RHSGiveFeedbackButton = styled(GiveFeedbackButton)`
+    && {
+        color: var(--center-channel-color-64);
+    }
+
+    &&:hover:not([disabled]) {
+        color: var(--center-channel-color-72);
+        background-color: var(--center-channel-color-08);
+    }
+`;
+
+const allComplete = (checklists: Checklist[]) => {
+    return notFinishedTasks(checklists) === 0;
+};
+
+const notFinishedTasks = (checklists: Checklist[]) => {
+    let count = 0;
+    for (const list of checklists) {
+        for (const item of list.items) {
+            if (item.state === ChecklistItemState.Open || item.state === ChecklistItemState.InProgress) {
+                count++;
+            }
+        }
+    }
+    return count;
+};
 
 const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props) => {
     const dispatch = useDispatch();
@@ -162,6 +204,18 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props)
 
         return ItemButtonsFormat.Long;
     };
+    const FinishButton = allComplete(checklists) ? StyledPrimaryButton : StyledTertiaryButton;
+    const active = (playbookRun !== undefined) && (playbookRun.current_status === PlaybookRunStatus.InProgress);
+
+    const checklistsPunchout = useMeasurePunchouts(
+        ['pb-checklists-inner-container'],
+        [],
+        {y: -5, height: 10, x: -5, width: 10},
+    );
+    const showRunDetailsChecklistsStep = useShowTutorialStep(
+        RunDetailsTutorialSteps.Checklists,
+        TutorialTourCategories.RUN_DETAILS
+    );
 
     return (
         <InnerContainer
@@ -208,7 +262,6 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props)
             </MainTitleBG>
             <ChecklistList
                 playbookRun={playbookRun}
-                enableFinishRun={parentContainer === ChecklistParent.RHS}
                 isReadOnly={viewerMode}
                 checklistsCollapseState={checklistsState}
                 onChecklistCollapsedStateChange={onChecklistCollapsedStateChange}
@@ -216,6 +269,29 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode}: Props)
                 showItem={showItem}
                 itemButtonsFormat={itemButtonsFormat()}
             />
+            {
+                active && parentContainer === ChecklistParent.RHS && playbookRun &&
+                <FinishButton onClick={() => dispatch(finishRun(playbookRun?.team_id || ''))}>
+                    {formatMessage({defaultMessage: 'Finish run'})}
+                </FinishButton>
+            }
+            <RHSGiveFeedbackButton/>
+            {showRunDetailsChecklistsStep && (
+                <TutorialTourTip
+                    title={<FormattedMessage defaultMessage='Track progress and ownership'/>}
+                    screen={<FormattedMessage defaultMessage='Assign, check off, or skip tasks to ensure the team is clear on how to move toward the finish line together.'/>}
+                    tutorialCategory={TutorialTourCategories.RUN_DETAILS}
+                    step={RunDetailsTutorialSteps.Checklists}
+                    showOptOut={false}
+                    placement='left'
+                    pulsatingDotPlacement='top-start'
+                    pulsatingDotTranslate={{x: 0, y: 0}}
+                    width={352}
+                    autoTour={true}
+                    punchOut={checklistsPunchout}
+                    telemetryTag={`tutorial_tip_Playbook_Run_Details_${RunDetailsTutorialSteps.Checklists}_Checklists`}
+                />
+            )}
         </InnerContainer>
     );
 };

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -15,6 +15,7 @@ import RHSWelcomeView from 'src/components/rhs/rhs_welcome_view';
 import RHSRunDetails from 'src/components/rhs/rhs_run_details';
 
 import {fetchPlaybookRunByChannel} from 'src/client';
+import {ToastProvider} from '../backstage/toast_banner';
 
 const RightHandSidebar = () => {
     const dispatch = useDispatch();
@@ -61,14 +62,22 @@ const RightHandSidebar = () => {
         }
     }
 
+    let content = null;
     if (rhsState === RHSState.ViewingPlaybookRun) {
         if (inPlaybookRun) {
-            return <RHSRunDetails/>;
+            content = <RHSRunDetails/>;
+        } else {
+            content = <RHSWelcomeView/>;
         }
-        return <RHSWelcomeView/>;
+    } else {
+        content = <RHSHome/>;
     }
 
-    return <RHSHome/>;
+    return (
+        <ToastProvider>
+            {content}
+        </ToastProvider>
+    );
 };
 
 export default RightHandSidebar;

--- a/webapp/src/components/rhs/rhs_post_update.tsx
+++ b/webapp/src/components/rhs/rhs_post_update.tsx
@@ -24,6 +24,8 @@ interface Props {
     collapsed: boolean;
     playbookRun: PlaybookRun;
     updatesExist: boolean;
+    readOnly?: boolean;
+    onReadOnlyInteract?: () => void;
 }
 
 const RHSPostUpdate = (props: Props) => {
@@ -101,6 +103,10 @@ const RHSPostUpdate = (props: Props) => {
                 updatesExist={props.updatesExist}
                 disabled={props.playbookRun.current_status === PlaybookRunStatus.Finished}
                 onClick={() => {
+                    if (props.readOnly && props.onReadOnlyInteract) {
+                        props.onReadOnlyInteract();
+                        return;
+                    }
                     dispatch(promptUpdateStatus(
                         props.playbookRun.team_id,
                         props.playbookRun.id,

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -27,7 +27,8 @@ import {useTutorialStepper} from '../tutorial/tutorial_tour_tip/manager';
 import {browserHistory} from 'src/webapp_globals';
 import {usePlaybookRunViewTelemetry} from 'src/hooks/telemetry';
 import {PlaybookRunViewTarget} from 'src/types/telemetry';
-import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 
 const RHSRunDetails = () => {
     const dispatch = useDispatch();
@@ -68,7 +69,13 @@ const RHSRunDetails = () => {
 
     const addToast = useToaster().add;
     const displayReadOnlyToast = () => {
-        addToast(formatMessage({defaultMessage: 'Become a participant to interact with this run'}), ToastType.Failure);
+        addToast({
+            content: formatMessage({defaultMessage: 'Become a participant to interact with this run'}),
+            toastStyle: ToastStyle.Informational,
+            buttonName: formatMessage({defaultMessage: 'Participate'}),
+            buttonCallback: () => console.log('I did it!'),
+            iconName: 'account-plus-outline',
+        });
     };
 
     const rhsContainerPunchout = useMeasurePunchouts(

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -74,12 +74,18 @@ const RHSRunDetails = () => {
 
     const {ParticipateConfirmModal, showParticipateConfirm} = useParticipateInRun(playbookRun?.id || '', 'channel_rhs');
     const addToast = useToaster().add;
+    const removeToast = useToaster().remove;
     const displayReadOnlyToast = useMemo(() => debounce(() => {
-        addToast({
+        let toastID = -1;
+        const showConfirm = () => {
+            removeToast(toastID);
+            showParticipateConfirm();
+        };
+        toastID = addToast({
             content: formatMessage({defaultMessage: 'Become a participant to interact with this run'}),
             toastStyle: ToastStyle.Informational,
             buttonName: formatMessage({defaultMessage: 'Participate'}),
-            buttonCallback: showParticipateConfirm,
+            buttonCallback: showConfirm,
             iconName: 'account-plus-outline',
         });
     }, toastDebounce, {leading: true, trailing: false}), []);

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -104,6 +104,7 @@ const RHSRunDetails = () => {
                         playbookRun={playbookRun}
                         parentContainer={ChecklistParent.RHS}
                         viewerMode={!isParticipant}
+                        onViewerModeInteract={displayReadOnlyToast}
                     />
                 </Scrollbars>
             </RHSContent>

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -5,7 +5,9 @@ import React, {useEffect, useRef} from 'react';
 import Scrollbars from 'react-custom-scrollbars';
 import {useDispatch, useSelector} from 'react-redux';
 
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {
     renderThumbHorizontal,
@@ -25,12 +27,16 @@ import {useTutorialStepper} from '../tutorial/tutorial_tour_tip/manager';
 import {browserHistory} from 'src/webapp_globals';
 import {usePlaybookRunViewTelemetry} from 'src/hooks/telemetry';
 import {PlaybookRunViewTarget} from 'src/types/telemetry';
+import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
 
 const RHSRunDetails = () => {
     const dispatch = useDispatch();
+    const {formatMessage} = useIntl();
     const scrollbarsRef = useRef<Scrollbars>(null);
+    const currentUserId = useSelector(getCurrentUserId);
 
     const playbookRun = useSelector(currentPlaybookRun);
+    const isParticipant = playbookRun?.participant_ids.includes(currentUserId);
     usePlaybookRunViewTelemetry(PlaybookRunViewTarget.ChannelsRHSDetails, playbookRun?.id);
 
     const prevStatus = usePrevious(playbookRun?.current_status);
@@ -60,6 +66,11 @@ const RHSRunDetails = () => {
         }
     }, [runDetailsStep]);
 
+    const addToast = useToaster().add;
+    const displayReadOnlyToast = () => {
+        addToast(formatMessage({defaultMessage: 'Become a participant to interact with this run'}), ToastType.Failure);
+    };
+
     const rhsContainerPunchout = useMeasurePunchouts(
         ['rhsContainer'],
         [],
@@ -84,11 +95,15 @@ const RHSRunDetails = () => {
                     renderView={renderView}
                     style={{position: 'absolute'}}
                 >
-                    <RHSAbout playbookRun={playbookRun}/>
+                    <RHSAbout
+                        playbookRun={playbookRun}
+                        readOnly={!isParticipant}
+                        onReadOnlyInteract={displayReadOnlyToast}
+                    />
                     <RHSChecklistList
                         playbookRun={playbookRun}
                         parentContainer={ChecklistParent.RHS}
-                        viewerMode={false}
+                        viewerMode={!isParticipant}
                     />
                 </Scrollbars>
             </RHSContent>

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useMemo} from 'react';
 import Scrollbars from 'react-custom-scrollbars';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import {debounce} from 'lodash';
 
 import {
     renderThumbHorizontal,
@@ -30,6 +32,8 @@ import {PlaybookRunViewTarget} from 'src/types/telemetry';
 import {useToaster} from 'src/components/backstage/toast_banner';
 import {ToastStyle} from 'src/components/backstage/toast';
 import {useParticipateInRun} from 'src/hooks';
+
+const toastDebounce = 2000;
 
 const RHSRunDetails = () => {
     const dispatch = useDispatch();
@@ -70,7 +74,7 @@ const RHSRunDetails = () => {
 
     const {ParticipateConfirmModal, showParticipateConfirm} = useParticipateInRun(playbookRun?.id || '', 'channel_rhs');
     const addToast = useToaster().add;
-    const displayReadOnlyToast = () => {
+    const displayReadOnlyToast = useMemo(() => debounce(() => {
         addToast({
             content: formatMessage({defaultMessage: 'Become a participant to interact with this run'}),
             toastStyle: ToastStyle.Informational,
@@ -78,7 +82,7 @@ const RHSRunDetails = () => {
             buttonCallback: showParticipateConfirm,
             iconName: 'account-plus-outline',
         });
-    };
+    }, toastDebounce, {leading: true, trailing: false}), []);
 
     const rhsContainerPunchout = useMeasurePunchouts(
         ['rhsContainer'],

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -29,6 +29,7 @@ import {usePlaybookRunViewTelemetry} from 'src/hooks/telemetry';
 import {PlaybookRunViewTarget} from 'src/types/telemetry';
 import {useToaster} from 'src/components/backstage/toast_banner';
 import {ToastStyle} from 'src/components/backstage/toast';
+import {useParticipateInRun} from 'src/hooks';
 
 const RHSRunDetails = () => {
     const dispatch = useDispatch();
@@ -67,13 +68,14 @@ const RHSRunDetails = () => {
         }
     }, [runDetailsStep]);
 
+    const {ParticipateConfirmModal, showParticipateConfirm} = useParticipateInRun(playbookRun?.id || '', 'channel_rhs');
     const addToast = useToaster().add;
     const displayReadOnlyToast = () => {
         addToast({
             content: formatMessage({defaultMessage: 'Become a participant to interact with this run'}),
             toastStyle: ToastStyle.Informational,
             buttonName: formatMessage({defaultMessage: 'Participate'}),
-            buttonCallback: () => console.log('I did it!'),
+            buttonCallback: showParticipateConfirm,
             iconName: 'account-plus-outline',
         });
     };
@@ -115,7 +117,7 @@ const RHSRunDetails = () => {
                     />
                 </Scrollbars>
             </RHSContent>
-
+            {ParticipateConfirmModal}
             {showRunDetailsSidePanelStep && (
                 <TutorialTourTip
                     title={<FormattedMessage defaultMessage='View run details in a side panel'/>}

--- a/webapp/src/hooks/crud.ts
+++ b/webapp/src/hooks/crud.ts
@@ -141,7 +141,7 @@ export function usePlaybooksCrud(
     const duplicatePlaybook = async (playbookId: Playbook['id']) => {
         await clientDuplicatePlaybook(playbookId);
         await fetchPlaybooks();
-        addToast(formatMessage({defaultMessage: 'Successfully duplicated playbook'}));
+        addToast({content: formatMessage({defaultMessage: 'Successfully duplicated playbook'})});
     };
 
     const sortBy = (colName: FetchPlaybooksParams['sort']) => {

--- a/webapp/src/hooks/run.tsx
+++ b/webapp/src/hooks/run.tsx
@@ -14,7 +14,8 @@ import {
 import {useRunMembership, useUpdateRun} from 'src/graphql/hooks';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
-import {ToastType, useToaster} from 'src/components/backstage/toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 import {CategoryItemType} from 'src/types/category';
 
 export const useFavoriteRun = (teamID: string, runID: string): [boolean, () => void] => {
@@ -47,8 +48,14 @@ export const useParticipateInRun = (playbookRunId: string, trigger: 'channel_rhs
     const [showParticipateConfirm, setShowParticipateConfirm] = useState(false);
     const onConfirmParticipate = async () => {
         addToRun()
-            .then(() => addToast(formatMessage({defaultMessage: 'You\'ve joined this run.'}), ToastType.Success))
-            .catch(() => addToast(formatMessage({defaultMessage: 'It wasn\'t possible to join the run'}), ToastType.Failure));
+            .then(() => addToast({
+                content: formatMessage({defaultMessage: 'You\'ve joined this run.'}),
+                toastStyle: ToastStyle.Success,
+            }))
+            .catch(() => addToast({
+                content: formatMessage({defaultMessage: 'It wasn\'t possible to join the run'}),
+                toastStyle: ToastStyle.Failure,
+            }));
         telemetryEvent(PlaybookRunEventTarget.Participate, {playbookrun_id: playbookRunId, from: trigger});
     };
     const ParticipateConfirmModal = (


### PR DESCRIPTION
## Summary
Adds a read-only view for channel members of a run channel who are not participants in the run.

Read only view:
![image](https://user-images.githubusercontent.com/3191642/196816203-3fe2ba7c-5f10-4ebb-9af0-1ead6994a64b.png)

Clicking on:
- Summary
- Owner dropdown
- Status update button
- Finish run button


Causes a toast to appear:
![image](https://user-images.githubusercontent.com/3191642/196816278-0ffebc7d-2807-45a9-a402-38a80dcbe3eb.png)

Clicking participate causes the participate first dialog to appear:
![image](https://user-images.githubusercontent.com/3191642/196816327-cf533d8d-0f96-4f09-96c9-36b20270aab7.png)


Note that is is currently impossible to be in the channel without being a participant.

Note for reviewers there is some refactoring of the toast code and and the checklist code. They are in separate commits. 

## Ticket Link

Fixes #1442
