### PR TITLE
hotfix(release): Remove latest package publish for matterbuild to work .

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -71,8 +71,6 @@ jobs:
     steps:
       - name: cd/checkout-repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          fetch-depth: "0"
 
       - name: cd/download-artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -102,8 +100,6 @@ jobs:
     steps:
       - name: cd/checkout-repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          fetch-depth: "0"
 
       - name: cd/download-artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -125,11 +121,10 @@ jobs:
 
       - name: cd/artifact-upload
         run: |
-          aws s3 cp dist/${GITHUB_REPOSITORY#*/}-latest.tar.gz s3://mattermost-plugins-ci/release/ --acl public-read --cache-control no-cache
           aws s3 cp dist/${GITHUB_REPOSITORY#*/}-${GITHUB_REF_NAME}.tar.gz s3://mattermost-plugins-ci/release/ --acl public-read --cache-control no-cache
 
       - name: cd/create-github-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md  dist/*.tar.gz
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file dist/release-notes.md  dist/*.tar.gz


### PR DESCRIPTION
Fixed release notes path

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->

Fix duplicate package on Github Release that makes matterbuild fail . 
Relevant [line](https://github.com/mattermost/matterbuild/blob/59f5f2df3571c981871ed21cf78a420d1934e539/server/plugin_release.go#L590) 
