### PR TITLE
MM-48888: Infinite loop on fetching roles when logging out

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -414,7 +414,7 @@ describe('playbooks > overview', () => {
             cy.visit(`/playbooks/playbooks/${testPlaybook.id}`);
 
             // # Click Run Playbook
-            cy.findByTestId('run-playbook').click({force: true});
+            cy.findByTestId('run-playbook').click();
 
             // * Verify that channel configuration matches playbook config
             cy.findByTestId('link-existing-channel-radio').should('not.be.checked');

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -157,7 +157,7 @@ describe('playbooks > overview', () => {
             cy.visit(`/playbooks/playbooks/${testPlaybookOnTeamForSwitching.id}`);
 
             // # Click Run Playbook
-            cy.findByTestId('run-playbook').click({force: true});
+            cy.findByTestId('run-playbook').click();
 
             // * Verify the playbook run creation dialog has opened
             cy.get('#playbooks_run_playbook_dialog').should('exist').within(() => {

--- a/tests-e2e/cypress/integration/playbooks/overview_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/overview_spec.js
@@ -319,7 +319,7 @@ describe('playbooks > overview', () => {
         cy.visit(`/playbooks/playbooks/${testPublicPlaybook.id}`);
 
         // # Click Run Playbook
-        cy.findByTestId('run-playbook').click({force: true});
+        cy.findByTestId('run-playbook').click();
 
         // # Enter the run name
         cy.findByTestId('run-name-input').clear().type('run1234567');

--- a/webapp/src/components/login_hook.tsx
+++ b/webapp/src/components/login_hook.tsx
@@ -2,9 +2,12 @@ import {useEffect} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 import {GlobalState} from '@mattermost/types/store';
 
+import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
+
 import {globalSettings} from 'src/selectors';
 import {actionSetGlobalSettings} from 'src/actions';
 import {notifyConnect, fetchGlobalSettings} from 'src/client';
+import {PlaybookRole} from 'src/types/permissions';
 
 // This component is meant to be registered as RootComponent.
 // It will be registered at initialize and "rendered" at login.
@@ -18,6 +21,9 @@ const LoginHook = () => {
         if (!hasGlobalSettings) {
             fetchAndStoreSettings();
         }
+
+        // Grab roles
+        dispatch(loadRolesIfNeeded([PlaybookRole.Member, PlaybookRole.Admin]));
 
         // Fire the first connect bot event.
         notifyConnect();

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -12,7 +12,6 @@ import {Client4} from 'mattermost-redux/client';
 import WebsocketEvents from 'mattermost-redux/constants/websocket';
 import {General} from 'mattermost-redux/constants';
 
-import {loadRolesIfNeeded} from 'mattermost-webapp/packages/mattermost-redux/src/actions/roles';
 import {FormattedMessage} from 'react-intl';
 
 import {ApolloClient, NormalizedCacheObject} from '@apollo/client';
@@ -67,7 +66,6 @@ import {CloudUpgradePost} from 'src/components/cloud_upgrade_post';
 import {UpdatePost} from 'src/components/update_post';
 import {UpdateRequestPost} from 'src/components/update_request_post';
 
-import {PlaybookRole} from './types/permissions';
 import {RetrospectivePost} from './components/retrospective_post';
 
 import {setPlaybooksGraphQLClient} from './graphql_client';
@@ -314,10 +312,6 @@ export default class Plugin {
             store.dispatch(actionSetGlobalSettings(await fetchGlobalSettings()));
         };
         getGlobalSettings();
-
-        // Grab roles
-        //@ts-ignore
-        store.dispatch(loadRolesIfNeeded([PlaybookRole.Member, PlaybookRole.Admin]));
 
         this.userActivityWatch();
 


### PR DESCRIPTION
## Summary
Move fetching roles to logged-in codepath to prevent repeat/infinite loop on login page.

![CleanShot 2022-12-07 at 15 46 45](https://user-images.githubusercontent.com/11724372/206303633-057d6c7f-729f-4c0c-8813-26221eec56ea.gif)

## Ticket Link
 - Fixes https://mattermost.atlassian.net/browse/MM-48888

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
