### PR TITLE
Owner display and update on finish

### DIFF
--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -62,6 +62,11 @@ const useFilteredSortedRuns = (channelID: string, listOptions: RunListOptions) =
 
     const error = inProgressResult.error || finishedResult.error;
 
+    const refetch = () => {
+        inProgressResult.refetch();
+        finishedResult.refetch();
+    };
+
     return {
         runsInProgress,
         numRunsInProgress,
@@ -71,6 +76,7 @@ const useFilteredSortedRuns = (channelID: string, listOptions: RunListOptions) =
         getMoreFinished,
         hasMoreInProgress,
         hasMoreFinished,
+        refetch,
         error,
     };
 };
@@ -127,6 +133,7 @@ const RightHandSidebar = () => {
     }
 
     const clearCurrentRunId = () => {
+        fetchedRuns.refetch();
         setCurrentRunId(undefined);
     };
 

--- a/webapp/src/components/rhs/rhs_run_list.tsx
+++ b/webapp/src/components/rhs/rhs_run_list.tsx
@@ -236,6 +236,8 @@ interface RHSRunListCardProps extends RunToDisplay {
 const RHSRunListCard = (props: RHSRunListCardProps) => {
     const {formatMessage} = useIntl();
 
+    const participatIDsWithoutOwner = props.participantIDs.filter((id) => id !== props.ownerUserID);
+
     return (
         <CardContainer
             onClick={props.onClick}
@@ -245,7 +247,7 @@ const RHSRunListCard = (props: RHSRunListCardProps) => {
                 <OwnerProfileChip userId={props.ownerUserID}/>
                 <ParticipantsProfiles>
                     <UserList
-                        userIds={props.participantIDs}
+                        userIds={participatIDsWithoutOwner}
                         sizeInPx={20}
                     />
                 </ParticipantsProfiles>


### PR DESCRIPTION
## Summary
Two runs list fixups.

- Remove owner from participants display. The run owner will no longer be displayed in the list of participants on the runs list card.
- Refetch when back clicked. This fixes the case where you finish the run (or change some other visible property) and navigate back to the runs list using the back button.

## Ticket Link
Fixes #1620
Fixes #1619
