### PR TITLE
add readtimeout to prometheus server

### DIFF
--- a/server/metrics/service.go
+++ b/server/metrics/service.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -24,7 +25,8 @@ func (el *ErrorLoggerWrapper) Println(v ...interface{}) {
 func NewMetricsServer(address string, metricsService *Metrics) *Service {
 	return &Service{
 		&http.Server{
-			Addr: address,
+			ReadTimeout: 30 * time.Second,
+			Addr:        address,
 			Handler: promhttp.HandlerFor(metricsService.registry, promhttp.HandlerOpts{
 				ErrorLog: &ErrorLoggerWrapper{},
 			}),


### PR DESCRIPTION
## Summary
A recent version of golangci warns about a missing readtimeout on prometheus metricsserver.
Added timeout of 30s. I was tempted of using ServiceSettings.ReadTimeout but it seemed too large and for another purpose.

## Ticket Link
Nope

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
