### PR TITLE
Move RHS opener to GraphQL

### DIFF
--- a/server/api/graphql_loader_run.go
+++ b/server/api/graphql_loader_run.go
@@ -7,9 +7,9 @@ import (
 	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
 )
 
-func graphQLStatusPostsLoader[V []app.StatusPost](ctx context.Context, keys []string) []*dataloader.Result[V] {
-	result := make([]*dataloader.Result[V], len(keys))
-	if len(keys) == 0 {
+func graphQLStatusPostsLoader[V []app.StatusPost](ctx context.Context, playbookRunIDs []string) []*dataloader.Result[V] {
+	result := make([]*dataloader.Result[V], len(playbookRunIDs))
+	if len(playbookRunIDs) == 0 {
 		return result
 	}
 
@@ -18,12 +18,12 @@ func graphQLStatusPostsLoader[V []app.StatusPost](ctx context.Context, keys []st
 		return populateResultWithError(err, result)
 	}
 
-	statusPostsByRunID, err := c.runStore.GetStatusPostsByIDs(keys)
+	statusPostsByRunID, err := c.runStore.GetStatusPostsByIDs(playbookRunIDs)
 	if err != nil {
 		return populateResultWithError(err, result)
 	}
 
-	for i, runID := range keys {
+	for i, runID := range playbookRunIDs {
 		statusPosts, ok := statusPostsByRunID[runID]
 		if !ok {
 			result[i] = &dataloader.Result[V]{Data: nil}
@@ -37,9 +37,9 @@ func graphQLStatusPostsLoader[V []app.StatusPost](ctx context.Context, keys []st
 	return result
 }
 
-func graphQLTimelineEventsLoader[V []app.TimelineEvent](ctx context.Context, keys []string) []*dataloader.Result[V] {
-	result := make([]*dataloader.Result[V], len(keys))
-	if len(keys) == 0 {
+func graphQLTimelineEventsLoader[V []app.TimelineEvent](ctx context.Context, playbookRunIDs []string) []*dataloader.Result[V] {
+	result := make([]*dataloader.Result[V], len(playbookRunIDs))
+	if len(playbookRunIDs) == 0 {
 		return result
 	}
 
@@ -48,17 +48,17 @@ func graphQLTimelineEventsLoader[V []app.TimelineEvent](ctx context.Context, key
 		return populateResultWithError(err, result)
 	}
 
-	timelineEvents, err := c.runStore.GetTimelineEventsByIDs(keys)
+	timelineEvents, err := c.runStore.GetTimelineEventsByIDs(playbookRunIDs)
 	if err != nil {
 		return populateResultWithError(err, result)
 	}
 
-	timelineEventsByRunID := make(map[string][]app.TimelineEvent)
+	timelineEventsByRunID := make(map[string]V)
 	for _, timelineEvent := range timelineEvents {
 		timelineEventsByRunID[timelineEvent.PlaybookRunID] = append(timelineEventsByRunID[timelineEvent.PlaybookRunID], timelineEvent)
 	}
 
-	for i, runID := range keys {
+	for i, runID := range playbookRunIDs {
 		timelineEvents, ok := timelineEventsByRunID[runID]
 		if !ok {
 			result[i] = &dataloader.Result[V]{Data: nil}
@@ -72,9 +72,9 @@ func graphQLTimelineEventsLoader[V []app.TimelineEvent](ctx context.Context, key
 	return result
 }
 
-func graphQLRunMetricsLoader[V []app.RunMetricData](ctx context.Context, keys []string) []*dataloader.Result[V] {
-	result := make([]*dataloader.Result[V], len(keys))
-	if len(keys) == 0 {
+func graphQLRunMetricsLoader[V []app.RunMetricData](ctx context.Context, playbookRunIDs []string) []*dataloader.Result[V] {
+	result := make([]*dataloader.Result[V], len(playbookRunIDs))
+	if len(playbookRunIDs) == 0 {
 		return result
 	}
 
@@ -83,12 +83,12 @@ func graphQLRunMetricsLoader[V []app.RunMetricData](ctx context.Context, keys []
 		return populateResultWithError(err, result)
 	}
 
-	metrics, err := c.runStore.GetMetricsByIDs(keys)
+	metrics, err := c.runStore.GetMetricsByIDs(playbookRunIDs)
 	if err != nil {
 		return populateResultWithError(err, result)
 	}
 
-	for i, runID := range keys {
+	for i, runID := range playbookRunIDs {
 		metrics, ok := metrics[runID]
 		if !ok {
 			result[i] = &dataloader.Result[V]{Data: nil}

--- a/server/api/graphql_loader_run.go
+++ b/server/api/graphql_loader_run.go
@@ -65,7 +65,7 @@ func graphQLTimelineEventsLoader[V []app.TimelineEvent](ctx context.Context, pla
 			continue
 		}
 		result[i] = &dataloader.Result[V]{
-			Data: V(timelineEvents),
+			Data: timelineEvents,
 		}
 	}
 

--- a/server/api/graphql_loader_run.go
+++ b/server/api/graphql_loader_run.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"context"
+
+	"github.com/graph-gophers/dataloader/v7"
+	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
+)
+
+func graphQLStatusPostsLoader[V []app.StatusPost](ctx context.Context, keys []string) []*dataloader.Result[V] {
+	result := make([]*dataloader.Result[V], len(keys))
+	if len(keys) == 0 {
+		return result
+	}
+
+	c, err := getContext(ctx)
+	if err != nil {
+		return populateResultWithError(err, result)
+	}
+
+	statusPostsByRunID, err := c.runStore.GetStatusPostsByIDs(keys)
+	if err != nil {
+		return populateResultWithError(err, result)
+	}
+
+	for i, runID := range keys {
+		statusPosts, ok := statusPostsByRunID[runID]
+		if !ok {
+			result[i] = &dataloader.Result[V]{Data: nil}
+			continue
+		}
+		result[i] = &dataloader.Result[V]{
+			Data: V(statusPosts),
+		}
+	}
+
+	return result
+}
+
+func graphQLTimelineEventsLoader[V []app.TimelineEvent](ctx context.Context, keys []string) []*dataloader.Result[V] {
+	result := make([]*dataloader.Result[V], len(keys))
+	if len(keys) == 0 {
+		return result
+	}
+
+	c, err := getContext(ctx)
+	if err != nil {
+		return populateResultWithError(err, result)
+	}
+
+	timelineEvents, err := c.runStore.GetTimelineEventsByIDs(keys)
+	if err != nil {
+		return populateResultWithError(err, result)
+	}
+
+	timelineEventsByRunID := make(map[string][]app.TimelineEvent)
+	for _, timelineEvent := range timelineEvents {
+		timelineEventsByRunID[timelineEvent.PlaybookRunID] = append(timelineEventsByRunID[timelineEvent.PlaybookRunID], timelineEvent)
+	}
+
+	for i, runID := range keys {
+		timelineEvents, ok := timelineEventsByRunID[runID]
+		if !ok {
+			result[i] = &dataloader.Result[V]{Data: nil}
+			continue
+		}
+		result[i] = &dataloader.Result[V]{
+			Data: V(timelineEvents),
+		}
+	}
+
+	return result
+}
+
+func graphQLRunMetricsLoader[V []app.RunMetricData](ctx context.Context, keys []string) []*dataloader.Result[V] {
+	result := make([]*dataloader.Result[V], len(keys))
+	if len(keys) == 0 {
+		return result
+	}
+
+	c, err := getContext(ctx)
+	if err != nil {
+		return populateResultWithError(err, result)
+	}
+
+	metrics, err := c.runStore.GetMetricsByIDs(keys)
+	if err != nil {
+		return populateResultWithError(err, result)
+	}
+
+	for i, runID := range keys {
+		metrics, ok := metrics[runID]
+		if !ok {
+			result[i] = &dataloader.Result[V]{Data: nil}
+			continue
+		}
+		result[i] = &dataloader.Result[V]{
+			Data: V(metrics),
+		}
+	}
+
+	return result
+}

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -85,6 +85,7 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 		Types:                   args.Types,
 		Page:                    page,
 		PerPage:                 perPage,
+		SkipExtras:              true,
 	}
 
 	runResults, err := c.playbookRunService.GetPlaybookRuns(requesterInfo, filterOptions)

--- a/server/api/graphql_run.go
+++ b/server/api/graphql_run.go
@@ -80,22 +80,46 @@ func (r *RunResolver) Checklists() []*ChecklistResolver {
 	return checklistResolvers
 }
 
-func (r *RunResolver) StatusPosts() []*StatusPostResolver {
+func (r *RunResolver) StatusPosts(ctx context.Context) ([]*StatusPostResolver, error) {
+	c, err := getContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	thunk := c.statusPostsLoader.Load(ctx, r.ID)
+
+	statusPosts, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
 	statusPostResolvers := make([]*StatusPostResolver, 0, len(r.PlaybookRun.StatusPosts))
-	for _, statusPost := range r.PlaybookRun.StatusPosts {
+	for _, statusPost := range statusPosts {
 		statusPostResolvers = append(statusPostResolvers, &StatusPostResolver{statusPost})
 	}
 
-	return statusPostResolvers
+	return statusPostResolvers, nil
 }
 
-func (r *RunResolver) TimelineEvents() []*TimelineEventResolver {
+func (r *RunResolver) TimelineEvents(ctx context.Context) ([]*TimelineEventResolver, error) {
+	c, err := getContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	thunk := c.timelineEventsLoader.Load(ctx, r.ID)
+
+	timelineEvents, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
 	timelineEventResolvers := make([]*TimelineEventResolver, 0, len(r.PlaybookRun.StatusPosts))
-	for _, event := range r.PlaybookRun.TimelineEvents {
+	for _, event := range timelineEvents {
 		timelineEventResolvers = append(timelineEventResolvers, &TimelineEventResolver{event})
 	}
 
-	return timelineEventResolvers
+	return timelineEventResolvers, nil
 }
 
 func (r *RunResolver) IsFavorite(ctx context.Context) (bool, error) {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -929,6 +929,15 @@ type PlaybookRunStore interface {
 
 	// GetStatusAsTopicMetadataByIDs gets PlaybookRunIDs and TeamIDs from runs by statusIDs
 	GetStatusAsTopicMetadataByIDs(statusIDs []string) ([]TopicMetadata, error)
+
+	// GetStatsPostsByIDs gets the status posts for playbook runs
+	GetStatusPostsByIDs(playbookRunID []string) (map[string][]StatusPost, error)
+
+	// GetTimelineEventsByIDs gets the timeline events for playbook runs.
+	GetTimelineEventsByIDs(playbookRunID []string) ([]TimelineEvent, error)
+
+	// GetMetricsByIDs gets the metrics for playbook runs.
+	GetMetricsByIDs(playbookRunID []string) (map[string][]RunMetricData, error)
 }
 
 // PlaybookRunTelemetry defines the methods that the PlaybookRunServiceImpl needs from the RudderTelemetry.

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -1095,6 +1095,9 @@ type PlaybookRunFilterOptions struct {
 
 	// Types filters by all run types in the list (inclusive)
 	Types []string
+
+	// Skip getting extra information (like timeline events and status posts). Used by GraphQL to limit the amount of data retrieved.
+	SkipExtras bool
 }
 
 // Clone duplicates the given options.

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -244,6 +244,7 @@ func (p *Plugin) OnActivate() error {
 		p.config,
 		p.permissions,
 		playbookStore,
+		playbookRunStore,
 		p.licenseChecker,
 	)
 	api.NewPlaybookHandler(

--- a/webapp/src/graphql/generated/graphql.ts
+++ b/webapp/src/graphql/generated/graphql.ts
@@ -369,6 +369,7 @@ export type Run = {
   summary: Scalars['String'];
   summaryModifiedAt: Scalars['Float'];
   teamID: Scalars['String'];
+  timelineEvents: Array<TimelineEvent>;
   type: PlaybookRunType;
   webhookOnStatusUpdateURLs: Array<Scalars['String']>;
 };

--- a/webapp/src/graphql/generated/graphql.ts
+++ b/webapp/src/graphql/generated/graphql.ts
@@ -369,7 +369,6 @@ export type Run = {
   summary: Scalars['String'];
   summaryModifiedAt: Scalars['Float'];
   teamID: Scalars['String'];
-  timelineEvents: Array<TimelineEvent>;
   type: PlaybookRunType;
   webhookOnStatusUpdateURLs: Array<Scalars['String']>;
 };

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -318,7 +318,7 @@ export default class Plugin {
         this.userActivityWatch();
 
         // Listen for channel changes and open the RHS when appropriate.
-        this.removeRHSListener = store.subscribe(makeRHSOpener(store));
+        this.removeRHSListener = store.subscribe(makeRHSOpener(store, graphqlClient));
 
         // Listen for channel changes to trigger welcome actions when appropriate.
         this.removeChannelSwitcherListener = store.subscribe(makeWelcomeMessagePoster(store));

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -31,6 +31,7 @@ const RunsOnTeamQuery = gql`
             edges {
                 node {
                     channel_id: channelID
+                    team_id: teamID
                 }
             }
         }


### PR DESCRIPTION
Migrates the RHS opener logic to GraphQL to reduce the overhead of fetching all the runs on the team. We where fetching all the data on each run when all we really needed was if there was an active run in the channel.

Status posts, timeline events, and metrics where set behind an option that GraphQL excludes and fetches separately itself if requested. 

This came up because a customer was encountering the `getTimelineEventsForPlaybookRun` subquery executing with near 1000 runs. This appears to be the only situation outside of having 1000 runs in a channel that this could happen. 