### PR TITLE
Limit task actions to 10

### DIFF
--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -529,6 +529,10 @@ func validateUpdateTaskActions(checklists []UpdateChecklist) error {
 	for _, checklist := range checklists {
 		for _, item := range checklist.Items {
 			if taskActions := item.TaskActions; taskActions != nil {
+				// Limit task actions to 10
+				if len(*taskActions) > 10 {
+					return errors.Errorf("playbook cannot have more than 10 task actions")
+				}
 				for _, ta := range *taskActions {
 					if err := app.ValidateTrigger(ta.Trigger); err != nil {
 						return err

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -262,6 +262,11 @@ func validatePreAssignment(pb app.Playbook) error {
 // validateTaskActions validates the taskactions in the given checklist
 // NOTE: Any changes to this function must be made to function 'validateUpdateTaskActions' for the GraphQL endpoint.
 func validateTaskActions(taskActions []app.TaskAction) error {
+	// Limit task actions to 10
+	if len(taskActions) > 10 {
+		return errors.Errorf("playbook cannot have more than 10 task actions")
+	}
+
 	for _, ta := range taskActions {
 		if err := app.ValidateTrigger(ta.Trigger); err != nil {
 			return err


### PR DESCRIPTION
## Summary
Limits the number of task actions you can have to 10. 

## Ticket Link

https://mattermost.atlassian.net/browse/MM-61244
