### PR TITLE
[Proposal] add eslint warning for relative imports

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -629,7 +629,7 @@
     "unused-imports/no-unused-imports": 2,
     "no-relative-import-paths/no-relative-import-paths": [
       "warn",
-      { "allowSameFolder": false }
+      { "allowSameFolder": true }
     ]
   },
   "overrides": [

--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -10,7 +10,8 @@
     "import",
     "formatjs",
     "@typescript-eslint",
-    "unused-imports"
+    "unused-imports",
+    "no-relative-import-paths"
   ],
   "env": {
     "browser": true,
@@ -625,7 +626,11 @@
     "formatjs/no-multiple-plurals": 2,
     "formatjs/enforce-placeholders": 2,
     "formatjs/no-literal-string-in-jsx": 2,
-    "unused-imports/no-unused-imports": 2
+    "unused-imports/no-unused-imports": 2,
+    "no-relative-import-paths/no-relative-import-paths": [
+      "warn",
+      { "allowSameFolder": false }
+    ]
   },
   "overrides": [
     {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -96,6 +96,7 @@
         "eslint-import-resolver-webpack": "0.13.2",
         "eslint-plugin-formatjs": "4.0.2",
         "eslint-plugin-import": "2.25.4",
+        "eslint-plugin-no-relative-import-paths": "1.5.0",
         "eslint-plugin-react": "7.28.0",
         "eslint-plugin-react-hooks": "4.3.0",
         "eslint-plugin-unused-imports": "2.0.0",
@@ -10507,6 +10508,12 @@
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.0.tgz",
+      "integrity": "sha512-4if/PGGzpSP+DfOscGZ2nYd8XObc5rN9Ux5lhDzAVqLEaz8XD3ikzApSogXBdf+lnpTsTE5LJSqXFmFpNkZ3LQ==",
       "dev": true
     },
     "node_modules/eslint-plugin-react": {
@@ -31578,6 +31585,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.0.tgz",
+      "integrity": "sha512-4if/PGGzpSP+DfOscGZ2nYd8XObc5rN9Ux5lhDzAVqLEaz8XD3ikzApSogXBdf+lnpTsTE5LJSqXFmFpNkZ3LQ==",
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.28.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -79,6 +79,7 @@
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-plugin-formatjs": "4.0.2",
     "eslint-plugin-import": "2.25.4",
+    "eslint-plugin-no-relative-import-paths": "1.5.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-unused-imports": "2.0.0",


### PR DESCRIPTION
## Summary
Warn if imports are relative.

bad
```ts
import {X} from '../module'
````

Good
```ts
import {X} from 'src/components/folder/module'
```

Motivations:
- Increase awareness on folder/context/parent-component
- Increase how easy is to refactor code from one module to another
- Increase how easy is to copy code from one module to another 


Also, at vscode autoimports can be configured as non-relative. 
![Screenshot 2022-11-30 at 11 54 12](https://user-images.githubusercontent.com/4096774/204781781-79d7a0a7-fa98-43bf-85dd-83f0910b4306.png)


## Ticket Link
Nope

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
