### PR TITLE
make view all runs the default filter at run list

### DIFF
--- a/tests-e2e/cypress/integration/runs/list_spec.js
+++ b/tests-e2e/cypress/integration/runs/list_spec.js
@@ -128,9 +128,6 @@ describe('runs > list', () => {
             cy.visit('/playbooks/runs');
 
             cy.get('#playbookRunList').within(() => {
-                // # Filter to all runs
-                cy.findByTestId('my-runs-only').click();
-
                 // # Make sure both runs are visible by default
                 cy.findByText('testUsers Run').should('be.visible');
                 cy.findByText('testAnotherUsers Run').should('be.visible');
@@ -153,9 +150,6 @@ describe('runs > list', () => {
             // # Open the product
             cy.visit('/playbooks');
             cy.get('#playbookRunList').within(() => {
-                // # Filter to all runs
-                cy.findByTestId('my-runs-only').click();
-
                 // Make sure both runs are visible by default
                 cy.findByText('testUsers Run').should('be.visible');
                 cy.findByText('testAnotherUsers Run').should('be.visible');
@@ -196,9 +190,6 @@ describe('runs > list', () => {
             cy.visit('/playbooks');
 
             cy.get('#playbookRunList').within(() => {
-                // # Filter to all runs
-                cy.findByTestId('my-runs-only').click();
-
                 // # Make sure runs are visible by default, and finished is not
                 cy.findByText('testUsers Run').should('be.visible');
                 cy.findByText('testAnotherUsers Run').should('be.visible');

--- a/tests-e2e/cypress/integration/runs/permissions_spec.js
+++ b/tests-e2e/cypress/integration/runs/permissions_spec.js
@@ -454,9 +454,6 @@ const assertRunIsVisible = (run, user) => {
     // # Open Runs
     cy.visit('/playbooks/runs');
 
-    // # Filter to all runs
-    cy.findByTestId('my-runs-only').click();
-
     // # Find the playbook run and click to open details view
     cy.get('#playbookRunList').within(() => {
         cy.findByText(run.name).click();
@@ -485,9 +482,6 @@ const assertRunIsNotVisible = (run, user) => {
 const assertRunIsNotVisibleInList = (run) => {
     // # Open Runs
     cy.visit('/playbooks/runs');
-
-    // # Filter to all runs
-    cy.findByTestId('my-runs-only').click();
 
     // * Verify the playbook run is not visible
     cy.get('#playbookRunList').within(() => {

--- a/webapp/src/components/backstage/runs_page.tsx
+++ b/webapp/src/components/backstage/runs_page.tsx
@@ -42,7 +42,7 @@ const defaultPlaybookFetchParams = {
     per_page: BACKSTAGE_LIST_PER_PAGE,
     sort: 'last_status_update_at',
     direction: 'desc',
-    participant_or_follower_id: 'me',
+    participant_or_follower_id: '',
     statuses: statusOptions
         .filter((opt) => opt.value !== 'Finished' && opt.value !== '')
         .map((opt) => opt.value),


### PR DESCRIPTION
## Summary
"My Runs Only" is disabled by default when visiting run lsit

## Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1670

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
