### PR TITLE
Add sort order to playbooks and checklists

### DIFF
--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -221,6 +221,9 @@ type Checklist struct {
 
 	// UpdateAt is when this checklist was last modified
 	UpdateAt int64 `json:"update_at" export:"-"`
+
+	// Sort order of the checklist items
+	SortOrder []string `json:"sort_order"`
 }
 
 func (c Checklist) GetItems() []ChecklistItemCommon {
@@ -229,6 +232,14 @@ func (c Checklist) GetItems() []ChecklistItemCommon {
 		items[i] = &c.Items[i]
 	}
 	return items
+}
+
+func (c Checklist) GetSortOrder() []string {
+	sortOrder := make([]string, len(c.Items))
+	for i, item := range c.Items {
+		sortOrder[i] = item.ID
+	}
+	return sortOrder
 }
 
 func (c Checklist) Clone() Checklist {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2412,6 +2412,8 @@ func (s *PlaybookRunServiceImpl) MoveChecklist(playbookRunID, userID string, sou
 	copy(playbookRunToModify.Checklists[destChecklistIdx+1:], playbookRunToModify.Checklists[destChecklistIdx:])
 	playbookRunToModify.Checklists[destChecklistIdx] = checklistMoved
 
+	playbookRunToModify.SortOrder = playbookRunToModify.GetSortOrder()
+
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update playbook run")
@@ -2470,11 +2472,14 @@ func (s *PlaybookRunServiceImpl) MoveChecklistItem(playbookRunID, userID string,
 	if sourceChecklistIdx == destChecklistIdx {
 		playbookRunToModify.Checklists[sourceChecklistIdx].Items = destChecklist
 		playbookRunToModify.Checklists[sourceChecklistIdx].UpdateAt = timestamp
+		playbookRunToModify.Checklists[sourceChecklistIdx].SortOrder = playbookRunToModify.Checklists[sourceChecklistIdx].GetSortOrder()
 	} else {
 		playbookRunToModify.Checklists[sourceChecklistIdx].Items = sourceChecklist
 		playbookRunToModify.Checklists[destChecklistIdx].Items = destChecklist
 		playbookRunToModify.Checklists[sourceChecklistIdx].UpdateAt = timestamp
 		playbookRunToModify.Checklists[destChecklistIdx].UpdateAt = timestamp
+		playbookRunToModify.Checklists[sourceChecklistIdx].SortOrder = playbookRunToModify.Checklists[sourceChecklistIdx].GetSortOrder()
+		playbookRunToModify.Checklists[destChecklistIdx].SortOrder = playbookRunToModify.Checklists[destChecklistIdx].GetSortOrder()
 	}
 
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)

--- a/server/app/playbook_test.go
+++ b/server/app/playbook_test.go
@@ -184,3 +184,27 @@ func TestPlaybookFilterOptions_Validate(t *testing.T) {
 		require.Equal(t, options, validOptions)
 	})
 }
+
+func TestChecklist_GetSortOrder(t *testing.T) {
+	checklist := Checklist{
+		Items: []ChecklistItem{
+			{ID: "item1"},
+			{ID: "item2"},
+		},
+	}
+
+	sortOrder := checklist.GetSortOrder()
+	require.Equal(t, []string{"item1", "item2"}, sortOrder)
+
+	checklist.Items = []ChecklistItem{
+		{ID: "item2"},
+		{ID: "item1"},
+	}
+
+	sortOrder = checklist.GetSortOrder()
+	require.Equal(t, []string{"item2", "item1"}, sortOrder)
+
+	checklist.Items = []ChecklistItem{}
+	sortOrder = checklist.GetSortOrder()
+	require.Equal(t, []string{}, sortOrder)
+}

--- a/server/sqlstore/playbook_run.go
+++ b/server/sqlstore/playbook_run.go
@@ -1155,6 +1155,12 @@ func (s *playbookRunStore) toPlaybookRun(rawPlaybookRun sqlPlaybookRun) (*app.Pl
 		playbookRun.StatusUpdateBroadcastChannelsEnabled = false
 	}
 
+	playbookRun.SortOrder = playbookRun.GetSortOrder()
+
+	for i := range playbookRun.Checklists {
+		playbookRun.Checklists[i].SortOrder = playbookRun.Checklists[i].GetSortOrder()
+	}
+
 	return &playbookRun, nil
 }
 

--- a/server/sqlstore/playbook_run_test.go
+++ b/server/sqlstore/playbook_run_test.go
@@ -102,8 +102,15 @@ func TestCreateAndGetPlaybookRun(t *testing.T) {
 
 				createPlaybookRunChannel(t, store, testCase.PlaybookRun)
 
-				_, err = playbookRunStore.GetPlaybookRun(expectedPlaybookRun.ID)
+				run, err := playbookRunStore.GetPlaybookRun(expectedPlaybookRun.ID)
 				require.NoError(t, err)
+
+				for i, checklist := range run.Checklists {
+					require.Equal(t, checklist.ID, run.SortOrder[i])
+					for j, item := range checklist.Items {
+						require.Equal(t, item.ID, checklist.SortOrder[j])
+					}
+				}
 			})
 		}
 	}


### PR DESCRIPTION
## Summary
I made some changes to add sort order also to the playbooks, to better handle a couple of things related to incremental updates and order in general.

## Ticket Link
NONE
