### PR TITLE
MM-50818 Fix module loading issues caused by shared modules

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -130,7 +130,7 @@ if (TARGET_IS_PRODUCT) {
 
                 // Set these to false so that any version provided by the web app will be accepted
                 requiredVersion: false,
-                version: false
+                version: false,
             };
         }
 

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -119,11 +119,18 @@ if (TARGET_IS_PRODUCT) {
         const sharedObject = {};
 
         for (const packageName of packageNames) {
-            // Set both versions to false so that the version of this module provided by the web app will be used
             sharedObject[packageName] = {
-                requiredVersion: false,
+
+                // Ensure only one copy of this package is ever loaded
                 singleton: true,
-                version: false,
+
+                // Set this to false to prevent Webpack from packaging any "fallback" version of this package so that
+                // only the version provided by the web app will be used
+                import: false,
+
+                // Set these to false so that any version provided by the web app will be accepted
+                requiredVersion: false,
+                version: false
             };
         }
 
@@ -141,8 +148,8 @@ if (TARGET_IS_PRODUCT) {
         },
         shared: [
             '@mattermost/client',
-            '@types/luxon',
-            '@types/react-bootstrap',
+
+            'luxon',
 
             makeSingletonSharedModules([
                 'react',

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -168,17 +168,7 @@ if (TARGET_IS_PRODUCT) {
 
     config.output = {
         path: path.join(__dirname, '/dist'),
-    };
-    config.externals = {
-        react: 'React',
-        'react-dom': 'ReactDOM',
-        redux: 'Redux',
-        luxon: 'Luxon',
-        'react-redux': 'ReactRedux',
-        'prop-types': 'PropTypes',
-        'react-bootstrap': 'ReactBootstrap',
-        'react-router-dom': 'ReactRouterDom',
-        'react-intl': 'ReactIntl',
+        chunkFilename: '[name].[contenthash].js',
     };
 } else {
     config.resolve.alias['react-intl'] = path.resolve(__dirname, '../../webapp/node_modules/react-intl/');


### PR DESCRIPTION
The errors that we were seeing where either Boards or Playbooks were failing to load when they were both loaded at the same time seems like it was happening due to an issue with the resolution of shared modules by module federation. Specifically, it seems to be due to how it was trying to choose which version of those shared modules to use between the ones bundled with the web app, Boards, and Playbooks.

Since I've been trying to make the web app the authority for these dependencies, I just changed it so that the Playbooks build will never include "fallback" versions of React and such since we know they'll always exist in the web app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50818

#### Related Pull Requests
https://github.com/mattermost/focalboard/pull/4605
https://github.com/mattermost/mattermost-webapp/pull/12282