### PR TITLE
Fix empty default owner issue

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/start_run_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/start_run_spec.js
@@ -53,7 +53,7 @@ describe('playbooks > start a run', () => {
     });
 
     // This data is intentionally changed here instead of via api
-    const fillPBE = ({name, summary, channelMode, channelNameToLink}) => {
+    const fillPBE = ({name, summary, channelMode, channelNameToLink, defaultOwnerEnabled}) => {
         // # fill channel name temaplte
         if (name) {
             cy.get('#create-new-channel input[type="text"]').clear().type('Channel template');
@@ -76,6 +76,19 @@ describe('playbooks > start a run', () => {
                 cy.findByText('Select a channel').click().type(`${channelNameToLink}{enter}`);
             });
         }
+
+        if (defaultOwnerEnabled) {
+            cy.get('#assign-owner').within(() => {
+                // * Verify that the toggle is unchecked
+                cy.get('label input').should('not.be.checked');
+
+                // # Click on the toggle to enable the setting
+                cy.get('label input').click({force: true});
+
+                // * Verify that the toggle is checked
+                cy.get('label input').should('be.checked');
+            });
+        }
     };
 
     describe('from playbook editor', () => {
@@ -85,7 +98,7 @@ describe('playbooks > start a run', () => {
                 cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
 
                 // Fill default values
-                fillPBE({name: 'Channel template', summary: 'run summary template', channelMode: 'create_new_channel'});
+                fillPBE({name: 'Channel template', summary: 'run summary template', channelMode: 'create_new_channel', defaultOwnerEnabled: true});
 
                 // # Click start a run button
                 cy.findByTestId('run-playbook').click();
@@ -159,7 +172,7 @@ describe('playbooks > start a run', () => {
                 cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
 
                 // # Fill default values
-                fillPBE({name: 'Channel template', summary: 'run summary template', channelMode: 'create_new_channel'});
+                fillPBE({name: 'Channel template', summary: 'run summary template', channelMode: 'create_new_channel', defaultOwnerEnabled: true});
 
                 // # Click start a run button
                 cy.findByTestId('run-playbook').click();

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -63,7 +63,7 @@ const RunPlaybookNewModal = ({
     const [showsearch, setShowsearch] = useState(true);
 
     let userId = useSelector(getCurrentUserId);
-    if (playbook?.default_owner_enabled) {
+    if (playbook?.default_owner_enabled && playbook.default_owner_id) {
         userId = playbook.default_owner_id;
     }
 


### PR DESCRIPTION

## Summary
This PR fixes an issue with an empty default owner. If the playbook was set to assign the default owner, but the owner value was empty, the `new run playbook modal` set an empty text as an owner id. Because of that, a run start was failing. 

## Ticket Link
No task

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Unit tests updated
