### PR TITLE
MM-48411 Fixed truncation on long team names

### DIFF
--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -105,7 +105,7 @@ const SidebarComponent = styled.div`
 const Header = styled.div`
     height: 52px;
     padding: 0 16px;
-
+    gap: 8px;
     display: flex;
     flex: initial;
     flex-flow: row nowrap;
@@ -115,14 +115,17 @@ const Header = styled.div`
 `;
 
 const TeamName = styled.h1`
+    display: inline-block;
+    margin: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     color: var(--sidebar-header-text-color);
-    cursor: pointer;
-    display: flex;
     font-family: Metropolis, sans-serif;
     font-weight: 600;
     font-size: 16px;
     line-height: 24px;
-    margin: 0px;
+    cursor: pointer;
 `;
 
 export default Sidebar;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
Fixed an issue in the sidebar where long team names wrapped on multiple lines and displayed poorly.

| Before | After |
| --- | --- |
| <img width="306" alt="image" src="https://github.com/mattermost/mattermost-plugin-playbooks/assets/2040554/ea5a77eb-1f76-4afb-a9b0-614a95a8f5ad"> | <img width="307" alt="image" src="https://github.com/mattermost/mattermost-plugin-playbooks/assets/2040554/ead7347f-308f-4d48-b100-b9cd4944b703"> |


## Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-48411