### PR TITLE
MM-48366: duplicate without members

### DIFF
--- a/webapp/src/components/backstage/playbook_list_row.tsx
+++ b/webapp/src/components/backstage/playbook_list_row.tsx
@@ -158,6 +158,7 @@ const PlaybookListRow = (props: Props) => {
         <PlaybookItem
             key={props.playbook.id}
             onClick={props.onClick}
+            data-testid='playbook-item'
         >
             <PlaybookItemTitle data-testid='playbook-title'>
                 <TextWithTooltip


### PR DESCRIPTION
## Summary
When duplicating a playbook, don't copy over the members list and instead automatically join it yourself. This allows you to immediately administrate the playbook, and avoids looping in other people who may not be interested.

![CleanShot 2022-11-11 at 16 59 05](https://user-images.githubusercontent.com/1023171/201429823-93644562-4008-4e8e-93df-766ee7916cb6.gif)


## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-48366