### PR TITLE
1667  Make run configuration labels clickable

### DIFF
--- a/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
@@ -9,7 +9,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {
     AutomationHeader,
-    AutomationLabel,
     AutomationTitle,
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
@@ -31,14 +30,12 @@ export const AutoAssignOwner = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
-                    inputId={'auto-assign-owner-toggle'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
-                />
-                <AutomationLabel htmlFor={'auto-assign-owner-toggle'}>
+                >
                     <FormattedMessage defaultMessage='Assign the owner role'/>
-                </AutomationLabel>
+                </Toggle>
             </AutomationTitle>
             <SelectorWrapper>
                 <AssignOwnerSelector

--- a/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
@@ -9,6 +9,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {
     AutomationHeader,
+    AutomationLabel,
     AutomationTitle,
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
@@ -30,11 +31,14 @@ export const AutoAssignOwner = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
+                    inputId={'auto-assign-owner-toggle'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <FormattedMessage defaultMessage='Assign the owner role'/>
+                <AutomationLabel htmlFor={'auto-assign-owner-toggle'}>
+                    <FormattedMessage defaultMessage='Assign the owner role'/>
+                </AutomationLabel>
             </AutomationTitle>
             <SelectorWrapper>
                 <AssignOwnerSelector

--- a/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/auto_assign_owner.tsx
@@ -34,7 +34,7 @@ export const AutoAssignOwner = (props: Props) => {
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <div><FormattedMessage defaultMessage='Assign the owner role'/></div>
+                <FormattedMessage defaultMessage='Assign the owner role'/>
             </AutomationTitle>
             <SelectorWrapper>
                 <AssignOwnerSelector

--- a/webapp/src/components/backstage/playbook_edit/automation/categorize_playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/categorize_playbook_run.tsx
@@ -31,7 +31,7 @@ export const CategorizePlaybookRun = (props: Props) => {
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <div><FormattedMessage defaultMessage='Add the channel to a sidebar category'/></div>
+                <FormattedMessage defaultMessage='Add the channel to a sidebar category'/>
             </AutomationTitle>
             <SelectorWrapper>
                 <StyledCategorySelector

--- a/webapp/src/components/backstage/playbook_edit/automation/categorize_playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/categorize_playbook_run.tsx
@@ -6,7 +6,12 @@ import {FormattedMessage, useIntl} from 'react-intl';
 
 import styled from 'styled-components';
 
-import {AutomationHeader, AutomationTitle, SelectorWrapper} from 'src/components/backstage/playbook_edit/automation/styles';
+import {
+    AutomationHeader,
+    AutomationLabel,
+    AutomationTitle,
+    SelectorWrapper,
+} from 'src/components/backstage/playbook_edit/automation/styles';
 import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
 import ClearIndicator from 'src/components/backstage/playbook_edit/automation/clear_indicator';
 import MenuList from 'src/components/backstage/playbook_edit/automation/menu_list';
@@ -27,11 +32,14 @@ export const CategorizePlaybookRun = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
+                    inputId={'categorize-playbook-run-toggle'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <FormattedMessage defaultMessage='Add the channel to a sidebar category'/>
+                <AutomationLabel htmlFor={'categorize-playbook-run-toggle'}>
+                    <FormattedMessage defaultMessage='Add the channel to a sidebar category'/>
+                </AutomationLabel>
             </AutomationTitle>
             <SelectorWrapper>
                 <StyledCategorySelector

--- a/webapp/src/components/backstage/playbook_edit/automation/categorize_playbook_run.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/categorize_playbook_run.tsx
@@ -8,7 +8,6 @@ import styled from 'styled-components';
 
 import {
     AutomationHeader,
-    AutomationLabel,
     AutomationTitle,
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
@@ -32,14 +31,12 @@ export const CategorizePlaybookRun = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
-                    inputId={'categorize-playbook-run-toggle'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
-                />
-                <AutomationLabel htmlFor={'categorize-playbook-run-toggle'}>
+                >
                     <FormattedMessage defaultMessage='Add the channel to a sidebar category'/>
-                </AutomationLabel>
+                </Toggle>
             </AutomationTitle>
             <SelectorWrapper>
                 <StyledCategorySelector

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import {SettingsOutlineIcon} from '@mattermost/compass-icons/components';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
@@ -77,7 +77,7 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade}: Props) =
                         checked={playbook.channel_mode === 'link_existing_channel'}
                         onChange={() => handleChannelModeChange('link_existing_channel')}
                     />
-                    <div>{formatMessage({defaultMessage: 'Link to an existing channel'})}</div>
+                    <FormattedMessage defaultMessage='Link to an existing channel'/>
                 </AutomationTitle>
                 <SelectorWrapper>
                     <StyledChannelSelector
@@ -102,7 +102,7 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade}: Props) =
                         checked={playbook.channel_mode === 'create_new_channel'}
                         onChange={() => handleChannelModeChange('create_new_channel')}
                     />
-                    <div>{formatMessage({defaultMessage: 'Create a run channel'})}</div>
+                    <FormattedMessage defaultMessage='Create a run channel'/>
                 </AutomationTitle>
                 <HorizontalSplit>
                     <VerticalSplit>

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -3,14 +3,19 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import {SettingsOutlineIcon} from '@mattermost/compass-icons/components';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import {PlaybookWithChecklist} from 'src/types/playbook';
 import {PatternedInput} from 'src/components/backstage/playbook_edit/automation/patterned_input';
-import {AutomationHeader, AutomationTitle, SelectorWrapper} from 'src/components/backstage/playbook_edit/automation/styles';
+import {
+    AutomationHeader,
+    AutomationLabel,
+    AutomationTitle,
+    SelectorWrapper,
+} from 'src/components/backstage/playbook_edit/automation/styles';
 import {HorizontalSpacer, RadioInput} from 'src/components/backstage/styles';
 import {showPlaybookActionsModal} from 'src/actions';
 import {useLinkRunToExistingChannelEnabled} from 'src/hooks/general';
@@ -72,12 +77,15 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade}: Props) =
                     css={{alignSelf: 'flex-start'}}
                 >
                     <ChannelModeRadio
+                        id={'link_existing_channel_radio'}
                         type='radio'
                         disabled={archived}
                         checked={playbook.channel_mode === 'link_existing_channel'}
                         onChange={() => handleChannelModeChange('link_existing_channel')}
                     />
-                    <FormattedMessage defaultMessage='Link to an existing channel'/>
+                    <AutomationLabel htmlFor={'link_existing_channel_radio'}>
+                        {formatMessage({defaultMessage: 'Link to an existing channel'})}
+                    </AutomationLabel>
                 </AutomationTitle>
                 <SelectorWrapper>
                     <StyledChannelSelector
@@ -97,12 +105,15 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade}: Props) =
             <AutomationHeader id={'create-new-channel'}>
                 <AutomationTitle css={{alignSelf: 'flex-start'}} >
                     <ChannelModeRadio
+                        id={'create_new_channel_radio'}
                         type='radio'
                         disabled={archived}
                         checked={playbook.channel_mode === 'create_new_channel'}
                         onChange={() => handleChannelModeChange('create_new_channel')}
                     />
-                    <FormattedMessage defaultMessage='Create a run channel'/>
+                    <AutomationLabel htmlFor={'create_new_channel_radio'}>
+                        {formatMessage({defaultMessage: 'Create a run channel'})}
+                    </AutomationLabel>
                 </AutomationTitle>
                 <HorizontalSplit>
                     <VerticalSplit>

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import {SettingsOutlineIcon} from '@mattermost/compass-icons/components';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
@@ -76,15 +76,14 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade}: Props) =
                 <AutomationTitle
                     css={{alignSelf: 'flex-start'}}
                 >
-                    <ChannelModeRadio
-                        id={'link_existing_channel_radio'}
-                        type='radio'
-                        disabled={archived}
-                        checked={playbook.channel_mode === 'link_existing_channel'}
-                        onChange={() => handleChannelModeChange('link_existing_channel')}
-                    />
-                    <AutomationLabel htmlFor={'link_existing_channel_radio'}>
-                        {formatMessage({defaultMessage: 'Link to an existing channel'})}
+                    <AutomationLabel disabled={archived}>
+                        <ChannelModeRadio
+                            type='radio'
+                            disabled={archived}
+                            checked={playbook.channel_mode === 'link_existing_channel'}
+                            onChange={() => handleChannelModeChange('link_existing_channel')}
+                        />
+                        <FormattedMessage defaultMessage='Link to an existing channel'/>
                     </AutomationLabel>
                 </AutomationTitle>
                 <SelectorWrapper>
@@ -104,15 +103,14 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade}: Props) =
             </AutomationHeader>}
             <AutomationHeader id={'create-new-channel'}>
                 <AutomationTitle css={{alignSelf: 'flex-start'}} >
-                    <ChannelModeRadio
-                        id={'create_new_channel_radio'}
-                        type='radio'
-                        disabled={archived}
-                        checked={playbook.channel_mode === 'create_new_channel'}
-                        onChange={() => handleChannelModeChange('create_new_channel')}
-                    />
-                    <AutomationLabel htmlFor={'create_new_channel_radio'}>
-                        {formatMessage({defaultMessage: 'Create a run channel'})}
+                    <AutomationLabel disabled={archived}>
+                        <ChannelModeRadio
+                            type='radio'
+                            disabled={archived}
+                            checked={playbook.channel_mode === 'create_new_channel'}
+                            onChange={() => handleChannelModeChange('create_new_channel')}
+                        />
+                        <FormattedMessage defaultMessage='Create a run channel'/>
                     </AutomationLabel>
                 </AutomationTitle>
                 <HorizontalSplit>

--- a/webapp/src/components/backstage/playbook_edit/automation/invite_users.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/invite_users.tsx
@@ -9,7 +9,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {
     AutomationHeader,
-    AutomationLabel,
     AutomationTitle,
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
@@ -32,14 +31,12 @@ export const InviteUsers = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
-                    inputId={'invite-users-toggle'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
-                />
-                <AutomationLabel htmlFor={'invite-users-toggle'}>
+                >
                     <FormattedMessage defaultMessage='Invite participants'/>
-                </AutomationLabel>
+                </Toggle>
             </AutomationTitle>
             <SelectorWrapper>
                 <InviteUsersSelector

--- a/webapp/src/components/backstage/playbook_edit/automation/invite_users.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/invite_users.tsx
@@ -9,6 +9,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {
     AutomationHeader,
+    AutomationLabel,
     AutomationTitle,
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
@@ -31,11 +32,14 @@ export const InviteUsers = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
+                    inputId={'invite-users-toggle'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <FormattedMessage defaultMessage='Invite participants'/>
+                <AutomationLabel htmlFor={'invite-users-toggle'}>
+                    <FormattedMessage defaultMessage='Invite participants'/>
+                </AutomationLabel>
             </AutomationTitle>
             <SelectorWrapper>
                 <InviteUsersSelector

--- a/webapp/src/components/backstage/playbook_edit/automation/invite_users.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/invite_users.tsx
@@ -35,7 +35,7 @@ export const InviteUsers = (props: Props) => {
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <div><FormattedMessage defaultMessage='Invite participants'/></div>
+                <FormattedMessage defaultMessage='Invite participants'/>
             </AutomationTitle>
             <SelectorWrapper>
                 <InviteUsersSelector

--- a/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
@@ -10,12 +10,15 @@ export const AutomationHeader = styled.div`
     width: 100%;
 `;
 
-export const AutomationTitle = styled.label`
+export const AutomationTitle = styled.div`
     display: flex;
     flex-direction: row;
     width: 350px;
     align-items: center;
     column-gap: 12px;
+`;
+
+export const AutomationLabel = styled.label`
     font-weight: inherit;
     margin-bottom: 0;
 `;

--- a/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
@@ -18,9 +18,14 @@ export const AutomationTitle = styled.div`
     column-gap: 12px;
 `;
 
-export const AutomationLabel = styled.label`
+export const AutomationLabel = styled.label<{disabled?: boolean}>`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 12px;
     font-weight: inherit;
     margin-bottom: 0;
+    cursor: ${({disabled}) => (disabled ? 'default' : 'pointer')};
 `;
 
 export const SelectorWrapper = styled.div`

--- a/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
@@ -16,6 +16,8 @@ export const AutomationTitle = styled.label`
     width: 350px;
     align-items: center;
     column-gap: 12px;
+    font-weight: inherit;
+    margin-bottom: 0;
 `;
 
 export const SelectorWrapper = styled.div`

--- a/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/styles.tsx
@@ -10,7 +10,7 @@ export const AutomationHeader = styled.div`
     width: 100%;
 `;
 
-export const AutomationTitle = styled.div`
+export const AutomationTitle = styled.label`
     display: flex;
     flex-direction: row;
     width: 350px;

--- a/webapp/src/components/backstage/playbook_edit/automation/toggle.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/toggle.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface ToggleProps {
-    inputId?: string;
+    children?: React.ReactNode
     isChecked: boolean;
     disabled?: boolean;
     onChange: () => void;
@@ -19,13 +19,13 @@ export const Toggle = (props: ToggleProps) => {
             tabIndex={0}
         >
             <InvisibleInput
-                id={props.inputId}
                 type='checkbox'
                 onChange={props.onChange}
                 checked={props.isChecked}
                 disabled={props.disabled}
             />
             <RoundSwitch disabled={props.disabled}/>
+            {props.children}
         </Label>
     );
 };
@@ -80,6 +80,10 @@ const InvisibleInput = styled.input`
 `;
 
 const Label = styled.label<DisabledProps>`
+    display: flex;
+    align-items: center;
+    column-gap: 12px;
+    font-weight: inherit;
     line-height: 0;
     cursor: ${({disabled}) => (disabled ? 'default' : 'pointer')};
     margin-bottom: 0;

--- a/webapp/src/components/backstage/playbook_edit/automation/toggle.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/toggle.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface ToggleProps {
+    inputId?: string;
     isChecked: boolean;
     disabled?: boolean;
     onChange: () => void;
@@ -18,6 +19,7 @@ export const Toggle = (props: ToggleProps) => {
             tabIndex={0}
         >
             <InvisibleInput
+                id={props.inputId}
                 type='checkbox'
                 onChange={props.onChange}
                 checked={props.isChecked}

--- a/webapp/src/components/backstage/playbook_edit/automation/webhook_setting.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/webhook_setting.tsx
@@ -34,7 +34,7 @@ export const WebhookSetting = (props: Props) => {
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <div>{props.textOnToggle}</div>
+                <span>{props.textOnToggle}</span>
             </AutomationTitle>
             <SelectorWrapper>
                 <PatternedTextArea

--- a/webapp/src/components/backstage/playbook_edit/automation/webhook_setting.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/webhook_setting.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 
 import {
     AutomationHeader,
-    AutomationLabel,
     AutomationTitle,
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
@@ -35,14 +34,12 @@ export const WebhookSetting = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
-                    inputId={'webhook-setting-radio'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
-                />
-                <AutomationLabel htmlFor={'webhook-setting-radio'}>
+                >
                     {props.textOnToggle}
-                </AutomationLabel>
+                </Toggle>
             </AutomationTitle>
             <SelectorWrapper>
                 <PatternedTextArea

--- a/webapp/src/components/backstage/playbook_edit/automation/webhook_setting.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/webhook_setting.tsx
@@ -3,7 +3,12 @@
 
 import React from 'react';
 
-import {AutomationHeader, AutomationTitle, SelectorWrapper} from 'src/components/backstage/playbook_edit/automation/styles';
+import {
+    AutomationHeader,
+    AutomationLabel,
+    AutomationTitle,
+    SelectorWrapper,
+} from 'src/components/backstage/playbook_edit/automation/styles';
 import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
 import PatternedTextArea from 'src/components/patterned_text_area';
 
@@ -30,11 +35,14 @@ export const WebhookSetting = (props: Props) => {
         <AutomationHeader>
             <AutomationTitle>
                 <Toggle
+                    inputId={'webhook-setting-radio'}
                     isChecked={props.enabled}
                     onChange={props.onToggle}
                     disabled={props.disabled}
                 />
-                <span>{props.textOnToggle}</span>
+                <AutomationLabel htmlFor={'webhook-setting-radio'}>
+                    {props.textOnToggle}
+                </AutomationLabel>
             </AutomationTitle>
             <SelectorWrapper>
                 <PatternedTextArea

--- a/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
@@ -21,7 +21,7 @@ import {CreateAChannel} from 'src/components/backstage/playbook_edit/automation/
 import {PROFILE_CHUNK_SIZE} from 'src/constants';
 
 import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
-import {AutomationLabel, AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
+import {AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
 
 import {useProxyState} from 'src/hooks';
 
@@ -180,7 +180,6 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                 <Setting id={'participant-joins-run'}>
                     <AutomationTitle>
                         <Toggle
-                            inputId={'participant-joins-run-toggle'}
                             disabled={archived}
                             isChecked={playbook.create_channel_member_on_new_participant}
                             onChange={() => {
@@ -188,10 +187,9 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                                     createChannelMemberOnNewParticipant: !playbook.create_channel_member_on_new_participant,
                                 });
                             }}
-                        />
-                        <AutomationLabel htmlFor={'participant-joins-run-toggle'}>
+                        >
                             <FormattedMessage defaultMessage='Add them to the run channel'/>
-                        </AutomationLabel>
+                        </Toggle>
                     </AutomationTitle>
                 </Setting>
             </StyledSection>
@@ -204,7 +202,6 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                 <Setting id={'participant-leaves-run'}>
                     <AutomationTitle>
                         <Toggle
-                            inputId={'participant-leaves-run-toggle'}
                             disabled={archived}
                             isChecked={playbook.remove_channel_member_on_removed_participant}
                             onChange={() => {
@@ -212,10 +209,9 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                                     removeChannelMemberOnRemovedParticipant: !playbook.remove_channel_member_on_removed_participant,
                                 });
                             }}
-                        />
-                        <AutomationLabel htmlFor={'participant-leaves-run-toggle'}>
+                        >
                             <FormattedMessage defaultMessage='Remove them from the run channel'/>
-                        </AutomationLabel>
+                        </Toggle>
                     </AutomationTitle>
                 </Setting>
             </StyledSection>

--- a/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
@@ -188,7 +188,7 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                                 });
                             }}
                         />
-                        <div><FormattedMessage defaultMessage='Add them to the run channel'/></div>
+                        <FormattedMessage defaultMessage='Add them to the run channel'/>
                     </AutomationTitle>
                 </Setting>
             </StyledSection>
@@ -209,7 +209,7 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                                 });
                             }}
                         />
-                        <div><FormattedMessage defaultMessage='Remove them from the run channel'/></div>
+                        <FormattedMessage defaultMessage='Remove them from the run channel'/>
                     </AutomationTitle>
                 </Setting>
             </StyledSection>

--- a/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, ComponentProps} from 'react';
+import React, {ComponentProps, useCallback} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {useDispatch} from 'react-redux';
@@ -9,7 +9,7 @@ import {useDispatch} from 'react-redux';
 import {getProfilesInTeam, searchProfiles} from 'mattermost-redux/actions/users';
 
 import styled from 'styled-components';
-import {PlayIcon, AccountPlusOutlineIcon, AccountMinusOutlineIcon} from '@mattermost/compass-icons/components';
+import {AccountMinusOutlineIcon, AccountPlusOutlineIcon, PlayIcon} from '@mattermost/compass-icons/components';
 
 import {FullPlaybook, Loaded, useUpdatePlaybook} from 'src/graphql/hooks';
 
@@ -21,7 +21,7 @@ import {CreateAChannel} from 'src/components/backstage/playbook_edit/automation/
 import {PROFILE_CHUNK_SIZE} from 'src/constants';
 
 import {Toggle} from 'src/components/backstage/playbook_edit/automation/toggle';
-import {AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
+import {AutomationLabel, AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
 
 import {useProxyState} from 'src/hooks';
 
@@ -180,6 +180,7 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                 <Setting id={'participant-joins-run'}>
                     <AutomationTitle>
                         <Toggle
+                            inputId={'participant-joins-run-toggle'}
                             disabled={archived}
                             isChecked={playbook.create_channel_member_on_new_participant}
                             onChange={() => {
@@ -188,7 +189,9 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                                 });
                             }}
                         />
-                        <FormattedMessage defaultMessage='Add them to the run channel'/>
+                        <AutomationLabel htmlFor={'participant-joins-run-toggle'}>
+                            <FormattedMessage defaultMessage='Add them to the run channel'/>
+                        </AutomationLabel>
                     </AutomationTitle>
                 </Setting>
             </StyledSection>
@@ -201,6 +204,7 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                 <Setting id={'participant-leaves-run'}>
                     <AutomationTitle>
                         <Toggle
+                            inputId={'participant-leaves-run-toggle'}
                             disabled={archived}
                             isChecked={playbook.remove_channel_member_on_removed_participant}
                             onChange={() => {
@@ -209,7 +213,9 @@ const LegacyActionsEdit = ({playbook}: Props) => {
                                 });
                             }}
                         />
-                        <FormattedMessage defaultMessage='Remove them from the run channel'/>
+                        <AutomationLabel htmlFor={'participant-leaves-run-toggle'}>
+                            <FormattedMessage defaultMessage='Remove them from the run channel'/>
+                        </AutomationLabel>
                     </AutomationTitle>
                 </Setting>
             </StyledSection>

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -407,6 +407,8 @@ const ChannelBlock = styled.label`
     width: 350px;
     align-items: center;
     column-gap: 12px;
+    font-weight: inherit;
+    margin-bottom: 0;
     align-self: 'flex-start';
 `;
 

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -261,7 +261,7 @@ const ConfigChannelSection = ({teamId, channelMode, channelId, createPublicRun, 
                     checked={linkExistingChannel}
                     onChange={() => onSetChannelMode('link_existing_channel')}
                 />
-                <div>{formatMessage({defaultMessage: 'Link to an existing channel'})}</div>
+                <FormattedMessage defaultMessage='Link to an existing channel'/>
             </ChannelBlock>
             {linkExistingChannel && (
                 <SelectorWrapper>
@@ -287,7 +287,7 @@ const ConfigChannelSection = ({teamId, channelMode, channelId, createPublicRun, 
                     checked={createNewChannel}
                     onChange={() => onSetChannelMode('create_new_channel')}
                 />
-                <div>{formatMessage({defaultMessage: 'Create a run channel'})}</div>
+                <FormattedMessage defaultMessage={'Create a run channel'}/>
             </ChannelBlock>
 
             {createNewChannel && (
@@ -401,7 +401,7 @@ const StyledRadioInput = styled(RadioInput)`
     }
 `;
 
-const ChannelBlock = styled.div`
+const ChannelBlock = styled.label`
     display: flex;
     flex-direction: row;
     width: 350px;

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -260,15 +260,12 @@ const ConfigChannelSection = ({teamId, channelMode, channelId, createPublicRun, 
         <ChannelContainer>
             <ChannelBlock>
                 <StyledRadioInput
-                    id={'link-existing-channel-radio'}
                     data-testid={'link-existing-channel-radio'}
                     type='radio'
                     checked={linkExistingChannel}
                     onChange={() => onSetChannelMode('link_existing_channel')}
                 />
-                <ChannelBlockLabel htmlFor={'link-existing-channel-radio'}>
-                    {formatMessage({defaultMessage: 'Link to an existing channel'})}
-                </ChannelBlockLabel>
+                <FormattedMessage defaultMessage='Link to an existing channel'/>
             </ChannelBlock>
             {linkExistingChannel && (
                 <SelectorWrapper>
@@ -289,13 +286,12 @@ const ConfigChannelSection = ({teamId, channelMode, channelId, createPublicRun, 
 
             <ChannelBlock >
                 <StyledRadioInput
-                    id={'create-channel-radio'}
                     data-testid={'create-channel-radio'}
                     type='radio'
                     checked={createNewChannel}
                     onChange={() => onSetChannelMode('create_new_channel')}
                 />
-                <ChannelBlockLabel htmlFor={'create-channel-radio'}>{formatMessage({defaultMessage: 'Create a run channel'})}</ChannelBlockLabel>
+                <FormattedMessage defaultMessage='Create a run channel'/>
             </ChannelBlock>
 
             {createNewChannel && (
@@ -409,18 +405,16 @@ const StyledRadioInput = styled(RadioInput)`
     }
 `;
 
-const ChannelBlock = styled.div`
+const ChannelBlock = styled.label`
     display: flex;
     flex-direction: row;
     width: 350px;
     align-items: center;
     column-gap: 12px;
     align-self: 'flex-start';
-`;
-
-const ChannelBlockLabel = styled.label`
     font-weight: inherit;
     margin-bottom: 0;
+    cursor: pointer;
 `;
 
 const SelectorWrapper = styled.div`

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, useState, useEffect} from 'react';
+import React, {ComponentProps, useEffect, useState} from 'react';
 
 import {FormattedMessage, useIntl} from 'react-intl';
 import styled from 'styled-components';
@@ -12,7 +12,11 @@ import {usePlaybook} from 'src/graphql/hooks';
 import {BaseInput, BaseTextArea} from 'src/components/assets/inputs';
 import GenericModal, {InlineLabel, ModalSideheading} from 'src/components/widgets/generic_modal';
 import {createPlaybookRun} from 'src/client';
-import {ButtonLabel, StyledChannelSelector, VerticalSplit} from 'src/components/backstage/playbook_edit/automation/channel_access';
+import {
+    ButtonLabel,
+    StyledChannelSelector,
+    VerticalSplit,
+} from 'src/components/backstage/playbook_edit/automation/channel_access';
 import ClearIndicator from 'src/components/backstage/playbook_edit/automation/clear_indicator';
 import MenuList from 'src/components/backstage/playbook_edit/automation/menu_list';
 import {HorizontalSpacer, RadioInput} from 'src/components/backstage/styles';
@@ -256,12 +260,15 @@ const ConfigChannelSection = ({teamId, channelMode, channelId, createPublicRun, 
         <ChannelContainer>
             <ChannelBlock>
                 <StyledRadioInput
+                    id={'link-existing-channel-radio'}
                     data-testid={'link-existing-channel-radio'}
                     type='radio'
                     checked={linkExistingChannel}
                     onChange={() => onSetChannelMode('link_existing_channel')}
                 />
-                <FormattedMessage defaultMessage='Link to an existing channel'/>
+                <ChannelBlockLabel htmlFor={'link-existing-channel-radio'}>
+                    {formatMessage({defaultMessage: 'Link to an existing channel'})}
+                </ChannelBlockLabel>
             </ChannelBlock>
             {linkExistingChannel && (
                 <SelectorWrapper>
@@ -282,12 +289,13 @@ const ConfigChannelSection = ({teamId, channelMode, channelId, createPublicRun, 
 
             <ChannelBlock >
                 <StyledRadioInput
+                    id={'create-channel-radio'}
                     data-testid={'create-channel-radio'}
                     type='radio'
                     checked={createNewChannel}
                     onChange={() => onSetChannelMode('create_new_channel')}
                 />
-                <FormattedMessage defaultMessage={'Create a run channel'}/>
+                <ChannelBlockLabel htmlFor={'create-channel-radio'}>{formatMessage({defaultMessage: 'Create a run channel'})}</ChannelBlockLabel>
             </ChannelBlock>
 
             {createNewChannel && (
@@ -401,15 +409,18 @@ const StyledRadioInput = styled(RadioInput)`
     }
 `;
 
-const ChannelBlock = styled.label`
+const ChannelBlock = styled.div`
     display: flex;
     flex-direction: row;
     width: 350px;
     align-items: center;
     column-gap: 12px;
+    align-self: 'flex-start';
+`;
+
+const ChannelBlockLabel = styled.label`
     font-weight: inherit;
     margin-bottom: 0;
-    align-self: 'flex-start';
 `;
 
 const SelectorWrapper = styled.div`

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -1,6 +1,6 @@
 import React, {ComponentProps, useEffect, useState} from 'react';
 
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import styled from 'styled-components';
 import {useSelector} from 'react-redux';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
@@ -123,15 +123,14 @@ const RunPlaybookModal = ({
             <AutomationTitle
                 css={{alignSelf: 'flex-start'}}
             >
-                <StyledRadioInput
-                    id={'link-existing-channel-radio'}
-                    data-testid={'link-existing-channel-radio'}
-                    type='radio'
-                    checked={linkExistingChannel}
-                    onChange={() => setChannelMode('link_existing_channel')}
-                />
-                <AutomationLabel htmlFor={'link-existing-channel-radio'}>
-                    {formatMessage({defaultMessage: 'Link to an existing channel'})}
+                <AutomationLabel>
+                    <StyledRadioInput
+                        data-testid={'link-existing-channel-radio'}
+                        type='radio'
+                        checked={linkExistingChannel}
+                        onChange={() => setChannelMode('link_existing_channel')}
+                    />
+                    <FormattedMessage defaultMessage='Link to an existing channel'/>
                 </AutomationLabel>
             </AutomationTitle>
             {linkExistingChannel && (
@@ -152,15 +151,14 @@ const RunPlaybookModal = ({
             )}
 
             <AutomationTitle css={{alignSelf: 'flex-start'}} >
-                <StyledRadioInput
-                    id={'create-channel-radio'}
-                    data-testid={'create-channel-radio'}
-                    type='radio'
-                    checked={createNewChannel}
-                    onChange={() => setChannelMode('create_new_channel')}
-                />
-                <AutomationLabel htmlFor={'create-channel-radio'}>
-                    {formatMessage({defaultMessage: 'Create a run channel'})}
+                <AutomationLabel>
+                    <StyledRadioInput
+                        data-testid={'create-channel-radio'}
+                        type='radio'
+                        checked={createNewChannel}
+                        onChange={() => setChannelMode('create_new_channel')}
+                    />
+                    <FormattedMessage defaultMessage='Create a run channel'/>
                 </AutomationLabel>
             </AutomationTitle>
 

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -25,7 +25,7 @@ import {AutomationLabel, AutomationTitle} from 'src/components/backstage/playboo
 import {
     ButtonLabel,
     StyledChannelSelector,
-    VerticalSplit
+    VerticalSplit,
 } from 'src/components/backstage/playbook_edit/automation/channel_access';
 
 import ClearIndicator from 'src/components/backstage/playbook_edit/automation/clear_indicator';

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -1,13 +1,13 @@
-import React, {ComponentProps, useState, useEffect} from 'react';
+import React, {ComponentProps, useEffect, useState} from 'react';
 
-import {FormattedMessage, useIntl} from 'react-intl';
+import {useIntl} from 'react-intl';
 import styled from 'styled-components';
 import {useSelector} from 'react-redux';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 
 import {Client4} from 'mattermost-redux/client';
 
-import {NotebookOutlineIcon, AccountOutlineIcon} from '@mattermost/compass-icons/components';
+import {AccountOutlineIcon, NotebookOutlineIcon} from '@mattermost/compass-icons/components';
 import {GlobalState} from '@mattermost/types/store';
 
 import {displayUsername, getFullName} from 'mattermost-redux/utils/user_utils';
@@ -21,8 +21,12 @@ import GenericModal, {InlineLabel} from 'src/components/widgets/generic_modal';
 import {createPlaybookRun} from 'src/client';
 import {navigateToPluginUrl} from 'src/browser_routing';
 
-import {AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
-import {ButtonLabel, StyledChannelSelector, VerticalSplit} from 'src/components/backstage/playbook_edit/automation/channel_access';
+import {AutomationLabel, AutomationTitle} from 'src/components/backstage/playbook_edit/automation/styles';
+import {
+    ButtonLabel,
+    StyledChannelSelector,
+    VerticalSplit
+} from 'src/components/backstage/playbook_edit/automation/channel_access';
 
 import ClearIndicator from 'src/components/backstage/playbook_edit/automation/clear_indicator';
 
@@ -120,12 +124,15 @@ const RunPlaybookModal = ({
                 css={{alignSelf: 'flex-start'}}
             >
                 <StyledRadioInput
+                    id={'link-existing-channel-radio'}
                     data-testid={'link-existing-channel-radio'}
                     type='radio'
                     checked={linkExistingChannel}
                     onChange={() => setChannelMode('link_existing_channel')}
                 />
-                <FormattedMessage defaultMessage='Link to an existing channel'/>
+                <AutomationLabel htmlFor={'link-existing-channel-radio'}>
+                    {formatMessage({defaultMessage: 'Link to an existing channel'})}
+                </AutomationLabel>
             </AutomationTitle>
             {linkExistingChannel && (
                 <SelectorWrapper>
@@ -146,12 +153,15 @@ const RunPlaybookModal = ({
 
             <AutomationTitle css={{alignSelf: 'flex-start'}} >
                 <StyledRadioInput
+                    id={'create-channel-radio'}
                     data-testid={'create-channel-radio'}
                     type='radio'
                     checked={createNewChannel}
                     onChange={() => setChannelMode('create_new_channel')}
                 />
-                <FormattedMessage defaultMessage='Create a run channel'/>
+                <AutomationLabel htmlFor={'create-channel-radio'}>
+                    {formatMessage({defaultMessage: 'Create a run channel'})}
+                </AutomationLabel>
             </AutomationTitle>
 
             {createNewChannel && (

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -1,6 +1,6 @@
 import React, {ComponentProps, useState, useEffect} from 'react';
 
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import styled from 'styled-components';
 import {useSelector} from 'react-redux';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
@@ -125,7 +125,7 @@ const RunPlaybookModal = ({
                     checked={linkExistingChannel}
                     onChange={() => setChannelMode('link_existing_channel')}
                 />
-                <div>{formatMessage({defaultMessage: 'Link to an existing channel'})}</div>
+                <FormattedMessage defaultMessage='Link to an existing channel'/>
             </AutomationTitle>
             {linkExistingChannel && (
                 <SelectorWrapper>
@@ -151,7 +151,7 @@ const RunPlaybookModal = ({
                     checked={createNewChannel}
                     onChange={() => setChannelMode('create_new_channel')}
                 />
-                <div>{formatMessage({defaultMessage: 'Create a run channel'})}</div>
+                <FormattedMessage defaultMessage='Create a run channel'/>
             </AutomationTitle>
 
             {createNewChannel && (


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
Makes configuration labels clickable by changing sibling to labels and using `for` with a reference to the respective input. 

[Screencast from 09.12.2022 15:09:38.webm](https://user-images.githubusercontent.com/8669935/206720881-2db6cf6e-dd56-48fa-9cf4-5b71890451bd.webm)

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
fixes #1667 

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
