### PR TITLE
Use proxy state item

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/edit/task_actions_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/edit/task_actions_spec.js
@@ -75,6 +75,12 @@ describe('playbooks > edit > task actions', () => {
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
 
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
+
             // Verify no actions are configured
             cy.findByText('Task Actions').should('exist');
             cy.apiGetPlaybook(testPlaybook.id).then((playbook) => {
@@ -105,6 +111,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions
             cy.findByText('1 action');
@@ -139,6 +151,12 @@ describe('playbooks > edit > task actions', () => {
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
 
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
+
             // Verify configured actions
             cy.findByText('1 action');
             cy.apiGetPlaybook(testPlaybook.id).then((playbook) => {
@@ -166,6 +184,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions
             cy.findByText('1 action');
@@ -196,6 +220,12 @@ describe('playbooks > edit > task actions', () => {
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
 
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
+
             // Re-open the dialog
             cy.findByText('1 action').click();
 
@@ -206,6 +236,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions
             cy.findByText('1 action');
@@ -236,6 +272,12 @@ describe('playbooks > edit > task actions', () => {
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
 
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
+
             // Re-open the dialog
             cy.findByText('1 action').click();
 
@@ -247,6 +289,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions
             cy.findByText('Task Actions');
@@ -278,6 +326,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify no actions are configured
             cy.findByText('Task Actions').should('exist');
@@ -314,6 +368,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions and user
             cy.findByText('1 action');
@@ -355,6 +415,12 @@ describe('playbooks > edit > task actions', () => {
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
 
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
+
             // Verify configured actions and user
             cy.findByText('1 action');
             cy.apiGetPlaybook(testPlaybook.id).then((playbook) => {
@@ -393,6 +459,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions and user
             cy.findByText('1 action');
@@ -434,6 +506,12 @@ describe('playbooks > edit > task actions', () => {
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
 
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
+
             // Re-open the dialog
             cy.findByText('1 action').click();
 
@@ -444,6 +522,12 @@ describe('playbooks > edit > task actions', () => {
 
             // Save the dialog
             cy.findByTestId('modal-confirm-button').click();
+
+            // Save the edit to trigger remote update
+            cy.findByTestId('checklist-item-save-button').click();
+
+            // Edit again
+            editTask();
 
             // Verify configured actions
             cy.findByText('1 action');

--- a/tests-e2e/cypress/integration/runs/rdp_main_taskactions_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_taskactions_spec.js
@@ -79,7 +79,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify no actions are configured
             cy.findByText('Task Actions').should('exist');
@@ -110,7 +112,9 @@ describe('runs > task actions', () => {
             cy.interceptTelemetry();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions
             cy.findByText('1 action');
@@ -154,7 +158,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions
             cy.findByText('1 action');
@@ -193,7 +199,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions
             cy.findByText('1 action');
@@ -233,7 +241,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // # Re-open the dialog
             cy.findByText('1 action').click();
@@ -244,7 +254,9 @@ describe('runs > task actions', () => {
             });
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions
             cy.findByText('1 action');
@@ -295,7 +307,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // # Re-open the dialog
             cy.findByText('1 action').click();
@@ -307,7 +321,9 @@ describe('runs > task actions', () => {
             });
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions
             cy.findByText('Task Actions');
@@ -348,7 +364,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify no actions are configured
             cy.findByText('Task Actions');
@@ -383,7 +401,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions and user
             cy.findByText('1 action');
@@ -445,7 +465,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions and user
             cy.findByText('1 action');
@@ -511,7 +533,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // * Verify configured actions and user
             cy.findByText('1 action');
@@ -562,7 +586,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // # Re-open the dialog
             cy.findByText('1 action').click();
@@ -573,7 +599,9 @@ describe('runs > task actions', () => {
             });
 
             // Save the dialog
+            cy.intercept('**/query').as('query');
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait('@query');
 
             // Verify configured actions
             cy.findByText('1 action');
@@ -632,7 +660,9 @@ describe('runs > task actions', () => {
             cy.findByText('Mark the task as done').click();
 
             // # Save the dialog
+            cy.intercept('**/query').as(`query${run.id}`);
             cy.findByTestId('modal-confirm-button').click();
+            cy.wait(`@query${run.id}`);
 
             // * Verify configured actions
             cy.findByText('1 action');

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -395,13 +395,16 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             {isEditing &&
                 <CancelSaveButtons
                     onCancel={() => {
-                        setIsEditing(false);
+                        // reset values while in edit mode to prevent re-save of old/current values
                         setTitleValue(props.checklistItem.title);
                         setDescValue(props.checklistItem.description);
                         setAssigneeID(props.checklistItem.assignee_id ?? '');
                         setDueDate(props.checklistItem.due_date);
                         setCommand(props.checklistItem.command);
                         setTaskActions(props.checklistItem.task_actions);
+
+                        // exit edit mode
+                        setIsEditing(false);
                         props.cancelAddingItem?.();
                     }}
                     onSave={() => {


### PR DESCRIPTION
## Summary
Follow up https://github.com/mattermost/mattermost-plugin-playbooks/pull/1563 and https://github.com/mattermost/mattermost-plugin-playbooks/pull/1556

**This is a POC to experiment/learn with state management** 

An scenario we usually play at: 
- component state and server state
- there're different interactions: live local save + cta to remote save, local&server save at the same time, double-save with control + modal.
- updates sometimes rely on receiving WebSocket messages

Some of the problems we deal with:
- you can cancel and changes are saved anyway
- you have to click in several different save cta to get it really saved
- if WS fail UI loses the ability to update, if the server is slow to send WS, UI takes time to update

I followed @calebroseland suggestions and played a bit with useProxyState. This code assumes that useProxyState can be used without onChange param.

Handle local state which triggers also a remote side effect to effectively persist in the server.

Several doubts and next steps are added inline as comments.



## Ticket Link
Related https://mattermost.atlassian.net/browse/MM-48857

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
