### PR TITLE
MM-53753 Fix error messages for too long json

### DIFF
--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -419,6 +419,19 @@ func TestCreateInvalidRuns(t *testing.T) {
 		requireErrorWithStatusCode(t, err, http.StatusInternalServerError)
 		assert.Nil(t, run)
 	})
+
+	t.Run("checklist title way too long", func(t *testing.T) {
+		run := e.BasicRun
+		require.Len(t, run.Checklists, 0)
+
+		// Create a valid checklist
+		err := e.PlaybooksClient.PlaybookRuns.CreateChecklist(context.Background(), run.ID, client.Checklist{
+			Title: strings.Repeat("T", 257*1024),
+			Items: []client.ChecklistItem{},
+		})
+		t.Logf("Error: %v", err)
+		require.Error(t, err)
+	})
 }
 
 func TestRunRetrieval(t *testing.T) {

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -1081,7 +1081,7 @@ func toSQLPlaybook(playbook app.Playbook) (*sqlPlaybook, error) {
 	}
 
 	if len(checklistsJSON) > maxJSONLength {
-		return nil, errors.Wrapf(err, "checklist json for playbook id '%s' is too long (max %d)", playbook.ID, maxJSONLength)
+		return nil, errors.Errorf("checklist json for playbook id '%s' is too long (max %d)", playbook.ID, maxJSONLength)
 	}
 
 	return &sqlPlaybook{

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -1613,7 +1613,7 @@ func toSQLPlaybookRun(playbookRun app.PlaybookRun) (*sqlPlaybookRun, error) {
 	}
 
 	if len(checklistsJSON) > maxJSONLength {
-		return nil, errors.Wrapf(err, "checklist json for playbook run id '%s' is too long (max %d)", playbookRun.ID, maxJSONLength)
+		return nil, errors.Errorf("checklist json for playbook run id '%s' is too long (max %d)", playbookRun.ID, maxJSONLength)
 	}
 
 	return &sqlPlaybookRun{

--- a/server/sqlstore/user_info.go
+++ b/server/sqlstore/user_info.go
@@ -107,7 +107,7 @@ func toSQLUserInfo(userInfo app.UserInfo) (*sqlUserInfo, error) {
 	}
 
 	if len(digestNotificationSettingsJSON) > maxJSONLength {
-		return nil, errors.Wrapf(err, "digestNotificationSettings json for user id '%s' is too long (max %d)", userInfo.ID, maxJSONLength)
+		return nil, errors.Errorf("digestNotificationSettings json for user id '%s' is too long (max %d)", userInfo.ID, maxJSONLength)
 	}
 
 	return &sqlUserInfo{


### PR DESCRIPTION
Turns out that if you wrap a nil error it returns nil instead of a new error. We were using Wrapf when we meant Errorf leading to a function returning (`nil`, `nil`) instead of (`nil`, `error`) as intended. 