### PR TITLE
MM-48599 Improve toast for participating in a run and toasts in general

### DIFF
--- a/webapp/src/components/backstage/toast.tsx
+++ b/webapp/src/components/backstage/toast.tsx
@@ -14,6 +14,9 @@ export interface ToastProps {
     buttonName?: string;
     buttonCallback?: () => void;
     closeCallback?: () => void;
+    interactive?: boolean;
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
 }
 
 export const Toast = (props: ToastProps) => {
@@ -30,9 +33,12 @@ export const Toast = (props: ToastProps) => {
             iconName = 'information-outline';
         }
     }
+    const interactive = props.interactive ?? Boolean(props.buttonCallback);
     return (
         <StyledToast
             toastStyle={props.toastStyle ?? ToastStyle.Success}
+            onMouseEnter={interactive ? props.onMouseEnter : undefined}
+            onMouseLeave={interactive ? props.onMouseLeave : undefined}
         >
             <StyledIcon className={`icon icon-${iconName}`}/>
             <StyledText>{props.content}</StyledText>

--- a/webapp/src/components/backstage/toast.tsx
+++ b/webapp/src/components/backstage/toast.tsx
@@ -14,7 +14,6 @@ export interface ToastProps {
     buttonName?: string;
     buttonCallback?: () => void;
     closeCallback?: () => void;
-    interactive?: boolean;
     onMouseEnter?: () => void;
     onMouseLeave?: () => void;
 }
@@ -33,12 +32,11 @@ export const Toast = (props: ToastProps) => {
             iconName = 'information-outline';
         }
     }
-    const interactive = props.interactive ?? Boolean(props.buttonCallback);
     return (
         <StyledToast
             toastStyle={props.toastStyle ?? ToastStyle.Success}
-            onMouseEnter={interactive ? props.onMouseEnter : undefined}
-            onMouseLeave={interactive ? props.onMouseLeave : undefined}
+            onMouseEnter={props.onMouseEnter}
+            onMouseLeave={props.onMouseLeave}
         >
             <StyledIcon className={`icon icon-${iconName}`}/>
             <StyledText>{props.content}</StyledText>

--- a/webapp/src/components/backstage/toast_banner.tsx
+++ b/webapp/src/components/backstage/toast_banner.tsx
@@ -8,7 +8,7 @@ const Ctx = React.createContext({} as ToastFuncs);
 
 const DEFAULT_DURATION = 3000;
 let toastCount = 0;
-const toastTimeoutMap :Record<number, number> = {};
+const toastTimeoutMap: Record<number, number> = {};
 
 const ToastContainer = styled.div`
     position: fixed;

--- a/webapp/src/components/backstage/toast_banner.tsx
+++ b/webapp/src/components/backstage/toast_banner.tsx
@@ -8,6 +8,7 @@ const Ctx = React.createContext({} as ToastFuncs);
 
 const DEFAULT_DURATION = 3000;
 let toastCount = 0;
+const toastTimeoutMap :Record<number, number> = {};
 
 const ToastContainer = styled.div`
     position: fixed;
@@ -39,30 +40,60 @@ interface ToastFuncs {
 export const ToastProvider = (props: Props) => {
     const [toasts, setToasts] = useState<ToastOptionsWithID[]>([]);
 
-    const add = (options: ToastOptions) => {
-        const id = toastCount++;
-        const duration = options.duration ?? DEFAULT_DURATION;
-
-        setToasts((ts) => [...ts, {id, ...options}]);
+    const addTimeout = (toastId: number, duration = DEFAULT_DURATION) => {
         if (duration <= 0) {
-            return id;
+            return;
         }
-
-        window.setTimeout(() => {
+        toastTimeoutMap[toastId] = window.setTimeout(() => {
+            removeTimeout(toastId);
             setToasts((ts) => {
-                const index = ts.findIndex((t) => t.id === id);
+                const index = ts.findIndex((t) => t.id === toastId);
                 if (index === -1) {
                     return ts;
                 }
                 return [...ts.slice(0, index), ...ts.slice(index + 1)];
             });
         }, duration);
+    };
+
+    const removeTimeout = (toastId: number) => {
+        if (!toastTimeoutMap[toastId]) {
+            return;
+        }
+        delete toastTimeoutMap[toastId];
+    };
+
+    const add = (options: ToastOptions) => {
+        const id = toastCount++;
+
+        setToasts((ts) => [...ts, {id, ...options}]);
+        addTimeout(id, options.duration);
 
         return id;
     };
 
     const remove = (id: number) => {
+        removeTimeout(id);
         setToasts((ts) => ts.filter((t: ToastOptionsWithID) => t.id !== id));
+    };
+
+    const onToastMouseEnter = (id: number) => {
+        if (!toastTimeoutMap[id]) {
+            return;
+        }
+        window.clearTimeout(toastTimeoutMap[id]);
+        removeTimeout(id);
+    };
+
+    const onToastMouseLeave = (id: number) => {
+        if (toastTimeoutMap[id]) {
+            return;
+        }
+        const toastOptions = toasts.find((toast) => toast.id === id);
+        if (!toastOptions) {
+            return;
+        }
+        addTimeout(id, toastOptions.duration);
     };
 
     return (
@@ -83,6 +114,8 @@ export const ToastProvider = (props: Props) => {
                                         remove(options.id);
                                         options.closeCallback?.();
                                     }}
+                                    onMouseEnter={() => onToastMouseEnter(options.id)}
+                                    onMouseLeave={() => onToastMouseLeave(options.id)}
                                 />
                             </CSSTransition>
                         );

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -108,6 +108,7 @@ const RHSRunDetails = (props: Props) => {
             buttonName: formatMessage({defaultMessage: 'Participate'}),
             buttonCallback: showConfirm,
             iconName: 'account-plus-outline',
+            duration: 4500,
         });
     }, toastDebounce, {leading: true, trailing: false}), []);
 

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -14,7 +14,7 @@ import {FormattedMessage, useIntl} from 'react-intl';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {debounce} from 'lodash';
+import {throttle} from 'lodash';
 
 import {
     RHSContainer,
@@ -48,7 +48,7 @@ import RHSRunDetailsTitle from './rhs_run_details_title';
 import RHSRunParticipants from './rhs_run_participants';
 import RHSRunParticipantsTitle from './rhs_run_participants_title';
 
-const toastDebounce = 2000;
+const toastDuration = 4500;
 
 interface Props {
     runID: string
@@ -96,7 +96,7 @@ const RHSRunDetails = (props: Props) => {
     const {ParticipateConfirmModal, showParticipateConfirm} = useParticipateInRun(playbookRun ?? undefined, 'channel_rhs');
     const addToast = useToaster().add;
     const removeToast = useToaster().remove;
-    const displayReadOnlyToast = useMemo(() => debounce(() => {
+    const displayReadOnlyToast = useMemo(() => throttle(() => {
         let toastID = -1;
         const showConfirm = () => {
             removeToast(toastID);
@@ -108,9 +108,9 @@ const RHSRunDetails = (props: Props) => {
             buttonName: formatMessage({defaultMessage: 'Participate'}),
             buttonCallback: showConfirm,
             iconName: 'account-plus-outline',
-            duration: 4500,
+            duration: toastDuration,
         });
-    }, toastDebounce, {leading: true, trailing: false}), []);
+    }, toastDuration, {leading: true, trailing: false}), []);
 
     const rhsContainerPunchout = useMeasurePunchouts(
         ['rhsContainer'],


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
Increased the duration the toast for participating in a run is shown from 3 to 4.5 seconds. 

Additionally, toasts will not be hidden while hovered. 

[Screencast from 04.01.2023 17:54:43.webm](https://user-images.githubusercontent.com/8669935/210608030-39b7800e-5c77-49de-91b0-652c250313be.webm)

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
[MM-48599](https://mattermost.atlassian.net/browse/MM-48599)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~


[MM-48599]: https://mattermost.atlassian.net/browse/MM-48599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ