### PR TITLE
MM-46983 Visual feedback for invalid run names

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/start_run_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/start_run_spec.js
@@ -147,37 +147,6 @@ describe('playbooks > start a run', () => {
     });
 
     describe('from playbook editor', () => {
-        it('error is shown when maximum length of run name is exceeded', () => {
-            // # Visit the selected playbook
-            cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
-
-            // # Click start a run button
-            cy.findByTestId('run-playbook').click();
-
-            cy.get('#root-portal.modal-open').within(() => {
-                // # Wait the modal to render
-                cy.wait(500);
-
-                // * Assert template name is empty
-                cy.findByTestId('run-name-input').should('have.value', '');
-
-                // # Type run name that exceeds maximum length
-                cy.findByTestId('run-name-input').type('a'.repeat(RUN_NAME_MAX_LENGTH + 1));
-
-                // # Click start button
-                cy.findByTestId('modal-confirm-button').click();
-
-                // * Assert error shown and contains maximum length in message
-                cy.findByTestId('run-name-error').should('contain', RUN_NAME_MAX_LENGTH);
-
-                // # Delete last character via backspace
-                cy.findByTestId('run-name-input').type('{backspace}');
-
-                // * Assert that error is not shown anymore
-                cy.findByTestId('run-name-error').should('not.exist');
-            });
-        });
-
         describe('pbe configured as create new channel', () => {
             it('defaults', () => {
                 // # Visit the selected playbook
@@ -576,6 +545,58 @@ describe('playbooks > start a run', () => {
 
                 // * Verify we are on channel Test Run Name
                 cy.url().should('include', `/${testTeam.name}/channels/test-run-name`);
+            });
+        });
+    });
+
+    describe('start run modal > invalid user input', () => {
+        it('submit button is disabled when run name is empty', () => {
+            // # Visit the selected playbook
+            cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
+
+            // # Click start a run button
+            cy.findByTestId('run-playbook').click();
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // # Wait the modal to render
+                cy.wait(500);
+
+                // * Assert template name is empty
+                cy.findByTestId('run-name-input').should('have.value', '');
+
+                // * Assert start button is disabled
+                cy.findByTestId('modal-confirm-button').should('have.attr', 'disabled');
+            });
+        });
+
+        it('error is shown when maximum length of run name is exceeded', () => {
+            // # Visit the selected playbook
+            cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
+
+            // # Click start a run button
+            cy.findByTestId('run-playbook').click();
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // # Wait the modal to render
+                cy.wait(500);
+
+                // * Assert template name is empty
+                cy.findByTestId('run-name-input').should('have.value', '');
+
+                // # Type run name that exceeds maximum length
+                cy.findByTestId('run-name-input').type('a'.repeat(RUN_NAME_MAX_LENGTH + 1));
+
+                // # Click start button
+                cy.findByTestId('modal-confirm-button').click();
+
+                // * Assert error shown and contains maximum length in message
+                cy.findByTestId('run-name-error').should('contain', RUN_NAME_MAX_LENGTH);
+
+                // # Delete last character via backspace
+                cy.findByTestId('run-name-input').type('{backspace}');
+
+                // * Assert that error is not shown anymore
+                cy.findByTestId('run-name-error').should('not.exist');
             });
         });
     });

--- a/tests-e2e/cypress/integration/playbooks/start_run_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/start_run_spec.js
@@ -6,6 +6,8 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
+const RUN_NAME_MAX_LENGTH = 64;
+
 describe('playbooks > start a run', () => {
     let testTeam;
     let testSysadmin;
@@ -145,6 +147,37 @@ describe('playbooks > start a run', () => {
     });
 
     describe('from playbook editor', () => {
+        it('error is shown when maximum length of run name is exceeded', () => {
+            // # Visit the selected playbook
+            cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
+
+            // # Click start a run button
+            cy.findByTestId('run-playbook').click();
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // # Wait the modal to render
+                cy.wait(500);
+
+                // * Assert template name is empty
+                cy.findByTestId('run-name-input').should('have.value', '');
+
+                // # Type run name that exceeds maximum length
+                cy.findByTestId('run-name-input').type('a'.repeat(RUN_NAME_MAX_LENGTH + 1));
+
+                // # Click start button
+                cy.findByTestId('modal-confirm-button').click();
+
+                // * Assert error shown and contains maximum length in message
+                cy.findByTestId('run-name-error').should('contain', RUN_NAME_MAX_LENGTH);
+
+                // # Delete last character via backspace
+                cy.findByTestId('run-name-input').type('{backspace}');
+
+                // * Assert that error is not shown anymore
+                cy.findByTestId('run-name-error').should('not.exist');
+            });
+        });
+
         describe('pbe configured as create new channel', () => {
             it('defaults', () => {
                 // # Visit the selected playbook

--- a/tests-e2e/cypress/integration/playbooks/start_run_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/start_run_spec.js
@@ -586,11 +586,11 @@ describe('playbooks > start a run', () => {
                 // # Type run name that exceeds maximum length
                 cy.findByTestId('run-name-input').type('a'.repeat(RUN_NAME_MAX_LENGTH + 1));
 
-                // # Click start button
-                cy.findByTestId('modal-confirm-button').click();
-
                 // * Assert error shown and contains maximum length in message
                 cy.findByTestId('run-name-error').should('contain', RUN_NAME_MAX_LENGTH);
+
+                // * Assert start button is disabled
+                cy.findByTestId('modal-confirm-button').should('have.attr', 'disabled');
 
                 // # Delete last character via backspace
                 cy.findByTestId('run-name-input').type('{backspace}');

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -467,6 +467,7 @@
   "m/Q4ye": "Rename checklist",
   "m8hzTK": "Last used {time}",
   "mCrdeS": "Total Playbook Runs",
+  "mILd++": "The run name should not exceed {maxLength} characters",
   "mLrh+0": "No due date",
   "mNgqXf": "To unlock this feature:",
   "mVpO8u": "Seen this before?",

--- a/webapp/src/components/assets/inputs.tsx
+++ b/webapp/src/components/assets/inputs.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
-export const BaseInput = styled.input`
+export const BaseInput = styled.input<{invalid?: boolean}>`
     transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
     background-color: rgb(var(--center-channel-bg-rgb));
     border: none;
-    box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
+    box-shadow: ${(props) => (props.invalid ? 'inset 0 0 0 2px var(--error-text)' : 'inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16)')};
     border-radius: 4px;
     height: 40px;
     line-height: 40px;
@@ -12,7 +12,7 @@ export const BaseInput = styled.input`
     font-size: 14px;
 
     &:focus {
-        box-shadow: inset 0 0 0 2px var(--button-bg);
+        box-shadow: ${(props) => (props.invalid ? 'inset 0 0 0 2px var(--error-text)' : 'inset 0 0 0 2px var(--button-bg)')};
     }
 `;
 

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -103,7 +103,7 @@ const RunPlaybookNewModal = ({
 
     const createNewChannel = channelMode === 'create_new_channel';
     const linkExistingChannel = channelMode === 'link_existing_channel';
-    const isFormValid = runName !== '' && runName.length <= 64 && (createNewChannel || channelId !== '');
+    const isFormValid = runName !== '' && (createNewChannel || channelId !== '');
 
     const onCreatePlaybook = () => {
         dispatch(displayPlaybookCreateModal({}));

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -103,7 +103,7 @@ const RunPlaybookNewModal = ({
 
     const createNewChannel = channelMode === 'create_new_channel';
     const linkExistingChannel = channelMode === 'link_existing_channel';
-    const isFormValid = runName !== '' && (createNewChannel || channelId !== '');
+    const isFormValid = runName !== '' && runName.length <= 64 && (createNewChannel || channelId !== '');
 
     const onCreatePlaybook = () => {
         dispatch(displayPlaybookCreateModal({}));

--- a/webapp/src/components/modals/new_run_playbook_modal.tsx
+++ b/webapp/src/components/modals/new_run_playbook_modal.tsx
@@ -200,7 +200,7 @@ const RunPlaybookNewModal = ({
                         value={runName}
                         onChange={onRunNameChange}
                     />
-                    {runNameError && <ErrorMessage>{runNameError}</ErrorMessage>}
+                    {runNameError && <ErrorMessage data-testid={'run-name-error'}>{runNameError}</ErrorMessage>}
 
                     <InlineLabel>{formatMessage({defaultMessage: 'Run summary'})}</InlineLabel>
                     <BaseTextArea

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -17,6 +17,8 @@ export const BACKSTAGE_LIST_PER_PAGE = 15;
 
 export const PROFILE_CHUNK_SIZE = 200;
 
+export const RUN_NAME_MAX_LENGTH = 64;
+
 export enum AdminNotificationType {
     VIEW_TIMELINE = 'start_trial_to_view_timeline',
     MESSAGE_TO_TIMELINE = 'start_trial_to_add_message_to_timeline',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
Implement visual feedback when a run name is invalid. A detailed error message will be shown in that case. 
Currently, it will only be checked if the run name exceeds 64 characters.

[Screencast from 21.12.2022 15:18:00.webm](https://user-images.githubusercontent.com/8669935/208926553-743590ef-30c8-485b-9d40-07fa01476cb1.webm)

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
[MM-46983](https://mattermost.atlassian.net/browse/MM-46983)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
