### PR TITLE
[MM-58791] Restrict graphql errors

### DIFF
--- a/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
+++ b/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
@@ -31,7 +31,6 @@ describe('api > graphql_errors', {testIsolation: true}, () => {
             method: 'POST',
             failOnStatusCode: false,
         }).then((response) => {
-            expect(response.status).to.equal(400);
             expect(response.body.errors).to.have.length(1);
             expect(response.body.errors[0].message).to.equal('Error while executing your request');
         });

--- a/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
+++ b/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
@@ -32,7 +32,8 @@ describe('api > graphql_errors', {testIsolation: true}, () => {
             failOnStatusCode: false,
         }).then((response) => {
             expect(response.status).to.equal(400);
-            expect(response.body.errors).to.equal('Error while executing your request');
+            expect(response.body.errors).to.have.length(1);
+            expect(response.body.errors[0]).to.equal('Error while executing your request');
         });
     });
 });

--- a/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
+++ b/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
@@ -33,7 +33,7 @@ describe('api > graphql_errors', {testIsolation: true}, () => {
         }).then((response) => {
             expect(response.status).to.equal(400);
             expect(response.body.errors).to.have.length(1);
-            expect(response.body.errors[0]).to.equal('Error while executing your request');
+            expect(response.body.errors[0].message).to.equal('Error while executing your request');
         });
     });
 });

--- a/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
+++ b/e2e-tests/tests/integration/playbooks/api/graphql_errors_spec.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+// Stage: @prod
+// Group: @playbooks
+
+describe('api > graphql_errors', {testIsolation: true}, () => {
+    let testUser;
+
+    before(() => {
+        cy.apiInitSetup().then(({user}) => {
+            testUser = user;
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    it('return a generic error', () => {
+        cy.request({
+            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            url: '/plugins/playbooks/api/v0/query',
+            body: {operationName: 'poc', query: 'query poc { __typename @a@a@a }'},
+            method: 'POST',
+            failOnStatusCode: false,
+        }).then((response) => {
+            expect(response.status).to.equal(400);
+            expect(response.body.errors).to.equal('Error while executing your request');
+        });
+    });
+});
+

--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/graph-gophers/dataloader/v7"
 	graphql "github.com/graph-gophers/graphql-go"
+	graphql_errors "github.com/graph-gophers/graphql-go/errors"
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/config"
@@ -183,7 +184,11 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 			}
 		}
 
-		if err := json.NewEncoder(w).Encode(map[string]string{"errors": "Error while executing your request"}); err != nil {
+		response.Errors = response.Errors[:1]
+		response.Errors[0].Message = "Error while executing your request"
+		response.Errors[0].Locations = []graphql_errors.Location{{Line: 0, Column: 0}}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
 			c.logger.WithError(err).Warn("Error while writing error response")
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -187,14 +187,10 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 		response.Errors = response.Errors[:1]
 		response.Errors[0].Message = "Error while executing your request"
 		response.Errors[0].Locations = []graphql_errors.Location{{Line: 0, Column: 0}}
-
+		w.WriteHeader(http.StatusBadRequest)
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			c.logger.WithError(err).Warn("Error while writing error response")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
 		}
-
-		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -188,8 +188,8 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 		response.Errors[0].Locations = []graphql_errors.Location{{Line: 0, Column: 0}}
 		// remove all other errors
 		response.Errors = response.Errors[:1]
-		w.WriteHeader(http.StatusBadRequest)
 		if err := json.NewEncoder(w).Encode(response); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
 			c.logger.WithError(err).Warn("Error while writing error response")
 		}
 		return

--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -184,9 +184,10 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 			}
 		}
 
-		response.Errors = response.Errors[:1]
 		response.Errors[0].Message = "Error while executing your request"
 		response.Errors[0].Locations = []graphql_errors.Location{{Line: 0, Column: 0}}
+		// remove all other errors
+		response.Errors = response.Errors[:1]
 		w.WriteHeader(http.StatusBadRequest)
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			c.logger.WithError(err).Warn("Error while writing error response")

--- a/server/api_graphql_runs_test.go
+++ b/server/api_graphql_runs_test.go
@@ -1143,7 +1143,7 @@ func TestBadGraphQLRequest(t *testing.T) {
 		Variables:     map[string]interface{}{"userID": "me"},
 	}, &result)
 	require.NoError(t, err)
-	require.Len(t, result.Errors, 4)
+	require.Len(t, result.Errors, 1)
 }
 
 // AddParticipants adds participants to the run


### PR DESCRIPTION
## Summary
Restrict how much error we display and log on Graphql requests.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-58791

## Checklist
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
- [x] Tests updated
