### PR TITLE
MM-48590 Add indicator for adding participants when at least one member alrady exists

### DIFF
--- a/webapp/src/components/rhs/rhs_participants.tsx
+++ b/webapp/src/components/rhs/rhs_participants.tsx
@@ -26,6 +26,16 @@ const RHSParticipants = (props: Props) => {
         props.setShowParticipants(true);
     };
 
+    const addParticipant = (
+        <LinkAddParticipants
+            to={'#'}
+            onClick={showParticipants}
+        >
+            {formatMessage({defaultMessage: 'Add participant'})}
+            <OpenInNewIcon size={11}/>
+        </LinkAddParticipants>
+    );
+
     const becomeParticipant = (
         <Tooltip
             id={'rhs-participate'}
@@ -49,15 +59,7 @@ const RHSParticipants = (props: Props) => {
                     <FormattedMessage defaultMessage='Nobody yet.'/>
                     {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
                     {' '}
-                    {props.onParticipate ? null : (
-                        <LinkAddParticipants
-                            to={'#'}
-                            onClick={showParticipants}
-                        >
-                            {formatMessage({defaultMessage: 'Add participant'})}
-                            <OpenInNewIcon size={11}/>
-                        </LinkAddParticipants>
-                    )}
+                    {props.onParticipate ? null : addParticipant}
                 </NoParticipants>
                 {props.onParticipate ? becomeParticipant : null}
             </Container>
@@ -84,7 +86,7 @@ const RHSParticipants = (props: Props) => {
                     sizeInPx={height}
                 />
             </UserRow>
-            {props.onParticipate ? becomeParticipant : null}
+            {props.onParticipate ? becomeParticipant : addParticipant}
         </Container>
     );
 };
@@ -151,6 +153,7 @@ const UserRow = styled.div`
     flex-direction: row;
 
     margin-left: -4px;
+    margin-right: 2px;
 
     border-radius: 44px;
     border: 6px solid transparent;
@@ -189,6 +192,9 @@ const IconWrapper = styled.div<{format: 'icon' | 'icontext'}>`
 `;
 
 const LinkAddParticipants = styled(Link)`
+    color: rgba(var(--center-channel-color-rgb), 0.72);
+    font-size: 11px;
+    line-height: 16px;
     display: inline-flex;
     align-items: center;
     svg {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
At the moment, it is not obvious how to add participants to a run in the RHS if there are members already. 
This PR adds a link for that case, similar to the link when there are no participants.

[Screencast from 13.01.2023 16:47:20.webm](https://user-images.githubusercontent.com/8669935/212362464-c0091bb9-f3da-4c2d-b6df-cea8974deb1c.webm)


## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
[MM-48590](https://mattermost.atlassian.net/browse/MM-48590)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
