### PR TITLE
GH-1767 Default to current channel when linking a new playbook run

### DIFF
--- a/tests-e2e/cypress/integration/channels/rhs/start_run_rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/start_run_rhs_spec.js
@@ -240,8 +240,8 @@ describe('channels rhs > start a run', () => {
                         // # Fill run name
                         cy.findByTestId('run-name-input').clear().type('Test Run Name');
 
-                        // # Fill Town square as the channel to be linked
-                        cy.findByText('Select a channel').click().type(`${testChannel.display_name}{enter}`);
+                        // # Select test channel instead of current channel
+                        cy.findByText('Town Square').click().type(`${testChannel.display_name}{enter}`);
 
                         // # Click start button
                         cy.findByTestId('modal-confirm-button').click();

--- a/tests-e2e/cypress/integration/channels/rhs/start_run_rhs_spec.js
+++ b/tests-e2e/cypress/integration/channels/rhs/start_run_rhs_spec.js
@@ -204,6 +204,85 @@ describe('channels rhs > start a run', () => {
                 });
             });
 
+            it('change to link to existing channel defaults to current channel', () => {
+                // # Fill default values
+                createPlaybook({
+                    title: 'Playbook title' + Date.now(),
+                    channelNameTemplate: 'Channel template',
+                    runSummaryTemplate: 'run summary template',
+                    channelMode: 'create_new_channel'
+                }).then((playbook) => {
+                    // # Visit the town square channel
+                    cy.visit(`/${testTeam.name}/channels/town-square`);
+
+                    // # Open playbooks RHS.
+                    cy.getPlaybooksAppBarIcon().should('be.visible').click();
+
+                    // # Click start a run button
+                    cy.findByTestId('rhs-runlist-start-run').click();
+
+                    cy.get('#root-portal.modal-open').within(() => {
+                        // # Wait the modal to render
+                        cy.wait(500);
+
+                        // * Assert we are at playbooks tab
+                        cy.findByText('Select a playbook').should('be.visible');
+
+                        // # Click on the playbook
+                        cy.findAllByText(playbook.title).eq(0).click();
+
+                        // # Wait the modal to render
+                        cy.wait(500);
+
+                        // # Change to link to existing channel
+                        cy.findByTestId('link-existing-channel-radio').click();
+
+                        // * Assert current channel is selected
+                        cy.findByText('Town Square').should('be.visible');
+                    });
+                });
+            });
+
+            it('change to link to existing channel with already selected channel', () => {
+                // # Fill default values
+                createPlaybook({
+                    title: 'Playbook title' + Date.now(),
+                    channelNameTemplate: 'Channel template',
+                    runSummaryTemplate: 'run summary template',
+                    channelMode: 'create_new_channel',
+                    channelId: testChannel.id,
+                }).then((playbook) => {
+                    // # Visit the town square channel
+                    cy.visit(`/${testTeam.name}/channels/town-square`);
+
+                    // # Open playbooks RHS.
+                    cy.getPlaybooksAppBarIcon().should('be.visible').click();
+
+                    // # Click start a run button
+                    cy.findByTestId('rhs-runlist-start-run').click();
+
+                    cy.get('#root-portal.modal-open').within(() => {
+                        // # Wait the modal to render
+                        cy.wait(500);
+
+                        // * Assert we are at playbooks tab
+                        cy.findByText('Select a playbook').should('be.visible');
+
+                        // # Click on the playbook
+                        cy.findAllByText(playbook.title).eq(0).click();
+
+                        // # Wait the modal to render
+                        cy.wait(500);
+
+                        // # Change to link to existing channel
+                        cy.findByTestId('link-existing-channel-radio').click();
+
+                        // * Assert selected channel is unchanged
+                        cy.findByText(testChannel.display_name).should('be.visible');
+                    });
+                });
+            });
+
             it('change to link to existing channel', () => {
                 // # Fill default values
                 createPlaybook({

--- a/tests-e2e/cypress/integration/playbooks/start_run_spec.js
+++ b/tests-e2e/cypress/integration/playbooks/start_run_spec.js
@@ -240,7 +240,29 @@ describe('playbooks > start a run', () => {
                 cy.findByTestId('run-summary-section').contains('Test Run Summary');
             });
 
-            it('change to link to exsiting channel', () => {
+            it('change to link to existing channel does not default to current channel', () => {
+                // # Visit the selected playbook
+                cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
+
+                // # Fill default values
+                fillPBE({name: 'Channel template', summary: 'run summary template', channelMode: 'create_new_channel', defaultOwnerEnabled: true});
+
+                // # Click start a run button
+                cy.findByTestId('run-playbook').click();
+
+                cy.get('#root-portal.modal-open').within(() => {
+                    // # Wait the modal to render
+                    cy.wait(500);
+
+                    // # Change to link to existing channel
+                    cy.findByTestId('link-existing-channel-radio').click();
+
+                    // * Assert selected channel is unchanged
+                    cy.findByText('Select a channel').should('be.visible');
+                });
+            });
+
+            it('change to link to existing channel', () => {
                 // # Visit the selected playbook
                 cy.visit(`/playbooks/playbooks/${testPlaybook.id}/outline`);
 

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -110,7 +110,7 @@ const RunPlaybookModal = ({
     const handleSetChannelMode = (mode: 'link_existing_channel' | 'create_new_channel') => {
         setChannelMode(mode);
 
-        // Default to current channel when choosing link
+        // Default to the current channel when choosing link to the existing channel, we are in a channel context and the playbook does not have a linked channel
         if (mode === 'link_existing_channel' && playbook?.channel_mode === 'create_new_channel' && channelId === '' && currentChannelId) {
             setChannelId(currentChannelId);
         }

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -7,6 +7,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {ArrowLeftIcon} from '@mattermost/compass-icons/components';
 import {ApolloProvider} from '@apollo/client';
 
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+
 import {getPlaybooksGraphQLClient} from 'src/graphql_client';
 import {usePlaybook} from 'src/graphql/hooks';
 import {BaseInput, BaseTextArea} from 'src/components/assets/inputs';
@@ -65,13 +67,14 @@ const RunPlaybookModal = ({
     const [showsearch, setShowsearch] = useState(true);
     const canCreatePlaybooks = useCanCreatePlaybooksInTeam(teamId || '');
 
+    const currentChannelId = useSelector(getCurrentChannelId);
     let userId = useSelector(getCurrentUserId);
     if (playbook?.default_owner_enabled && playbook.default_owner_id) {
         userId = playbook.default_owner_id;
     }
 
     useEffect(() => {
-        if (playbook && playbook.channel_mode === 'create_new_channel') {
+        if (playbook?.channel_mode === 'create_new_channel') {
             setRunName(playbook.channel_name_template);
         }
     }, [playbook, playbook?.channel_name_template, playbook?.channel_mode]);
@@ -103,6 +106,15 @@ const RunPlaybookModal = ({
     const createNewChannel = channelMode === 'create_new_channel';
     const linkExistingChannel = channelMode === 'link_existing_channel';
     const isFormValid = runName !== '' && runName.length <= RUN_NAME_MAX_LENGTH && (createNewChannel || channelId !== '');
+
+    const handleSetChannelMode = (mode: 'link_existing_channel' | 'create_new_channel') => {
+        setChannelMode(mode);
+
+        // Default to current channel when choosing link
+        if (mode === 'link_existing_channel' && playbook?.channel_mode === 'create_new_channel' && channelId === '' && currentChannelId) {
+            setChannelId(currentChannelId);
+        }
+    };
 
     const onCreatePlaybook = () => {
         dispatch(displayPlaybookCreateModal({}));
@@ -192,7 +204,7 @@ const RunPlaybookModal = ({
                         channelMode={channelMode}
                         createPublicRun={createPublicRun}
                         onSetCreatePublicRun={setCreatePublicRun}
-                        onSetChannelMode={setChannelMode}
+                        onSetChannelMode={handleSetChannelMode}
                         onSetChannelId={setChannelId}
                     />
                 </Body>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
If a playbook defaults to "Create a run channel" and "Link run to an existing channel" is chosen, the default channel will be the current one instead of none.

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
Fixes #1767 

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
