### PR TITLE
connect apollo dev tools

### DIFF
--- a/webapp/src/graphql/apollo.tsx
+++ b/webapp/src/graphql/apollo.tsx
@@ -35,6 +35,7 @@ export function makeGraphqlClient() {
     };
     const graphqlClient = new ApolloClient({
         link: new HttpLink({fetch: graphqlFetch}),
+        connectToDevTools: true,
         cache: new InMemoryCache({
             typePolicies: {
                 Query: {


### PR DESCRIPTION
## Summary
Oneliner to connect dev tools.

Not sure yet if this should be only done in development (instrospection is already disabled server side for production)

It needs EnableTesting and EnableDeveloper as true in the mattermost-server.

## Ticket Link
Nope

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
