### PR TITLE
restore the missing Plugin telemetry key

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,5 +1,4 @@
 # Include custom targets and environment variables here
-GO_BUILD_FLAGS += -ldflags "-X main.rudderDataplaneURL=$(MM_RUDDER_DATAPLANE_URL) -X main.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
 
 ## Generate mocks.
 mocks:

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -42,12 +42,9 @@ const (
 	CollectionTypeRun = "run"
 )
 
-// These credentials for Rudder need to be populated at build-time,
-// passing the following flags to the go build command:
-// -ldflags "-X main.rudderDataplaneURL=<url> -X main.rudderWriteKey=<write_key>"
-var (
-	rudderDataplaneURL string
-	rudderWriteKey     string
+const (
+	rudderDataplaneURL = "https://pdat.matterlytics.com"
+	rudderWriteKey     = "1ag0Mv7LPf5uJNhcnKomqg0ENFd"
 )
 
 type TelemetryClient interface {


### PR DESCRIPTION
## Summary
For now, we're just hard-coding this while still honouring the server configuration as to whether or not to emit telemetry in the first place.

In the future, we should integrate knowledge of the service environment and use that to key off which key (if any) to use.

## Ticket Link
None.