### PR TITLE
[fix] CD revisiting naming for artifacts generated

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: cd/rename-artifacts
         run: |
-          mv dist/*.tar.gz dist/${GITHUB_REPOSITORY#*/}-${GITHUB_REF_NAME}.tar.gz
+          mv dist/*.tar.gz dist/playbooks-${GITHUB_REF_NAME}.tar.gz
 
       - name: cd/rename-artifacts
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
@@ -120,7 +120,7 @@ jobs:
 
       - name: cd/artifact-upload
         run: |
-          aws s3 cp dist/${GITHUB_REPOSITORY#*/}-${GITHUB_REF_NAME}.tar.gz s3://mattermost-plugins-ci/release/ --acl public-read --cache-control no-cache
+          aws s3 cp dist/playbooks-${GITHUB_REF_NAME}.tar.gz s3://mattermost-plugins-ci/release/ --acl public-read --cache-control no-cache
 
       - uses: jnwng/github-app-installation-token-action@c54add4c02866dc41e106745ac6dcf5cdd6339e5
         id: installationToken


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->

We are currently using the scheme: `${GITHUB_REPOSITORY#*/}-${GITHUB_REF_NAME}.tar.gz` to name the playbook-plugin artifact, in the CD process. 

CircleCI pipelines used the following naming scheme: `${GITHUB_REF_NAME}.tar.gz`
Previous CircleCI release example: https://github.com/mattermost/mattermost-plugin-playbooks/releases/tag/v1.36.2

We are aligning with the previous naming scheme.


## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-5870


## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
