### PR TITLE
Remove reminants of channel permissions.

### DIFF
--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -431,6 +431,18 @@ func TestChecklistManagement(t *testing.T) {
 		require.Equal(t, title, editedRun.Checklists[0].Title)
 	})
 
+	t.Run("checklist creation - failure: no permissions", func(t *testing.T) {
+		run := createNewRunWithNoChecklists(t)
+		title := "A new checklist"
+
+		// Create a valid, empty checklist
+		err := e.PlaybooksClient2.PlaybookRuns.CreateChecklist(context.Background(), run.ID, client.Checklist{
+			Title: title,
+			Items: []client.ChecklistItem{},
+		})
+		require.Error(t, err)
+	})
+
 	t.Run("checklist creation - success: checklist with items", func(t *testing.T) {
 		run := createNewRunWithNoChecklists(t)
 		title := "A new checklist"

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1752,14 +1752,6 @@ func (s *PlaybookRunServiceImpl) AddChecklist(playbookRunID, userID string, chec
 		return errors.Wrapf(err, "failed to retrieve playbook run")
 	}
 
-	if !s.hasPermissionToModifyPlaybookRun(playbookRunToModify, userID) {
-		return errors.New("user does not have permission to modify playbook run")
-	}
-
-	if !s.hasPermissionToModifyPlaybookRun(playbookRunToModify, userID) {
-		return errors.New("user does not have permission to modify playbook run")
-	}
-
 	playbookRunToModify.Checklists = append(playbookRunToModify.Checklists, checklist)
 
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)
@@ -2227,10 +2219,6 @@ func (s *PlaybookRunServiceImpl) checklistParamsVerify(playbookRunID, userID str
 		return nil, errors.Wrapf(err, "failed to retrieve playbook run")
 	}
 
-	if !s.hasPermissionToModifyPlaybookRun(playbookRunToModify, userID) {
-		return nil, errors.New("user does not have permission to modify playbook run")
-	}
-
 	if checklistNumber < 0 || checklistNumber >= len(playbookRunToModify.Checklists) {
 		return nil, errors.New("invalid checklist number")
 	}
@@ -2278,11 +2266,6 @@ func (s *PlaybookRunServiceImpl) UpdateDescription(playbookRunID, description st
 	s.poster.PublishWebsocketEventToChannel(playbookRunUpdatedWSEvent, playbookRun, playbookRun.ChannelID)
 
 	return nil
-}
-
-func (s *PlaybookRunServiceImpl) hasPermissionToModifyPlaybookRun(playbookRun *PlaybookRun, userID string) bool {
-	// PlaybookRun main channel membership is required to modify playbook run
-	return s.pluginAPI.User.HasPermissionToChannel(userID, playbookRun.ChannelID, model.PermissionReadChannel)
 }
 
 func (s *PlaybookRunServiceImpl) createPlaybookRunChannel(playbookRun *PlaybookRun, header string, public bool) (*model.Channel, error) {


### PR DESCRIPTION
## Summary
Removes instance where we continued to check channel permissions instead of run permissions. 

## Ticket Link
Fixes #1539
