### PR TITLE
combine EnableDeveloper and EnableTesting

### DIFF
--- a/server/api/tabapp_test.go
+++ b/server/api/tabapp_test.go
@@ -121,7 +121,7 @@ func TestValidateToken(t *testing.T) {
 	}
 
 	type parameters struct {
-		EnableDeveloper bool
+		EnableDeveloperAndTesting bool
 	}
 
 	runPermutations(t, parameters{}, func(t *testing.T, params parameters) {
@@ -130,8 +130,8 @@ func TestValidateToken(t *testing.T) {
 			r := makeRequest(t, nil)
 			expectedTenantIDs := []string{}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
-			if params.EnableDeveloper {
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
+			if params.EnableDeveloperAndTesting {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)
@@ -144,8 +144,8 @@ func TestValidateToken(t *testing.T) {
 			r := makeRequest(t, newRawToken(""))
 			expectedTenantIDs := []string{}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
-			if params.EnableDeveloper {
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
+			if params.EnableDeveloperAndTesting {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)
@@ -158,7 +158,7 @@ func TestValidateToken(t *testing.T) {
 			r := makeRequest(t, newRawToken("invalid"))
 			expectedTenantIDs := []string{}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusInternalServerError, validationErr.StatusCode)
 		})
@@ -168,7 +168,7 @@ func TestValidateToken(t *testing.T) {
 			r := makeRequest(t, newRawToken("invalid"))
 			expectedTenantIDs := []string{}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -178,7 +178,7 @@ func TestValidateToken(t *testing.T) {
 			r := makeRequest(t, newToken(t, priv, nil))
 			expectedTenantIDs := []string{}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -202,7 +202,7 @@ func TestValidateToken(t *testing.T) {
 			r := makeRequest(t, &signed)
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -219,7 +219,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -237,7 +237,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -255,7 +255,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -272,7 +272,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -290,7 +290,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -308,7 +308,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -325,7 +325,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -343,7 +343,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -361,7 +361,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -379,8 +379,8 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
-			if params.EnableDeveloper {
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
+			if params.EnableDeveloperAndTesting {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)
@@ -401,7 +401,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -420,7 +420,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{expectedTid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -440,7 +440,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{expectedTid1, expectedTid2}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			require.NotNil(t, validationErr)
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
@@ -458,7 +458,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{tid}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			assert.Nil(t, validationErr)
 		})
 
@@ -476,7 +476,7 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{expectedTid1, expectedTid2}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
 			assert.Nil(t, validationErr)
 		})
 
@@ -493,8 +493,8 @@ func TestValidateToken(t *testing.T) {
 			}))
 			expectedTenantIDs := []string{"*"}
 
-			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloper)
-			if params.EnableDeveloper {
+			validationErr := validateToken(jwtKeyFunc, r, expectedTenantIDs, params.EnableDeveloperAndTesting)
+			if params.EnableDeveloperAndTesting {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)

--- a/server/api_tabapp_test.go
+++ b/server/api_tabapp_test.go
@@ -43,9 +43,10 @@ func TestTabAppGetRuns(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	setDeveloperMode := func(t *testing.T, enable bool) {
+	setDeveloperAndTestingMode := func(t *testing.T, enable bool) {
 		var patchedConfig model.Config
 		patchedConfig.ServiceSettings.EnableDeveloper = model.NewPointer(enable)
+		patchedConfig.ServiceSettings.EnableTesting = model.NewPointer(enable)
 		_, _, err := e.ServerAdminClient.PatchConfig(context.Background(), &patchedConfig)
 		require.NoError(t, err)
 	}
@@ -71,7 +72,7 @@ func TestTabAppGetRuns(t *testing.T) {
 
 	t.Run("feature disabled", func(t *testing.T) {
 		setTabApp(t, false)
-		setDeveloperMode(t, false)
+		setDeveloperAndTestingMode(t, false)
 
 		response, err := do(t, http.MethodGet, nil)
 		require.Error(t, err)
@@ -81,7 +82,7 @@ func TestTabAppGetRuns(t *testing.T) {
 
 	t.Run("CORS headers, no provided Origin header", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, false)
+		setDeveloperAndTestingMode(t, false)
 
 		response, err := do(t, http.MethodOptions, nil)
 		require.NoError(t, err)
@@ -91,7 +92,7 @@ func TestTabAppGetRuns(t *testing.T) {
 
 	t.Run("CORS headers, matching Origin header", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, false)
+		setDeveloperAndTestingMode(t, false)
 
 		response, err := do(t, http.MethodOptions, map[string]string{
 			"Origin": api.MicrosoftTeamsAppDomain,
@@ -103,7 +104,7 @@ func TestTabAppGetRuns(t *testing.T) {
 
 	t.Run("CORS headers, mis-matched Origin header", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, false)
+		setDeveloperAndTestingMode(t, false)
 
 		response, err := do(t, http.MethodOptions, map[string]string{
 			"Origin": "example.com",
@@ -113,9 +114,9 @@ func TestTabAppGetRuns(t *testing.T) {
 		assertCORS(t, api.MicrosoftTeamsAppDomain, response)
 	})
 
-	t.Run("CORS headers, mis-matched Origin header, developer mode", func(t *testing.T) {
+	t.Run("CORS headers, mis-matched Origin header, developer + testing mode", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, true)
+		setDeveloperAndTestingMode(t, true)
 
 		response, err := do(t, http.MethodOptions, map[string]string{
 			"Origin": "example.com",
@@ -125,9 +126,9 @@ func TestTabAppGetRuns(t *testing.T) {
 		assertCORS(t, "example.com", response)
 	})
 
-	t.Run("fetch runs, none to return (no token and developer mode)", func(t *testing.T) {
+	t.Run("fetch runs, none to return (no token and developer + testing mode)", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, true)
+		setDeveloperAndTestingMode(t, true)
 
 		response, err := do(t, http.MethodGet, map[string]string{
 			"Authorization": "",
@@ -144,9 +145,9 @@ func TestTabAppGetRuns(t *testing.T) {
 		require.Empty(t, tabAppResults.Posts)
 	})
 
-	t.Run("fetch runs, one to return (no token and developer mode), show full name disabled", func(t *testing.T) {
+	t.Run("fetch runs, one to return (no token and developer + testing mode), show full name disabled", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, true)
+		setDeveloperAndTestingMode(t, true)
 		setShowFullName(t, false)
 
 		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
@@ -190,9 +191,9 @@ func TestTabAppGetRuns(t *testing.T) {
 		require.Empty(t, tabAppResults.Posts)
 	})
 
-	t.Run("fetch runs, one to return (no token and developer mode), show full name enabled", func(t *testing.T) {
+	t.Run("fetch runs, one to return (no token and developer + testing mode), show full name enabled", func(t *testing.T) {
 		setTabApp(t, true)
-		setDeveloperMode(t, true)
+		setDeveloperAndTestingMode(t, true)
 		setShowFullName(t, true)
 
 		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{


### PR DESCRIPTION
## Summary
Require the `ServiceSettings.EnableDeveloper` and `ServiceSettings.EnableTesting` flags to allow local development mode that doesn't enforce JWT validation.

## Ticket Link
None