### PR TITLE
[MM-48764] Fix spacing for buttons when screens are small

### DIFF
--- a/webapp/src/components/checklist_item/inputs.tsx
+++ b/webapp/src/components/checklist_item/inputs.tsx
@@ -136,6 +136,15 @@ export const CancelSaveContainer = styled.div`
     padding: 8px;
     text-align: right;
     white-space: nowrap;
+    
+    /* Add responsive padding for narrow screens */
+    @media (max-width: 768px) {
+        padding: 8px 16px 8px 8px;
+    }
+    
+    @media (max-width: 480px) {
+        padding: 8px 20px 8px 8px;
+    }
 `;
 
 const CancelButton = styled(TertiaryButton)`


### PR DESCRIPTION
## Summary
Address save/cancel buttons being too close to the edge when the screen width is below 1600px

![CleanShot 2025-06-11 at 17 28 17@2x](https://github.com/user-attachments/assets/5fe20676-b458-419d-a47a-199ae3a1408c)


## Ticket Link
[MM-48764](https://mattermost.atlassian.net/browse/MM-48764)

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Telemetry updated~~
~~- [ ] Gated by experimental feature flag~~
~~- [ ] Unit tests updated~~


[MM-48764]: https://mattermost.atlassian.net/browse/MM-48764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ