### PR TITLE
Revert "MM-48603 Fixed RHS hover styling on checklist area"

### DIFF
--- a/webapp/src/components/checklist/checklist_list.tsx
+++ b/webapp/src/components/checklist/checklist_list.tsx
@@ -419,7 +419,7 @@ const NewChecklist = styled.div`
     background-color: rgba(var(--center-channel-color-rgb), 0.04);
     z-index: 1;
     position: sticky;
-    top: 48px; // height of rhs_checklists MainTitle
+    top: 0;
     border-radius: 4px 4px 0px 0px;
 
     display: flex;

--- a/webapp/src/components/checklist/collapsible_checklist.tsx
+++ b/webapp/src/components/checklist/collapsible_checklist.tsx
@@ -201,12 +201,12 @@ const ProgressLine = styled.div<{width: number}>`
 
 export const HorizontalBG = styled.div<{menuIsOpen: boolean}>`
     background-color: var(--center-channel-bg);
-    
+
     /* sets a higher z-index to the checklist with open menu */
     z-index: ${({menuIsOpen}) => (menuIsOpen ? '2' : '1')};
 
     position: sticky;
-    top: 48px; // height of rhs_checklists MainTitle
+    top: 0;
 `;
 
 const Horizontal = styled.div`

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -328,6 +328,7 @@ const InnerContainer = styled.div<{parentContainer?: ChecklistParent}>`
 `;
 
 const MainTitleBG = styled.div<{numChecklists: number}>`
+    background-color: var(--center-channel-bg);
     z-index: ${({numChecklists}) => numChecklists + 2};
     position: sticky;
     top: 0;


### PR DESCRIPTION
Reverts mattermost/mattermost-plugin-playbooks#1926

See https://mattermost.atlassian.net/browse/MM-60057

Did not find a way to quickly fix the underlying ticket, but this change results in a more degraded UI and we need to revert this for the v10 release!