### PR TITLE
Avoid spurious session errors

### DIFF
--- a/server/api/signal.go
+++ b/server/api/signal.go
@@ -60,12 +60,6 @@ func (h *SignalHandler) playbookRun(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	isMobile, err := getBoolField("isMobile", req.Context, w)
-	if err != nil {
-		h.returnError(publicErrorMessage, err, c.logger, w)
-		return
-	}
-
 	postID, err := getStringField("postID", req.Context, w)
 	if err != nil {
 		h.returnError(publicErrorMessage, err, c.logger, w)
@@ -84,7 +78,7 @@ func (h *SignalHandler) playbookRun(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := h.playbookRunService.OpenCreatePlaybookRunDialog(req.TeamId, req.UserId, req.TriggerId, postID, "", []app.Playbook{pbook}, isMobile, post.Id); err != nil {
+	if err := h.playbookRunService.OpenCreatePlaybookRunDialog(req.TeamId, req.UserId, req.TriggerId, postID, "", []app.Playbook{pbook}, post.Id); err != nil {
 		h.returnError("can't open dialog", errors.Wrap(err, "can't open a dialog"), c.logger, w)
 		return
 	}
@@ -141,18 +135,6 @@ func getStringField(field string, context map[string]interface{}, w http.Respons
 	fieldValue, ok := fieldInt.(string)
 	if !ok {
 		return "", errors.Errorf("%s field is not a string", field)
-	}
-	return fieldValue, nil
-}
-
-func getBoolField(field string, context map[string]interface{}, w http.ResponseWriter) (bool, error) {
-	fieldInt, ok := context[field]
-	if !ok {
-		return false, errors.Errorf("no %s field in the request context", field)
-	}
-	fieldValue, ok := fieldInt.(bool)
-	if !ok {
-		return false, errors.Errorf("%s field is not a string", field)
 	}
 	return fieldValue, nil
 }

--- a/server/app/action.go
+++ b/server/app/action.go
@@ -86,7 +86,7 @@ type ChannelActionService interface {
 	CheckAndSendMessageOnJoin(userID, channelID string) bool
 
 	// MessageHasBeenPosted suggests playbooks to the user if triggered
-	MessageHasBeenPosted(sessionID string, post *model.Post)
+	MessageHasBeenPosted(post *model.Post)
 }
 
 type ChannelActionStore interface {

--- a/server/app/actions_service.go
+++ b/server/app/actions_service.go
@@ -382,7 +382,7 @@ func (a *channelActionServiceImpl) CheckAndSendMessageOnJoin(userID, channelID s
 	return true
 }
 
-func (a *channelActionServiceImpl) MessageHasBeenPosted(sessionID string, post *model.Post) {
+func (a *channelActionServiceImpl) MessageHasBeenPosted(post *model.Post) {
 	if post.IsSystemMessage() || a.keywordsThreadIgnorer.IsIgnored(post.RootId, post.UserId) || a.poster.IsFromPoster(post) {
 		return
 	}
@@ -401,12 +401,6 @@ func (a *channelActionServiceImpl) MessageHasBeenPosted(sessionID string, post *
 
 	// Finish early if there are no actions to prompt running a playbook
 	if len(actions) == 0 {
-		return
-	}
-
-	session, err := a.api.Session.Get(sessionID)
-	if err != nil {
-		logrus.WithError(err).WithField("session_id", sessionID).Error("can't get session")
 		return
 	}
 
@@ -448,7 +442,7 @@ func (a *channelActionServiceImpl) MessageHasBeenPosted(sessionID string, post *
 		}
 
 		if actionExecuted {
-			a.telemetry.RunChannelAction(action, session.UserId)
+			a.telemetry.RunChannelAction(action, post.UserId)
 		}
 	}
 
@@ -462,7 +456,7 @@ func (a *channelActionServiceImpl) MessageHasBeenPosted(sessionID string, post *
 	}
 
 	message := getPlaybookSuggestionsMessage(triggeredPlaybooks, presentTriggers)
-	attachment := getPlaybookSuggestionsSlackAttachment(triggeredPlaybooks, post.Id, session.IsMobileApp(), a.configService.GetManifest().Id)
+	attachment := getPlaybookSuggestionsSlackAttachment(triggeredPlaybooks, post.Id, a.configService.GetManifest().Id)
 
 	rootID := post.RootId
 	if rootID == "" {
@@ -498,7 +492,7 @@ func getPlaybookSuggestionsMessage(suggestedPlaybooks []Playbook, triggers []str
 	return message
 }
 
-func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, isMobile bool, pluginID string) *model.SlackAttachment {
+func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, pluginID string) *model.SlackAttachment {
 	ignoreButton := &model.PostAction{
 		Id:   "ignoreKeywordsButton",
 		Name: "No, ignore thread",
@@ -521,7 +515,6 @@ func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, 
 				Context: map[string]interface{}{
 					"postID":          postID,
 					"selected_option": playbooks[0].ID,
-					"isMobile":        isMobile,
 				},
 			},
 			Style: "primary",
@@ -549,8 +542,7 @@ func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, 
 		Integration: &model.PostActionIntegration{
 			URL: fmt.Sprintf("/plugins/%s/api/v0/signal/keywords/run-playbook", pluginID),
 			Context: map[string]interface{}{
-				"isMobile": isMobile,
-				"postID":   postID,
+				"postID": postID,
 			},
 		},
 		Options: options,

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -592,7 +592,7 @@ type PlaybookRunService interface {
 	CreatePlaybookRun(playbookRun *PlaybookRun, playbook *Playbook, userID string, public bool) (*PlaybookRun, error)
 
 	// OpenCreatePlaybookRunDialog opens an interactive dialog to start a new playbook run.
-	OpenCreatePlaybookRunDialog(teamID, ownerID, triggerID, postID, clientID string, playbooks []Playbook, isMobileApp bool, promptPostID string) error
+	OpenCreatePlaybookRunDialog(teamID, ownerID, triggerID, postID, clientID string, playbooks []Playbook, promptPostID string) error
 
 	// OpenUpdateStatusDialog opens an interactive dialog so the user can update the playbook run's status.
 	OpenUpdateStatusDialog(playbookRunID, userID, triggerID string) error
@@ -806,7 +806,7 @@ type PlaybookRunService interface {
 	GraphqlUpdate(id string, setmap map[string]interface{}) error
 
 	// MessageHasBeenPosted checks posted messages for triggers that may trigger task actions
-	MessageHasBeenPosted(sessionID string, post *model.Post)
+	MessageHasBeenPosted(post *model.Post)
 }
 
 // PlaybookRunStore defines the methods the PlaybookRunServiceImpl needs from the interfaceStore.

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -501,7 +501,7 @@ func (s *PlaybookRunServiceImpl) failedInvitedUserActions(usersFailedToInvite []
 }
 
 // OpenCreatePlaybookRunDialog opens a interactive dialog to start a new playbook run.
-func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID, triggerID, postID, clientID string, playbooks []Playbook, isMobileApp bool, promptPostID string) error {
+func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID, triggerID, postID, clientID string, playbooks []Playbook, promptPostID string) error {
 
 	filteredPlaybooks := make([]Playbook, 0, len(playbooks))
 	for _, playbook := range playbooks {
@@ -510,7 +510,7 @@ func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID
 		}
 	}
 
-	dialog, err := s.newPlaybookRunDialog(teamID, requesterID, postID, clientID, filteredPlaybooks, isMobileApp, promptPostID)
+	dialog, err := s.newPlaybookRunDialog(teamID, requesterID, postID, clientID, filteredPlaybooks, promptPostID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create new playbook run dialog")
 	}
@@ -2450,7 +2450,7 @@ func (s *PlaybookRunServiceImpl) newFinishPlaybookRunDialog(playbookRun *Playboo
 	}
 }
 
-func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postID, clientID string, playbooks []Playbook, isMobileApp bool, promptPostID string) (*model.Dialog, error) {
+func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postID, clientID string, playbooks []Playbook, promptPostID string) (*model.Dialog, error) {
 	user, err := s.pluginAPI.User.Get(requesterID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch owner user")
@@ -2475,18 +2475,10 @@ func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postI
 		})
 	}
 
-	newPlaybookMarkdown := ""
-	if !isMobileApp {
-		data := map[string]interface{}{
-			"RunURL": getPlaybooksNewRelativeURL(),
-		}
-		newPlaybookMarkdown = T("app.user.new_run.new_playbook", data)
-	}
-
 	data := map[string]interface{}{
 		"Username": getUserDisplayName(user),
 	}
-	introText := T("app.user.new_run.intro", data) + "\n\n" + newPlaybookMarkdown
+	introText := T("app.user.new_run.intro", data)
 
 	defaultPlaybookID := ""
 	defaultChannelNameTemplate := ""
@@ -3551,7 +3543,7 @@ func (s *PlaybookRunServiceImpl) dmPostToUsersWithPermission(users []string, pos
 	}
 }
 
-func (s *PlaybookRunServiceImpl) MessageHasBeenPosted(sessionID string, post *model.Post) {
+func (s *PlaybookRunServiceImpl) MessageHasBeenPosted(post *model.Post) {
 	runIDs, err := s.store.GetPlaybookRunIDsForChannel(post.ChannelId)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {

--- a/server/app/urls.go
+++ b/server/app/urls.go
@@ -16,10 +16,6 @@ func GetPlaybookDetailsRelativeURL(playbookID string) string {
 	return fmt.Sprintf("%s/%s", PlaybooksPath, playbookID)
 }
 
-func getPlaybooksNewRelativeURL() string {
-	return fmt.Sprintf("%s/new", PlaybooksPath)
-}
-
 // absolute urls
 func getRunDetailsURL(siteURL string, playbookRunID string) string {
 	return fmt.Sprintf("%s%s", siteURL, GetRunDetailsRelativeURL(playbookRunID))

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -270,13 +270,7 @@ func (r *Runner) actionRun(args []string) {
 		return
 	}
 
-	session, err := r.pluginAPI.Session.Get(r.context.SessionId)
-	if err != nil {
-		r.warnUserAndLogErrorf("Error retrieving session: %v", err)
-		return
-	}
-
-	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, postID, clientID, playbooksResults.Items, session.IsMobileApp(), ""); err != nil {
+	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, postID, clientID, playbooksResults.Items, ""); err != nil {
 		r.warnUserAndLogErrorf("Error: %v", err)
 		return
 	}
@@ -325,13 +319,7 @@ func (r *Runner) actionRunPlaybook(args []string) {
 		return
 	}
 
-	session, err := r.pluginAPI.Session.Get(r.context.SessionId)
-	if err != nil {
-		r.warnUserAndLogErrorf("Error retrieving session: %v", err)
-		return
-	}
-
-	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, "", clientID, playbook, session.IsMobileApp(), ""); err != nil {
+	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, "", clientID, playbook, ""); err != nil {
 		r.warnUserAndLogErrorf("Error: %v", err)
 		return
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -334,8 +334,8 @@ func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.Ch
 }
 
 func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
-	p.channelActionService.MessageHasBeenPosted(c.SessionId, post)
-	p.playbookRunService.MessageHasBeenPosted(c.SessionId, post)
+	p.channelActionService.MessageHasBeenPosted(post)
+	p.playbookRunService.MessageHasBeenPosted(post)
 }
 
 func (p *Plugin) newMetricsInstance() *metrics.Metrics {

--- a/tests-e2e/cypress/integration/channels/run_dialog_spec.js
+++ b/tests-e2e/cypress/integration/channels/run_dialog_spec.js
@@ -93,16 +93,6 @@ describe('channels > run dialog', () => {
         });
     });
 
-    it('shows create playbook link', () => {
-        cy.get('#interactiveDialogModal').within(() => {
-            // # Follow link
-            cy.findByText('Click here').click();
-
-            // * Verify it's the new playbook page
-            cy.url().should('include', 'playbooks/new');
-        });
-    });
-
     it('shows expected metadata', () => {
         cy.get('#interactiveDialogModal').within(() => {
             // * Shows current user as owner.


### PR DESCRIPTION
## Summary
The impetus for this change was to find and eliminate the source of the following ERROR logs in production:

> GetSessionByld: We encountered an error finding the session.

and logging a blank `sessionID`. The code in question was our `MessageHasBeenPosted` hook handler, which assumed that all messages posted had come from an active session. But this isn't the case for bots, to which the actions service intentionally wanted to respond.

Upon examining how the fetched session was used, I realized it was only to suppress one line in the `/playbook run` modal that linked to the Playbooks product as a way of explaining how to create a playbook:

![CleanShot 2023-01-24 at 16 28 40@2x](https://user-images.githubusercontent.com/1023171/214408511-0ab1d604-36e2-40c8-bfca-7dd009dff934.png)

As this functionality is not available on mobile, the message made no sense, so we attempted to suppress it in that case:

![IMG_4C97897D5C17-1](https://user-images.githubusercontent.com/1023171/214409200-ef70b307-8576-436e-9cc8-8cc7c159a155.jpeg)

Unfortunately, the suppression is driven by the session of the user that created the post, not the user consuming it. In some cases, that might be the same person, achieving the desired outcome, but in all other cases, it's more than likely to be wrong for one of the users.

The good news is that none of this is really necessary anymore, as our primary use case for launching a playbook no longer relies on this interactive dialog in the first place. So just rip out all this handling, sidestepping the potential for the ERROR log altogether.

## Ticket Link
None.