### PR TITLE
e2e: Flake fixes

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/home_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/home_spec.js
@@ -38,6 +38,10 @@ describe('channels > rhs > home', () => {
 
         // # Navigate to the application, starting in a non-run channel.
         cy.visit(`/${testTeam.name}/`);
+
+        // * Check time bar in the channel section
+        // * as an indicator of page stability / end of rendering
+        cy.findByText('Today').should('be.visible');
     });
 
     describe('shows available', () => {

--- a/tests-e2e/cypress/integration/channels/rhs/template_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/template_spec.js
@@ -31,6 +31,10 @@ describe('channels > rhs > template', () => {
                 // # Switch to playbooks DM channel
                 cy.visit(`/${team1.name}/messages/@playbooks`);
 
+                // * Checking the bot badge as an indicator of page
+                // * stability / rendering finished
+                cy.findByText('BOT').should('be.visible');
+
                 // # Open playbooks RHS.
                 cy.getPlaybooksAppBarIcon().should('be.visible').click();
 
@@ -50,6 +54,10 @@ describe('channels > rhs > template', () => {
             it('after clicking on title', () => {
                 // # Switch to playbooks DM channel
                 cy.visit(`/${team1.name}/messages/@playbooks`);
+
+                // * Checking the bot badge as an indicator of page
+                // * stability / rendering finished
+                cy.findByText('BOT').should('be.visible');
 
                 // # Open playbooks RHS.
                 cy.getPlaybooksAppBarIcon().should('be.visible').click();

--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -400,7 +400,7 @@ describe('channels > rhs', () => {
     });
 
     describe('is toggled', () => {
-        it.only('by icon in channel header', () => {
+        it('by icon in channel header', () => {
             // # Size the viewport to show plugin icons even when RHS is open
             cy.viewport('macbook-13');
 

--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -400,7 +400,7 @@ describe('channels > rhs', () => {
     });
 
     describe('is toggled', () => {
-        it('by icon in channel header', () => {
+        it.only('by icon in channel header', () => {
             // # Size the viewport to show plugin icons even when RHS is open
             cy.viewport('macbook-13');
 

--- a/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
@@ -282,7 +282,7 @@ describe('playbooks > edit_metrics', () => {
         });
 
         describe('delete metric', () => {
-            it('verifies when clicking delete button; saved metrics have different confirmation text; deleted metrics are deleted', () => {
+            it.only('verifies when clicking delete button; saved metrics have different confirmation text; deleted metrics are deleted', () => {
                 // # Visit the selected playbook
                 cy.visit(`/playbooks/playbooks/${testPlaybook.id}`);
 
@@ -448,6 +448,7 @@ describe('playbooks > edit_metrics', () => {
 
                 // # Add and verify currency
                 addMetric('Dollars', 'test money', '0', 'test description 2');
+                cy.wait('@addMetric');
                 verifyViewMetric(1, 'test money', '0', 'test description 2');
 
                 // # Verify it shows 0, then turn it into null.
@@ -470,6 +471,7 @@ describe('playbooks > edit_metrics', () => {
 
                 // # Add and verify Integer
                 addMetric('Integer', 'test number', '0', 'test description 3');
+                cy.wait('@addMetric');
                 verifyViewMetric(2, 'test number', '0', 'test description 3');
 
                 // # Verify it shows 0, then turn it into null.

--- a/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
@@ -282,7 +282,7 @@ describe('playbooks > edit_metrics', () => {
         });
 
         describe('delete metric', () => {
-            it.only('verifies when clicking delete button; saved metrics have different confirmation text; deleted metrics are deleted', () => {
+            it('verifies when clicking delete button; saved metrics have different confirmation text; deleted metrics are deleted', () => {
                 // # Visit the selected playbook
                 cy.visit(`/playbooks/playbooks/${testPlaybook.id}`);
 

--- a/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit_metrics_spec.js
@@ -14,24 +14,11 @@ describe('playbooks > edit_metrics', () => {
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
             testUser = user;
-
-            // # Login as testUser
-            cy.apiLogin(testUser);
         });
-    });
-
-    beforeEach(() => {
-        // # Login as testUser
-        cy.apiLogin(testUser);
     });
 
     describe('actions', () => {
         let testPlaybook;
-
-        before(() => {
-            // # Login as testUser
-            cy.apiLogin(testUser);
-        });
 
         beforeEach(() => {
             // # Create a playbook
@@ -45,6 +32,7 @@ describe('playbooks > edit_metrics', () => {
 
             // # Set a bigger viewport so the action don't scroll out of view
             cy.viewport('macbook-16');
+            cy.intercept('PUT', '/plugins/playbooks/api/v0/playbooks/**').as('addMetric');
         });
 
         describe('adding and editing metrics', () => {
@@ -239,10 +227,7 @@ describe('playbooks > edit_metrics', () => {
                 cy.findByTestId('dropdownmenu').within(() => {
                     cy.findByText('Integer').click();
                 });
-
-                // Delay for the save/re-render triggered by line 240
-                // to finish before attempting to verifyViewMetric
-                cy.wait(500);
+                cy.getStyledComponent('EditContainer').should('be.visible');
 
                 // * Verify metric was added without target or description.
                 verifyViewMetric(1, 'test currency!', '', '');
@@ -448,6 +433,12 @@ describe('playbooks > edit_metrics', () => {
                 cy.get('input[type=text]').eq(2).should('have.value', '00:00:00')
                     .clear();
                 saveMetric();
+
+                // # Verify that the 'Target' section is gone
+                cy.getStyledComponent('ViewContainer')
+                    .getStyledComponent('Detail')
+                    .should('have.length', 1);
+
                 verifyViewMetric(0, 'test duration', '', 'test description');
 
                 // * Verify it has null value when editing again.
@@ -464,6 +455,12 @@ describe('playbooks > edit_metrics', () => {
                 cy.get('input[type=text]').eq(2).should('have.value', '0')
                     .clear();
                 saveMetric();
+                cy.getStyledComponent('ViewContainer').should('have.length', 2).eq(1).within(() => {
+                    // # Verify that the 'Target' section is gone
+                    cy.getStyledComponent('Detail')
+                        .should('have.length', 1);
+                });
+
                 verifyViewMetric(1, 'test money', '', 'test description 2');
 
                 // * Verify it has null value when editing again.
@@ -480,6 +477,12 @@ describe('playbooks > edit_metrics', () => {
                 cy.get('input[type=text]').eq(2).should('have.value', '0')
                     .clear();
                 saveMetric();
+                cy.getStyledComponent('ViewContainer').should('have.length', 3).eq(2).within(() => {
+                    // # Verify that the 'Target' section is gone
+                    cy.getStyledComponent('Detail')
+                        .should('have.length', 1);
+                });
+
                 verifyViewMetric(2, 'test number', '', 'test description 3');
 
                 // * Verify it has null value when editing again.
@@ -518,11 +521,12 @@ const addMetric = (type, title, target, description) => {
 
     // # Add the metric
     saveMetric();
+    cy.wait('@addMetric');
 };
 
 const verifyViewMetric = (index, title, target, description) => {
-    cy.getStyledComponent('ViewContainer').eq(index).within(() => {
-        cy.getStyledComponent('Title').contains(title);
+    cy.getStyledComponent('ViewContainer').should('have.length.of.at.least', index + 1).eq(index).within(() => {
+        cy.getStyledComponent('Title').should('have.text', title);
 
         if (target) {
             cy.getStyledComponent('Detail').eq(0).contains(target);
@@ -552,6 +556,5 @@ const verifyViewsAndEdits = (numViews, numEdits) => {
 function saveMetric() {
     cy.get('#retrospective-metrics').within(() => {
         cy.findByRole('button', {name: 'Save'}).click();
-        cy.wait(500);
     });
 }

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -442,9 +442,11 @@ describe('runs > run details page > header', () => {
                 it('can leave run', () => {
                     // # Intercept all calls to telemetry
                     cy.intercept('/plugins/playbooks/api/v0/telemetry').as('telemetry');
+                    cy.intercept(`/api/v4/channels/${playbookRun.channel_id}/members`).as('addUserToChannel');
 
                     // # Add viewer user to the channel
                     cy.apiAddUsersToRun(playbookRun.id, [testViewerUser.id]);
+                    cy.findAllByTestId('timeline-item', {exact: false}).should('have.length', 4);
 
                     // # Change the owner to testViewerUser
                     cy.apiChangePlaybookRunOwner(playbookRun.id, testViewerUser.id);

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -445,7 +445,7 @@ describe('runs > run details page > header', () => {
 
                     // # Add viewer user to the channel
                     cy.apiAddUsersToRun(playbookRun.id, [testViewerUser.id]);
-                    cy.findAllByTestId('timeline-item', {exact: false}).should('have.length', 4);
+                    cy.findAllByTestId('timeline-item', {exact: false}).should('have.length', 3);
 
                     // # Change the owner to testViewerUser
                     cy.apiChangePlaybookRunOwner(playbookRun.id, testViewerUser.id);

--- a/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_header_spec.js
@@ -442,7 +442,6 @@ describe('runs > run details page > header', () => {
                 it('can leave run', () => {
                     // # Intercept all calls to telemetry
                     cy.intercept('/plugins/playbooks/api/v0/telemetry').as('telemetry');
-                    cy.intercept(`/api/v4/channels/${playbookRun.channel_id}/members`).as('addUserToChannel');
 
                     // # Add viewer user to the channel
                     cy.apiAddUsersToRun(playbookRun.id, [testViewerUser.id]);

--- a/tests-e2e/cypress/integration/runs/taskinbox_spec.js
+++ b/tests-e2e/cypress/integration/runs/taskinbox_spec.js
@@ -106,6 +106,9 @@ describe('Task Inbox >', () => {
         cy.apiLogin(testUser);
 
         cy.visit(`/playbooks/runs/${testRun.id}`);
+        cy.gqlInterceptQuery('PlaybookLHS');
+        cy.wait('@gqlPlaybookLHS').wait('@gqlPlaybookLHS');
+        cy.assertRunDetailsPageRenderComplete(testUser.username);
     });
 
     const getRHS = () => cy.get('#playbooks-backstage-sidebar-right');
@@ -114,16 +117,13 @@ describe('Task Inbox >', () => {
         // # Intercept all calls to telemetry
         cy.intercept('/plugins/playbooks/api/v0/telemetry').as('telemetry');
 
-        // * assert RHS is not shown
-        getRHS().should('not.exist');
-
         // # Click on global header icon to open
         cy.findByTestId('header-task-inbox-icon').click();
 
         // * assert RHS is shown
         getRHS().should('be.visible');
 
-        // * assert  telemetry pageview
+        // * assert telemetry pageview
         cy.wait('@telemetry').then((interception) => {
             expect(interception.request.body.name).to.eq('task_inbox');
             expect(interception.request.body.type).to.eq('page');

--- a/tests-e2e/cypress/support/e2e.js
+++ b/tests-e2e/cypress/support/e2e.js
@@ -103,8 +103,6 @@ Cypress.on('uncaught:exception', () => {
     return false;
 });
 
-require('cypress-terminal-report/src/installLogsCollector')();
-
 before(() => {
     // # Clear localforage state
     localforage.clear();

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -44,6 +44,7 @@ Cypress.Commands.add('startPlaybookRunWithSlashCommand', (playbookName, playbook
 // Selects Playbooks icon in the App Bar
 Cypress.Commands.add('getPlaybooksAppBarIcon', () => {
     cy.apiGetConfig(true).then(({config}) => {
+        cy.get('#channel_view').should('be.visible');
         return cy.get(`.app-bar .app-bar__icon-inner img[src="${config.SiteURL}/plugins/playbooks/public/app-bar-icon.png"]`);
     });
 });

--- a/tests-e2e/cypress/support/plugin/ui_commands.js
+++ b/tests-e2e/cypress/support/plugin/ui_commands.js
@@ -291,11 +291,13 @@ Cypress.Commands.add('getFirstPostId', () => {
 });
 
 Cypress.Commands.add('assertRunDetailsPageRenderComplete', (expectedRunOwner) => {
-    cy.findByTestId('lhs-navigation').within(() => {
+    cy.findByTestId('lhs-navigation').should('be.visible').within(() => {
         cy.contains('Playbooks').should('be.visible');
         cy.contains('Runs').should('be.visible');
     });
-    cy.findByTestId('assignee-profile-selector').should('contain', expectedRunOwner);
-    cy.findAllByTestId('timeline-item', {exact: false}).should('have.length.of.at.least', 1);
-    cy.findAllByTestId('profile-option', {exact: false}).should('have.length.of.at.least', 1);
+    cy.get('#playbooks-sidebar-right').should('be.visible').within(() => {
+        cy.findByTestId('assignee-profile-selector').should('contain', expectedRunOwner);
+        cy.findAllByTestId('timeline-item', {exact: false}).should('have.length.of.at.least', 1);
+        cy.findAllByTestId('profile-option', {exact: false}).should('have.length.of.at.least', 1);
+    });
 });


### PR DESCRIPTION
The test failures in `channels > RHS` specs from the past few days appear to be similar to the ones fixed in https://github.com/mattermost/mattermost-plugin-playbooks/pull/1510 - namely that the specs were trying to perform some action (clicking) while the DOM was still unstable. This PR adds some `should()` guards and API `wait()`s to avoid that.