### PR TITLE
allow status post for channels I am not a member yet but they are joinable

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -755,15 +755,6 @@ func (h *PlaybookRunHandler) status(c *Context, w http.ResponseWriter, r *http.R
 
 // updateStatus returns a publicMessage and an internal error
 func (h *PlaybookRunHandler) updateStatus(playbookRunID, userID string, options app.StatusUpdateOptions) (string, error) {
-	playbookRunToModify, err := h.playbookRunService.GetPlaybookRun(playbookRunID)
-	if err != nil {
-		return "", err
-	}
-
-	if err := h.permissions.RunUpdateStatus(userID, playbookRunToModify); err != nil {
-		return "Not authorized", err
-	}
-
 	options.Message = strings.TrimSpace(options.Message)
 	if options.Message == "" {
 		return "message must not be empty", errors.New("message field empty")


### PR DESCRIPTION
## Summary
We require write permissions for every broadcasted channel when posting status updates.

This change makes the user automatically join those channels that are public before checking the permissions and posting the update.

Personally, I don't consider this a final solution (code is more complex, and forcing to join channels may be confusing) but a workaround. I'd be more inclined to remove the check for all broadcasted channels. In the case we delay or reject that permission check removal, this PR could mitigate the bad side-effects. 

## Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1690

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
