### PR TITLE
Force enable link run feature flag

### DIFF
--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -34,8 +34,10 @@ func NewSettingsHandler(router *mux.Router, api *pluginapi.Client, configService
 func (h *SettingsHandler) getSettings(w http.ResponseWriter, r *http.Request) {
 	cfg := h.config.GetConfiguration()
 	settings := client.GlobalSettings{
-		EnableExperimentalFeatures:      cfg.EnableExperimentalFeatures,
-		LinkRunToExistingChannelEnabled: cfg.LinkRunToExistingChannelEnabled,
+		EnableExperimentalFeatures: cfg.EnableExperimentalFeatures,
+
+		// This feature flag is hard-coded on, and will be removed in a subsequent release.
+		LinkRunToExistingChannelEnabled: true,
 	}
 
 	ReturnJSON(w, &settings, http.StatusOK)

--- a/server/api_settings_test.go
+++ b/server/api_settings_test.go
@@ -22,7 +22,10 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("get some settings", func(t *testing.T) {
-			defaultSettings := &client.GlobalSettings{}
+			defaultSettings := &client.GlobalSettings{
+				EnableExperimentalFeatures:      false,
+				LinkRunToExistingChannelEnabled: true,
+			}
 
 			settings, err := e.PlaybooksClient.Settings.Get(context.Background())
 			require.NoError(t, err)

--- a/tests-e2e/cypress/integration/api/settings_spec.js
+++ b/tests-e2e/cypress/integration/api/settings_spec.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('api > settings', () => {
+    let testUser;
+
+    before(() => {
+        cy.apiInitSetup().then(({user}) => {
+            testUser = user;
+        });
+    });
+
+    describe('settings', () => {
+        const getSettings = () => {
+            return cy.request({
+                headers: {'X-Requested-With': 'XMLHttpRequest'},
+                url: '/plugins/playbooks/api/v0/settings',
+                method: 'GET',
+            }).then((response) => {
+                expect(response.status).to.equal(200);
+                return cy.wrap(response.body);
+            });
+        };
+
+        it('should return true for flag link_run_to_existing_channel_enabled when enabled', () => {
+            // # Login as admin
+            cy.apiAdminLogin();
+
+            // # Disable feature flag
+            cy.apiEnsureFeatureFlag('linkruntoexistingchannelenabled', true);
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+
+            // # Verify feature flag
+            getSettings().then((settings) => {
+                expect(settings.link_run_to_existing_channel_enabled).to.equal(true);
+            });
+        });
+
+        it('should still return true for flag link_run_to_existing_channel_enabled when disabled', () => {
+            // # Login as admin
+            cy.apiAdminLogin();
+
+            // # Disable feature flag
+            cy.apiEnsureFeatureFlag('linkruntoexistingchannelenabled', false);
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+
+            // # Verify feature flag
+            getSettings().then((settings) => {
+                expect(settings.link_run_to_existing_channel_enabled).to.equal(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Force the feature flag for linking multiple runs to a channel to be `true`, regardless of its actual setting. We'll rip this out altogether in an upcoming release.

## Ticket Link
Fixes: https://github.com/mattermost/mattermost-plugin-playbooks/issues/1656

## Checklist
- [x] Unit tests updated
