### PR TITLE
MM 44807 Adjust outline hover effects

### DIFF
--- a/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
@@ -72,6 +72,7 @@ const Outline = ({playbook, refetch}: Props) => {
             <Section
                 id={'status-updates'}
                 title={formatMessage({defaultMessage: 'Status Updates'})}
+                hasSubtitle={true}
                 hoverEffect={true}
                 headerRight={(
                     <HoverMenuContainer data-testid={'status-update-toggle'}>
@@ -118,6 +119,7 @@ const Outline = ({playbook, refetch}: Props) => {
             <Section
                 id={'retrospective'}
                 title={formatMessage({defaultMessage: 'Retrospective'})}
+                hasSubtitle={retrospectiveAccess && !playbook.retrospective_enabled}
                 hoverEffect={true}
                 headerRight={(
                     <HoverMenuContainer>

--- a/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
@@ -88,6 +88,16 @@ const Outline = ({playbook, refetch}: Props) => {
                         />
                     </HoverMenuContainer>
                 )}
+                onHeaderClick={() => {
+                    if (archived) {
+                        return;
+                    }
+                    updatePlaybook({
+                        statusUpdateEnabled: !playbook.status_update_enabled,
+                        webhookOnStatusUpdateEnabled: !playbook.status_update_enabled,
+                        broadcastEnabled: !playbook.status_update_enabled,
+                    });
+                }}
             >
                 <StatusUpdates
                     playbook={playbook}
@@ -122,6 +132,14 @@ const Outline = ({playbook, refetch}: Props) => {
                         />
                     </HoverMenuContainer>
                 )}
+                onHeaderClick={() => {
+                    if (archived || !retrospectiveAccess) {
+                        return;
+                    }
+                    updatePlaybook({
+                        retrospectiveEnabled: !playbook.retrospective_enabled,
+                    });
+                }}
             >
                 <Retrospective
                     playbook={playbook}
@@ -204,7 +222,6 @@ const HoverMenuContainer = styled.div`
     position: relative;
     height: 32px;
     right: 1px;
-    top: 2px;
 `;
 
 export default Outline;

--- a/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/outline.tsx
@@ -48,6 +48,26 @@ const Outline = ({playbook, refetch}: Props) => {
         setChecklistCollapseState(state);
     };
 
+    const toggleStatusUpdate = () => {
+        if (archived) {
+            return;
+        }
+        updatePlaybook({
+            statusUpdateEnabled: !playbook.status_update_enabled,
+            webhookOnStatusUpdateEnabled: !playbook.status_update_enabled,
+            broadcastEnabled: !playbook.status_update_enabled,
+        });
+    };
+
+    const toggleRetrospective = () => {
+        if (archived || !retrospectiveAccess) {
+            return;
+        }
+        updatePlaybook({
+            retrospectiveEnabled: !playbook.retrospective_enabled,
+        });
+    };
+
     return (
         <Sections
             playbookId={playbook.id}
@@ -79,26 +99,11 @@ const Outline = ({playbook, refetch}: Props) => {
                         <Toggle
                             disabled={archived}
                             isChecked={playbook.status_update_enabled}
-                            onChange={() => {
-                                updatePlaybook({
-                                    statusUpdateEnabled: !playbook.status_update_enabled,
-                                    webhookOnStatusUpdateEnabled: !playbook.status_update_enabled,
-                                    broadcastEnabled: !playbook.status_update_enabled,
-                                });
-                            }}
+                            onChange={toggleStatusUpdate}
                         />
                     </HoverMenuContainer>
                 )}
-                onHeaderClick={() => {
-                    if (archived) {
-                        return;
-                    }
-                    updatePlaybook({
-                        statusUpdateEnabled: !playbook.status_update_enabled,
-                        webhookOnStatusUpdateEnabled: !playbook.status_update_enabled,
-                        broadcastEnabled: !playbook.status_update_enabled,
-                    });
-                }}
+                onHeaderClick={toggleStatusUpdate}
             >
                 <StatusUpdates
                     playbook={playbook}
@@ -126,22 +131,11 @@ const Outline = ({playbook, refetch}: Props) => {
                         <Toggle
                             disabled={archived || !retrospectiveAccess}
                             isChecked={playbook.retrospective_enabled}
-                            onChange={() => {
-                                updatePlaybook({
-                                    retrospectiveEnabled: !playbook.retrospective_enabled,
-                                });
-                            }}
+                            onChange={toggleRetrospective}
                         />
                     </HoverMenuContainer>
                 )}
-                onHeaderClick={() => {
-                    if (archived || !retrospectiveAccess) {
-                        return;
-                    }
-                    updatePlaybook({
-                        retrospectiveEnabled: !playbook.retrospective_enabled,
-                    });
-                }}
+                onHeaderClick={toggleRetrospective}
             >
                 <Retrospective
                     playbook={playbook}

--- a/webapp/src/components/backstage/playbook_editor/outline/section.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section.tsx
@@ -15,6 +15,7 @@ interface Props {
     headerRight?: React.ReactNode;
     hoverEffect?: boolean;
     onHeaderClick?: () => void;
+    hasSubtitle?: boolean;
 }
 
 const Section = ({
@@ -24,6 +25,7 @@ const Section = ({
     children,
     hoverEffect,
     onHeaderClick,
+    hasSubtitle,
 }: Props) => {
     const {url} = useRouteMatch();
 
@@ -33,6 +35,7 @@ const Section = ({
         >
             <Header
                 $clickable={Boolean(onHeaderClick)}
+                $hasSubtitle={hasSubtitle}
                 $hoverEffect={hoverEffect}
                 onClick={onHeaderClick}
             >
@@ -60,7 +63,7 @@ const Wrapper = styled.div`
     padding: 0.5rem 3rem 2rem;
 `;
 
-const Header = styled.div<{ $clickable?: boolean; $hoverEffect?: boolean; $hideHeaderRight?: boolean; }>`
+const Header = styled.div<{ $clickable?: boolean; $hoverEffect?: boolean; $hasSubtitle?: boolean; $hideHeaderRight?: boolean; }>`
     ${({$clickable}) => $clickable && css`
         cursor: pointer;
     `}
@@ -81,7 +84,7 @@ const Header = styled.div<{ $clickable?: boolean; $hoverEffect?: boolean; $hideH
     align-items: center;
     justify-content: space-between;
     margin-top: 20px;
-    margin-bottom: 10px;
+    margin-bottom: ${({$hasSubtitle}) => ($hasSubtitle ? '2px' : '10px')};
     padding: 4px 0 4px 8px;
 `;
 

--- a/webapp/src/components/backstage/playbook_editor/outline/section.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section.tsx
@@ -14,6 +14,7 @@ interface Props {
     children?: React.ReactNode;
     headerRight?: React.ReactNode;
     hoverEffect?: boolean;
+    onHeaderClick?: () => void;
 }
 
 const Section = ({
@@ -22,15 +23,19 @@ const Section = ({
     headerRight,
     children,
     hoverEffect,
+    onHeaderClick,
 }: Props) => {
     const {url} = useRouteMatch();
 
     return (
         <Wrapper
             id={id}
-            $hoverEffect={hoverEffect}
         >
-            <Header>
+            <Header
+                $clickable={Boolean(onHeaderClick)}
+                $hoverEffect={hoverEffect}
+                onClick={onHeaderClick}
+            >
                 <Title>
                     <CopyLink
                         id={`section-link-${id}`}
@@ -51,7 +56,14 @@ const Section = ({
     );
 };
 
-const Wrapper = styled.div<{$hoverEffect?: boolean; $hideHeaderRight?: boolean;}>`
+const Wrapper = styled.div`
+    padding: 0.5rem 3rem 2rem;
+`;
+
+const Header = styled.div<{ $clickable?: boolean; $hoverEffect?: boolean; $hideHeaderRight?: boolean; }>`
+    ${({$clickable}) => $clickable && css`
+        cursor: pointer;
+    `}
     ${({$hoverEffect}) => $hoverEffect && css`
         ${HeaderRight} {
             opacity: 0
@@ -64,8 +76,13 @@ const Wrapper = styled.div<{$hoverEffect?: boolean; $hideHeaderRight?: boolean;}
             }
         }
     `}
-    padding: 0.5rem 3rem 2rem;
     border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    padding: 4px 0 4px 8px;
 `;
 
 const HeaderRight = styled.div``;
@@ -76,22 +93,20 @@ const Title = styled.h3`
     font-weight: 600;
     line-height: 28px;
     white-space: nowrap;
+    margin: 0;
+    position: relative;
 
     ${CopyLink} {
         margin-left: -1.25em;
         opacity: 1;
         transition: opacity ease 0.15s;
+        position: absolute;
+        left: -10px;
     }
 
     &:not(:hover) ${CopyLink}:not(:hover) {
         opacity: 0;
     }
-`;
-
-const Header = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
 `;
 
 export default Section;

--- a/webapp/src/components/backstage/playbook_editor/outline/section_retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_retrospective.tsx
@@ -65,7 +65,7 @@ const SectionRetrospective = ({playbook, refetch}: Props) => {
                 </BackstageSubheader>
                 <StyledSelect
                     value={retrospectiveReminderOptions.find((option) => option.value === playbook.retrospective_reminder_interval_seconds)}
-                    onChange={(option: { label: string; value: number; }) => {
+                    onChange={(option: {label: string; value: number;}) => {
                         updatePlaybook({
                             retrospectiveReminderIntervalSeconds: option?.value,
                         });

--- a/webapp/src/components/backstage/playbook_editor/outline/section_retrospective.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_retrospective.tsx
@@ -4,6 +4,8 @@
 import React, {useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
+import styled from 'styled-components';
+
 import {useAllowRetrospectiveAccess} from 'src/hooks';
 
 import {Card} from 'src/components/backstage/playbook_preview_cards';
@@ -47,7 +49,9 @@ const SectionRetrospective = ({playbook, refetch}: Props) => {
     }
 
     if (!playbook.retrospective_enabled) {
-        return <FormattedMessage defaultMessage='A retrospective is not expected.'/>;
+        return (<RetrospectiveTextContainer>
+            <FormattedMessage defaultMessage='A retrospective is not expected.'/>
+        </RetrospectiveTextContainer>);
     }
 
     return (
@@ -61,7 +65,7 @@ const SectionRetrospective = ({playbook, refetch}: Props) => {
                 </BackstageSubheader>
                 <StyledSelect
                     value={retrospectiveReminderOptions.find((option) => option.value === playbook.retrospective_reminder_interval_seconds)}
-                    onChange={(option: {label: string; value: number;}) => {
+                    onChange={(option: { label: string; value: number; }) => {
                         updatePlaybook({
                             retrospectiveReminderIntervalSeconds: option?.value,
                         });
@@ -111,5 +115,9 @@ const SectionRetrospective = ({playbook, refetch}: Props) => {
         </Card>
     );
 };
+
+const RetrospectiveTextContainer = styled.div`
+    padding: 0 8px;
+`;
 
 export default SectionRetrospective;

--- a/webapp/src/components/backstage/playbook_editor/outline/section_status_updates.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_status_updates.tsx
@@ -53,7 +53,7 @@ const StatusUpdates = ({playbook}: Props) => {
                                         setSeconds={(seconds: number) => {
                                             if (
                                                 seconds !== playbook.reminder_timer_default_seconds &&
-                                            seconds > 0
+                                                seconds > 0
                                             ) {
                                                 updatePlaybook({
                                                     reminderTimerDefaultSeconds: seconds,
@@ -78,7 +78,7 @@ const StatusUpdates = ({playbook}: Props) => {
                                         onChannelsSelected={(channelIds: string[]) => {
                                             if (
                                                 channelIds.length !== playbook.broadcast_channel_ids.length ||
-                                            channelIds.some((id) => !playbook.broadcast_channel_ids.includes(id))
+                                                channelIds.some((id) => !playbook.broadcast_channel_ids.includes(id))
                                             ) {
                                                 updatePlaybook({
                                                     broadcastChannelIDs: channelIds,

--- a/webapp/src/components/widgets/copy_link.tsx
+++ b/webapp/src/components/widgets/copy_link.tsx
@@ -33,7 +33,8 @@ const CopyLink = ({
     const {formatMessage} = useIntl();
     const [wasCopied, setWasCopied] = useState(false);
 
-    const copyLink = () => {
+    const copyLink = (e: React.MouseEvent) => {
+        e.stopPropagation();
         copyToClipboard(to);
         setWasCopied(true);
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
The hover effects in the playbook outline are now more consistent.
Only section headers with a right header element are highlighted on hovering.

![msedge_ZvIexJGS9g](https://user-images.githubusercontent.com/8669935/201663153-29223761-cac6-49d3-b52e-e308548342f2.png)

## Ticket Link
[MM-44807](https://mattermost.atlassian.net/browse/MM-44807)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
