### PR TITLE
Refactor code to move out fav/unfav from UpdateRun

### DIFF
--- a/server/api/schema.graphqls
+++ b/server/api/schema.graphqls
@@ -32,6 +32,7 @@ type Mutation {
 	addPlaybookMember(playbookID: String!, userID: String!): String!
 	removePlaybookMember(playbookID: String!, userID: String!): String!
 
+	setRunFavorite(id: String!, fav: Boolean!): String!
 	updateRun(id: String!, updates: RunUpdates!): String!
 	addRunParticipants(runID: String!, userIDs: [String!]!, forceAddToChannel: Boolean = false): String!
 	removeRunParticipants(runID: String!, userIDs: [String!]!): String!
@@ -266,7 +267,6 @@ type TimelineEvent {
 input RunUpdates {
 	name: String
 	summary: String
-	isFavorite: Boolean
 	createChannelMemberOnNewParticipant: Boolean
 	removeChannelMemberOnRemovedParticipant: Boolean
 	statusUpdateBroadcastChannelsEnabled: Boolean

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1197,6 +1197,9 @@ func (s *PlaybookRunServiceImpl) RestorePlaybookRun(playbookRunID, userID string
 
 // GraphqlUpdate updates fields based on a setmap
 func (s *PlaybookRunServiceImpl) GraphqlUpdate(id string, setmap map[string]interface{}) error {
+	if len(setmap) == 0 {
+		return nil
+	}
 	if err := s.store.GraphqlUpdate(id, setmap); err != nil {
 		return err
 	}

--- a/webapp/src/components/backstage/lhs_run_dot_menu.tsx
+++ b/webapp/src/components/backstage/lhs_run_dot_menu.tsx
@@ -12,7 +12,7 @@ import DotMenu from 'src/components/dot_menu';
 import {useToaster} from 'src/components/backstage/toast_banner';
 import {ToastStyle} from 'src/components/backstage/toast';
 import {Role, Separator} from 'src/components/backstage/playbook_runs/shared';
-import {useUpdateRun} from 'src/graphql/hooks';
+import {useSetRunFavorite} from 'src/graphql/hooks';
 import {useRunFollowers} from 'src/hooks';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
 
@@ -33,7 +33,7 @@ interface Props {
 export const LHSRunDotMenu = ({playbookRunId, isFavorite, ownerUserId, participantIDs, followerIDs, hasPermanentViewerAccess}: Props) => {
     const {formatMessage} = useIntl();
     const {add: addToast} = useToaster();
-    const updateRun = useUpdateRun(playbookRunId);
+    const setRunFavorite = useSetRunFavorite(playbookRunId);
     const currentUser = useSelector(getCurrentUser);
     const refreshLHS = useLHSRefresh();
 
@@ -44,7 +44,7 @@ export const LHSRunDotMenu = ({playbookRunId, isFavorite, ownerUserId, participa
     const role = participantIDs.includes(currentUser.id) ? Role.Participant : Role.Viewer;
 
     const toggleFavorite = () => {
-        updateRun({isFavorite: !isFavorite});
+        setRunFavorite(!isFavorite);
     };
 
     // TODO: converge with src/hooks/run useFollowRun

--- a/webapp/src/graphql/generated_types.ts
+++ b/webapp/src/graphql/generated_types.ts
@@ -77,6 +77,7 @@ export type Mutation = {
     deleteMetric: Scalars['String'];
     removePlaybookMember: Scalars['String'];
     removeRunParticipants: Scalars['String'];
+    setRunFavorite: Scalars['String'];
     updateMetric: Scalars['String'];
     updatePlaybook: Scalars['String'];
     updateRun: Scalars['String'];
@@ -118,6 +119,11 @@ export type MutationRemovePlaybookMemberArgs = {
 export type MutationRemoveRunParticipantsArgs = {
     runID: Scalars['String'];
     userIDs: Array<Scalars['String']>;
+};
+
+export type MutationSetRunFavoriteArgs = {
+    fav: Scalars['Boolean'];
+    id: Scalars['String'];
 };
 
 export type MutationUpdateMetricArgs = {
@@ -334,7 +340,6 @@ export type RunEdge = {
 export type RunUpdates = {
     broadcastChannelIDs?: InputMaybe<Array<Scalars['String']>>;
     createChannelMemberOnNewParticipant?: InputMaybe<Scalars['Boolean']>;
-    isFavorite?: InputMaybe<Scalars['Boolean']>;
     name?: InputMaybe<Scalars['String']>;
     removeChannelMemberOnRemovedParticipant?: InputMaybe<Scalars['Boolean']>;
     statusUpdateBroadcastChannelsEnabled?: InputMaybe<Scalars['Boolean']>;
@@ -424,6 +429,13 @@ export type RhsFinishedRunsQueryVariables = Exact<{
 }>;
 
 export type RhsFinishedRunsQuery = { __typename?: 'Query', runs: { __typename?: 'RunConnection', totalCount: number, edges: Array<{ __typename?: 'RunEdge', node: { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook: { __typename?: 'Playbook', title: string } } }>, pageInfo: { __typename?: 'PageInfo', endCursor: string, hasNextPage: boolean } } };
+
+export type SetRunFavoriteMutationVariables = Exact<{
+    id: Scalars['String'];
+    fav: Scalars['Boolean'];
+}>;
+
+export type SetRunFavoriteMutation = { __typename?: 'Mutation', setRunFavorite: string };
 
 export type UpdateRunMutationVariables = Exact<{
     id: Scalars['String'];
@@ -868,6 +880,38 @@ export function useRhsFinishedRunsLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
 export type RhsFinishedRunsQueryHookResult = ReturnType<typeof useRhsFinishedRunsQuery>;
 export type RhsFinishedRunsLazyQueryHookResult = ReturnType<typeof useRhsFinishedRunsLazyQuery>;
 export type RhsFinishedRunsQueryResult = Apollo.QueryResult<RhsFinishedRunsQuery, RhsFinishedRunsQueryVariables>;
+export const SetRunFavoriteDocument = gql`
+    mutation SetRunFavorite($id: String!, $fav: Boolean!) {
+  setRunFavorite(id: $id, fav: $fav)
+}
+    `;
+export type SetRunFavoriteMutationFn = Apollo.MutationFunction<SetRunFavoriteMutation, SetRunFavoriteMutationVariables>;
+
+/**
+ * __useSetRunFavoriteMutation__
+ *
+ * To run a mutation, you first call `useSetRunFavoriteMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSetRunFavoriteMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [setRunFavoriteMutation, { data, loading, error }] = useSetRunFavoriteMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      fav: // value for 'fav'
+ *   },
+ * });
+ */
+export function useSetRunFavoriteMutation(baseOptions?: Apollo.MutationHookOptions<SetRunFavoriteMutation, SetRunFavoriteMutationVariables>) {
+    const options = {...defaultOptions, ...baseOptions};
+    return Apollo.useMutation<SetRunFavoriteMutation, SetRunFavoriteMutationVariables>(SetRunFavoriteDocument, options);
+}
+export type SetRunFavoriteMutationHookResult = ReturnType<typeof useSetRunFavoriteMutation>;
+export type SetRunFavoriteMutationResult = Apollo.MutationResult<SetRunFavoriteMutation>;
+export type SetRunFavoriteMutationOptions = Apollo.BaseMutationOptions<SetRunFavoriteMutation, SetRunFavoriteMutationVariables>;
 export const UpdateRunDocument = gql`
     mutation UpdateRun($id: String!, $updates: RunUpdates!) {
   updateRun(id: $id, updates: $updates)

--- a/webapp/src/graphql/hooks.ts
+++ b/webapp/src/graphql/hooks.ts
@@ -18,6 +18,7 @@ import {
     useRemoveRunParticipantsMutation,
     useUpdatePlaybookMutation,
     useUpdateRunMutation,
+    useSetRunFavoriteMutation,
 } from 'src/graphql/generated_types';
 
 export type FullPlaybook = PlaybookQuery['playbook']
@@ -59,6 +60,21 @@ export const useUpdateRun = (id?: string) => {
 
     return useCallback((updates: RunUpdates) => {
         return innerUpdateRun({variables: {id: id || '', updates}});
+    }, [id, innerUpdateRun]);
+};
+
+export const useSetRunFavorite = (id: string|undefined) => {
+    const [innerUpdateRun] = useSetRunFavoriteMutation({
+        refetchQueries: [
+            PlaybookLhsDocument,
+        ],
+    });
+
+    return useCallback((fav: boolean) => {
+        if (id === undefined) {
+            return;
+        }
+        innerUpdateRun({variables: {id, fav}});
     }, [id, innerUpdateRun]);
 };
 

--- a/webapp/src/graphql/runs.graphql
+++ b/webapp/src/graphql/runs.graphql
@@ -75,6 +75,10 @@ query RHSFinishedRuns(
 	}
 }
 
+mutation SetRunFavorite($id: String!, $fav: Boolean!) {
+  setRunFavorite(id: $id, fav: $fav)
+}
+
 mutation UpdateRun($id: String!, $updates: RunUpdates!) {
   updateRun(id: $id, updates: $updates)
 }

--- a/webapp/src/hooks/run.tsx
+++ b/webapp/src/hooks/run.tsx
@@ -9,14 +9,14 @@ import {useUpdateEffect} from 'react-use';
 import {
     isFavoriteItem,
 } from 'src/client';
-import {useUpdateRun} from 'src/graphql/hooks';
+import {useSetRunFavorite} from 'src/graphql/hooks';
 import {CategoryItemType} from 'src/types/category';
 import BecomeParticipantsModal from 'src/components/backstage/playbook_runs/playbook_run/become_participant_modal';
 import {PlaybookRun} from 'src/types/playbook_run';
 
 export const useFavoriteRun = (teamID: string, runID: string): [boolean, () => void] => {
     const [isFavoriteRun, setIsFavoriteRun] = useState(false);
-    const updateRun = useUpdateRun(runID);
+    const setRunFavorite = useSetRunFavorite(runID);
 
     useEffect(() => {
         isFavoriteItem(teamID, runID, CategoryItemType.RunItemType)
@@ -25,13 +25,8 @@ export const useFavoriteRun = (teamID: string, runID: string): [boolean, () => v
     }, [teamID, runID]);
 
     const toggleFavorite = () => {
-        if (isFavoriteRun) {
-            updateRun({isFavorite: false});
-            setIsFavoriteRun(false);
-            return;
-        }
-        updateRun({isFavorite: true});
-        setIsFavoriteRun(true);
+        setRunFavorite(!isFavoriteRun);
+        setIsFavoriteRun(!isFavoriteRun);
     };
     return [isFavoriteRun, toggleFavorite];
 };


### PR DESCRIPTION
## Summary

* Add new GraphQL mutation to fav/unfav a run
* Remove IsFavorite from UpdateRun mutation
* Add tests in server to test the new functionality
* Update schema
* Change webapp code to use the new mutation

## Ticket Link

Closes https://github.com/mattermost/mattermost-server/issues/21706

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~Telemetry updated~
- [ ] ~Gated by experimental feature flag~
- [x] Unit tests updated
