### PR TITLE
Add a test to help detect potential sync issues with work template

### DIFF
--- a/webapp/src/components/templates/template_data.test.ts
+++ b/webapp/src/components/templates/template_data.test.ts
@@ -2,6 +2,7 @@ import TemplateData from './template_data';
 
 describe('TemplateData', () => {
     // if a template is missing, this might break the work templates feature.
+    // reminder: because playbook templates don't have an ID, we rely on their name to identify them.
     // if this breaks, contact the @channel team to figure out what should be done.
     const knownTemplatesInWorkTemplate = [
         'Product Release',

--- a/webapp/src/components/templates/template_data.test.ts
+++ b/webapp/src/components/templates/template_data.test.ts
@@ -1,0 +1,22 @@
+import TemplateData from './template_data';
+
+describe('TemplateData', () => {
+    // if a template is missing, this might break the work templates feature.
+    // if this breaks, contact the @channel team to figure out what should be done.
+    const knownTemplatesInWorkTemplate = [
+        'Product Release',
+        'Incident Resolution',
+        'Customer Onboarding',
+        'Employee Onboarding',
+        'Feature Lifecycle',
+        'Bug Bash',
+    ];
+
+    knownTemplatesInWorkTemplate.forEach((templateName) => {
+        it(`should contains ${templateName} for work template`, () => {
+            expect(
+                TemplateData.find((template) => template.title.trim() === templateName),
+            ).not.toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
I didn't really want to do this PR but this is how it is 😬 Because this is kind of a "first", I opened a thread here: [community.mattermost.com/core/pl/t7d16sx83tnw7phhh8bp9h844a](https://community.mattermost.com/core/pl/t7d16sx83tnw7phhh8bp9h844a)

Work templates rely on the fact that certain playbook templates exist, but we have no way to guarantee this on the mattermost-server/webapp side. This test acts as a warning that something might break in work templates because a templates has been renamed/removed.

## Ticket Link
N/A

## Checklist
N/A
