### PR TITLE
reset commandLastRunAt when command is updated

### DIFF
--- a/client/playbook_runs.go
+++ b/client/playbook_runs.go
@@ -315,6 +315,33 @@ func (s *PlaybookRunService) SetItemAssignee(ctx context.Context, playbookRunID 
 	return err
 }
 
+func (s *PlaybookRunService) SetItemCommand(ctx context.Context, playbookRunID string, checklistIdx int, itemIdx int, newCommand string) error {
+	createURL := fmt.Sprintf("runs/%s/checklists/%d/item/%d/command", playbookRunID, checklistIdx, itemIdx)
+	body := struct {
+		Command string `json:"command"`
+	}{newCommand}
+
+	req, err := s.client.newRequest(http.MethodPut, createURL, body)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	return err
+}
+
+func (s *PlaybookRunService) RunItemCommand(ctx context.Context, playbookRunID string, checklistIdx int, itemIdx int) error {
+	createURL := fmt.Sprintf("runs/%s/checklists/%d/item/%d/run", playbookRunID, checklistIdx, itemIdx)
+
+	req, err := s.client.newRequest(http.MethodPost, createURL, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	return err
+}
+
 func (s *PlaybookRunService) SetItemDueDate(ctx context.Context, playbookRunID string, checklistIdx int, itemIdx int, duedate int64) error {
 	createURL := fmt.Sprintf("runs/%s/checklists/%d/item/%d/duedate", playbookRunID, checklistIdx, itemIdx)
 	body := struct {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1608,6 +1608,11 @@ func (s *PlaybookRunServiceImpl) SetCommandToChecklistItem(playbookRunID, userID
 		return errors.New("invalid checklist item indices")
 	}
 
+	// CommandLastRun is reset to avoid misunderstandings when the command is changed but the date
+	// of the previous run is set (and show rerun in the UI)
+	if playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].Command != newCommand {
+		playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].CommandLastRun = 0
+	}
 	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].Command = newCommand
 
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)


### PR DESCRIPTION
## Summary
Set again the lastCommandRunAt to 0 when the command is updated (with a different command). The goal is to avoid the situation where we have a command with "Rerun" label in UI and timestamp in DB but the command that was run is another different previous one.

The history for the first command is still kept in the timeline. We don't store in the timeline which task triggered the slash command, but we still don't have task ids anyway.

Added tests for SetCommand and RunCommand that were missing (+ client functions).

## Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1760

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated
