### PR TITLE
MM-60420: treat bots as participants

### DIFF
--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -1166,7 +1166,7 @@ func TestGetParticipantsActiveTotal(t *testing.T) {
 			createRuns(store, playbookRunStore, playbook1ID, []userInfo{alice, bob, bot1}, team1ID, 3, app.StatusInProgress)
 			createRuns(store, playbookRunStore, playbook2ID, []userInfo{tom, bob}, team2ID, 5, app.StatusInProgress)
 
-			expected := 2*3 + 2*5 // ignore bots
+			expected := 3*3 + 2*5
 			actual, err := playbookRunStore.GetParticipantsActiveTotal()
 			require.NoError(t, err)
 			require.Equal(t, int64(expected), actual)

--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -96,8 +96,7 @@ func (s *StatsStore) TotalActiveParticipants(filters *StatsFilters) int {
 		From("IR_Run_Participants as rp").
 		Join("IR_Incident AS i ON i.ID = rp.IncidentID").
 		Where("i.EndAt = 0").
-		Where("rp.IsParticipant = true").
-		Where(sq.Expr("rp.UserId NOT IN (SELECT UserId FROM Bots)"))
+		Where("rp.IsParticipant = true")
 
 	query = applyFilters(query, filters)
 
@@ -316,8 +315,7 @@ func (s *StatsStore) ActiveParticipantsPerDayLastXDays(x int, filters *StatsFilt
 
 	q = q.
 		From("IR_Incident as i").
-		InnerJoin("ChannelMemberHistory as cmh ON i.ChannelId = cmh.ChannelId").
-		Where(sq.Expr("cmh.UserId NOT IN (SELECT UserId FROM Bots)"))
+		InnerJoin("ChannelMemberHistory as cmh ON i.ChannelId = cmh.ChannelId")
 	q = applyFilters(q, filters)
 
 	counts, err := s.performQueryForXCols(q, x)

--- a/server/sqlstore/stats_test.go
+++ b/server/sqlstore/stats_test.go
@@ -196,41 +196,41 @@ func TestTotalInProgressPlaybookRuns(t *testing.T) {
 		}
 
 		addUsersToRuns(t, store, []userInfo{bob, lucy, phil}, []string{playbookRuns[0].ID, playbookRuns[1].ID, playbookRuns[2].ID, playbookRuns[3].ID, playbookRuns[5].ID, playbookRuns[6].ID, playbookRuns[7].ID, playbookRuns[8].ID})
-		addUsersToRuns(t, store, []userInfo{bob, quincy}, []string{playbookRuns[4].ID})
-		addUsersToRuns(t, store, []userInfo{john}, []string{playbookRuns[0].ID})
+		addUsersToRuns(t, store, []userInfo{bob, quincy, bot1}, []string{playbookRuns[4].ID})
+		addUsersToRuns(t, store, []userInfo{john, bot2}, []string{playbookRuns[0].ID})
 		addUsersToRuns(t, store, []userInfo{jane}, []string{playbookRuns[0].ID, playbookRuns[1].ID})
 
 		t.Run(driverName+" Active Participants - team1", func(t *testing.T) {
 			result := statsStore.TotalActiveParticipants(&StatsFilters{
 				TeamID: team1id,
 			})
-			assert.Equal(t, 5, result)
+			assert.Equal(t, 6, result)
 		})
 
 		t.Run(driverName+" Active Participants - team2", func(t *testing.T) {
 			result := statsStore.TotalActiveParticipants(&StatsFilters{
 				TeamID: team2id,
 			})
-			assert.Equal(t, 4, result)
+			assert.Equal(t, 5, result)
 		})
 
 		t.Run(driverName+" Active Participants, playbook1", func(t *testing.T) {
 			result := statsStore.TotalActiveParticipants(&StatsFilters{
 				PlaybookID: "playbook1",
 			})
-			assert.Equal(t, 5, result)
+			assert.Equal(t, 6, result)
 		})
 
 		t.Run(driverName+" Active Participants, playbook2", func(t *testing.T) {
 			result := statsStore.TotalActiveParticipants(&StatsFilters{
 				PlaybookID: "playbook2",
 			})
-			assert.Equal(t, 4, result)
+			assert.Equal(t, 5, result)
 		})
 
 		t.Run(driverName+" Active Participants, all", func(t *testing.T) {
 			result := statsStore.TotalActiveParticipants(&StatsFilters{})
-			assert.Equal(t, 6, result)
+			assert.Equal(t, 8, result)
 		})
 
 		t.Run(driverName+" In-progress Playbook Runs - team1", func(t *testing.T) {


### PR DESCRIPTION
## Summary
In support of the MS Teams Tab App, and to unlock other security workflows involving bot participation in runs, let's allow bots to be participants of playbook runs.

## Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-60420