### PR TITLE
enable empty checklist as droppable are for tasks

### DIFF
--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -75,6 +75,7 @@ const GenericChecklist = (props: Props) => {
     const keys = generateKeys(props.checklist.items.map((item) => props.id + item.title));
 
     return (
+
         <Droppable
             droppableId={props.checklistIndex.toString()}
             direction='vertical'
@@ -131,21 +132,21 @@ const GenericChecklist = (props: Props) => {
                             />
                         }
                         {droppableProvided.placeholder}
+                        {props.readOnly ? null : (
+                            <AddTaskLink
+                                disabled={props.readOnly}
+                                onClick={() => {
+                                    setAddingItem(true);
+                                }}
+                                data-testid={`add-new-task-${props.checklistIndex}`}
+                            >
+                                <IconWrapper>
+                                    <i className='icon icon-plus'/>
+                                </IconWrapper>
+                                {formatMessage({defaultMessage: 'Add a task'})}
+                            </AddTaskLink>
+                        )}
                     </div>
-                    {props.readOnly ? null : (
-                        <AddTaskLink
-                            disabled={props.readOnly}
-                            onClick={() => {
-                                setAddingItem(true);
-                            }}
-                            data-testid={`add-new-task-${props.checklistIndex}`}
-                        >
-                            <IconWrapper>
-                                <i className='icon icon-plus'/>
-                            </IconWrapper>
-                            {formatMessage({defaultMessage: 'Add a task'})}
-                        </AddTaskLink>
-                    )}
                 </ChecklistContainer>
             )}
         </Droppable>


### PR DESCRIPTION
## Summary
Addtask block now is inside droppable area, so drop is accessible even with no items inside.

Addtask is not dragable, and the behavior will be the same. tasks can not be dropped below addtask.

Approaches that I tried and didn't work:
- placeholder: is already in place and is only activated when you drag items from that list
- droppable.snapshot.isDraggingOver: did not trigger because droppable height was 0 


https://user-images.githubusercontent.com/4096774/202436165-4a295d7a-38fc-4c68-9a36-ac19f8f858f4.mp4




## Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-48309

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
