### PR TITLE
MM-48580: avoid error loading without teams

### DIFF
--- a/tests-e2e/cypress/integration/playbooks/onboarding_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/onboarding_spec.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+describe('playbooks > onboarding', () => {
+    let testUserWithoutTeam;
+
+    before(() => {
+        cy.apiInitSetup().then(() => {
+            cy.apiCreateUser().then(({user: userWithoutTeam}) => {
+                testUserWithoutTeam = userWithoutTeam;
+            });
+        });
+    });
+
+    describe('should redirect to team selection', () => {
+        it('on a fresh page load', () => {
+            // # Login as testUserWithoutTeam
+            cy.apiLogin(testUserWithoutTeam);
+
+            // # Open the product
+            cy.visit('/playbooks');
+
+            // # Verify the redirection
+            cy.url().should('include', '/select_team');
+        });
+
+        it('on redirect after login ', () => {
+            // # Login as testUserWithoutTeam
+            cy.apiLogin(testUserWithoutTeam);
+
+            // # Open the product, redirecting to /playbooks after loading
+            cy.visit('/login?redirect_to=%2Fplaybooks');
+
+            // # Verify the redirection
+            cy.url().should('include', '/select_team');
+        });
+    });
+});
+

--- a/webapp/src/components/backstage/main_body.tsx
+++ b/webapp/src/components/backstage/main_body.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {
     Redirect,
     Route,
@@ -36,9 +36,17 @@ const useInitTeamRoutingLogic = () => {
     const currentTeamId = useSelector(getCurrentTeamId);
     const currentUserId = useSelector(getCurrentUserId);
 
+    const history = useHistory();
+
+    useEffect(() => {
+        if (currentUserId?.length > 0 && teams.length === 0) {
+            history.push('/select_team');
+        }
+    });
+
     // ? consider moving to multi-product or plugin infrastructure
     // see https://github.com/mattermost/mattermost-webapp/blob/25043262dbab1fc2f9ac6972b1f1b0b1f9c20ae0/stores/local_storage_store.jsx#L9
-    const [prevTeamId, setPrevTeamId] = useLocalStorage(`user_prev_team:${currentUserId}`, teams[0].id, {raw: true});
+    const [prevTeamId, setPrevTeamId] = useLocalStorage(`user_prev_team:${currentUserId}`, teams[0]?.id, {raw: true});
 
     /**
      * * These routes will select the proper team they belong too.


### PR DESCRIPTION
## Summary
If a user doesn't have any teams, redirect them to the `/select_team` handler.

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-48580