### PR TITLE
MM-48600 Fix run actions modal not updating state when changing run

### DIFF
--- a/webapp/src/components/run_actions_modal.tsx
+++ b/webapp/src/components/run_actions_modal.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
+import {useUpdateEffect} from 'react-use';
 import {useDispatch, useSelector} from 'react-redux';
 import {useIntl} from 'react-intl';
 import styled from 'styled-components';
@@ -40,17 +41,29 @@ const RunActionsModal = ({playbookRun, readOnly}: Props) => {
     const [isValid, setIsValid] = useState<boolean>(true);
     const updateRun = useUpdateRun(playbookRun.id);
 
-    // Update states on run change
-    // When this component is already mounted, the initial states passed above will not be used
-    // Therefore the states have to be explicitly updated when the run changes
-    useEffect(() => {
+    useUpdateEffect(() => {
         setBroadcastToChannelsEnabled(playbookRun.status_update_broadcast_channels_enabled);
+    }, [playbookRun.status_update_broadcast_channels_enabled]);
+
+    useUpdateEffect(() => {
         setSendOutgoingWebhookEnabled(playbookRun.status_update_broadcast_webhooks_enabled);
+    }, [playbookRun.status_update_broadcast_webhooks_enabled]);
+
+    useUpdateEffect(() => {
         setCreateChannelMemberEnabled(playbookRun.create_channel_member_on_new_participant);
+    }, [playbookRun.create_channel_member_on_new_participant]);
+
+    useUpdateEffect(() => {
         setRemoveChannelMemberEnabled(playbookRun.remove_channel_member_on_removed_participant);
+    }, [playbookRun.remove_channel_member_on_removed_participant]);
+
+    useUpdateEffect(() => {
         setChannelIds(playbookRun.broadcast_channel_ids);
+    }, [playbookRun.broadcast_channel_ids]);
+
+    useUpdateEffect(() => {
         setWebhooks(playbookRun.webhook_on_status_update_urls);
-    }, [playbookRun]);
+    }, [playbookRun.webhook_on_status_update_urls]);
 
     const onHide = () => {
         dispatch(hideRunActionsModal());

--- a/webapp/src/components/run_actions_modal.tsx
+++ b/webapp/src/components/run_actions_modal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useIntl} from 'react-intl';
 import styled from 'styled-components';
@@ -39,6 +39,18 @@ const RunActionsModal = ({playbookRun, readOnly}: Props) => {
     const [webhooks, setWebhooks] = useState(playbookRun.webhook_on_status_update_urls);
     const [isValid, setIsValid] = useState<boolean>(true);
     const updateRun = useUpdateRun(playbookRun.id);
+
+    // Update states on run change
+    // When this component is already mounted, the initial states passed above will not be used
+    // Therefore the states have to be explicitly updated when the run changes
+    useEffect(() => {
+        setBroadcastToChannelsEnabled(playbookRun.status_update_broadcast_channels_enabled);
+        setSendOutgoingWebhookEnabled(playbookRun.status_update_broadcast_webhooks_enabled);
+        setCreateChannelMemberEnabled(playbookRun.create_channel_member_on_new_participant);
+        setRemoveChannelMemberEnabled(playbookRun.remove_channel_member_on_removed_participant);
+        setChannelIds(playbookRun.broadcast_channel_ids);
+        setWebhooks(playbookRun.webhook_on_status_update_urls);
+    }, [playbookRun]);
 
     const onHide = () => {
         dispatch(hideRunActionsModal());


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
The run actions modal did not show the correct data when changing runs.

This was caused because `useState` does not use the provided initial state if the component has mounted with a state already which is the case here, when the first run is visited. 

To avoid this issue, all states will be synced when the run changes.

[Screencast from 04.01.2023 15:49:45.webm](https://user-images.githubusercontent.com/8669935/210581554-ca316de4-49b3-4e6e-bc15-c6f7e697b954.webm)

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
[MM-48600](https://mattermost.atlassian.net/browse/MM-48600)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~


[MM-48600]: https://mattermost.atlassian.net/browse/MM-48600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ