### PR TITLE
[MM-44899] Fix assignee chip styling

### DIFF
--- a/webapp/src/components/checklist_item/assign_to.tsx
+++ b/webapp/src/components/checklist_item/assign_to.tsx
@@ -167,8 +167,7 @@ const StyledProfileSelector = styled(ProfileSelector)`
     }
 
     .NoName-Assigned-button {
-        background: none;
-        padding: 0px;
+        padding: 0 6px 0 0;
 
         .image {
             background: rgba(var(--center-channel-color-rgb),0.08);
@@ -219,6 +218,7 @@ export const AssignToContainer = styled.div`
         margin-left: 36px;
     }
     max-width: calc(100% - 210px);
+    display: flex;
 `;
 
 const ControlComponentAnchor = styled.a`


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
The condensed assignee chip now correctly has a background color and padding to the right.
Additionally, a bug was fixed for smaller screen sizes that caused the dropdown arrow of the chip to overflow.

Here's how it looks now:
![msedge_8qX9sHk2Si](https://user-images.githubusercontent.com/8669935/201380268-1f5167a9-ebb0-47ed-b03f-3aefe3a5bae8.png)

## Ticket Link
[MM-44899](https://mattermost.atlassian.net/browse/MM-44899)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~