### PR TITLE
fix: Revert testing to free runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-22.04
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -208,7 +208,7 @@ jobs:
           search_path: tests/integration
 
   e2e-cypress-tests:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     name: e2e-cypress-tests-run-${{ matrix.runId }}
     needs:
       - lint


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository-specific documentation at https://developers.mattermost.com/contribute/getting-started/

REMEMBER TO:
- Run `make i18n-extract` and commit changes to synchronize any new or removed messages
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
-->

## Summary
<!--
A description of what this pull request does
-->
Revert to free runners 

## Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.:

  Fixes: https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the Jira ticket.
-->

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
