### PR TITLE
fix overfetch channel actions

### DIFF
--- a/webapp/src/components/channel_actions_modal.tsx
+++ b/webapp/src/components/channel_actions_modal.tsx
@@ -104,10 +104,10 @@ const ChannelActionsModal = () => {
             });
         };
 
-        if (channelID) {
+        if (channelID && show) {
             getActions(channelID);
         }
-    }, [channelID, welcomeMsgInit, categorizationInit, promptInit]);
+    }, [channelID, show, welcomeMsgInit, categorizationInit, promptInit]);
 
     const onHide = () => {
         welcomeMsgReset();

--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -203,11 +203,11 @@ export const handleWebsocketChannelUpdated = (getState: GetStateFunc, dispatch: 
 export const handleWebsocketChannelViewed = (getState: GetStateFunc, dispatch: Dispatch) => {
     return async (msg: WebSocketMessage<{ channel_id: string, prev_viewed_at?: number}>) => {
         const channelId = msg.data.channel_id;
-        const isAlreadyViewed = msg.data.prev_viewed_at === 0;
+        const isAlreadyViewed = Boolean(msg.data.prev_viewed_at);
 
         // if the user has already viewed the channel, there's no need to fetch actions again
         // prev_viewed_at is not coming for server 7.7 and below, so we additionally check redux
-        if (!isAlreadyViewed || hasViewedByChannelID(getState())[channelId]) {
+        if (isAlreadyViewed || hasViewedByChannelID(getState())[channelId]) {
             return;
         }
 

--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -201,12 +201,13 @@ export const handleWebsocketChannelUpdated = (getState: GetStateFunc, dispatch: 
 };
 
 export const handleWebsocketChannelViewed = (getState: GetStateFunc, dispatch: Dispatch) => {
-    return async (msg: WebSocketMessage<{ channel_id: string }>) => {
+    return async (msg: WebSocketMessage<{ channel_id: string, prev_viewed_at?: number}>) => {
         const channelId = msg.data.channel_id;
+        const isAlreadyViewed = msg.data.prev_viewed_at === 0;
 
-        // if the user has already viewed the channel,
-        // there's no need to fetch actions again
-        if (hasViewedByChannelID(getState())[channelId]) {
+        // if the user has already viewed the channel, there's no need to fetch actions again
+        // prev_viewed_at is not coming for server 7.7 and below, so we additionally check redux
+        if (!isAlreadyViewed || hasViewedByChannelID(getState())[channelId]) {
             return;
         }
 


### PR DESCRIPTION
## Summary
Two different actions on the channelactions management to reduce the number of calls on every channel switch. There are two kind of fetch:

**/plugins/playbooks/api/v0/actions/channels/<Channelid>**

Make channel actions modal fetch action ONLY when is shown, not when it's rendered but hidden. Before this change, channel actions were fetched on every channel switch.

**/plugins/playbooks/api/v0/actions/channels/<Channelid>?trigger_type=new_member_joins**

Several actions done here:
 - kept hasviewedchannel redux reducer/actions/seelctors to guarantee backwards compatibility with old servers
 - added prev_viewed_at to websocket data at mattermost-server
 - use prev_viewed_at to trigger just the first time


Before 
https://user-images.githubusercontent.com/4096774/213535360-fda5437a-67b0-416d-bbfc-9f216c37fd81.mp4


After
https://user-images.githubusercontent.com/4096774/213535329-e6caa3d5-71d9-42dd-a531-17601581a656.mp4


This PR relies on[ some small change](https://github.com/mattermost/mattermost-server/pull/22111) on mattermost-server. If the mattermost-server don't send that new field, we will work as we previously did (just prevent fetch after viewing channels once per session)


## Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1731

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
