### PR TITLE
MM-64738: fix incorrect requesterid when adding invitees to created run

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -457,7 +457,7 @@ func (s *PlaybookRunServiceImpl) CreatePlaybookRun(playbookRun *PlaybookRun, pb 
 		}
 	}
 
-	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, s.configService.GetConfiguration().BotUserID, false)
+	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false)
 	if err != nil {
 		logrus.WithError(err).WithFields(map[string]any{
 			"playbookRunId":  playbookRun.ID,


### PR DESCRIPTION
## Summary
Fixes an issue where the playbooks bot was the actor adding invited users, rather than the correct user starting the run.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-64738

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] Telemetry updated
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated
