### PR TITLE
[MM-50623] Add support for Calls slash commands

### DIFF
--- a/webapp/src/components/checklist_item/command.tsx
+++ b/webapp/src/components/checklist_item/command.tsx
@@ -6,11 +6,13 @@ import styled, {css} from 'styled-components';
 import {clientRunChecklistItemSlashCommand} from 'src/client';
 import TextWithTooltipWhenEllipsis from 'src/components/widgets/text_with_tooltip_when_ellipsis';
 import CommandInput from 'src/components/command_input';
+import {CallsSlashCommandPrefix} from 'src/constants';
+import {runCallsSlashCommand} from 'src/utils';
 
 import Dropdown from 'src/components/dropdown';
 
 import LoadingSpinner from 'src/components/assets/loading_spinner';
-import {useTimeout} from 'src/hooks';
+import {useRun, useTimeout} from 'src/hooks';
 
 import {CancelSaveButtons} from './inputs';
 import {DropdownArrow} from './assign_to';
@@ -37,6 +39,7 @@ const Command = (props: CommandProps) => {
     const [command, setCommand] = useState(props.command);
     const dispatch = useDispatch();
 
+    const [playbookRun] = useRun(String(props.playbookRunId));
     const [commandOpen, setCommandOpen] = useState(false);
 
     // Setting running to true triggers the timeout by setting the delay to RunningTimeout
@@ -70,6 +73,9 @@ const Command = (props: CommandProps) => {
                 if (!running) {
                     setRunning(true);
                     clientRunChecklistItemSlashCommand(dispatch, props.playbookRunId || '', props.checklistNum, props.itemNum);
+                    if (props.command?.startsWith(CallsSlashCommandPrefix) && playbookRun) {
+                        runCallsSlashCommand(props.command, playbookRun.channel_id, playbookRun.team_id);
+                    }
                 }
             }}
         >

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -32,3 +32,5 @@ export const DateTimeFormats = {
     // eslint-disable-next-line no-undefined
     DATE_MED_NO_YEAR: {...DateTime.DATE_MED, year: undefined},
 };
+
+export const CallsSlashCommandPrefix = '/call ';

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -122,3 +122,13 @@ export function getDistinctAssignees(checklists: Checklist[]) {
     ];
 }
 
+export function runCallsSlashCommand(command: string, channelId: string, teamId: string) {
+    window.postMessage({
+        type: 'calls-run-slash-command',
+        message: command,
+        args: {
+            channel_id: channelId,
+            team_id: teamId,
+        },
+    }, window.origin);
+}


### PR DESCRIPTION
#### Summary

PR adds support for running Calls slash commands from Playbooks checklist items. The change on this side is minimal as we are simply sending a client event to trigger the handler on the Calls side (see related PR below). Let me know if it makes sense.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/343

#### Video

https://user-images.githubusercontent.com/1832946/220467796-65bf1711-7dec-4459-af2a-333058140fdb.mp4

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50623


