### PR TITLE
 GH-1676: only open rhs when in a channel

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs_spec.js
@@ -195,6 +195,44 @@ describe('channels > rhs', () => {
             // * Verify the playbook run RHS is not open.
             cy.get('#rhsContainer').should('not.exist');
         });
+
+        it('when starting a new run of a newly-created playbook created from RHS in a newly-created channel', () => {
+            // # Create a new channel
+            const channelName = 'playbook-test-' + Date.now();
+            cy.apiCreateChannel(testTeam.id, channelName, channelName, 'O').then(({channel}) => {
+                // # Navigate to the new channel
+                cy.visit(`/${testTeam.name}/channels/${channel.name}`);
+
+                // # Open RHS
+                cy.getPlaybooksAppBarIcon().click();
+
+                // # Wait a bit
+                cy.wait(TIMEOUTS.TWO_SEC);
+
+                // # Create a new playbook
+                cy.findAllByTestId('use-playbook').first().click();
+                cy.findByTestId('modal-confirm-button').click();
+
+                // * Verify we're in the playbook edit screen
+                cy.findByTestId('playbook-members');
+
+                // # Run the playbook
+                cy.findByTestId('run-playbook').click();
+                cy.findByTestId('run-name-input').type('Playbook Run');
+
+                // # Link to the new channel
+                cy.findByTestId('link-existing-channel-radio').click();
+                cy.get('#link-existing-channel-selector input').type(`${channel.name}{enter}`, {force: true});
+
+                cy.findByTestId('modal-confirm-button').click();
+
+                // # Wait a bit
+                cy.wait(TIMEOUTS.FIVE_SEC);
+
+                // * Verify the playbook run RHS is not open.
+                cy.get('#rhsContainer').should('not.exist');
+            });
+        });
     });
 
     describe('opens', () => {

--- a/webapp/src/components/rhs/rhs_home_item.tsx
+++ b/webapp/src/components/rhs/rhs_home_item.tsx
@@ -330,7 +330,10 @@ export const RHSHomeTemplate = ({
                     </MetaItem>
                 </Meta>
             </div>
-            <RunButton onClick={() => onUse(template)}>
+            <RunButton
+                data-testid={'use-playbook'}
+                onClick={() => onUse(template)}
+            >
                 <OpenInNewIcon color={'var(--button-bg)'}/>
                 {formatMessage({defaultMessage: 'Use'})}
             </RunButton>

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -7,6 +7,8 @@ import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
+import {matchPath} from 'react-router-dom';
+
 import {fetchPlaybookRuns, telemetryEventForPlaybookRun} from 'src/client';
 import {currentPlaybookRun, isPlaybookRunRHSOpen, inPlaybookRunChannel} from 'src/selectors';
 import {PlaybookRunStatus} from 'src/types/playbook_run';
@@ -24,12 +26,14 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
         const currentChannel = getCurrentChannel(state);
         const currentTeam = getCurrentTeam(state);
         const playbookRun = currentPlaybookRun(state);
+        const url = new URL(window.location.href);
+        const isInChannel = matchPath(url.pathname, {path: '/:team/:path(channels|messages)/:identifier/:postid?'});
 
         //@ts-ignore Views not in global state
         const mmRhsOpen = state.views.rhs.isSidebarOpen;
 
         // Wait for a valid team and channel before doing anything.
-        if (!currentChannel || !currentTeam) {
+        if (!isInChannel || !currentChannel || !currentTeam) {
             return;
         }
 
@@ -47,11 +51,10 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
             store.dispatch(receivedTeamPlaybookRuns(fetched.items));
         }
 
-        // Record and remove telemetry
-        const url = new URL(window.location.href);
         const searchParams = new URLSearchParams(url.searchParams);
 
         if (searchParams.has('telem_action') && searchParams.has('telem_run_id')) {
+            // Record and remove telemetry
             const action = searchParams.get('telem_action') || '';
             const runId = searchParams.get('telem_run_id') || '';
             telemetryEventForPlaybookRun(runId, action);


### PR DESCRIPTION
# Summary
Adds a check to ensure we're viewing a channel before opening RHS. `currentChannelId` can sometimes have a value even though you're not in a channel. 

# Ticket Link
- Fixes: #1676 

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~[ ] Telemetry updated~
- ~[ ] Gated by experimental feature flag~
- [x] Unit tests updated
