### PR TITLE
fix(api): remove trailing slash from removeTimelineEvent API

### DIFF
--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -1249,7 +1249,7 @@ paths:
         500:
           $ref: "#/components/responses/500"
 
-  /plugins/playbooks/api/v0/runs/{id}/timeline/{event_id}/:
+  /plugins/playbooks/api/v0/runs/{id}/timeline/{event_id}:
     delete:
       summary: Remove a timeline event from the playbook run
       operationId: removeTimelineEvent


### PR DESCRIPTION
## Summary

Removes the trailing slash from removeTimelineEvent API, which is an unintentional error in #468.

## Ticket Link

- Closes #1965

## Checklist

- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
