### PR TITLE
[MM-58377] Make sure we have an enterprise license when activating the plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace github.com/golang/mock => github.com/golang/mock v1.4.4
 require (
 	github.com/Masterminds/squirrel v1.5.2
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -48,7 +49,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.3.3 // indirect
 	github.com/bits-and-blooms/bloom/v3 v3.3.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blevesearch/bleve/v2 v2.3.6-0.20221111171245-56dc9b25507e // indirect
 	github.com/blevesearch/bleve_index_api v1.0.5 // indirect
 	github.com/blevesearch/geo v0.1.15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ replace github.com/golang/mock => github.com/golang/mock v1.4.4
 require (
 	github.com/Masterminds/squirrel v1.5.2
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/blang/semver/v4 v4.0.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -49,6 +48,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.3.3 // indirect
 	github.com/bits-and-blooms/bloom/v3 v3.3.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blevesearch/bleve/v2 v2.3.6-0.20221111171245-56dc9b25507e // indirect
 	github.com/blevesearch/bleve_index_api v1.0.5 // indirect
 	github.com/blevesearch/geo v0.1.15 // indirect

--- a/server/api_playbooks_test.go
+++ b/server/api_playbooks_test.go
@@ -65,7 +65,6 @@ func TestPlaybooks(t *testing.T) {
 			Title:  "test6 - to be archived",
 			TeamID: e.BasicTeam.Id,
 		})
-		t.Log("err is", err)
 		assert.NoError(t, err)
 
 		playbook, err := e.PlaybooksClient.Playbooks.Get(context.Background(), id)

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -174,8 +174,12 @@ func Setup(t *testing.T) *TestEnvironment {
 	err = utils.TranslationsPreInit()
 	require.NoError(t, err)
 
+	e20license := model.NewTestLicense()
+	e20license.SkuShortName = model.LicenseShortSkuE20
+
 	options := []sapp.Option{
 		sapp.ConfigStore(configStore),
+		sapp.WithLicense(e20license),
 	}
 	server, err := sapp.NewServer(options...)
 	require.NoError(t, err)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/api"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/bot"
@@ -112,15 +111,7 @@ func (p *Plugin) OnActivate() error {
 	pluginAPIClient := pluginapi.NewClient(p.API, p.Driver)
 	p.pluginAPI = pluginAPIClient
 
-	v2, err := semver.Parse("2.0.0")
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse semver")
-	}
-	pluginVersion, err := semver.Parse(manifest.Version)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse plugin version")
-	}
-	if pluginVersion.GTE(v2) && !pluginapi.IsE20LicensedOrDevelopment(
+	if !pluginapi.IsE20LicensedOrDevelopment(
 		pluginAPIClient.Configuration.GetConfig(),
 		pluginAPIClient.System.GetLicense(),
 	) {


### PR DESCRIPTION
## Summary
Add license check when starting playbooks if the version is 2.0+

Also see the Mattermost PR: https://github.com/mattermost/mattermost/pull/27335

Note: there is another ticket for cleaning up all the license checks for pro and enterprise:  https://mattermost.atlassian.net/browse/MM-58700

## Ticket Link
https://mattermost.atlassian.net/browse/MM-58377