### PR TITLE
remove double check of errs

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -647,11 +647,6 @@ func (h *PlaybookRunHandler) getPlaybookRunByChannel(c *Context, w http.Response
 	}
 
 	playbookRun := playbookRuns[0]
-	if err != nil {
-		h.HandleError(w, c.logger, err)
-		return
-	}
-
 	ReturnJSON(w, &playbookRun, http.StatusOK)
 }
 
@@ -995,12 +990,6 @@ func (h *PlaybookRunHandler) reminderButtonUpdate(c *Context, w http.ResponseWri
 	err := json.NewDecoder(r.Body).Decode(&requestData)
 	if err != nil || requestData == nil {
 		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "missing request data", nil)
-		return
-	}
-
-	if err != nil {
-		h.HandleErrorWithCode(w, c.logger, http.StatusInternalServerError, "error getting playbook run",
-			errors.Wrapf(err, "reminderButtonUpdate failed to find playbookRunID for channelID: %s", requestData.ChannelId))
 		return
 	}
 


### PR DESCRIPTION
## Summary
govet is complainig about two blocks of errs being checked twice

```
server/api/playbook_runs.go:650:9: nilness: impossible condition: nil != nil (govet)
        if err != nil {
               ^
server/api/playbook_runs.go:1001:9: nilness: impossible condition: nil != nil (govet)
        if err != nil {
```

One of them is treated as 400 and 500 error, I kept the 400 but 0/5 on that

## Ticket Link
No

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
