### PR TITLE
Make playbook retrieval optional for case where user has no permissions.

### DIFF
--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -19,6 +19,11 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 	if err != nil {
 		return nil, err
 	}
+	userID := c.r.Header.Get("Mattermost-User-ID")
+
+	if err := c.permissions.PlaybookView(userID, playbookID); err != nil {
+		return nil, err
+	}
 
 	playbook, err := c.playbookService.Get(playbookID)
 	if err != nil {
@@ -31,17 +36,7 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 func (r *PlaybookRootResolver) Playbook(ctx context.Context, args struct {
 	ID string
 }) (*PlaybookResolver, error) {
-	c, err := getContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 	playbookID := args.ID
-	userID := c.r.Header.Get("Mattermost-User-ID")
-
-	if err := c.permissions.PlaybookView(userID, playbookID); err != nil {
-		return nil, err
-	}
-
 	return getGraphqlPlaybook(ctx, playbookID)
 }
 

--- a/server/api/graphql_run.go
+++ b/server/api/graphql_run.go
@@ -135,11 +135,12 @@ func (r *RunResolver) Metadata(ctx context.Context) (*MetadataResolver, error) {
 }
 
 func (r *RunResolver) Playbook(ctx context.Context) (*PlaybookResolver, error) {
-	if val, err := getGraphqlPlaybook(ctx, r.PlaybookID); err != nil {
+	val, err := getGraphqlPlaybook(ctx, r.PlaybookID)
+	if err != nil {
 		return nil, nil
-	} else {
-		return val, nil
 	}
+
+	return val, nil
 }
 
 func (r *RunResolver) LastUpdatedAt(ctx context.Context) float64 {

--- a/server/api/graphql_run.go
+++ b/server/api/graphql_run.go
@@ -135,7 +135,11 @@ func (r *RunResolver) Metadata(ctx context.Context) (*MetadataResolver, error) {
 }
 
 func (r *RunResolver) Playbook(ctx context.Context) (*PlaybookResolver, error) {
-	return getGraphqlPlaybook(ctx, r.PlaybookID)
+	if val, err := getGraphqlPlaybook(ctx, r.PlaybookID); err != nil {
+		return nil, nil
+	} else {
+		return val, nil
+	}
 }
 
 func (r *RunResolver) LastUpdatedAt(ctx context.Context) float64 {

--- a/server/api/graphql_run.go
+++ b/server/api/graphql_run.go
@@ -135,8 +135,16 @@ func (r *RunResolver) Metadata(ctx context.Context) (*MetadataResolver, error) {
 }
 
 func (r *RunResolver) Playbook(ctx context.Context) (*PlaybookResolver, error) {
+	c, err := getContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	val, err := getGraphqlPlaybook(ctx, r.PlaybookID)
 	if err != nil {
+		if !errors.Is(err, app.ErrNoPermissions) {
+			c.logger.WithError(err).Error("error retrieving playbook of run")
+		}
 		return nil, nil
 	}
 

--- a/server/api/schema.graphqls
+++ b/server/api/schema.graphqls
@@ -191,7 +191,7 @@ type PlaybookMetricConfig {
 type Run {
 	id: String!
 	playbookID: String!
-	playbook: Playbook!
+	playbook: Playbook
 	name: String!
 	ownerUserID: String!
 	channelID: String!

--- a/webapp/src/components/rhs/rhs_run_list.tsx
+++ b/webapp/src/components/rhs/rhs_run_list.tsx
@@ -36,7 +36,7 @@ interface RunToDisplay {
     name: string
     participantIDs: string[]
     ownerUserID: string
-    playbook: PlaybookToDisplay
+    playbook?: Maybe<PlaybookToDisplay>
     lastUpdatedAt: number
 }
 
@@ -330,12 +330,14 @@ const RHSRunListCard = (props: RHSRunListCardProps) => {
                         {time: DateTime.fromMillis(props.lastUpdatedAt).toRelative()}
                     )}
                 </LastUpdatedText>
-                <PlaybookChip>
-                    <StyledBookOutlineIcon
-                        size={11}
-                    />
-                    {props.playbook.title}
-                </PlaybookChip>
+                {props.playbook &&
+                    <PlaybookChip>
+                        <StyledBookOutlineIcon
+                            size={11}
+                        />
+                        {props.playbook.title}
+                    </PlaybookChip>
+                }
             </InfoRow>
         </CardContainer>
     );

--- a/webapp/src/graphql/generated_types.ts
+++ b/webapp/src/graphql/generated_types.ts
@@ -300,7 +300,7 @@ export type Run = {
     name: Scalars['String'];
     ownerUserID: Scalars['String'];
     participantIDs: Array<Scalars['String']>;
-    playbook: Playbook;
+    playbook?: Maybe<Playbook>;
     playbookID: Scalars['String'];
     postID: Scalars['String'];
     previousReminder: Scalars['Float'];
@@ -408,7 +408,7 @@ export type RunQueryVariables = Exact<{
 
 export type RunQuery = { __typename?: 'Query', run?: { __typename?: 'Run', id: string, name: string, ownerUserID: string, participantIDs: Array<string>, metadata: { __typename?: 'Metadata', followers: Array<string> } } | null };
 
-export type RhsRunFieldsFragment = { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook: { __typename?: 'Playbook', title: string } };
+export type RhsRunFieldsFragment = { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook?: { __typename?: 'Playbook', title: string } | null };
 
 export type RhsActiveRunsQueryVariables = Exact<{
     channelID: Scalars['String'];
@@ -418,7 +418,7 @@ export type RhsActiveRunsQueryVariables = Exact<{
     after?: InputMaybe<Scalars['String']>;
 }>;
 
-export type RhsActiveRunsQuery = { __typename?: 'Query', runs: { __typename?: 'RunConnection', totalCount: number, edges: Array<{ __typename?: 'RunEdge', node: { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook: { __typename?: 'Playbook', title: string } } }>, pageInfo: { __typename?: 'PageInfo', endCursor: string, hasNextPage: boolean } } };
+export type RhsActiveRunsQuery = { __typename?: 'Query', runs: { __typename?: 'RunConnection', totalCount: number, edges: Array<{ __typename?: 'RunEdge', node: { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook?: { __typename?: 'Playbook', title: string } | null } }>, pageInfo: { __typename?: 'PageInfo', endCursor: string, hasNextPage: boolean } } };
 
 export type RhsFinishedRunsQueryVariables = Exact<{
     channelID: Scalars['String'];
@@ -428,7 +428,7 @@ export type RhsFinishedRunsQueryVariables = Exact<{
     after?: InputMaybe<Scalars['String']>;
 }>;
 
-export type RhsFinishedRunsQuery = { __typename?: 'Query', runs: { __typename?: 'RunConnection', totalCount: number, edges: Array<{ __typename?: 'RunEdge', node: { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook: { __typename?: 'Playbook', title: string } } }>, pageInfo: { __typename?: 'PageInfo', endCursor: string, hasNextPage: boolean } } };
+export type RhsFinishedRunsQuery = { __typename?: 'Query', runs: { __typename?: 'RunConnection', totalCount: number, edges: Array<{ __typename?: 'RunEdge', node: { __typename?: 'Run', id: string, name: string, participantIDs: Array<string>, ownerUserID: string, lastUpdatedAt: number, playbook?: { __typename?: 'Playbook', title: string } | null } }>, pageInfo: { __typename?: 'PageInfo', endCursor: string, hasNextPage: boolean } } };
 
 export type SetRunFavoriteMutationVariables = Exact<{
     id: Scalars['String'];


### PR DESCRIPTION
## Summary

Make playbook retrieval optional for runs in GraphQL for the case where the user has permissions to the run but not the playbook that created it. 

Shows as blank in the RHS:
![image](https://user-images.githubusercontent.com/3191642/205134506-41488e68-bf6b-45a7-8fe2-46212c871e9d.png)


