### PR TITLE
MM-48449: avoid race with /playbook

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1716,6 +1716,13 @@ func (s *PlaybookRunServiceImpl) RunChecklistItemSlashCommand(playbookRunID, use
 		return "", errors.Wrap(err, "failed to run slash command")
 	}
 
+	// Fetch the playbook run again, in case the slash command actually changed the run
+	// (e.g. `/playbook owner`).
+	playbookRun, err = s.store.GetPlaybookRun(playbookRunID)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to retrieve playbook run after running slash command")
+	}
+
 	// Record the last (successful) run time.
 	playbookRun.Checklists[checklistNumber].Items[itemNumber].CommandLastRun = model.GetMillis()
 

--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -199,7 +199,7 @@ describe('channels > rhs > checklist', () => {
             });
         });
 
-        it.only('runs /playbook slash commands', () => {
+        it('runs /playbook slash commands', () => {
             cy.get('#rhsContainer').should('exist').within(() => {
                 // * Verify the `/playbook check 0 0` command has not yet been run.
                 cy.findAllByTestId('run').eq(2).should('have.text', 'Run');

--- a/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/checklist_spec.js
@@ -31,7 +31,7 @@ describe('channels > rhs > checklist', () => {
                         items: [
                             {title: 'Step 1', command: '/invalid'},
                             {title: 'Step 2', command: '/echo VALID'},
-                            {title: 'Step 3'},
+                            {title: 'Step 3', command: '/playbook check 0 0'},
                             {title: 'Step 4'},
                             {title: 'Step 5'},
                             {title: 'Step 6'},
@@ -196,6 +196,39 @@ describe('channels > rhs > checklist', () => {
 
                 // * Verify the valid command has been run.
                 cy.findAllByTestId('run').eq(1).should('have.text', 'Rerun');
+            });
+        });
+
+        it.only('runs /playbook slash commands', () => {
+            cy.get('#rhsContainer').should('exist').within(() => {
+                // * Verify the `/playbook check 0 0` command has not yet been run.
+                cy.findAllByTestId('run').eq(2).should('have.text', 'Run');
+
+                // * Run the slash command
+                cy.findAllByTestId('run').eq(2).click();
+
+                // * Verify the command has now been run.
+                cy.findAllByTestId('run').eq(2).should('have.text', 'Rerun');
+
+                // * Verify the first checklist item is checked
+                cy.findAllByTestId('checkbox-item-container').eq(0).within(() => {
+                    // # Check the overdue task
+                    cy.get('input').should('be.checked');
+                });
+            });
+
+            // # Reload the page
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            cy.get('#rhsContainer').should('exist').within(() => {
+                // * Verify the command has still been run.
+                cy.findAllByTestId('run').eq(2).should('have.text', 'Rerun');
+
+                // * Verify the first checklist item is still checked
+                cy.findAllByTestId('checkbox-item-container').eq(0).within(() => {
+                    // # Check the overdue task
+                    cy.get('input').should('be.checked');
+                });
             });
         });
 


### PR DESCRIPTION
## Summary
If a task slash command uses `/playbook ...` which in turn modifies the run (e.g. `/playbook owner @username`), the update from that slash command gets overwritten by the code invoking the slash command to record the execution of same.

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-48449

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
