### PR TITLE
1681 Add loading indicator to new playbook run modal

### DIFF
--- a/webapp/src/components/playbooks_selector.tsx
+++ b/webapp/src/components/playbooks_selector.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import styled from 'styled-components';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {ApolloProvider} from '@apollo/client';
-import {BookOutlineIcon, BookLockOutlineIcon, PlusIcon} from '@mattermost/compass-icons/components';
+import {BookLockOutlineIcon, BookOutlineIcon, PlusIcon} from '@mattermost/compass-icons/components';
 import Scrollbars from 'react-custom-scrollbars';
 import {DateTime} from 'luxon';
 
@@ -16,6 +16,7 @@ import {getPlaybooksGraphQLClient} from 'src/graphql_client';
 import {PrimaryButton} from 'src/components/assets/buttons';
 import SearchSvg from 'src/components/assets/illustrations/search_svg';
 import ClipboardChecklistSvg from 'src/components/assets/illustrations/clipboard_checklist_svg';
+import LoadingSpinner from 'src/components/assets/loading_spinner';
 
 interface Props {
     teamID: string;
@@ -99,6 +100,10 @@ const PlaybooksSelector = (props: Props) => {
                 <ErrorSubTitle>{formatMessage({defaultMessage: 'Please check spelling or try another search'})}</ErrorSubTitle>
             </ErrorContainer>
         );
+    }
+
+    if (loading) {
+        return <LoadingContainer><LoadingSpinner/></LoadingContainer>;
     }
 
     return (
@@ -249,4 +254,9 @@ const Plus = styled(PlusIcon)`
 const ClipboardSvg = styled(ClipboardChecklistSvg)`
     height:150px;
     width:150px;
+`;
+
+const LoadingContainer = styled(Container)`
+    padding-top: 10px;
+    align-items: center;
 `;

--- a/webapp/src/components/playbooks_selector.tsx
+++ b/webapp/src/components/playbooks_selector.tsx
@@ -257,6 +257,6 @@ const ClipboardSvg = styled(ClipboardChecklistSvg)`
 `;
 
 const LoadingContainer = styled(Container)`
-    padding-top: 10px;
+    justify-content: center;
     align-items: center;
 `;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
Add a loading indicator to the new playbook run modal. 
I could only reproduce the long loading times that are mentioned in the issue by manually throttling the connection.

[Screencast from 15.12.2022 17:46:06.webm](https://user-images.githubusercontent.com/8669935/207919524-f4614d2d-95c5-45e5-8aee-8ff711aaedbb.webm)

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
Fixes #1681 

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
