### PR TITLE
MM-50738 Remove keyword prompt post instead of editing it.

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -266,6 +266,7 @@ func (h *PlaybookRunHandler) createPlaybookRunFromDialog(c *Context, w http.Resp
 			TeamID:      request.TeamId,
 			ChannelID:   playbook.GetRunChannelID(),
 			Name:        name,
+			PostID:      state.PostID,
 			PlaybookID:  playbookID,
 			Type:        app.RunTypePlaybook,
 		},

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -266,7 +266,6 @@ func (h *PlaybookRunHandler) createPlaybookRunFromDialog(c *Context, w http.Resp
 			TeamID:      request.TeamId,
 			ChannelID:   playbook.GetRunChannelID(),
 			Name:        name,
-			PostID:      state.PostID,
 			PlaybookID:  playbookID,
 			Type:        app.RunTypePlaybook,
 		},
@@ -306,14 +305,6 @@ func (h *PlaybookRunHandler) createPlaybookRunFromDialog(c *Context, w http.Resp
 		return
 	}
 
-	// If the dialog was spawn from a prompt post (the one that is automatically sent when
-	// certain keywords are posted in a channel), then we need to edit that original post
-	if state.PromptPostID != "" {
-		if err := h.editPromptPost(state.PromptPostID, playbookID, playbookRun.ID, userID, name); err != nil {
-			c.logger.WithError(err).Error("failed editing the prompt post")
-		}
-	}
-
 	channel, err := h.pluginAPI.Channel.Get(playbookRun.ChannelID)
 	if err != nil {
 		h.HandleErrorWithCode(w, c.logger, http.StatusInternalServerError, "unable to get new channel", err)
@@ -340,33 +331,6 @@ func (h *PlaybookRunHandler) createPlaybookRunFromDialog(c *Context, w http.Resp
 
 	w.Header().Add("Location", fmt.Sprintf("/api/v0/runs/%s", playbookRun.ID))
 	w.WriteHeader(http.StatusCreated)
-}
-
-func (h *PlaybookRunHandler) editPromptPost(promptPostID string, playbookID string, runID string, userID string, runName string) error {
-	post, err := h.pluginAPI.Post.GetPost(promptPostID)
-	if err != nil {
-		return errors.Wrapf(err, "unable to retrieve the post with ID %q", promptPostID)
-	}
-
-	playbook, err := h.playbookService.Get(playbookID)
-	if err != nil {
-		return errors.Wrapf(err, "unable to retrieve the playbook with ID %q", playbookID)
-	}
-
-	user, err := h.pluginAPI.User.Get(userID)
-	if err != nil {
-		return errors.Wrapf(err, "unable to retrieve the user with ID %q", userID)
-	}
-
-	// Update the message and remove the attachments; i.e., the buttons
-	post.Message = fmt.Sprintf("@%s started the run [%s](%s) using the [%s](%s) playbook.",
-		user.Username, runName, app.GetRunDetailsRelativeURL(runID), playbook.Title, app.GetPlaybookDetailsRelativeURL(playbookID))
-	model.ParseSlackAttachment(post, []*model.SlackAttachment{})
-	if err := h.pluginAPI.Post.UpdatePost(post); err != nil {
-		return errors.Wrapf(err, "unable to update the post with ID %q", post.Id)
-	}
-
-	return nil
 }
 
 // addToTimelineDialog handles the interactive dialog submission when a user clicks the

--- a/server/api/signal.go
+++ b/server/api/signal.go
@@ -60,30 +60,22 @@ func (h *SignalHandler) playbookRun(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	postID, err := getStringField("postID", req.Context, w)
-	if err != nil {
-		h.returnError(publicErrorMessage, err, c.logger, w)
-		return
-	}
-
-	post, err := h.api.Post.GetPost(req.PostId)
-	if err != nil {
-		h.returnError(fmt.Sprintf("unable to get original post with ID %q", postID), err, c.logger, w)
-		return
-	}
-
 	pbook, err := h.playbookService.Get(id)
 	if err != nil {
 		h.returnError("can't get chosen playbook", errors.Wrapf(err, "can't get chosen playbook, id - %s", id), c.logger, w)
 		return
 	}
 
-	if err := h.playbookRunService.OpenCreatePlaybookRunDialog(req.TeamId, req.UserId, req.TriggerId, postID, "", []app.Playbook{pbook}, post.Id); err != nil {
+	if err := h.playbookRunService.OpenCreatePlaybookRunDialog(req.TeamId, req.UserId, req.TriggerId, "", "", []app.Playbook{pbook}); err != nil {
 		h.returnError("can't open dialog", errors.Wrap(err, "can't open a dialog"), c.logger, w)
 		return
 	}
 
 	ReturnJSON(w, &model.PostActionIntegrationResponse{}, http.StatusOK)
+	if err := h.api.Post.DeletePost(req.PostId); err != nil {
+		h.returnError("unable to delete original post", err, c.logger, w)
+		return
+	}
 }
 
 func (h *SignalHandler) ignoreKeywords(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/app/actions_service.go
+++ b/server/app/actions_service.go
@@ -492,7 +492,7 @@ func getPlaybookSuggestionsMessage(suggestedPlaybooks []Playbook, triggers []str
 	return message
 }
 
-func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, pluginID string) *model.SlackAttachment {
+func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, triggeringPostID string, pluginID string) *model.SlackAttachment {
 	ignoreButton := &model.PostAction{
 		Id:   "ignoreKeywordsButton",
 		Name: "No, ignore thread",
@@ -500,7 +500,7 @@ func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, 
 		Integration: &model.PostActionIntegration{
 			URL: fmt.Sprintf("/plugins/%s/api/v0/signal/keywords/ignore-thread", pluginID),
 			Context: map[string]interface{}{
-				"postID": postID,
+				"postID": triggeringPostID,
 			},
 		},
 	}
@@ -513,7 +513,7 @@ func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, 
 			Integration: &model.PostActionIntegration{
 				URL: fmt.Sprintf("/plugins/%s/api/v0/signal/keywords/run-playbook", pluginID),
 				Context: map[string]interface{}{
-					"postID":          postID,
+					"postID":          triggeringPostID,
 					"selected_option": playbooks[0].ID,
 				},
 			},
@@ -542,7 +542,7 @@ func getPlaybookSuggestionsSlackAttachment(playbooks []Playbook, postID string, 
 		Integration: &model.PostActionIntegration{
 			URL: fmt.Sprintf("/plugins/%s/api/v0/signal/keywords/run-playbook", pluginID),
 			Context: map[string]interface{}{
-				"postID": postID,
+				"postID": triggeringPostID,
 			},
 		},
 		Options: options,

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -592,7 +592,7 @@ type PlaybookRunService interface {
 	CreatePlaybookRun(playbookRun *PlaybookRun, playbook *Playbook, userID string, public bool) (*PlaybookRun, error)
 
 	// OpenCreatePlaybookRunDialog opens an interactive dialog to start a new playbook run.
-	OpenCreatePlaybookRunDialog(teamID, ownerID, triggerID, postID, clientID string, playbooks []Playbook, promptPostID string) error
+	OpenCreatePlaybookRunDialog(teamID, ownerID, triggerID, postID, clientID string, playbooks []Playbook) error
 
 	// OpenUpdateStatusDialog opens an interactive dialog so the user can update the playbook run's status.
 	OpenUpdateStatusDialog(playbookRunID, userID, triggerID string) error

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -501,7 +501,7 @@ func (s *PlaybookRunServiceImpl) failedInvitedUserActions(usersFailedToInvite []
 }
 
 // OpenCreatePlaybookRunDialog opens a interactive dialog to start a new playbook run.
-func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID, triggerID, postID, clientID string, playbooks []Playbook, promptPostID string) error {
+func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID, triggerID, postID, clientID string, playbooks []Playbook) error {
 
 	filteredPlaybooks := make([]Playbook, 0, len(playbooks))
 	for _, playbook := range playbooks {
@@ -510,7 +510,7 @@ func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID
 		}
 	}
 
-	dialog, err := s.newPlaybookRunDialog(teamID, requesterID, postID, clientID, filteredPlaybooks, promptPostID)
+	dialog, err := s.newPlaybookRunDialog(teamID, requesterID, postID, clientID, filteredPlaybooks)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create new playbook run dialog")
 	}
@@ -2474,7 +2474,7 @@ func (s *PlaybookRunServiceImpl) newFinishPlaybookRunDialog(playbookRun *Playboo
 	}
 }
 
-func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postID, clientID string, playbooks []Playbook, promptPostID string) (*model.Dialog, error) {
+func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postID, clientID string, playbooks []Playbook) (*model.Dialog, error) {
 	user, err := s.pluginAPI.User.Get(requesterID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch owner user")
@@ -2483,9 +2483,8 @@ func (s *PlaybookRunServiceImpl) newPlaybookRunDialog(teamID, requesterID, postI
 	T := i18n.GetUserTranslations(user.Locale)
 
 	state, err := json.Marshal(DialogState{
-		PostID:       postID,
-		ClientID:     clientID,
-		PromptPostID: promptPostID,
+		PostID:   postID,
+		ClientID: clientID,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal DialogState")

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -270,7 +270,7 @@ func (r *Runner) actionRun(args []string) {
 		return
 	}
 
-	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, postID, clientID, playbooksResults.Items, ""); err != nil {
+	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, postID, clientID, playbooksResults.Items); err != nil {
 		r.warnUserAndLogErrorf("Error: %v", err)
 		return
 	}
@@ -319,7 +319,7 @@ func (r *Runner) actionRunPlaybook(args []string) {
 		return
 	}
 
-	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, "", clientID, playbook, ""); err != nil {
+	if err := r.playbookRunService.OpenCreatePlaybookRunDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, "", clientID, playbook); err != nil {
 		r.warnUserAndLogErrorf("Error: %v", err)
 		return
 	}


### PR DESCRIPTION
## Summary
Removes the editing of the keyword prompt action post and instead deletes it, leaving the notifications of run creation to the regular channels. 

## Ticket Link
https://mattermost.atlassian.net/browse/MM-50738

