### PR TITLE
fix: Add horizontal margins to PaginationRow component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ server/e2etest.config.json
 
 # Notice
 .notice-work
+.aider*
+.env

--- a/webapp/src/components/pagination_row.tsx
+++ b/webapp/src/components/pagination_row.tsx
@@ -6,13 +6,12 @@ import {FormattedMessage} from 'react-intl';
 import styled from 'styled-components';
 
 const PaginationRowDiv = styled.div`
-    margin: 10px 0 20px;
+    margin: 10px 32px 20px;
     font-size: 14px;
     display: grid;
     align-items: center;
     grid-template-columns: minmax(20rem, min-content) auto minmax(20rem, min-content);
     justify-content: space-between;
-    padding: 0 2px;
 `;
 
 const Count = styled.span`

--- a/webapp/src/components/pagination_row.tsx
+++ b/webapp/src/components/pagination_row.tsx
@@ -6,7 +6,7 @@ import {FormattedMessage} from 'react-intl';
 import styled from 'styled-components';
 
 const PaginationRowDiv = styled.div`
-    margin: 10px 32px 20px;
+    margin: 10px 16px 20px;
     font-size: 14px;
     display: grid;
     align-items: center;


### PR DESCRIPTION
## Summary
The PaginationRow components didn't have any margin and the next/previous buttons where to close to the border

## Ticket Link
[MM-61918](https://mattermost.atlassian.net/browse/MM-61918)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated

## Screenshot
![imagen](https://github.com/user-attachments/assets/cff0701f-9169-4f24-bc30-2fb9a556b28e)

[MM-61918]: https://mattermost.atlassian.net/browse/MM-61918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ