### PR TITLE
force golangci to recent commit to solve macos issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
@@ -25,9 +24,6 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - varcheck
-    # disabled until is compatible with go1.18 https://github.com/golangci/golangci-lint/issues/2649
-    # - structcheck
 
 linters-settings:
   gofmt:

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,14 @@ endif
 	cd tests-e2e && npm run fix
 
 
+## Check & install golangci version
+# Pinned version to commit until 10.2 is released since some macos version have problems
+# with the native diff tools used by typecheck (gometalinter problem)
 .PHONY: check-golangci
 check-golangci:
 ifneq ($(HAS_SERVER),)
 	@echo Ckecking golangci-lint
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@8f6de2c65895749d9ced401cde189d80f41617a0
 endif
 
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -3623,9 +3623,7 @@ func (s *PlaybookRunServiceImpl) doActions(taskActions []Action, runID string, u
 			}
 			if a.Payload.Enabled {
 				if err := s.ModifyCheckedState(runID, userID, ChecklistItemStateClosed, checklistNum, itemNum); err != nil {
-					if err != nil {
-						return errors.Wrapf(err, "can't mark item as done")
-					}
+					return errors.Wrapf(err, "can't mark item as done")
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
Some MacOS users (@jecepeda and I for example) can not run `make check-style` since golangci is broken after Ventura upgrade.
Apparently the native diff is not compatible with some time format used by `gofmt diff`.

More info https://github.com/golangci/golangci-lint/issues/3402, https://github.com/golangci/golangci-lint/issues/3087 and https://github.com/golangci/golangci-lint/issues/3375

```
/Users/jpeso/code/mattermost-plugin-playbooks/bin/golangci-lint run ./...
level=warning msg="[runner] Can't run linter goanalysis_metalinter: gofmt: can't extract issues from gofmt diff output \"--- /Users/jpeso/code/mattermost-plugin-playbooks/server/manifest.go.orig\\t2023-01-13 16:25:14\\n+++ /Users/jpeso/code/mattermost-plugin-playbooks/server/manifest.go\\t2023-01-13 16:25:14\\n@@ -3,8 +3,8 @@\\n package main\\n \\n import (\\n-\\t\\\"strings\\\"\\n \\t\\\"encoding/json\\\"\\n+\\t\\\"strings\\\"\\n \\n \\t\\\"github.com/mattermost/mattermost-server/v6/model\\\"\\n )\\n\": can't parse patch: parsing time \"2023-01-13 16:25:14\" as \"2006-01-02 15:04:05 -0700\": cannot parse \"\" as \"-0700\""
level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: gofmt: can't extract issues from gofmt diff output \"--- /Users/jpeso/code/mattermost-plugin-playbooks/server/manifest.go.orig\\t2023-01-13 16:25:14\\n+++ /Users/jpeso/code/mattermost-plugin-playbooks/server/manifest.go\\t2023-01-13 16:25:14\\n@@ -3,8 +3,8 @@\\n package main\\n \\n import (\\n-\\t\\\"strings\\\"\\n \\t\\\"encoding/json\\\"\\n+\\t\\\"strings\\\"\\n \\n \\t\\\"github.com/mattermost/mattermost-server/v6/model\\\"\\n )\\n\": can't parse patch: parsing time \"2023-01-13 16:25:14\" as \"2006-01-02 15:04:05 -0700\": cannot parse \"\" as \"-0700\"\n\n"
```

The issue has been fixed at master for more than a month but there's been no release (since October 22nd). It's not very nice to pin the commit version of the package but is a working solution until golangci release 10.50.2 version. 


Additionally, the list of linters has been updated, removing deprecated ones and fixing a new error that appeared.

## Ticket Link
No

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
