### PR TITLE
respect fullname setting at getOwners

### DIFF
--- a/client/playbook_run.go
+++ b/client/playbook_run.go
@@ -275,3 +275,12 @@ type RunMetricData struct {
 	MetricConfigID string   `json:"metric_config_id"`
 	Value          null.Int `json:"value"`
 }
+
+// OwnerInfo holds the summary information of a owner.
+type OwnerInfo struct {
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Nickname  string `json:"nickname"`
+}

--- a/client/playbook_runs.go
+++ b/client/playbook_runs.go
@@ -329,3 +329,20 @@ func (s *PlaybookRunService) SetItemDueDate(ctx context.Context, playbookRunID s
 	_, err = s.client.do(ctx, req, nil)
 	return err
 }
+
+// Get a playbook run.
+func (s *PlaybookRunService) GetOwners(ctx context.Context) ([]OwnerInfo, error) {
+	req, err := s.client.newRequest(http.MethodGet, "runs/owners", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	owners := make([]OwnerInfo, 0)
+	resp, err := s.client.do(ctx, req, &owners)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	return owners, nil
+}

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -1415,7 +1415,8 @@ func TestGetOwners(t *testing.T) {
 	t.Run("showfullname set to true", func(t *testing.T) {
 		cfg := e.Srv.Config()
 		cfg.PrivacySettings.ShowFullName = model.NewBool(true)
-		e.ServerClient.UpdateConfig(cfg)
+		_, _, err = e.ServerAdminClient.UpdateConfig(cfg)
+		require.NoError(t, err)
 
 		owners, err := e.PlaybooksClient.PlaybookRuns.GetOwners(context.Background())
 		require.NoError(t, err)
@@ -1441,7 +1442,8 @@ func TestGetOwners(t *testing.T) {
 	t.Run("showfullname set to false", func(t *testing.T) {
 		cfg := e.Srv.Config()
 		cfg.PrivacySettings.ShowFullName = model.NewBool(false)
-		e.ServerClient.UpdateConfig(cfg)
+		_, _, err = e.ServerAdminClient.UpdateConfig(cfg)
+		require.NoError(t, err)
 
 		owners, err := e.PlaybooksClient.PlaybookRuns.GetOwners(context.Background())
 		require.NoError(t, err)

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -498,13 +498,6 @@ type OwnerInfo struct {
 	Nickname  string `json:"nickname"`
 }
 
-func (o *OwnerInfo) Sanitize(options map[string]bool) {
-	if len(options) != 0 && !options["fullname"] {
-		o.FirstName = ""
-		o.LastName = ""
-	}
-}
-
 // DialogState holds the start playbook run interactive dialog's state as it appears in the client
 // and is submitted back to the server.
 type DialogState struct {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -498,6 +498,13 @@ type OwnerInfo struct {
 	Nickname  string `json:"nickname"`
 }
 
+func (o *OwnerInfo) Sanitize(options map[string]bool) {
+	if len(options) != 0 && !options["fullname"] {
+		o.FirstName = ""
+		o.LastName = ""
+	}
+}
+
 // DialogState holds the start playbook run interactive dialog's state as it appears in the client
 // and is submitted back to the server.
 type DialogState struct {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1336,7 +1336,7 @@ func (s *PlaybookRunServiceImpl) GetOwners(requesterInfo RequesterInfo, options 
 	}
 
 	// ShowFullName is coming as nil when setting is set to false
-	// TODO: further investigation
+	// TODO: further investigation https://mattermost.atlassian.net/browse/MM-48464
 	var showFullName bool
 	if IsSystemAdmin(requesterInfo.UserID, s.pluginAPI) {
 		showFullName = true
@@ -1348,7 +1348,10 @@ func (s *PlaybookRunServiceImpl) GetOwners(requesterInfo RequesterInfo, options 
 	}
 
 	for k, o := range owners {
-		o.Sanitize(map[string]bool{"fullname": showFullName})
+		if !showFullName {
+			o.FirstName = ""
+			o.LastName = ""
+		}
 		owners[k] = o
 	}
 	return owners, nil

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1334,6 +1334,21 @@ func (s *PlaybookRunServiceImpl) GetOwners(requesterInfo RequesterInfo, options 
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get owners from the store")
 	}
+
+	// ShowFullName is coming as nil when setting is set to false
+	// TODO: further investigation
+	showFullName := false
+	cfg := s.pluginAPI.Configuration.GetConfig()
+	if cfg.PrivacySettings.ShowFullName != nil {
+		showFullName = *cfg.PrivacySettings.ShowFullName
+	}
+
+	if !showFullName {
+		for k, o := range owners {
+			o.Sanitize(map[string]bool{"fullname": showFullName})
+			owners[k] = o
+		}
+	}
 	return owners, nil
 }
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1337,10 +1337,14 @@ func (s *PlaybookRunServiceImpl) GetOwners(requesterInfo RequesterInfo, options 
 
 	// ShowFullName is coming as nil when setting is set to false
 	// TODO: further investigation
-	showFullName := false
-	cfg := s.pluginAPI.Configuration.GetConfig()
-	if cfg.PrivacySettings.ShowFullName != nil {
-		showFullName = *cfg.PrivacySettings.ShowFullName
+	var showFullName bool
+	if IsSystemAdmin(requesterInfo.UserID, s.pluginAPI) {
+		showFullName = true
+	} else {
+		cfg := s.pluginAPI.Configuration.GetConfig()
+		if cfg.PrivacySettings.ShowFullName != nil {
+			showFullName = *cfg.PrivacySettings.ShowFullName
+		}
 	}
 
 	for k, o := range owners {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1343,11 +1343,9 @@ func (s *PlaybookRunServiceImpl) GetOwners(requesterInfo RequesterInfo, options 
 		showFullName = *cfg.PrivacySettings.ShowFullName
 	}
 
-	if !showFullName {
-		for k, o := range owners {
-			o.Sanitize(map[string]bool{"fullname": showFullName})
-			owners[k] = o
-		}
+	for k, o := range owners {
+		o.Sanitize(map[string]bool{"fullname": showFullName})
+		owners[k] = o
 	}
 	return owners, nil
 }

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -211,16 +211,20 @@ func (e *TestEnvironment) CreateClients() {
 	e.AdminUser = admin
 
 	user, _ := e.A.CreateUser(request.EmptyContext(e.logger), &model.User{
-		Email:    "playbooksuser@example.com",
-		Username: "playbooksuser",
-		Password: userPassword,
+		Email:     "playbooksuser@example.com",
+		Username:  "playbooksuser",
+		Password:  userPassword,
+		FirstName: "First 1",
+		LastName:  "Last 1",
 	})
 	e.RegularUser = user
 
 	user2, _ := e.A.CreateUser(request.EmptyContext(e.logger), &model.User{
-		Email:    "playbooksuser2@example.com",
-		Username: "playbooksuser2",
-		Password: userPassword,
+		Email:     "playbooksuser2@example.com",
+		Username:  "playbooksuser2",
+		Password:  userPassword,
+		FirstName: "First 2",
+		LastName:  "Last 2",
 	})
 	e.RegularUser2 = user2
 

--- a/webapp/src/components/backstage/runs_list/filters.tsx
+++ b/webapp/src/components/backstage/runs_list/filters.tsx
@@ -133,7 +133,7 @@ const Filters = ({fetchParams, setFetchParams, fixedPlaybook, fixedFinished}: Pr
     };
 
     async function fetchOwners() {
-        const owners = await fetchOwnersInTeam(currentTeamId);
+        const owners = await fetchOwnersInTeam(fetchParams.team_id || currentTeamId);
         return owners.map((c) => {
             //@ts-ignore TODO Fix this strangeness
             return {...c, id: c.user_id} as UserProfile;


### PR DESCRIPTION
## Summary
Honour PrivacySettings.ShowFullName value at getOwners endpoint.

Added client function and tests.

It's a bit surprising to get a nil value when is false from GetConfig() server calls, but it will be investigated separately.

## Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-48008

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
