### PR TITLE
set to true tutorial point for drafts in e2e

### DIFF
--- a/tests-e2e/cypress/support/api/preference.js
+++ b/tests-e2e/cypress/support/api/preference.js
@@ -337,6 +337,12 @@ Cypress.Commands.add('apiDisableTutorials', (userId) => {
             category: 'insights',
             name: 'insights_tutorial_state',
             value: '{"insights_modal_viewed":true}'
+        },
+        {
+            user_id: userId,
+            category: 'drafts',
+            name: 'drafts_tour_tip_showed',
+            value: '{"drafts_tour_tip_showed":true}'
         }
     ];
 


### PR DESCRIPTION
## Summary
Set tutotial point for draft as viewed in e2e tests.
 
![Screenshot 2023-01-16 at 10 11 36](https://user-images.githubusercontent.com/4096774/212640646-7d203382-39ff-4237-bd23-5cb5f25f6788.png)

## Ticket Link
No

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
