### PR TITLE
fix DEFAULT_* handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ GO_TEST_FLAGS ?= -race
 GO_BUILD_FLAGS ?=
 MM_UTILITIES_DIR ?= ../mattermost-utilities
 DLV_DEBUG_PORT := 2346
-DEFAULT_GOOS := $(shell go env GOOS)
-DEFAULT_GOARCH := $(shell go env GOARCH)
+DEFAULT_GOOS ?= $(shell go env GOOS)
+DEFAULT_GOARCH ?= $(shell go env GOARCH)
 
 export GO111MODULE=on
 
@@ -206,7 +206,7 @@ endif
 	mkdir -p server/dist;
 ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
 	@echo Building plugin only for $(DEFAULT_GOOS)-$(DEFAULT_GOARCH) because MM_SERVICESETTINGS_ENABLEDEVELOPER is enabled
-	cd server && env CGO_ENABLED=0 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-$(DEFAULT_GOOS)-$(DEFAULT_GOARCH);
+	cd server && env CGO_ENABLED=0 GOOS=$(DEFAULT_GOOS) GOARCH=$(DEFAULT_GOARCH) $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-$(DEFAULT_GOOS)-$(DEFAULT_GOARCH);
 
 ifneq ($(MM_DEBUG),)
 	cd server && ./dist/plugin-$(DEFAULT_GOOS)-$(DEFAULT_GOARCH) graphqlcheck


### PR DESCRIPTION
## Summary
We added `DEFAULT_GOOS` and `DEFAULT_GOARCH` a while back so it was easy to cross compile for a quick deploy, e.g.:
```sh
export MM_SERVICESETTINGS_ENABLEDEVELOPER=true 
export MM_DEBUG= 
export DEFAULT_GOOS=linux 
export DEFAULT_GOARCH=amd64 
make dist 
```

Somehow or another, this was just done wrong. I need to fix this "upstream" in the starter template too.

## Ticket Link
None