### PR TITLE
MM-48607 Fix bug that caused the upgrade modal to not be shown when requesting an update

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/status_update.tsx
@@ -433,7 +433,10 @@ const RequestUpdateButton = ({type, onClick, disabled = false}: {disabled: boole
             {type === 'dotmenu' ? (
                 <DotMenuItem
                     disabled={disabled}
-                    onClick={() => setShowUpgradeModal(true)}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        setShowUpgradeModal(true);
+                    }}
                 >
                     {formatMessage({defaultMessage: 'Request update...'})}
                     <KeyVariantCircleIcon


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
Fix a bug that caused the upgrade modal to not be shown when requesting an update. 
The bug was caused because the click event that caused the modal to be shown was propagated and immediately triggered `onHide` of the upgrade modal which closed the modal. 

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
[MM-48607](https://mattermost.atlassian.net/browse/MM-48607)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
