### PR TITLE
Remove en.json from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
+
+# i18n PRs
 webapp/i18n/* @mattermost/playbooks
+webapp/i18n/en.json @ghost
 assets/i18n/* @mattermost/playbooks
+assets/i18n/en.json @ghost


### PR DESCRIPTION
## Summary
`en.json` gets changed a lot. The initial i18n entries in CODEOWNERS only intended cover the i18n PRs, which only touch non-en.json files. CODEOWNERS [doesn't support negative patterns](https://git-scm.com/docs/gitattributes#:~:text=negative%20patterns%20are%20forbidden), so like https://github.com/NixOS/nixpkgs/pull/31758/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R86, we use @ghost to negate en.json.

#### Screenshots
|  before  |  after  |
|----|----|
| ![CleanShot 2022-11-21 at 11 35 00@2x](https://user-images.githubusercontent.com/11724372/203123117-d2bc70a7-0fb6-41b1-927c-4c5639da98e5.png) | ![CleanShot 2022-11-21 at 11 35 24@2x](https://user-images.githubusercontent.com/11724372/203123029-c4d46431-869c-479d-9b6f-e7c4b6339794.png) |
| ![CleanShot 2022-11-21 at 11 40 18@2x](https://user-images.githubusercontent.com/11724372/203123698-8f1e794c-2773-41a7-a476-84c98c4ce619.png) | ![CleanShot 2022-11-21 at 11 39 37@2x](https://user-images.githubusercontent.com/11724372/203123557-08446803-4890-4aa0-aa90-bbc89bd7ed11.png) |
| | ![CleanShot 2022-11-21 at 11 48 29@2x](https://user-images.githubusercontent.com/11724372/203125197-8285c4c3-f4b0-494b-9c76-b5f92f5f274e.png) |
| | ![CleanShot 2022-11-21 at 11 46 01@2x](https://user-images.githubusercontent.com/11724372/203124808-a29bb6b4-5766-4422-9c0f-32914fc00654.png) |

## Ticket Link
None

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
