### PR TITLE
Adding time/tzdata for systems without tzdata installed.

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -24,6 +24,8 @@ import (
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 	"github.com/mattermost/mattermost-plugin-api/cluster"
+
+	_ "time/tzdata" // for systems that don't have tzdata installed
 )
 
 const (


### PR DESCRIPTION
## Summary

Adding `time/tzdata` as import for systems and docker images without tzdata installed. 
