### PR TITLE
Downgrade field missing errors to warnings for logging.

### DIFF
--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -147,6 +147,8 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 
 		if errors.Is(err, app.ErrNoPermissions) {
 			errLogger.Warn("Warning executing request")
+		} else if err.Rule == "FieldsOnCorrectType" {
+			errLogger.Warn("Query for non existent field")
 		} else {
 			errLogger.Error("Error executing request")
 		}


### PR DESCRIPTION
## Summary
Errors of the form:
```
error [2023-01-24 10:19:15.485 -08:00] Error executing request                       caller="app/plugin_api.go:976" plugin_id=playbooks error="graphql: Cannot query field "id" on type "RunConnection". (line 8, column 5)" operation=PlaybookLHS request_id=mqdpw6c3ntynfbi4qquazt59xc plugin_caller="github.com/mattermost/mattermost-plugin-playbooks/server/api/graphql.go:159"
```
where appearing in production systems where playbooks was upgraded as old clients where trying to make requests for fields that had been removed.

Downgrading the warning to an error and changing the text to be more specific will allow the reduction of noise errors in production. These errors will now be of the form:
```
warn  [2023-01-24 10:48:20.503 -08:00] Query for non existent field                  caller="app/plugin_api.go:979" plugin_id=playbooks request_id=io93pyi6jf863gc7fzkpem7etr error="graphql: Cannot query field "id" on type "RunConnection". (line 8, column 5)" operation=PlaybookLHS plugin_caller="github.com/mattermost/mattermost-plugin-playbooks/server/api/graphql.go:151"
```

Fixes: https://mattermost.atlassian.net/browse/MM-49844