### PR TITLE
revert #1554 - allow run participants to post update 

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -696,7 +696,7 @@ func (h *PlaybookRunHandler) getChannels(c *Context, w http.ResponseWriter, r *h
 
 	playbookRuns, err := h.playbookRunService.GetPlaybookRuns(requesterInfo, *filterOptions)
 	if err != nil {
-		h.HandleError(w, c.logger, errors.Wrapf(err, "failed to get owners"))
+		h.HandleError(w, c.logger, errors.Wrapf(err, "failed to get playbookRuns"))
 		return
 	}
 
@@ -755,12 +755,9 @@ func (h *PlaybookRunHandler) status(c *Context, w http.ResponseWriter, r *http.R
 
 // updateStatus returns a publicMessage and an internal error
 func (h *PlaybookRunHandler) updateStatus(playbookRunID, userID string, options app.StatusUpdateOptions) (string, error) {
-	playbookRunToModify, err := h.playbookRunService.GetPlaybookRun(playbookRunID)
-	if err != nil {
-		return "", err
-	}
 
-	if err := h.permissions.RunUpdateStatus(userID, playbookRunToModify); err != nil {
+	// user must be a participant to be able to post an update
+	if err := h.permissions.RunManageProperties(userID, playbookRunID); err != nil {
 		return "Not authorized", err
 	}
 

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -502,7 +502,7 @@ func TestRunRetrieval(t *testing.T) {
 	})
 }
 
-func TestRunStatus(t *testing.T) {
+func TestRunPostStatusUpdate(t *testing.T) {
 	e := Setup(t)
 	e.CreateBasic()
 
@@ -537,9 +537,9 @@ func TestRunStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, run)
 
-		// Update should fail because no access to private broadcast channel
+		// Update should work even when we don't have access to private broadcast channel
 		err = e.PlaybooksClient.PlaybookRuns.UpdateStatus(context.Background(), run.ID, "update", 600)
-		requireErrorWithStatusCode(t, err, http.StatusForbidden)
+		assert.NoError(t, err)
 	})
 }
 

--- a/server/app/permissions_service.go
+++ b/server/app/permissions_service.go
@@ -445,20 +445,6 @@ func (p *PermissionsService) RunView(userID, runID string) error {
 	return p.PlaybookView(userID, run.PlaybookID)
 }
 
-func (p *PermissionsService) RunUpdateStatus(userID string, playbookRun *PlaybookRun) error {
-	if !CanPostToChannel(userID, playbookRun.ChannelID, p.pluginAPI) {
-		return errors.Wrapf(ErrNoPermissions, "user %s cannot post to playbook run channel %s", userID, playbookRun.ChannelID)
-	}
-
-	for _, channelID := range playbookRun.BroadcastChannelIDs {
-		if !CanPostToChannel(userID, channelID, p.pluginAPI) {
-			return errors.Wrapf(ErrNoPermissions, "user %s cannot post to broadcast channel %s", userID, channelID)
-		}
-	}
-
-	return nil
-}
-
 func (p *PermissionsService) ChannelActionCreate(userID, channelID string) error {
 	if IsSystemAdmin(userID, p.pluginAPI) || CanManageChannelProperties(userID, channelID, p.pluginAPI) {
 		return nil


### PR DESCRIPTION
## Summary
Revert https://github.com/mattermost/mattermost-plugin-playbooks/pull/1554

Allow run participants to post updates without checking permissions on every channel configured for broadcast.

## Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1690

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
