### PR TITLE
make get actions trigger just if modal is shown

### DIFF
--- a/webapp/src/components/channel_actions_modal.tsx
+++ b/webapp/src/components/channel_actions_modal.tsx
@@ -104,10 +104,10 @@ const ChannelActionsModal = () => {
             });
         };
 
-        if (channelID) {
+        if (channelID && show) {
             getActions(channelID);
         }
-    }, [channelID, welcomeMsgInit, categorizationInit, promptInit]);
+    }, [channelID, show, welcomeMsgInit, categorizationInit, promptInit]);
 
     const onHide = () => {
         welcomeMsgReset();


### PR DESCRIPTION
## Summary
Extracted from https://github.com/mattermost/mattermost-plugin-playbooks/pull/1748. The rest of the original PR is being discussed more in-depth.

**/plugins/playbooks/api/v0/actions/channels/**

Make channel actions modal fetch action ONLY when is shown, not when it's rendered but hidden. Before this change, channel actions were fetched on every channel switch.

## Ticket Link
Fixes (partially) #1731

## Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
