### PR TITLE
MM-48917 Make interactive playbook run dialogs translatable

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -86,6 +86,90 @@
     "translation": "You have 0 assigned tasks."
   },
   {
+    "id": "app.user.new_run.intro",
+    "translation": "**Owner** {{.Username}}"
+  },
+  {
+    "id": "app.user.new_run.new_playbook",
+    "translation": "[Click here]({{.RunURL}}) to create your own playbook."
+  },
+  {
+    "id": "app.user.new_run.playbook",
+    "translation": "Playbook"
+  },
+  {
+    "id": "app.user.new_run.run_name",
+    "translation": "Run name"
+  },
+  {
+    "id": "app.user.new_run.submit_label",
+    "translation": "Start run"
+  },
+  {
+    "id": "app.user.new_run.title",
+    "translation": "Run playbook"
+  },
+  {
+    "id": "app.user.run.add_checklist_item.description",
+    "translation": "Description"
+  },
+  {
+    "id": "app.user.run.add_checklist_item.name",
+    "translation": "Name"
+  },
+  {
+    "id": "app.user.run.add_checklist_item.submit_label",
+    "translation": "Add task"
+  },
+  {
+    "id": "app.user.run.add_checklist_item.title",
+    "translation": "Add new task"
+  },
+  {
+    "id": "app.user.run.add_to_timeline.playbook_run",
+    "translation": "Playbook Run"
+  },
+  {
+    "id": "app.user.run.add_to_timeline.submit_label",
+    "translation": "Add to run timeline"
+  },
+  {
+    "id": "app.user.run.add_to_timeline.summary",
+    "translation": "Summary"
+  },
+  {
+    "id": "app.user.run.add_to_timeline.summary.help",
+    "translation": "Max 64 chars"
+  },
+  {
+    "id": "app.user.run.add_to_timeline.summary.placeholder",
+    "translation": "Short summary shown in the timeline"
+  },
+  {
+    "id": "app.user.run.add_to_timeline.title",
+    "translation": "Add to run timeline"
+  },
+  {
+    "id": "app.user.run.confirm_finish.num_outstanding",
+    "translation": "There are **{{.Count}}** outstanding tasks."
+  },
+  {
+    "id": "app.user.run.confirm_finish.one_outstanding",
+    "translation": "There is **1 outstanding task**."
+  },
+  {
+    "id": "app.user.run.confirm_finish.question",
+    "translation": "Are you sure you want to finish the run *{{.RunName}}* for all participants?"
+  },
+  {
+    "id": "app.user.run.confirm_finish.submit_label",
+    "translation": "Finish run"
+  },
+  {
+    "id": "app.user.run.confirm_finish.title",
+    "translation": "Confirm finish run"
+  },
+  {
     "id": "app.user.run.request_join_channel",
     "translation": "@{{.Name}} is a run participant and wants join this channel. Any member of the channel can invite them.\n"
   },
@@ -100,5 +184,41 @@
   {
     "id": "app.user.run.status_enable",
     "translation": "@{{.Username}} enabled the status updates for [{{.RunName}}]({{.RunURL}})"
+  },
+  {
+    "id": "app.user.run.update_status.change_since_last_update",
+    "translation": "Change since last update"
+  },
+  {
+    "id": "app.user.run.update_status.finish_run",
+    "translation": "Finish run"
+  },
+  {
+    "id": "app.user.run.update_status.finish_run.placeholder",
+    "translation": "Also mark the run as finished"
+  },
+  {
+    "id": "app.user.run.update_status.intro",
+    "translation": "Provide an update to the stakeholders."
+  },
+  {
+    "id": "app.user.run.update_status.num_channel",
+    "translation": "This post will be broadcasted to {{.Count}} channels."
+  },
+  {
+    "id": "app.user.run.update_status.one_channel",
+    "translation": "This post will be broadcasted to 1 channel."
+  },
+  {
+    "id": "app.user.run.update_status.reminder_for_next_update",
+    "translation": "Reminder for next update"
+  },
+  {
+    "id": "app.user.run.update_status.submit_label",
+    "translation": "Update status"
+  },
+  {
+    "id": "app.user.run.update_status.title",
+    "translation": "Status update"
   }
 ]

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -151,15 +151,10 @@
   },
   {
     "id": "app.user.run.confirm_finish.num_outstanding",
-    "translation": "There are **{{.Count}}** outstanding tasks."
-  },
-  {
-    "id": "app.user.run.confirm_finish.one_outstanding",
-    "translation": "There is **1 outstanding task**."
-  },
-  {
-    "id": "app.user.run.confirm_finish.question",
-    "translation": "Are you sure you want to finish the run *{{.RunName}}* for all participants?"
+    "translation": {
+      "one": "There is **{{.Count}} outstanding task**. Are you sure you want to finish the run *{{.RunName}}* for all participants?",
+      "other": "There are **{{.Count}} outstanding tasks**. Are you sure you want to finish the run *{{.RunName}}* for all participants?"
+    }
   },
   {
     "id": "app.user.run.confirm_finish.submit_label",
@@ -198,16 +193,11 @@
     "translation": "Also mark the run as finished"
   },
   {
-    "id": "app.user.run.update_status.intro",
-    "translation": "Provide an update to the stakeholders."
-  },
-  {
     "id": "app.user.run.update_status.num_channel",
-    "translation": "This post will be broadcasted to {{.Count}} channels."
-  },
-  {
-    "id": "app.user.run.update_status.one_channel",
-    "translation": "This post will be broadcasted to 1 channel."
+    "translation": {
+      "one": "Provide an update to the stakeholders. This post will be broadcasted to {{.Count}} channel.",
+      "other": "Provide an update to the stakeholders. This post will be broadcasted to {{.Count}} channels."
+    }
   },
   {
     "id": "app.user.run.update_status.reminder_for_next_update",

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -997,7 +997,7 @@ func (h *PlaybookRunHandler) reminderButtonUpdate(c *Context, w http.ResponseWri
 		return
 	}
 
-	if err = h.playbookRunService.OpenUpdateStatusDialog(playbookRunID, requestData.TriggerId); err != nil {
+	if err = h.playbookRunService.OpenUpdateStatusDialog(playbookRunID, requestData.UserId, requestData.TriggerId); err != nil {
 		h.HandleError(w, c.logger, errors.New("reminderButtonUpdate failed to open update status dialog"))
 		return
 	}

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -584,13 +584,13 @@ type PlaybookRunService interface {
 	OpenCreatePlaybookRunDialog(teamID, ownerID, triggerID, postID, clientID string, playbooks []Playbook, isMobileApp bool, promptPostID string) error
 
 	// OpenUpdateStatusDialog opens an interactive dialog so the user can update the playbook run's status.
-	OpenUpdateStatusDialog(playbookRunID, triggerID string) error
+	OpenUpdateStatusDialog(playbookRunID, userID, triggerID string) error
 
 	// OpenAddToTimelineDialog opens an interactive dialog so the user can add a post to the playbook run timeline.
 	OpenAddToTimelineDialog(requesterInfo RequesterInfo, postID, teamID, triggerID string) error
 
 	// OpenAddChecklistItemDialog opens an interactive dialog so the user can add a post to the playbook run timeline.
-	OpenAddChecklistItemDialog(triggerID, playbookRunID string, checklist int) error
+	OpenAddChecklistItemDialog(triggerID, userID, playbookRunID string, checklist int) error
 
 	// AddPostToTimeline adds an event based on a post to a playbook run's timeline.
 	AddPostToTimeline(playbookRunID, userID, postID, summary string) error
@@ -602,7 +602,7 @@ type PlaybookRunService interface {
 	UpdateStatus(playbookRunID, userID string, options StatusUpdateOptions) error
 
 	// OpenFinishPlaybookRunDialog opens the dialog to confirm the run should be finished.
-	OpenFinishPlaybookRunDialog(playbookRunID, triggerID string) error
+	OpenFinishPlaybookRunDialog(playbookRunID, userID, triggerID string) error
 
 	// FinishPlaybookRun changes a run's state to Finished. If run is already in Finished state, the call is a noop.
 	FinishPlaybookRun(playbookRunID, userID string) error

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2443,13 +2443,7 @@ func (s *PlaybookRunServiceImpl) newFinishPlaybookRunDialog(playbookRun *Playboo
 		"RunName": playbookRun.Name,
 		"Count":   outstanding,
 	}
-
-	message := T("app.user.run.confirm_finish.question", data)
-	if outstanding == 1 {
-		message = T("app.user.run.confirm_finish.one_outstanding") + " " + message
-	} else if outstanding > 1 {
-		message = T("app.user.run.confirm_finish.num_outstanding", data) + " " + message
-	}
+	message := T("app.user.run.confirm_finish.num_outstanding", data)
 
 	return &model.Dialog{
 		Title:            T("app.user.run.confirm_finish.title"),
@@ -2533,16 +2527,10 @@ func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postI
 func (s *PlaybookRunServiceImpl) newUpdatePlaybookRunDialog(description, message string, broadcastChannelNum int, reminderTimer time.Duration, locale string) (*model.Dialog, error) {
 	T := i18n.GetUserTranslations(locale)
 
-	introductionText := T("app.user.run.update_status.intro") + " "
-
-	if broadcastChannelNum == 1 {
-		introductionText += T("app.user.run.update_status.one_channel")
-	} else {
-		data := map[string]interface{}{
-			"Count": broadcastChannelNum,
-		}
-		introductionText += T("app.user.run.update_status.num_channel", data)
+	data := map[string]interface{}{
+		"Count": broadcastChannelNum,
 	}
+	introductionText := T("app.user.run.update_status.num_channel", data)
 
 	reminderOptions := []*model.PostActionOptions{
 		{

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -454,7 +454,7 @@ func (r *Runner) actionAddChecklistItem(args []string) {
 
 	// If we didn't get the item's text, then use the interactive dialog
 	if len(args) == index {
-		if err := r.playbookRunService.OpenAddChecklistItemDialog(r.args.TriggerId, playbookRuns[run].ID, checklist); err != nil {
+		if err := r.playbookRunService.OpenAddChecklistItemDialog(r.args.TriggerId, r.args.UserId, playbookRuns[run].ID, checklist); err != nil {
 			r.warnUserAndLogErrorf("Error: %v", err)
 			return
 		}
@@ -841,7 +841,7 @@ func (r *Runner) actionFinishByID(args []string) {
 		return
 	}
 
-	err := r.playbookRunService.OpenFinishPlaybookRunDialog(args[0], r.args.TriggerId)
+	err := r.playbookRunService.OpenFinishPlaybookRunDialog(args[0], r.args.UserId, r.args.TriggerId)
 	if err != nil {
 		r.warnUserAndLogErrorf("Error finishing the playbook run: %v", err)
 		return
@@ -887,7 +887,7 @@ func (r *Runner) actionUpdate(args []string) {
 		return
 	}
 
-	err = r.playbookRunService.OpenUpdateStatusDialog(playbookRuns[run].ID, r.args.TriggerId)
+	err = r.playbookRunService.OpenUpdateStatusDialog(playbookRuns[run].ID, r.args.UserId, r.args.TriggerId)
 	switch {
 	case errors.Is(err, app.ErrPlaybookRunNotActive):
 		r.postCommandResponse("This playbook run has already been closed.")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
Changed all hard-coded strings of the interactive dialogs related to playbook runs in the backend to use the i18n translated string instead.
This means, that the following dialogs can now be translated to the user's locale:
-  AddChecklistItemDialog - `/playbook checkadd 0 0`
- FinishPlaybookRunDialog - `/playbook finish 0`
- PlaybookRunDialog - `/playbook run`
- UpdatePlaybookRunDialog - `/playbook update 0`
- AddToTimelineDialog

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
[MM-48917](https://mattermost.atlassian.net/browse/MM-48917)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
