### PR TITLE
Warn instead of Error on unrecognized user tz

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,7 +347,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermost/mm-ee-test:prerelease
+        image: mattermost/mattermost-cloud:latest
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2257,7 +2257,9 @@ func (s *PlaybookRunServiceImpl) buildTodoDigestMessage(userID string, force boo
 
 	timezone, err := timeutils.GetUserTimezone(user)
 	if err != nil {
-		return nil, err
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"user_id": user.Id,
+		}).Warn("failed to get user timezone")
 	}
 
 	part2 := buildAssignedTaskMessageSummary(digestMessageItems.assignedRuns, user.Locale, timezone, !force)


### PR DESCRIPTION
## Summary
Instead of erroring out on `/playbook todo` or the weekly digest message, just log a warning when a user's timezone isn't recognized:

```
{"timestamp":"2023-07-21 14:03:56.435 -03:00","level":"warn","msg":"failed to get user timezone","caller":"app/plugin_api.go:979","plugin_id":"playbooks","error":"unknown time zone Asia/Jerusalem2","user_id":"soa5qdiwnig8dkmekej37p8gmw","plugin_caller":"github.com/mattermost/mattermost-plugin-playbooks/server/app/playbook_run_service.go:2262"}
```

In practice, this won't occur because the timezone is really invalid, but because the operating system lacks the necessary tzdata.

## Ticket Link
None.