### PR TITLE
MM-49791: Disable edit summary after run finished

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -152,4 +152,71 @@ describe('channels > rhs > header', () => {
             cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').contains('new summary');
         });
     });
+
+    describe('edit summary of finished run', () => {
+        let playbookRunChannelName;
+        let finishedPlaybookRun;
+
+        beforeEach(() => {
+            // # Run the playbook
+            const now = Date.now();
+            const playbookRunName = 'Playbook Run (' + now + ')';
+            playbookRunChannelName = 'playbook-run-' + now;
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName,
+                ownerUserId: testUser.id,
+            }).then((playbookRun) => {
+                finishedPlaybookRun = playbookRun;
+            });
+        });
+
+        it('by clicking on placeholder', () => {
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # Wait for the RHS to open
+            cy.get('#rhsContainer').should('be.visible');
+
+            // # Mark the run as finished
+            cy.apiFinishRun(finishedPlaybookRun.id);
+
+            // # click on the field
+            cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').click();
+
+            // # verify textarea does not appear
+            cy.get('#rhsContainer').findByTestId('textarea-description').should('not.exist');
+
+            // # Verify no prompt to join appears (timeout ensures it fails right away before toast disappears)
+            cy.findByText('Become a participant to interact with this run', {timeout: 500}).should('not.exist');
+        });
+
+        it('by clicking on dot menu item', () => {
+            // # Navigate directly to the application and the playbook run channel
+            cy.visit(`/${testTeam.name}/channels/${playbookRunChannelName}`);
+
+            // # Wait for the RHS to open
+            cy.get('#rhsContainer').should('be.visible');
+
+            // # Mark the run as finished
+            cy.apiFinishRun(finishedPlaybookRun.id);
+
+            // # click on the field
+            cy.get('#rhsContainer').within(() => {
+                cy.findByTestId('buttons-row').invoke('show').within(() => {
+                    cy.findAllByRole('button').eq(1).click();
+                });
+            });
+
+            // # verify the menu items
+            cy.findByTestId('dropdownmenu').within(() => {
+                cy.get('span').should('have.length', 2);
+                cy.findByText('Edit run summary').should('not.exist');
+            });
+
+            // # Verify no prompt to join appears (timeout ensures it fails right away before toast disappears)
+            cy.findByText('Become a participant to interact with this run', {timeout: 500}).should('not.exist');
+        });
+    });
 });

--- a/tests-e2e/cypress/integration/channels/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/header_spec.js
@@ -185,10 +185,10 @@ describe('channels > rhs > header', () => {
             // # click on the field
             cy.get('#rhsContainer').findByTestId('rendered-description').should('be.visible').click();
 
-            // # verify textarea does not appear
+            // * Verify textarea does not appear
             cy.get('#rhsContainer').findByTestId('textarea-description').should('not.exist');
 
-            // # Verify no prompt to join appears (timeout ensures it fails right away before toast disappears)
+            // * Verify no prompt to join appears (timeout ensures it fails right away before toast disappears)
             cy.findByText('Become a participant to interact with this run', {timeout: 500}).should('not.exist');
         });
 
@@ -209,13 +209,13 @@ describe('channels > rhs > header', () => {
                 });
             });
 
-            // # verify the menu items
+            // * Verify the menu items
             cy.findByTestId('dropdownmenu').within(() => {
                 cy.get('span').should('have.length', 2);
                 cy.findByText('Edit run summary').should('not.exist');
             });
 
-            // # Verify no prompt to join appears (timeout ensures it fails right away before toast disappears)
+            // * Verify no prompt to join appears (timeout ensures it fails right away before toast disappears)
             cy.findByText('Become a participant to interact with this run', {timeout: 500}).should('not.exist');
         });
     });

--- a/tests-e2e/cypress/integration/runs/rdp_main_summary_spec.js
+++ b/tests-e2e/cypress/integration/runs/rdp_main_summary_spec.js
@@ -121,6 +121,17 @@ describe('runs > run details page > summary', () => {
             // * Assert last edition date is not visible
             cy.findByTestId('run-summary-section').should('not.contain', 'Last edited');
         });
+
+        it('can not be edited once run is finished', () => {
+            // # Finish the run
+            cy.apiFinishRun(testRun.id);
+
+            // # Mouseover the summary
+            cy.findByTestId('run-summary-section').trigger('mouseover');
+
+            // * Verify that the edit button is not rendered
+            cy.findByTestId('run-summary-section').findByTestId('hover-menu-edit-button').should('not.exist');
+        });
     });
 
     describe('as viewer', () => {

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/checklists.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/checklists.tsx
@@ -24,7 +24,7 @@ const Checklists = ({id, playbookRun, role}: Props) => {
                 id={id}
                 playbookRun={playbookRun}
                 parentContainer={ChecklistParent.RunDetails}
-                viewerMode={role === Role.Viewer}
+                readOnly={role === Role.Viewer}
             />
         </Container>
     );

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/summary.tsx
@@ -40,6 +40,7 @@ const Summary = ({
     );
 
     const placeholder = role === Role.Participant ? formatMessage({defaultMessage: 'Add a run summary'}) : formatMessage({defaultMessage: 'There\'s no summary'});
+    const disabled = (Role.Viewer === role || playbookRun.end_at > 0);
 
     return (
         <Container
@@ -54,7 +55,7 @@ const Summary = ({
                 {playbookRun.summary_modified_at > 0 && modifiedAtMessage}
             </Header>
             <MarkdownEdit
-                disabled={Role.Viewer === role}
+                disabled={disabled}
                 placeholder={placeholder}
                 value={playbookRun.summary}
                 onSave={(value) => {

--- a/webapp/src/components/checklist/checklist_list.tsx
+++ b/webapp/src/components/checklist/checklist_list.tsx
@@ -48,7 +48,7 @@ interface Props {
     onEveryChecklistCollapsedStateChange: (state: Record<number, boolean>) => void;
     showItem?: (checklistItem: ChecklistItem, myId: string) => boolean;
     itemButtonsFormat?: ItemButtonsFormat;
-    onViewerModeInteract?: () => void;
+    onReadOnlyInteract?: () => void;
 }
 
 const ChecklistList = ({
@@ -60,7 +60,7 @@ const ChecklistList = ({
     onEveryChecklistCollapsedStateChange,
     showItem,
     itemButtonsFormat,
-    onViewerModeInteract,
+    onReadOnlyInteract,
 }: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
@@ -366,7 +366,7 @@ const ChecklistList = ({
                                                     onUpdateChecklist={(newChecklist: Checklist) => onUpdateChecklist(checklistIndex, newChecklist)}
                                                     showItem={showItem}
                                                     itemButtonsFormat={itemButtonsFormat}
-                                                    onViewerModeInteract={onViewerModeInteract}
+                                                    onReadOnlyInteract={onReadOnlyInteract}
                                                 />
                                             </CollapsibleChecklist>
                                         );

--- a/webapp/src/components/checklist/generic_checklist.tsx
+++ b/webapp/src/components/checklist/generic_checklist.tsx
@@ -28,7 +28,7 @@ interface Props {
     onUpdateChecklist: (newChecklist: Checklist) => void;
     showItem?: (checklistItem: ChecklistItem, myId: string) => boolean
     itemButtonsFormat?: ItemButtonsFormat;
-    onViewerModeInteract?: () => void;
+    onReadOnlyInteract?: () => void;
 }
 
 const GenericChecklist = (props: Props) => {
@@ -108,7 +108,7 @@ const GenericChecklist = (props: Props) => {
                                     onDuplicateChecklistItem={() => onDuplicateChecklistItem(index)}
                                     onDeleteChecklistItem={() => onDeleteChecklistItem(index)}
                                     itemButtonsFormat={props.itemButtonsFormat}
-                                    onViewerModeInteract={props.onViewerModeInteract}
+                                    onReadOnlyInteract={props.onReadOnlyInteract}
                                 />
                             );
                         })}
@@ -127,7 +127,7 @@ const GenericChecklist = (props: Props) => {
                                 }}
                                 onAddChecklistItem={onAddChecklistItem}
                                 itemButtonsFormat={props.itemButtonsFormat}
-                                onViewerModeInteract={props.onViewerModeInteract}
+                                onReadOnlyInteract={props.onReadOnlyInteract}
                             />
                         }
                         {droppableProvided.placeholder}

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -76,7 +76,7 @@ interface ChecklistItemProps {
     onDeleteChecklistItem?: () => void;
     buttonsFormat?: ButtonsFormat;
     participantUserIds: string[];
-    onViewerModeInteract?: () => void
+    onReadOnlyInteract?: () => void
 }
 
 export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => {
@@ -352,7 +352,7 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
                     disabled={isSkipped() || props.playbookRunId === undefined}
                     item={props.checklistItem}
                     onChange={(item: ChecklistItemState) => props.onChange?.(item)}
-                    onViewerModeInteract={props.onViewerModeInteract}
+                    onReadOnlyInteract={props.onReadOnlyInteract}
                 />
                 <ChecklistItemTitleWrapper
                     onClick={() => props.collapsibleDescription && props.checklistItem.description !== '' && toggleDescription()}

--- a/webapp/src/components/checklist_item/checklist_item_draggable.tsx
+++ b/webapp/src/components/checklist_item/checklist_item_draggable.tsx
@@ -23,7 +23,7 @@ interface Props {
     onDuplicateChecklistItem?: () => void;
     onDeleteChecklistItem?: () => void;
     itemButtonsFormat?: ItemButtonsFormat;
-    onViewerModeInteract?: () => void
+    onReadOnlyInteract?: () => void
 }
 
 const DraggableChecklistItem = (props: Props) => {
@@ -52,7 +52,7 @@ const DraggableChecklistItem = (props: Props) => {
                     onDuplicateChecklistItem={props.onDuplicateChecklistItem}
                     onDeleteChecklistItem={props.onDeleteChecklistItem}
                     buttonsFormat={props.itemButtonsFormat}
-                    onViewerModeInteract={props.onViewerModeInteract}
+                    onReadOnlyInteract={props.onReadOnlyInteract}
                 />
             )}
         </Draggable>

--- a/webapp/src/components/checklist_item/inputs.tsx
+++ b/webapp/src/components/checklist_item/inputs.tsx
@@ -13,7 +13,7 @@ interface CheckBoxButtonProps {
     item: ChecklistItem;
     readOnly: boolean;//when true, component can receive events, but can't be modified.
     disabled?: boolean;
-    onViewerModeInteract?: () => void;
+    onReadOnlyInteract?: () => void;
 }
 
 export const CheckBoxButton = (props: CheckBoxButtonProps) => {
@@ -33,7 +33,7 @@ export const CheckBoxButton = (props: CheckBoxButtonProps) => {
     //     and leaving the item in an unknown state
     const handleOnChange = async () => {
         if (props.readOnly) {
-            props.onViewerModeInteract?.();
+            props.onReadOnlyInteract?.();
             return;
         }
         const newValue = isChecked ? ChecklistItemState.Open : ChecklistItemState.Closed;

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -47,8 +47,8 @@ interface Props {
     playbookRun: PlaybookRun;
     parentContainer: ChecklistParent;
     id?: string;
-    viewerMode: boolean;
-    onViewerModeInteract?: () => void
+    readOnly: boolean;
+    onReadOnlyInteract?: () => void
 }
 
 export enum ChecklistParent {
@@ -93,7 +93,7 @@ const notFinishedTasks = (checklists: Checklist[]) => {
     return count;
 };
 
-const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode, onViewerModeInteract}: Props) => {
+const RHSChecklistList = ({id, playbookRun, parentContainer, readOnly, onReadOnlyInteract}: Props) => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const channelId = useSelector(getCurrentChannelId);
@@ -200,7 +200,7 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode, onViewe
             return ItemButtonsFormat.Short;
         }
 
-        if (viewerMode) {
+        if (readOnly) {
             return ItemButtonsFormat.Mixed;
         }
 
@@ -264,20 +264,20 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, viewerMode, onViewe
             </MainTitleBG>
             <ChecklistList
                 playbookRun={playbookRun}
-                isReadOnly={viewerMode}
+                isReadOnly={readOnly}
                 checklistsCollapseState={checklistsState}
                 onChecklistCollapsedStateChange={onChecklistCollapsedStateChange}
                 onEveryChecklistCollapsedStateChange={onEveryChecklistCollapsedStateChange}
                 showItem={showItem}
                 itemButtonsFormat={itemButtonsFormat()}
-                onViewerModeInteract={onViewerModeInteract}
+                onReadOnlyInteract={onReadOnlyInteract}
             />
             {
                 active && parentContainer === ChecklistParent.RHS && playbookRun &&
                 <FinishButton
                     onClick={() => {
-                        if (viewerMode && onViewerModeInteract) {
-                            onViewerModeInteract();
+                        if (readOnly && onReadOnlyInteract) {
+                            onReadOnlyInteract();
                         } else {
                             dispatch(finishRun(playbookRun?.team_id || '', playbookRun?.id));
                         }

--- a/webapp/src/components/rhs/rhs_run_details.tsx
+++ b/webapp/src/components/rhs/rhs_run_details.tsx
@@ -140,6 +140,12 @@ const RHSRunDetails = (props: Props) => {
         );
     }
 
+    const readOnly = !isParticipant || playbookRun.current_status === PlaybookRunStatus.Finished;
+    let onReadOnlyInteract;
+    if (playbookRun.current_status !== PlaybookRunStatus.Finished) {
+        onReadOnlyInteract = displayReadOnlyToast;
+    }
+
     return (
         <>
             <RHSTitleRemoteRender>
@@ -162,15 +168,15 @@ const RHSRunDetails = (props: Props) => {
                     >
                         <RHSAbout
                             playbookRun={playbookRun}
-                            readOnly={!isParticipant}
-                            onReadOnlyInteract={playbookRun.current_status === PlaybookRunStatus.Finished ? undefined : displayReadOnlyToast}
+                            readOnly={readOnly}
+                            onReadOnlyInteract={onReadOnlyInteract}
                             setShowParticipants={setShowParticipants}
                         />
                         <RHSChecklistList
                             playbookRun={playbookRun}
                             parentContainer={ChecklistParent.RHS}
-                            viewerMode={!isParticipant}
-                            onViewerModeInteract={playbookRun.current_status === PlaybookRunStatus.Finished ? undefined : displayReadOnlyToast}
+                            readOnly={readOnly}
+                            onReadOnlyInteract={onReadOnlyInteract}
                         />
                     </Scrollbars>
                 </RHSContent>


### PR DESCRIPTION
## Summary
This is a client-side only change to disable the functionality for editing a run summary after a run has finished. The GraphQL endpoint currently seems to allow edits regardless, and I didn't want to tackle locking that down here.

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-49791