### PR TITLE
ensure settings are fetched after login

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -5,12 +5,11 @@ import React, {useEffect} from 'react';
 import {useLocation, useRouteMatch, matchPath} from 'react-router-dom';
 import {useSelector} from 'react-redux';
 import styled, {css} from 'styled-components';
-
 import {GlobalState} from '@mattermost/types/store';
 import {Theme} from 'mattermost-redux/types/themes';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {useForceDocumentTitle} from 'src/hooks';
+import {useForceDocumentTitle, useEnsureSettings} from 'src/hooks';
 import CloudModal from 'src/components/cloud_modal';
 import {applyTheme} from 'src/components/backstage/css_utils';
 
@@ -28,6 +27,9 @@ const BackstageContainer = styled.div`
 
 const Backstage = () => {
     const {pathname} = useLocation();
+
+    // ensure settings are loaded if user just logged in
+    useEnsureSettings();
     const {url} = useRouteMatch();
     const noContainerScroll = matchPath<{playbookRunId?: string; playbookId?: string;}>(pathname, {
         path: [`${url}/runs/:playbookRunId`],

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -9,7 +9,7 @@ import {GlobalState} from '@mattermost/types/store';
 import {Theme} from 'mattermost-redux/types/themes';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {useForceDocumentTitle, useEnsureSettings} from 'src/hooks';
+import {useForceDocumentTitle} from 'src/hooks';
 import CloudModal from 'src/components/cloud_modal';
 import {applyTheme} from 'src/components/backstage/css_utils';
 
@@ -28,8 +28,6 @@ const BackstageContainer = styled.div`
 const Backstage = () => {
     const {pathname} = useLocation();
 
-    // ensure settings are loaded if user just logged in
-    useEnsureSettings();
     const {url} = useRouteMatch();
     const noContainerScroll = matchPath<{playbookRunId?: string; playbookId?: string;}>(pathname, {
         path: [`${url}/runs/:playbookRunId`],

--- a/webapp/src/components/login_hook.tsx
+++ b/webapp/src/components/login_hook.tsx
@@ -1,0 +1,29 @@
+import {useEffect} from 'react';
+import {useSelector, useDispatch} from 'react-redux';
+import {GlobalState} from '@mattermost/types/store';
+
+import {globalSettings} from 'src/selectors';
+import {actionSetGlobalSettings} from 'src/actions';
+import {notifyConnect, fetchGlobalSettings} from 'src/client';
+
+// This component is meant to be registered as RootComponent.
+// It will be registered at initialize and "rendered" at login.
+const LoginHook = () => {
+    const dispatch = useDispatch();
+    const hasGlobalSettings = useSelector((state: GlobalState) => Boolean(globalSettings(state)));
+    const fetchAndStoreSettings = async () => dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
+
+    useEffect(() => {
+        // Ensure settings fetch
+        if (!hasGlobalSettings) {
+            fetchAndStoreSettings();
+        }
+
+        // Fire the first connect bot event.
+        notifyConnect();
+    }, []);
+
+    return null;
+};
+
+export default LoginHook;

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -3,19 +3,15 @@
 
 import React, {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-
 import {GlobalState} from '@mattermost/types/store';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-
 import styled from 'styled-components';
 
 import {setRHSOpen} from 'src/actions';
+import {useEnsureSettings} from 'src/hooks/general';
 import RHSRunDetails from 'src/components/rhs/rhs_run_details';
-
 import {ToastProvider} from 'src/components/backstage/toast_banner';
-
 import {useRhsActiveRunsQuery, useRhsFinishedRunsQuery} from 'src/graphql/generated_types';
-
 import LoadingSpinner from 'src/components/assets/loading_spinner';
 
 import RHSRunList, {FilterType, RunListOptions} from './rhs_run_list';
@@ -106,12 +102,15 @@ const defaultListOptions : RunListOptions = {
 // RightHandSidebar the sidebar for integration of playbooks into channels
 //
 // Rules for automatic display:
-// No Runs Ever -> RHS Home
-// Only Finished Runs -> Runs list blank state
-// Single active run (ignoring finished) -> Details page for that run (back button goes to runs list)
-// Multiple active runs -> Runs list
+// * No Runs Ever -> RHS Home
+// * Only Finished Runs -> Runs list blank state
+// * Single active run (ignoring finished) -> Details page for that run (back button goes to runs list)
+// * Multiple active runs -> Runs list
 const RightHandSidebar = () => {
     useSetRHSState();
+
+    // ensure settings are loaded if user just logged in
+    useEnsureSettings();
     const currentChannelId = useSelector<GlobalState, string>(getCurrentChannelId);
     const [currentRunId, setCurrentRunId] = useState<string|undefined>();
     const [listOptions, setListOptions] = useState<RunListOptions>(defaultListOptions);

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -8,7 +8,6 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import styled from 'styled-components';
 
 import {setRHSOpen} from 'src/actions';
-import {useEnsureSettings} from 'src/hooks/general';
 import RHSRunDetails from 'src/components/rhs/rhs_run_details';
 import {ToastProvider} from 'src/components/backstage/toast_banner';
 import {useRhsActiveRunsQuery, useRhsFinishedRunsQuery} from 'src/graphql/generated_types';
@@ -109,8 +108,6 @@ const defaultListOptions : RunListOptions = {
 const RightHandSidebar = () => {
     useSetRHSState();
 
-    // ensure settings are loaded if user just logged in
-    useEnsureSettings();
     const currentChannelId = useSelector<GlobalState, string>(getCurrentChannelId);
     const [currentRunId, setCurrentRunId] = useState<string|undefined>();
     const [listOptions, setListOptions] = useState<RunListOptions>(defaultListOptions);

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -51,7 +51,6 @@ import {getProfileSetForChannel,
 } from 'src/selectors';
 import {
     fetchPlaybookRuns,
-    fetchGlobalSettings,
     clientFetchPlaybook,
     fetchPlaybookRunStatusUpdates,
     fetchPlaybookRun,
@@ -60,7 +59,6 @@ import {
 } from 'src/client';
 import {isCloud} from 'src/license';
 import {resolve} from 'src/utils';
-import {actionSetGlobalSettings} from 'src/actions';
 
 export type FetchMetadata = {
     isFetching: boolean;
@@ -290,22 +288,6 @@ export function useExperimentalFeaturesEnabled() {
 
 export function useLinkRunToExistingChannelEnabled() {
     return useSelector(selectLinkRunToExistingChannelEnabled);
-}
-
-let isFetchingSettings = false;
-export async function useEnsureSettings() {
-    const dispatch = useDispatch();
-    const hasGlobalSettings = useSelector((state: GlobalState) => Boolean(globalSettings(state)));
-    if (!hasGlobalSettings && !isFetchingSettings) {
-        isFetchingSettings = true;
-        try {
-            dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
-            isFetchingSettings = false;
-        } catch (e) {
-            isFetchingSettings = false;
-            throw e;
-        }
-    }
 }
 
 // useProfilesInChannel ensures at least the first page of members for the given channel has been

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -292,11 +292,19 @@ export function useLinkRunToExistingChannelEnabled() {
     return useSelector(selectLinkRunToExistingChannelEnabled);
 }
 
+let isFetchingSettings = false;
 export async function useEnsureSettings() {
     const dispatch = useDispatch();
     const hasGlobalSettings = useSelector((state: GlobalState) => Boolean(globalSettings(state)));
-    if (!hasGlobalSettings) {
-        dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
+    if (!hasGlobalSettings && !isFetchingSettings) {
+        isFetchingSettings = true;
+        try {
+            dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
+            isFetchingSettings = false;
+        } catch (e) {
+            isFetchingSettings = false;
+            throw e;
+        }
     }
 }
 

--- a/webapp/src/hooks/general.ts
+++ b/webapp/src/hooks/general.ts
@@ -51,6 +51,7 @@ import {getProfileSetForChannel,
 } from 'src/selectors';
 import {
     fetchPlaybookRuns,
+    fetchGlobalSettings,
     clientFetchPlaybook,
     fetchPlaybookRunStatusUpdates,
     fetchPlaybookRun,
@@ -59,6 +60,7 @@ import {
 } from 'src/client';
 import {isCloud} from 'src/license';
 import {resolve} from 'src/utils';
+import {actionSetGlobalSettings} from 'src/actions';
 
 export type FetchMetadata = {
     isFetching: boolean;
@@ -288,6 +290,14 @@ export function useExperimentalFeaturesEnabled() {
 
 export function useLinkRunToExistingChannelEnabled() {
     return useSelector(selectLinkRunToExistingChannelEnabled);
+}
+
+export async function useEnsureSettings() {
+    const dispatch = useDispatch();
+    const hasGlobalSettings = useSelector((state: GlobalState) => Boolean(globalSettings(state)));
+    if (!hasGlobalSettings) {
+        dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
+    }
 }
 
 // useProfilesInChannel ensures at least the first page of members for the given channel has been

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -23,7 +23,7 @@ import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {GlobalSelectStyle} from 'src/components/backstage/styles';
 import GlobalHeaderRight from 'src/components/global_header_right';
-
+import LoginHook from 'src/components/login_hook';
 import {makeRHSOpener} from 'src/rhs_opener';
 import {makeSlashCommandHook} from 'src/slash_command';
 import {
@@ -42,7 +42,7 @@ import Backstage from 'src/components/backstage/backstage';
 import PostMenuModal from 'src/components/post_menu_modal';
 import ChannelActionsModal from 'src/components/channel_actions_modal';
 import {
-    setToggleRHSAction, actionSetGlobalSettings, showChannelActionsModal,
+    setToggleRHSAction, showChannelActionsModal,
 } from 'src/actions';
 import reducer from 'src/reducer';
 import {
@@ -64,7 +64,7 @@ import {
     WEBSOCKET_PLAYBOOK_ARCHIVED,
     WEBSOCKET_PLAYBOOK_RESTORED,
 } from 'src/types/websocket_events';
-import {fetchGlobalSettings, fetchSiteStats, getMyTopPlaybooks, getTeamTopPlaybooks, notifyConnect, setSiteUrl} from 'src/client';
+import {fetchSiteStats, getMyTopPlaybooks, getTeamTopPlaybooks, notifyConnect, setSiteUrl} from 'src/client';
 import {CloudUpgradePost} from 'src/components/cloud_upgrade_post';
 import {UpdatePost} from 'src/components/update_post';
 import {UpdateRequestPost} from 'src/components/update_request_post';
@@ -199,6 +199,7 @@ export default class Plugin {
         registry.registerPostDropdownMenuComponent(AttachToPlaybookRunPostMenu);
         registry.registerRootComponent(PostMenuModal);
         registry.registerRootComponent(ChannelActionsModal);
+        registry.registerRootComponent(LoginHook);
 
         // App Bar icon
         if (registry.registerAppBarComponent) {
@@ -287,10 +288,6 @@ export default class Plugin {
             lastActivityTime = now;
         };
         document.addEventListener('click', this.activityFunc);
-
-        // We have user activity right now because the plugin is loading
-        // so fire the first connect event.
-        notifyConnect();
     }
 
     public initialize(registry: PluginRegistry, store: Store<GlobalState>): void {
@@ -311,12 +308,6 @@ export default class Plugin {
         setPlaybooksGraphQLClient(graphqlClient);
 
         this.doRegistrations(registry, store, graphqlClient);
-
-        // Grab global settings
-        const getGlobalSettings = async () => {
-            store.dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
-        };
-        getGlobalSettings();
 
         // Grab roles
         //@ts-ignore

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -42,7 +42,7 @@ import Backstage from 'src/components/backstage/backstage';
 import PostMenuModal from 'src/components/post_menu_modal';
 import ChannelActionsModal from 'src/components/channel_actions_modal';
 import {
-    setToggleRHSAction, showChannelActionsModal,
+    setToggleRHSAction, actionSetGlobalSettings, showChannelActionsModal,
 } from 'src/actions';
 import reducer from 'src/reducer';
 import {
@@ -64,7 +64,7 @@ import {
     WEBSOCKET_PLAYBOOK_ARCHIVED,
     WEBSOCKET_PLAYBOOK_RESTORED,
 } from 'src/types/websocket_events';
-import {fetchSiteStats, getMyTopPlaybooks, getTeamTopPlaybooks, notifyConnect, setSiteUrl} from 'src/client';
+import {fetchGlobalSettings, fetchSiteStats, getMyTopPlaybooks, getTeamTopPlaybooks, notifyConnect, setSiteUrl} from 'src/client';
 import {CloudUpgradePost} from 'src/components/cloud_upgrade_post';
 import {UpdatePost} from 'src/components/update_post';
 import {UpdateRequestPost} from 'src/components/update_request_post';
@@ -308,6 +308,14 @@ export default class Plugin {
         setPlaybooksGraphQLClient(graphqlClient);
 
         this.doRegistrations(registry, store, graphqlClient);
+
+        // https://mattermost.atlassian.net/browse/MM-48872
+        // This is handled by LoginHook, but it doesn't seem compatible with e2e tests.
+        // Grab global settings
+        const getGlobalSettings = async () => {
+            store.dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
+        };
+        getGlobalSettings();
 
         // Grab roles
         //@ts-ignore


### PR DESCRIPTION
## Summary
Plugin settings are needed, among other things, to handle feature flags.
When a user initializes app unlogged, settings call returns a 401 (obviously) and is not refetched anymore.

Added hook to ensure settings are fetched, if empty will retry the fetch. Triggered in two main points backstage and main rhs.



## Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1644

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
