### PR TITLE
MM-48783: Ensure run summary updates in RHS.

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -110,7 +110,14 @@ describe('channels > rhs > header', () => {
 
             // * make sure the updated summary is here
             cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').contains('new summary');
+
+            // * reload the page
+            cy.reload();
+
+            // * make sure the updated summary is still there
+            cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').contains('new summary');
         });
+
         it('by clicking on dot menu item', () => {
             // # Run the playbook
             const now = Date.now();

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -645,13 +645,6 @@ export const changeChannelName = async (channelId: string, newName: string) => {
     });
 };
 
-export const updatePlaybookRunDescription = async (playbookRunId: string, newDescription: string) => {
-    await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunId}/update-description`, {
-        method: 'PUT',
-        body: JSON.stringify({description: newDescription}),
-    });
-};
-
 export const notifyConnect = async () => {
     await doFetchWithoutResponse(`${apiUrl}/bot/connect`, {
         method: 'GET',

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -11,7 +11,7 @@ import {UserProfile} from '@mattermost/types/users';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
-import {setOwner, changeChannelName, updatePlaybookRunDescription} from 'src/client';
+import {setOwner, changeChannelName} from 'src/client';
 import ProfileSelector from 'src/components/profile/profile_selector';
 import RHSPostUpdate from 'src/components/rhs/rhs_post_update';
 import {useProfilesInTeam, useParticipateInRun, useEnsureProfiles} from 'src/hooks';
@@ -22,6 +22,7 @@ import RHSAboutTitle, {DefaultRenderedTitle} from 'src/components/rhs/rhs_about_
 import RHSAboutDescription from 'src/components/rhs/rhs_about_description';
 import {currentRHSAboutCollapsedState} from 'src/selectors';
 import {setRHSAboutCollapsedState} from 'src/actions';
+import {useUpdateRun} from 'src/graphql/hooks';
 
 interface Props {
     playbookRun: PlaybookRun;
@@ -36,6 +37,7 @@ const RHSAbout = (props: Props) => {
     const collapsed = useSelector(currentRHSAboutCollapsedState);
     const channel = useSelector(getCurrentChannel);
     const profilesInTeam = useProfilesInTeam();
+    const updateRun = useUpdateRun(props.playbookRun.id);
 
     const myUserId = useSelector(getCurrentUserId);
     const shouldShowParticipate = myUserId !== props.playbookRun.owner_user_id && props.playbookRun.participant_ids.find((id: string) => id === myUserId) === undefined;
@@ -68,7 +70,7 @@ const RHSAbout = (props: Props) => {
     };
 
     const onDescriptionEdit = (value: string) => {
-        updatePlaybookRunDescription(props.playbookRun.id, value);
+        updateRun({summary: value});
     };
 
     const [editingSummary, setEditingSummary] = useState(false);


### PR DESCRIPTION
## Summary
The `update-description` endpoint no longer exists, and the e2e tests verifying the RHS run summary updates didn't reload the page to ensure the updates were persisted.

Fix the test and use the new GraphQL endpoint instead.

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-48783