### PR TITLE
POST playbook api specification includes public boolean definition

### DIFF
--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -1405,6 +1405,10 @@ paths:
                   type: boolean
                   description: A boolean indicating whether the playbook runs created from this playbook should be public or private.
                   example: true
+                public:
+                  type: boolean
+                  description: A boolean indicating whether the playbook is licensed as public or private. Required 'true' for free tier.
+                  example: true
                 checklists:
                   type: array
                   description: The stages defined by this playbook.


### PR DESCRIPTION
## Summary
Identifies a hidden API field required to successfully create a Playbook, using the free tier. 

## Ticket Link

Not a ticket, but a common error identified and disclosed in the forums.
https://forum.mattermost.com/t/error-unable-to-decode-playboook/15315/5?utm_source=mattermost&utm_medium=in-product&utm_content=post_attachment_opengraph&uid=pitfe5zmwbgixyq13uwdfa1age&sid=93mykbogbjfrbbdqphx3zhze5c


