### PR TITLE
force all non-same-folder imports to be non-relative

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -628,7 +628,7 @@
     "formatjs/no-literal-string-in-jsx": 2,
     "unused-imports/no-unused-imports": 2,
     "no-relative-import-paths/no-relative-import-paths": [
-      "warn",
+      "error",
       { "allowSameFolder": true }
     ]
   },

--- a/webapp/src/components/assets/illustrations/bug_search_svg.tsx
+++ b/webapp/src/components/assets/illustrations/bug_search_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const BugSearch = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/clipboard_checklist_svg.tsx
+++ b/webapp/src/components/assets/illustrations/clipboard_checklist_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const ClipboardChecklist = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/dumpster_fire_svg.tsx
+++ b/webapp/src/components/assets/illustrations/dumpster_fire_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const DumpsterFire = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/gears_svg.tsx
+++ b/webapp/src/components/assets/illustrations/gears_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const Gears = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/handshake_svg.tsx
+++ b/webapp/src/components/assets/illustrations/handshake_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const Handshake = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/light_bulb_svg.tsx
+++ b/webapp/src/components/assets/illustrations/light_bulb_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const LightBulb = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/rocket_man_svg.tsx
+++ b/webapp/src/components/assets/illustrations/rocket_man_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const RocketMan = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/rocket_svg.tsx
+++ b/webapp/src/components/assets/illustrations/rocket_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const Rocket = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/assets/illustrations/smiley_sunglasses_svg.tsx
+++ b/webapp/src/components/assets/illustrations/smiley_sunglasses_svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Svg from '../svg';
+import Svg from 'src/components/assets/svg';
 
 const SmileySunglasses = (props: {className?: string}) => (
     <Svg

--- a/webapp/src/components/backstage/archive_playbook_modal.tsx
+++ b/webapp/src/components/backstage/archive_playbook_modal.tsx
@@ -3,7 +3,8 @@ import {FormattedMessage, useIntl} from 'react-intl';
 
 import {Banner} from 'src/components/backstage/styles';
 import {Playbook} from 'src/types/playbook';
-import ConfirmModal from '../widgets/confirmation_modal';
+
+import ConfirmModal from 'src/components/widgets/confirmation_modal';
 
 import {useLHSRefresh} from './lhs_navigation';
 

--- a/webapp/src/components/backstage/lhs_navigation.tsx
+++ b/webapp/src/components/backstage/lhs_navigation.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {PlaybookLhsDocument} from 'src/graphql/generated_types';
-import PlaybooksSidebar from '../sidebar/playbooks_sidebar';
+
+import PlaybooksSidebar from 'src/components/sidebar/playbooks_sidebar';
 
 const LHSContainer = styled.div`
     width: 240px;

--- a/webapp/src/components/backstage/playbook_editor/controls.tsx
+++ b/webapp/src/components/backstage/playbook_editor/controls.tsx
@@ -35,7 +35,8 @@ import {createGlobalState} from 'react-use';
 
 import {pluginUrl, navigateToPluginUrl} from 'src/browser_routing';
 import {PlaybookPermissionsMember, useAllowMakePlaybookPrivate, useHasPlaybookPermission, useHasTeamPermission} from 'src/hooks';
-import {useToaster} from '../toast_banner';
+
+import {useToaster} from 'src/components/backstage/toast_banner';
 
 import {
     duplicatePlaybook as clientDuplicatePlaybook,
@@ -50,19 +51,27 @@ import {
 } from 'src/client';
 import {OVERLAY_DELAY} from 'src/constants';
 import {ButtonIcon, PrimaryButton, SecondaryButton} from 'src/components/assets/buttons';
-import CheckboxInput from '../runs_list/checkbox_input';
+
+import CheckboxInput from 'src/components/backstage/runs_list/checkbox_input';
 
 import {displayEditPlaybookAccessModal, openPlaybookRunModal} from 'src/actions';
 import {PlaybookPermissionGeneral} from 'src/types/permissions';
 import DotMenu, {DropdownMenuItem as DropdownMenuItemBase, DropdownMenuItemStyled, iconSplitStyling} from 'src/components/dot_menu';
-import useConfirmPlaybookArchiveModal from '../archive_playbook_modal';
+
+import useConfirmPlaybookArchiveModal from 'src/components/backstage/archive_playbook_modal';
+
 import CopyLink from 'src/components/widgets/copy_link';
-import useConfirmPlaybookRestoreModal from '../restore_playbook_modal';
+
+import useConfirmPlaybookRestoreModal from 'src/components/backstage/restore_playbook_modal';
+
 import {usePlaybookMembership, useUpdatePlaybook} from 'src/graphql/hooks';
-import {StyledDropdownMenuItem} from '../shared';
+
+import {StyledDropdownMenuItem} from 'src/components/backstage/shared';
+
 import {copyToClipboard} from 'src/utils';
-import {useLHSRefresh} from '../lhs_navigation';
-import useConfirmPlaybookConvertPrivateModal from '../convert_private_playbook_modal';
+
+import {useLHSRefresh} from 'src/components/backstage/lhs_navigation';
+import useConfirmPlaybookConvertPrivateModal from 'src/components/backstage/convert_private_playbook_modal';
 
 type ControlProps = {
     playbook: {

--- a/webapp/src/components/backstage/playbook_editor/outline/inputs/update_timer_selector.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/inputs/update_timer_selector.tsx
@@ -11,7 +11,8 @@ import {
     Mode,
     Option,
 } from 'src/components/datetime_input';
-import {Placeholder} from '../section_status_updates';
+
+import {Placeholder} from 'src/components/backstage/playbook_editor/outline/section_status_updates';
 
 interface Props {
     seconds: number;

--- a/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
@@ -19,8 +19,10 @@ import {AutoAssignOwner} from 'src/components/backstage/playbook_edit/automation
 import {WebhookSetting} from 'src/components/backstage/playbook_edit/automation/webhook_setting';
 import {CreateAChannel} from 'src/components/backstage/playbook_edit/automation/channel_access';
 import {PROFILE_CHUNK_SIZE} from 'src/constants';
-import {Toggle} from '../../playbook_edit/automation/toggle';
-import {AutomationTitle} from '../../playbook_edit/automation/styles';
+
+import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
+import {AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
+
 import {useProxyState} from 'src/hooks';
 
 interface Props {

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -30,7 +30,7 @@ import PresetTemplates from 'src/components/templates/template_data';
 import {RegularHeading} from 'src/styles/headings';
 import {pluginUrl} from 'src/browser_routing';
 
-import Header from '../widgets/header';
+import Header from 'src/components/widgets/header';
 
 import CheckboxInput from './runs_list/checkbox_input';
 import useConfirmPlaybookArchiveModal from './archive_playbook_modal';

--- a/webapp/src/components/backstage/playbook_list_row.tsx
+++ b/webapp/src/components/backstage/playbook_list_row.tsx
@@ -15,7 +15,7 @@ import {GlobalState} from '@mattermost/types/store';
 import {useHasPlaybookPermission, useHasTeamPermission} from 'src/hooks';
 import {Playbook} from 'src/types/playbook';
 import TextWithTooltip from 'src/components/widgets/text_with_tooltip';
-import DotMenu, {DropdownMenuItem as DropdownMenuItemBase, DropdownMenuItemStyled, iconSplitStyling} from 'src/components/dot_menu';
+import DotMenu, {DropdownMenuItem as DropdownMenuItemBase, DropdownMenuItemStyled, iconSplitStyling, DotMenuButton} from 'src/components/dot_menu';
 import Tooltip from 'src/components/widgets/tooltip';
 import {createPlaybookRun, playbookExportProps, telemetryEventForPlaybook} from 'src/client';
 import {PlaybookPermissionGeneral} from 'src/types/permissions';
@@ -24,8 +24,6 @@ import {navigateToUrl} from 'src/browser_routing';
 import {usePlaybookMembership} from 'src/graphql/hooks';
 import {Timestamp} from 'src/webapp_globals';
 import {openPlaybookRunModal} from 'src/actions';
-
-import {DotMenuButton} from 'src/components/dot_menu';
 
 import {InfoLine} from './styles';
 import {playbookIsTutorialPlaybook} from './playbook_editor/controls';

--- a/webapp/src/components/backstage/playbook_list_row.tsx
+++ b/webapp/src/components/backstage/playbook_list_row.tsx
@@ -25,7 +25,7 @@ import {usePlaybookMembership} from 'src/graphql/hooks';
 import {Timestamp} from 'src/webapp_globals';
 import {openPlaybookRunModal} from 'src/actions';
 
-import {DotMenuButton} from '../dot_menu';
+import {DotMenuButton} from 'src/components/dot_menu';
 
 import {InfoLine} from './styles';
 import {playbookIsTutorialPlaybook} from './playbook_editor/controls';

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/add_participant_modal.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/add_participant_modal.tsx
@@ -15,10 +15,13 @@ import {General} from 'mattermost-webapp/packages/mattermost-redux/src/constants
 import GenericModal from 'src/components/widgets/generic_modal';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {useManageRunMembership} from 'src/graphql/hooks';
-import CheckboxInput from '../../runs_list/checkbox_input';
+
+import CheckboxInput from 'src/components/backstage/runs_list/checkbox_input';
+
 import {isCurrentUserChannelMember} from 'src/selectors';
 
-import ProfileAutocomplete from '../../profile_autocomplete';
+import ProfileAutocomplete from 'src/components/backstage/profile_autocomplete';
+
 import {useChannel} from 'src/hooks';
 import {telemetryEvent} from 'src/client';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/become_participant_modal.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/become_participant_modal.tsx
@@ -10,13 +10,17 @@ import {General} from 'mattermost-webapp/packages/mattermost-redux/src/constants
 import {getCurrentUserId} from 'mattermost-webapp/packages/mattermost-redux/src/selectors/entities/common';
 
 import GenericModal from 'src/components/widgets/generic_modal';
-import CheckboxInput from '../../runs_list/checkbox_input';
+
+import CheckboxInput from 'src/components/backstage/runs_list/checkbox_input';
+
 import {PlaybookRun} from 'src/types/playbook_run';
 import {useChannel} from 'src/hooks';
 import {isCurrentUserChannelMember} from 'src/selectors';
 import {useManageRunMembership} from 'src/graphql/hooks';
-import {useToaster} from '../../toast_banner';
-import {ToastStyle} from '../../toast';
+
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
+
 import {requestJoinChannel, telemetryEvent} from 'src/client';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/controls.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/controls.tsx
@@ -11,9 +11,10 @@ import {useAllowChannelExport, useExportLogAvailable} from 'src/hooks';
 import {ShowRunActionsModal} from 'src/types/actions';
 import {PlaybookRun, playbookRunIsActive} from 'src/types/playbook_run';
 import {copyToClipboard} from 'src/utils';
-import {StyledDropdownMenuItem, StyledDropdownMenuItemRed} from '../../shared';
-import {useToaster} from '../../toast_banner';
-import {Role, Separator} from '../shared';
+
+import {StyledDropdownMenuItem, StyledDropdownMenuItemRed} from 'src/components/backstage/shared';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {Role, Separator} from 'src/components/backstage/playbook_runs/shared';
 
 import {useToggleRunStatusUpdate} from './enable_disable_run_status_update';
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/finish_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/finish_run.tsx
@@ -13,7 +13,8 @@ import {finishRun} from 'src/client';
 import {modals} from 'src/webapp_globals';
 import {outstandingTasks} from 'src/components/modals/update_run_status_modal';
 import {makeUncontrolledConfirmModalDefinition} from 'src/components/widgets/confirmation_modal';
-import {useLHSRefresh} from '../../lhs_navigation';
+
+import {useLHSRefresh} from 'src/components/backstage/lhs_navigation';
 
 export const useOnFinishRun = (playbookRun: PlaybookRun) => {
     const dispatch = useDispatch();

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/metrics/metric_input.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/metrics/metric_input.tsx
@@ -7,7 +7,8 @@ import styled from 'styled-components';
 import {useIntl} from 'react-intl';
 
 import {useClickOutsideRef} from 'src/hooks';
-import {StyledInput, HelpText, ErrorText} from '../../shared';
+
+import {StyledInput, HelpText, ErrorText} from 'src/components/backstage/playbook_runs/shared';
 
 interface Props {
     id: string;
@@ -85,11 +86,11 @@ const InputContainer = styled.div`
 
 const Title = styled.div`
     font-weight: 600;
-    
+
     :after {
         content: attr(data-end);
         color: red;
-    }    
+    }
 `;
 
 const Error = ({text}: { text: string }) => (
@@ -114,9 +115,9 @@ const InputWithIcon = styled.span`
 const Header = styled.div`
     display: flex;
     flex: 1;
-    
+
     font-size: 14px;
-    line-height: 20px;    
+    line-height: 20px;
     margin: 0 0 8px 0;
 `;
 
@@ -127,7 +128,7 @@ const TargetTitle = styled.div`
     align-items: center;
     justify-content: flex-end;
 
-    color: rgba(var(--center-channel-color-rgb), 0.72);    
+    color: rgba(var(--center-channel-color-rgb), 0.72);
 `;
 
 const Target = ({title, text}: { title: string, text?: string }) => {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/restore_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/restore_run.tsx
@@ -8,7 +8,8 @@ import {PlaybookRun} from 'src/types/playbook_run';
 import {restoreRun} from 'src/client';
 import {modals} from 'src/webapp_globals';
 import {makeUncontrolledConfirmModalDefinition} from 'src/components/widgets/confirmation_modal';
-import {useLHSRefresh} from '../../lhs_navigation';
+
+import {useLHSRefresh} from 'src/components/backstage/lhs_navigation';
 
 export const useOnRestoreRun = (playbookRun: PlaybookRun) => {
     const dispatch = useDispatch();

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs.tsx
@@ -6,7 +6,8 @@ import React, {ReactNode} from 'react';
 import Scrollbars from 'react-custom-scrollbars';
 import styled from 'styled-components';
 
-import {renderThumbVertical, renderTrackHorizontal, renderView} from '../../../rhs/rhs_shared';
+import {renderThumbVertical, renderTrackHorizontal, renderView} from 'src/components/rhs/rhs_shared';
+
 import {ExpandRight} from 'src/components/backstage/playbook_runs/shared';
 
 export enum RHSContent {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_overview.tsx
@@ -35,7 +35,7 @@ import {PlaybookRun, Metadata} from 'src/types/playbook_run';
 import {PlaybookWithChecklist} from 'src/types/playbook';
 import {CompassIcon} from 'src/types/compass';
 
-import {useLHSRefresh} from '../../lhs_navigation';
+import {useLHSRefresh} from 'src/components/backstage/lhs_navigation';
 
 import {FollowState} from './rhs_info';
 

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
@@ -14,11 +14,15 @@ import {getCurrentUser} from 'mattermost-webapp/packages/mattermost-redux/src/se
 import Profile from 'src/components/profile/profile';
 import Tooltip from 'src/components/widgets/tooltip';
 import {formatProfileName} from 'src/components/profile/profile_selector';
-import SearchInput from '../../search_input';
+
+import SearchInput from 'src/components/backstage/search_input';
+
 import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 import DotMenu, {DropdownMenuItem} from 'src/components/dot_menu';
 import {useManageRunMembership} from 'src/graphql/hooks';
-import {Role} from '../shared';
+
+import {Role} from 'src/components/backstage/playbook_runs/shared';
+
 import {PlaybookRun} from 'src/types/playbook_run';
 
 import {telemetryEvent} from 'src/client';

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_timeline.tsx
@@ -11,7 +11,8 @@ import {DateTime} from 'luxon';
 import {useIntl} from 'react-intl';
 import Scrollbars from 'react-custom-scrollbars';
 
-import {renderThumbVertical, renderTrackHorizontal, renderView} from '../../../rhs/rhs_shared';
+import {renderThumbVertical, renderTrackHorizontal, renderView} from 'src/components/rhs/rhs_shared';
+
 import TimelineEventItem from 'src/components/backstage/playbook_runs/playbook_run/retrospective/timeline_event_item';
 import {PlaybookRun} from 'src/types/playbook_run';
 import {clientRemoveTimelineEvent} from 'src/client';

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -26,9 +26,9 @@ import {HamburgerButton} from 'src/components/assets/icons/three_dots_icon';
 import Tooltip from 'src/components/widgets/tooltip';
 import {PlaybookRunEventTarget} from 'src/types/telemetry';
 
-import {useToaster} from '../../toast_banner';
+import {useToaster} from 'src/components/backstage/toast_banner';
 
-import {ToastStyle} from '../../toast';
+import {ToastStyle} from 'src/components/backstage/toast';
 
 import StatusUpdateCard from './update_card';
 import {RHSContent} from './rhs';

--- a/webapp/src/components/backstage/restore_playbook_modal.tsx
+++ b/webapp/src/components/backstage/restore_playbook_modal.tsx
@@ -2,7 +2,9 @@ import React, {useRef, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {Banner} from 'src/components/backstage/styles';
-import ConfirmModal from '../widgets/confirmation_modal';
+
+import ConfirmModal from 'src/components/widgets/confirmation_modal';
+
 import {Playbook} from 'src/types/playbook';
 
 import {useLHSRefresh} from './lhs_navigation';

--- a/webapp/src/components/backstage/runs_list/playbook_selector.tsx
+++ b/webapp/src/components/backstage/runs_list/playbook_selector.tsx
@@ -5,8 +5,9 @@ import React, {useEffect, useState} from 'react';
 import ReactSelect, {ActionTypes, ControlProps, StylesConfig} from 'react-select';
 import styled from 'styled-components';
 
-import {FilterButton} from '../../backstage/styles';
-import {Playbook} from '../../../types/playbook';
+import {FilterButton} from 'src/components/backstage/styles';
+import {Playbook} from 'src/types/playbook';
+
 import {SelectedButton} from 'src/components/team/team_selector';
 import Dropdown from 'src/components/dropdown';
 

--- a/webapp/src/components/backstage/runs_list/row.tsx
+++ b/webapp/src/components/backstage/runs_list/row.tsx
@@ -26,9 +26,10 @@ import {
     unfollowPlaybookRun,
     followPlaybookRun,
 } from 'src/client';
-import {InfoLine} from '../styles';
-import {useToaster} from '../toast_banner';
-import {ToastStyle} from '../toast';
+
+import {InfoLine} from 'src/components/backstage/styles';
+import {useToaster} from 'src/components/backstage/toast_banner';
+import {ToastStyle} from 'src/components/backstage/toast';
 
 const SmallText = styled.div`
     font-weight: 400;

--- a/webapp/src/components/backstage/runs_page.tsx
+++ b/webapp/src/components/backstage/runs_page.tsx
@@ -21,7 +21,7 @@ import {useRunsList} from 'src/hooks';
 
 import {pluginUrl} from 'src/browser_routing';
 
-import Header from '../widgets/header';
+import Header from 'src/components/widgets/header';
 
 import RunList from './runs_list/runs_list';
 import NoContentPage from './runs_page_no_content';

--- a/webapp/src/components/backstage/select_users_below.tsx
+++ b/webapp/src/components/backstage/select_users_below.tsx
@@ -13,11 +13,11 @@ import {getTeammateNameDisplaySetting} from 'mattermost-webapp/packages/mattermo
 
 import {displayUsername} from 'mattermost-webapp/packages/mattermost-redux/src/utils/user_utils';
 
-import Profile from '../profile/profile';
+import Profile from 'src/components/profile/profile';
 
 import {Playbook, PlaybookMember} from 'src/types/playbook';
 
-import DotMenu, {DropdownMenuItem} from '../dot_menu';
+import DotMenu, {DropdownMenuItem} from 'src/components/dot_menu';
 
 import {useHasPlaybookPermission, useHasSystemPermission} from 'src/hooks';
 

--- a/webapp/src/components/backstage/shared.tsx
+++ b/webapp/src/components/backstage/shared.tsx
@@ -3,7 +3,7 @@
 
 import styled from 'styled-components';
 
-import {DotMenuButton, DropdownMenuItem} from '../dot_menu';
+import {DotMenuButton, DropdownMenuItem} from 'src/components/dot_menu';
 
 export const DotMenuButtonStyled = styled(DotMenuButton)`
     flex-shrink: 0;
@@ -35,7 +35,7 @@ export const StyledDropdownMenuItemRed = styled(StyledDropdownMenuItem)`
 
             svg {
                 fill: var(--button-color);
-            }            
+            }
         }
     }
 `;

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -21,7 +21,8 @@ import {
 import {ChecklistItem as ChecklistItemType, ChecklistItemState} from 'src/types/playbook';
 
 import {DateTimeOption} from 'src/components/datetime_selector';
-import {Mode} from '../datetime_input';
+
+import {Mode} from 'src/components/datetime_input';
 
 import ChecklistItemHoverMenu, {HoverMenu} from './hover_menu';
 import ChecklistItemDescription from './description';

--- a/webapp/src/components/checklist_item/description.tsx
+++ b/webapp/src/components/checklist_item/description.tsx
@@ -5,10 +5,11 @@ import React from 'react';
 import styled, {css} from 'styled-components';
 import {useIntl} from 'react-intl';
 
-import MarkdownTextbox from '../markdown_textbox';
+import MarkdownTextbox from 'src/components/markdown_textbox';
 
 import {useUniqueId} from 'src/utils';
-import FormattedMarkdown from '../formatted_markdown';
+
+import FormattedMarkdown from 'src/components/formatted_markdown';
 
 import {CollapsibleChecklistItemDescription} from './inputs';
 

--- a/webapp/src/components/checklist_item/duedate.tsx
+++ b/webapp/src/components/checklist_item/duedate.tsx
@@ -11,9 +11,10 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {Placement} from '@floating-ui/react-dom-interactions';
 
-import DateTimeSelector, {DateTimeOption, optionFromMillis} from '../datetime_selector';
-import {labelFrom, Mode, ms, Option, useMakeOption} from '../datetime_input';
-import {ChecklistHoverMenuButton} from '../rhs/rhs_shared';
+import DateTimeSelector, {DateTimeOption, optionFromMillis} from 'src/components/datetime_selector';
+import {labelFrom, Mode, ms, Option, useMakeOption} from 'src/components/datetime_input';
+import {ChecklistHoverMenuButton} from 'src/components/rhs/rhs_shared';
+
 import {Timestamp} from 'src/webapp_globals';
 import {useAllowSetTaskDueDate} from 'src/hooks';
 import UpgradeModal from 'src/components/backstage/upgrade_modal';

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -20,11 +20,14 @@ import {BaseInput} from 'src/components/assets/inputs';
 import GenericModal, {InlineLabel} from 'src/components/widgets/generic_modal';
 import {createPlaybookRun} from 'src/client';
 import {navigateToPluginUrl} from 'src/browser_routing';
-import {AutomationTitle} from '../backstage/playbook_edit/automation/styles';
-import {ButtonLabel, StyledChannelSelector, VerticalSplit} from '../backstage/playbook_edit/automation/channel_access';
+
+import {AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
+import {ButtonLabel, StyledChannelSelector, VerticalSplit} from 'src/components/backstage/playbook_edit/automation/channel_access';
+
 import ClearIndicator from 'src/components/backstage/playbook_edit/automation/clear_indicator';
-import MenuList from '../backstage/playbook_edit/automation/menu_list';
-import {HorizontalSpacer, RadioInput} from '../backstage/styles';
+
+import MenuList from 'src/components/backstage/playbook_edit/automation/menu_list';
+import {HorizontalSpacer, RadioInput} from 'src/components/backstage/styles';
 
 const ID = 'playbooks_run_playbook_dialog';
 

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -24,13 +24,17 @@ import {
 } from 'src/components/datetime_input';
 
 import {usePost, useRun, useFormattedUsernames} from 'src/hooks';
-import MarkdownTextbox from '../markdown_textbox';
+
+import MarkdownTextbox from 'src/components/markdown_textbox';
+
 import {pluginUrl} from 'src/browser_routing';
 import {fetchPlaybookRunMetadata, postStatusUpdate} from 'src/client';
 import {Metadata, PlaybookRun} from 'src/types/playbook_run';
 import {nearest} from 'src/utils';
 import Tooltip from 'src/components/widgets/tooltip';
-import WarningIcon from '../assets/icons/warning_icon';
+
+import WarningIcon from 'src/components/assets/icons/warning_icon';
+
 import CheckboxInput from 'src/components/backstage/runs_list/checkbox_input';
 import {makeUncontrolledConfirmModalDefinition} from 'src/components/widgets/confirmation_modal';
 import {modals, browserHistory} from 'src/webapp_globals';

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -18,7 +18,9 @@ import styled from 'styled-components';
 
 import Profile from 'src/components/profile/profile';
 import ProfileButton from 'src/components/profile/profile_button';
-import {FilterButton} from '../backstage/styles';
+
+import {FilterButton} from 'src/components/backstage/styles';
+
 import Dropdown from 'src/components/dropdown';
 
 export interface Option {

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -40,7 +40,9 @@ import MultiCheckbox, {CheckboxOption} from 'src/components/multi_checkbox';
 import {DotMenuButton} from 'src/components/dot_menu';
 import {SemiBoldHeading} from 'src/styles/headings';
 import ChecklistList from 'src/components/checklist/checklist_list';
-import {AnchorLinkTitle} from '../backstage/playbook_runs/shared';
+
+import {AnchorLinkTitle} from 'src/components/backstage/playbook_runs/shared';
+
 import {ButtonsFormat as ItemButtonsFormat} from 'src/components/checklist_item/checklist_item';
 import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 import TutorialTourTip, {useMeasurePunchouts, useShowTutorialStep} from 'src/components/tutorial/tutorial_tour_tip';

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -12,11 +12,11 @@ import styled from 'styled-components';
 import {setRHSOpen} from 'src/actions';
 import RHSRunDetails from 'src/components/rhs/rhs_run_details';
 
-import {ToastProvider} from '../backstage/toast_banner';
+import {ToastProvider} from 'src/components/backstage/toast_banner';
 
 import {useRhsActiveRunsQuery, useRhsFinishedRunsQuery} from 'src/graphql/generated_types';
 
-import LoadingSpinner from '../assets/loading_spinner';
+import LoadingSpinner from 'src/components/assets/loading_spinner';
 
 import RHSRunList, {FilterType, RunListOptions} from './rhs_run_list';
 import RHSHome from './rhs_home';

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -24,7 +24,9 @@ import {PlaybookRunStatus} from 'src/types/playbook_run';
 import TutorialTourTip, {useMeasurePunchouts, useShowTutorialStep} from 'src/components/tutorial/tutorial_tour_tip';
 import {FINISHED, RunDetailsTutorialSteps, SKIPPED, TutorialTourCategories} from 'src/components/tutorial/tours';
 import {displayRhsRunDetailsTourDialog} from 'src/actions';
-import {useTutorialStepper} from '../tutorial/tutorial_tour_tip/manager';
+
+import {useTutorialStepper} from 'src/components/tutorial/tutorial_tour_tip/manager';
+
 import {browserHistory} from 'src/webapp_globals';
 import {usePlaybookRunViewTelemetry} from 'src/hooks/telemetry';
 import {PlaybookRunViewTarget} from 'src/types/telemetry';

--- a/webapp/src/components/rhs/rhs_run_participants.tsx
+++ b/webapp/src/components/rhs/rhs_run_participants.tsx
@@ -10,8 +10,10 @@ import {
     RHSContainer,
     RHSContent,
 } from 'src/components/rhs/rhs_shared';
-import {Participants} from '../backstage/playbook_runs/playbook_run/rhs_participants';
-import {Role} from '../backstage/playbook_runs/shared';
+
+import {Participants} from 'src/components/backstage/playbook_runs/playbook_run/rhs_participants';
+import {Role} from 'src/components/backstage/playbook_runs/shared';
+
 import {PlaybookRun} from 'src/types/playbook_run';
 
 interface Props {

--- a/webapp/src/components/rhs/rhs_timeline_placeholder.tsx
+++ b/webapp/src/components/rhs/rhs_timeline_placeholder.tsx
@@ -9,7 +9,8 @@ import {useIntl} from 'react-intl';
 
 import UpgradeBanner from 'src/components/upgrade_banner';
 import {AdminNotificationType} from 'src/constants';
-import UpgradeTimelineBackgroundSvg from '../assets/upgrade_timeline_background_svg';
+
+import UpgradeTimelineBackgroundSvg from 'src/components/assets/upgrade_timeline_background_svg';
 
 const Container = styled.div`
     margin: 18px 15px;

--- a/webapp/src/components/sidebar/create_playbook_dropdown.tsx
+++ b/webapp/src/components/sidebar/create_playbook_dropdown.tsx
@@ -10,10 +10,10 @@ import {displayPlaybookCreateModal} from 'src/actions';
 import {useImportPlaybook} from 'src/components/backstage/import_playbook';
 import {navigateToPluginUrl} from 'src/browser_routing';
 
-import Menu from '../widgets/menu/menu';
-import MenuItem from '../widgets/menu/menu_item';
-import MenuGroup from '../widgets/menu/menu_group';
-import MenuWrapper from '../widgets/menu/menu_wrapper';
+import Menu from 'src/components/widgets/menu/menu';
+import MenuItem from 'src/components/widgets/menu/menu_item';
+import MenuGroup from 'src/components/widgets/menu/menu_group';
+import MenuWrapper from 'src/components/widgets/menu/menu_wrapper';
 
 import {OVERLAY_DELAY} from 'src/constants';
 import {useCanCreatePlaybooksOnAnyTeam} from 'src/hooks';

--- a/webapp/src/components/sidebar/item.tsx
+++ b/webapp/src/components/sidebar/item.tsx
@@ -5,7 +5,8 @@ import classNames from 'classnames';
 import styled, {css} from 'styled-components';
 
 import Tooltip from 'src/components/widgets/tooltip';
-import {DotMenuButton} from '../dot_menu';
+
+import {DotMenuButton} from 'src/components/dot_menu';
 
 interface ItemProps {
     icon: string;
@@ -128,7 +129,7 @@ export const StyledNavLink = styled(NavLink)`
             ${DotMenuButton} {
                 opacity: 1;
             }
-        }        
+        }
     }
 `;
 

--- a/webapp/src/components/sidebar/playbooks_sidebar.tsx
+++ b/webapp/src/components/sidebar/playbooks_sidebar.tsx
@@ -9,8 +9,9 @@ import {ReservedCategory, useReservedCategoryTitleMapper} from 'src/hooks';
 import {usePlaybookLhsQuery} from 'src/graphql/generated_types';
 
 import {pluginUrl} from 'src/browser_routing';
-import {LHSPlaybookDotMenu} from '../backstage/lhs_playbook_dot_menu';
-import {LHSRunDotMenu} from '../backstage/lhs_run_dot_menu';
+
+import {LHSPlaybookDotMenu} from 'src/components/backstage/lhs_playbook_dot_menu';
+import {LHSRunDotMenu} from 'src/components/backstage/lhs_run_dot_menu';
 
 import Sidebar, {SidebarGroup} from './sidebar';
 import CreatePlaybookDropdown from './create_playbook_dropdown';

--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -9,7 +9,7 @@ import Scrollbars from 'react-custom-scrollbars';
 
 import {OVERLAY_DELAY} from 'src/constants';
 
-import {renderThumbVertical, renderTrackHorizontal, renderView} from '../rhs/rhs_shared';
+import {renderThumbVertical, renderTrackHorizontal, renderView} from 'src/components/rhs/rhs_shared';
 
 import Group from './group';
 

--- a/webapp/src/components/templates/template_item.tsx
+++ b/webapp/src/components/templates/template_item.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 import {isKeyPressed, KeyCodes} from 'src/utils';
 
-import Tooltip from '../widgets/tooltip';
+import Tooltip from 'src/components/widgets/tooltip';
 
 interface Props {
     label?: string;

--- a/webapp/src/components/templates/template_selector.tsx
+++ b/webapp/src/components/templates/template_selector.tsx
@@ -12,7 +12,8 @@ import {telemetryEventForTemplate, savePlaybook} from 'src/client';
 import {StyledSelect} from 'src/components/backstage/styles';
 import {setPlaybookDefaults} from 'src/types/playbook';
 import {usePlaybooksRouting} from 'src/hooks';
-import {useLHSRefresh} from '../backstage/lhs_navigation';
+
+import {useLHSRefresh} from 'src/components/backstage/lhs_navigation';
 
 import TemplateItem from './template_item';
 import PresetTemplates, {PresetTemplate} from './template_data';

--- a/webapp/src/components/tutorial/tutorial_tour_tip/manager.ts
+++ b/webapp/src/components/tutorial/tutorial_tour_tip/manager.ts
@@ -12,7 +12,7 @@ import {savePreferences as storeSavePreferences} from 'mattermost-redux/actions/
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {Client4} from 'mattermost-redux/client';
 
-import {FINISHED, SKIPPED, TTCategoriesMapToSteps} from '../tours';
+import {FINISHED, SKIPPED, TTCategoriesMapToSteps} from 'src/components/tutorial/tours';
 
 import {isKeyPressed, KeyCodes} from 'src/utils';
 

--- a/webapp/src/components/widgets/confirmation_modal.tsx
+++ b/webapp/src/components/widgets/confirmation_modal.tsx
@@ -5,7 +5,7 @@ import React, {useState} from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-import {PrimaryButton, TertiaryButton} from '../assets/buttons';
+import {PrimaryButton, TertiaryButton} from 'src/components/assets/buttons';
 
 import {DefaultFooterContainer, StyledModal, Buttons, ModalHeading} from './generic_modal';
 

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -32,19 +32,23 @@ import {UserProfile} from '@mattermost/types/users';
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 import {ClientError} from '@mattermost/client';
-
 import {useHistory, useLocation} from 'react-router-dom';
 import qs from 'qs';
 import {haveITeamPermission} from 'mattermost-webapp/packages/mattermost-redux/src/selectors/entities/roles';
-
 import {useUpdateEffect} from 'react-use';
-
 import {debounce, isEqual} from 'lodash';
 
 import {FetchPlaybookRunsParams, PlaybookRun} from 'src/types/playbook_run';
 import {EmptyPlaybookStats} from 'src/types/stats';
 import {PROFILE_CHUNK_SIZE} from 'src/constants';
-import {getProfileSetForChannel, selectExperimentalFeatures, getRun, selectLinkRunToExistingChannelEnabled} from 'src/selectors';
+import {getProfileSetForChannel,
+    selectExperimentalFeatures,
+    getRun,
+    selectLinkRunToExistingChannelEnabled,
+    globalSettings,
+    isCurrentUserAdmin,
+    noopSelector,
+} from 'src/selectors';
 import {
     fetchPlaybookRuns,
     clientFetchPlaybook,
@@ -53,14 +57,7 @@ import {
     fetchPlaybookStats,
     fetchPlaybookRunMetadata,
 } from 'src/client';
-
 import {isCloud} from 'src/license';
-import {
-    globalSettings,
-    isCurrentUserAdmin,
-    noopSelector,
-} from 'src/selectors';
-
 import {resolve} from 'src/utils';
 
 export type FetchMetadata = {

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -54,12 +54,13 @@ import {
     fetchPlaybookRunMetadata,
 } from 'src/client';
 
-import {isCloud} from '../license';
+import {isCloud} from 'src/license';
 import {
     globalSettings,
     isCurrentUserAdmin,
     noopSelector,
-} from '../selectors';
+} from 'src/selectors';
+
 import {resolve} from 'src/utils';
 
 export type FetchMetadata = {

--- a/webapp/src/hooks/license.ts
+++ b/webapp/src/hooks/license.ts
@@ -1,6 +1,6 @@
 import {useSelector} from 'react-redux';
 
-import {isE10LicensedOrDevelopment, isE20LicensedOrDevelopment} from '../license';
+import {isE10LicensedOrDevelopment, isE20LicensedOrDevelopment} from 'src/license';
 
 // useAllowAddMessageToTimelineInCurrentTeam returns whether a user can add a
 // post to the timeline in the current team


### PR DESCRIPTION
## Summary
Follow https://github.com/mattermost/mattermost-plugin-playbooks/pull/1624
eslint rule set to error, isntead of warning
fixed all imports to have non-relative path

I had to run  `npm run fix` and then, replace the import paths removing the initial slash. 

## Ticket Link
No

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
