### PR TITLE
Adding channel filtering support to runs listing graphql API

### DIFF
--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -34,10 +34,11 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 }
 
 func (r *RunRootResolver) Runs(ctx context.Context, args struct {
-	TeamID                  string `url:"team_id,omitempty"`
+	TeamID                  string
 	Sort                    string
 	Statuses                []string
-	ParticipantOrFollowerID string `url:"participant_or_follower,omitempty"`
+	ParticipantOrFollowerID string
+	ChannelID               string
 }) ([]*RunResolver, error) {
 	c, err := getContext(ctx)
 	if err != nil {
@@ -60,6 +61,7 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 		TeamID:                  args.TeamID,
 		Statuses:                args.Statuses,
 		ParticipantOrFollowerID: args.ParticipantOrFollowerID,
+		ChannelID:               args.ChannelID,
 		IncludeFavorites:        true,
 		Page:                    0,
 		PerPage:                 10000,

--- a/server/api/schema.graphqls
+++ b/server/api/schema.graphqls
@@ -15,6 +15,7 @@ type Query {
 		sort: String = "",
 		statuses: [String!] = [],
 		participantOrFollowerID: String = "",
+		channelID: String = "",
 	): [Run!]!
 }
 

--- a/server/api_graphql_runs_test.go
+++ b/server/api_graphql_runs_test.go
@@ -52,6 +52,42 @@ func TestGraphQLRunList(t *testing.T) {
 		assert.Equal(t, e.BasicRun.Name, rResultTest.Data.Runs[0].Name)
 		assert.False(t, rResultTest.Data.Runs[0].IsFavorite)
 	})
+
+	t.Run("list by channel", func(t *testing.T) {
+		var rResultTest struct {
+			Data struct {
+				Runs []struct {
+					ID         string
+					Name       string
+					IsFavorite bool
+				}
+			}
+			Errors []struct {
+				Message string
+				Path    string
+			}
+		}
+		testRunsQuery := `
+		query Runs($channelID: String!) {
+			runs(channelID: $channelID) {
+				id
+				name
+				isFavorite
+			}
+		}
+		`
+		err := e.PlaybooksClient.DoGraphql(context.Background(), &client.GraphQLInput{
+			Query:         testRunsQuery,
+			OperationName: "Runs",
+			Variables:     map[string]interface{}{"channelID": e.BasicRun.ChannelID},
+		}, &rResultTest)
+		require.NoError(t, err)
+
+		assert.Len(t, rResultTest.Data.Runs, 1)
+		assert.Equal(t, e.BasicRun.ID, rResultTest.Data.Runs[0].ID)
+		assert.Equal(t, e.BasicRun.Name, rResultTest.Data.Runs[0].Name)
+		assert.False(t, rResultTest.Data.Runs[0].IsFavorite)
+	})
 }
 
 func TestGraphQLChangeRunParticipants(t *testing.T) {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -1029,6 +1029,9 @@ type PlaybookRunFilterOptions struct {
 	// StartedLT filters playbook runs that were started before the unix time given (in millis).
 	// A value of 0 means the filter is ignored (which is the default).
 	StartedLT int64 `url:"started_lt,omitempty"`
+
+	// ChannelID filters to playbook runs that are associated with the given channel ID
+	ChannelID string `url:"channel_id,omitempty"`
 }
 
 // Clone duplicates the given options.
@@ -1107,6 +1110,10 @@ func (o PlaybookRunFilterOptions) Validate() (PlaybookRunFilterOptions, error) {
 	}
 	if options.StartedLT < 0 {
 		options.StartedLT = 0
+	}
+
+	if options.ChannelID != "" && !model.IsValidId(options.ChannelID) {
+		return PlaybookRunFilterOptions{}, errors.New("bad parameter 'channel_id': must be 26 characters or blank")
 	}
 
 	for _, s := range options.Statuses {

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -339,6 +339,11 @@ func (s *playbookRunStore) GetPlaybookRuns(requesterInfo app.RequesterInfo, opti
 		queryForTotal = queryForTotal.Where(sq.Like{column: fmt.Sprint("%", searchString, "%")})
 	}
 
+	if options.ChannelID != "" {
+		queryForResults = queryForResults.Where(sq.Eq{"i.ChannelId": options.ChannelID})
+		queryForTotal = queryForTotal.Where(sq.Eq{"i.ChannelId": options.ChannelID})
+	}
+
 	queryForResults = queryActiveBetweenTimes(queryForResults, options.ActiveGTE, options.ActiveLT)
 	queryForTotal = queryActiveBetweenTimes(queryForTotal, options.ActiveGTE, options.ActiveLT)
 

--- a/webapp/src/graphql/generated_types.ts
+++ b/webapp/src/graphql/generated_types.ts
@@ -256,6 +256,7 @@ export type QueryRunArgs = {
 };
 
 export type QueryRunsArgs = {
+    channelID?: InputMaybe<Scalars['String']>;
     participantOrFollowerID?: InputMaybe<Scalars['String']>;
     sort?: InputMaybe<Scalars['String']>;
     statuses?: InputMaybe<Array<Scalars['String']>>;


### PR DESCRIPTION
## Summary
Adds the ability to list runs by channel using the GraphQL API. 
Note that it's currently impossible to get in a state where this API will actually return multiple results. The unique constraint needs to be removed, see #1560 
There should be no problem with committing this directly to master. 

There was some discussion in the ticket around making `participantOrFollowerID` optional, however it already has a default in the schema. 

I also think the changes here are simple enough not to warrent a new root resolver for this case.

## Ticket Link
Fixes #1545
