### PR TITLE
MM-48866: avoid assuming current channel

### DIFF
--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -141,6 +141,11 @@ const RightHandSidebar = () => {
         setCurrentRunId(undefined);
     };
 
+    // Not a channel
+    if (!Boolean(currentChannelId)) {
+        return <RHSHome/>;
+    }
+
     // No runs (ever) in this channel
     if (fetchedRuns.numRunsInProgress + fetchedRuns.numRunsFinished === 0) {
         return <RHSHome/>;

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -142,7 +142,7 @@ const RightHandSidebar = () => {
     };
 
     // Not a channel
-    if (!Boolean(currentChannelId)) {
+    if (!currentChannelId) {
         return <RHSHome/>;
     }
 

--- a/webapp/src/components/rhs/rhs_run_list.tsx
+++ b/webapp/src/components/rhs/rhs_run_list.tsx
@@ -64,7 +64,7 @@ interface Props {
     numFinished: number
 }
 
-const getCurrentChannelName = (state: GlobalState) => getCurrentChannel(state).display_name;
+const getCurrentChannelName = (state: GlobalState) => getCurrentChannel(state)?.display_name;
 
 const RHSRunList = (props: Props) => {
     const {formatMessage} = useIntl();


### PR DESCRIPTION
## Summary
When opening Insights or Threads, there is no `currentChannelId`, and this can lead to a crash. Detect this early, and render the same screen we show when there has never been a run in the channel.

Fixes: https://mattermost.atlassian.net/browse/MM-48866

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-48866