### PR TITLE
MM-48603 Fixed RHS hover styling on checklist area

### DIFF
--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -328,7 +328,6 @@ const InnerContainer = styled.div<{parentContainer?: ChecklistParent}>`
 `;
 
 const MainTitleBG = styled.div<{numChecklists: number}>`
-    background-color: var(--center-channel-bg);
     z-index: ${({numChecklists}) => numChecklists + 2};
     position: sticky;
     top: 0;


### PR DESCRIPTION
## Summary
Fixed issue with the hover state on the checklist area where the title background was set and preventing the hover background from showing through. 

| Before | After |
| --- | --- |
| <img width="474" alt="image" src="https://github.com/mattermost/mattermost-plugin-playbooks/assets/2040554/a8ee2521-8e38-4157-b2c4-c9ebeb5c2ff6"> | <img width="481" alt="image" src="https://github.com/mattermost/mattermost-plugin-playbooks/assets/2040554/6657b3be-2e27-4712-b4f3-f41db79564fe"> |

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-48603
