### PR TITLE
Remove NOT IN

### DIFF
--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -97,7 +97,7 @@ func (s *StatsStore) TotalActiveParticipants(filters *StatsFilters) int {
 		Join("IR_Incident AS i ON i.ID = rp.IncidentID").
 		Where("i.EndAt = 0").
 		Where("rp.IsParticipant = true").
-		Where(sq.Expr("rp.UserId NOT IN (SELECT UserId FROM Bots)"))
+		Where(sq.Expr("NOT EXISTS(SELECT 1 FROM Bots as bo WHERE bo.UserId = rp.UserId)"))
 
 	query = applyFilters(query, filters)
 
@@ -317,7 +317,7 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 	q = q.
 		From("IR_Incident as i").
 		InnerJoin("ChannelMemberHistory as cmh ON i.ChannelId = cmh.ChannelId").
-		Where(sq.Expr("cmh.UserId NOT IN (SELECT UserId FROM Bots)"))
+		Where(sq.Expr("NOT EXISTS(SELECT 1 FROM Bots as bo WHERE bo.UserId = cmh.UserId)"))
 	q = applyFilters(q, filters)
 
 	counts, err := s.performQueryForXCols(q, x)


### PR DESCRIPTION
## Summary
Removing occurrences of `NOT IN` in the sql queries. Here is the rational for it
https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_NOT_IN

There are bunch on `NOT IN` uses in the server repo as well, with pretty complicated selects inside so theoretically might even have nullable results. That should be changed as well.

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
