### PR TITLE
[MM-47542] Add collections and topics support to playbooks

### DIFF
--- a/server/app/permissions_service.go
+++ b/server/app/permissions_service.go
@@ -90,7 +90,7 @@ func (p *PermissionsService) hasPermissionsToPlaybook(userID string, playbook Pl
 	return p.pluginAPI.User.HasPermissionToTeam(userID, playbook.TeamID, permission)
 }
 
-func (p *PermissionsService) hasPermissionsToRun(userID string, run *PlaybookRun, permission *model.Permission) bool {
+func (p *PermissionsService) HasPermissionsToRun(userID string, run *PlaybookRun, permission *model.Permission) bool {
 	// Check at run level
 	if p.pluginAPI.User.RolesGrantPermission(p.getRunRole(userID, run), permission.Id) {
 		return true
@@ -406,7 +406,7 @@ func (p *PermissionsService) RunManageProperties(userID, runID string) error {
 		return errors.Wrapf(err, "Unable to get run to determine permissions, run id `%s`", runID)
 	}
 
-	if p.hasPermissionsToRun(userID, run, model.PermissionRunManageProperties) {
+	if p.HasPermissionsToRun(userID, run, model.PermissionRunManageProperties) {
 		return nil
 	}
 

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -530,6 +530,18 @@ type RunAction struct {
 	StatusUpdateBroadcastWebhooksEnabled bool `json:"status_update_broadcast_webhooks_enabled"`
 }
 
+type RunMetadata struct {
+	ID     string
+	Name   string
+	TeamID string
+}
+
+type TopicMetadata struct {
+	ID     string
+	RunID  string
+	TeamID string
+}
+
 const (
 	ActionTypeBroadcastChannels = "broadcast_to_channels"
 	ActionTypeBroadcastWebhooks = "broadcast_to_webhooks"
@@ -745,6 +757,19 @@ type PlaybookRunService interface {
 
 	// AddParticipants adds users to the participants list
 	AddParticipants(playbookRunID string, userIDs []string, requesterUserID string) error
+
+	// GetPlaybookRunIDsForUser returns run ids where user is a participant or is following
+	GetPlaybookRunIDsForUser(userID string) ([]string, error)
+
+	// GetRunMetadataByIDs returns playbook runs metadata by passed run IDs.
+	// Notice that order of passed ids and returned runs might not coincide
+	GetRunMetadataByIDs(runIDs []string) ([]RunMetadata, error)
+
+	// GetTaskMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by taskIDs
+	GetTaskMetadataByIDs(taskIDs []string) ([]TopicMetadata, error)
+
+	// GetStatusMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by statusIDs
+	GetStatusMetadataByIDs(statusIDs []string) ([]TopicMetadata, error)
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.
@@ -851,6 +876,19 @@ type PlaybookRunStore interface {
 
 	// GetSchemeRolesForTeam scheme role ids for the team
 	GetSchemeRolesForTeam(teamID string) (string, string, string, error)
+
+	// GetPlaybookRunIDsForUser returns run ids where user is a participant or is following
+	GetPlaybookRunIDsForUser(userID string) ([]string, error)
+
+	// GetRunMetadataByIDs returns playbook runs metadata by passed run IDs.
+	// Notice that order of passed ids and returned runs might not coincide
+	GetRunMetadataByIDs(runIDs []string) ([]RunMetadata, error)
+
+	// GetTaskMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by taskIDs
+	GetTaskMetadataByIDs(taskIDs []string) ([]TopicMetadata, error)
+
+	// GetStatusMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by statusIDs
+	GetStatusMetadataByIDs(statusIDs []string) ([]TopicMetadata, error)
 }
 
 // PlaybookRunTelemetry defines the methods that the PlaybookRunServiceImpl needs from the RudderTelemetry.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -3282,3 +3282,24 @@ func (s *PlaybookRunServiceImpl) dmPostToUsersWithPermission(users []string, pos
 		}
 	}
 }
+
+// GetPlaybookRunIDsForUser returns run ids where user is a participant or is following
+func (s *PlaybookRunServiceImpl) GetPlaybookRunIDsForUser(userID string) ([]string, error) {
+	return s.store.GetPlaybookRunIDsForUser(userID)
+}
+
+// GetRunMetadataByIDs returns playbook runs metadata by passed run IDs.
+// Notice that order of passed ids and returned runs might not coincide
+func (s *PlaybookRunServiceImpl) GetRunMetadataByIDs(runIDs []string) ([]RunMetadata, error) {
+	return s.store.GetRunMetadataByIDs(runIDs)
+}
+
+// GetTaskMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by taskIDs
+func (s *PlaybookRunServiceImpl) GetTaskMetadataByIDs(taskIDs []string) ([]TopicMetadata, error) {
+	return s.store.GetTaskMetadataByIDs(taskIDs)
+}
+
+// GetStatusMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by statusIDs
+func (s *PlaybookRunServiceImpl) GetStatusMetadataByIDs(statusIDs []string) ([]TopicMetadata, error) {
+	return s.store.GetStatusMetadataByIDs(statusIDs)
+}

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -31,6 +31,9 @@ type Configuration struct {
 
 	// AdminLogVerbose: set to include full context with admin log messages.
 	AdminLogVerbose bool
+
+	// ThreadsEverywhereEnabled is a feature flag on a server
+	ThreadsEverywhereEnabled bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/config/service.go
+++ b/server/config/service.go
@@ -43,6 +43,7 @@ func NewConfigService(api *pluginapi.Client, manifest *model.Manifest) *ServiceI
 
 	// api.LoadPluginConfiguration never returns an error, so ignore it.
 	_ = api.Configuration.LoadPluginConfiguration(c.configuration)
+	c.configuration.ThreadsEverywhereEnabled = c.api.Configuration.GetConfig().FeatureFlags.ThreadsEverywhere
 
 	return c
 }
@@ -122,6 +123,7 @@ func (c *ServiceImpl) OnConfigurationChange() error {
 	}
 
 	configuration.BotUserID = c.configuration.BotUserID
+	configuration.ThreadsEverywhereEnabled = c.api.Configuration.GetConfig().FeatureFlags.ThreadsEverywhere
 
 	c.setConfiguration(configuration)
 


### PR DESCRIPTION


## Summary
PR as a part of threads everywhere feature adds support for collections and topics in playbooks.
Registers `run` collection type, also `task` and `status` topic types
Adds hooks
`UserHasPermissionToCollection`
`GetAllCollectionIDsForUser`
`GetAllUserIdsForCollection`
`GetCollectionMetadataByIds`
`GetTopicMetadataByIds`


This PR depends on https://github.com/mattermost/mattermost-server/pull/21446, so do not pay attention to the failed checks. Will update the `.mod` file after server PR will be merged

## Ticket Link

  Fixes: https://mattermost.atlassian.net/browse/MM-47542



## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- [X] Gated by experimental feature flag
- [X] Unit tests updated
