### PR TITLE
Remove deprecated ExperimentalViewArchivedChannels from e2e test configs

### DIFF
--- a/e2e-tests/tests/integration/playbooks/runs/rdp_rhs_runinfo_spec.js
+++ b/e2e-tests/tests/integration/playbooks/runs/rdp_rhs_runinfo_spec.js
@@ -198,9 +198,8 @@ describe('runs > run details page > run info', {testIsolation: true}, () => {
                 cy.apiDeleteChannel(testRun.channel_id).then(() => {
                     cy.visit(`/playbooks/runs/${testRun.id}`);
 
-                    // https://mattermost.atlassian.net/browse/MM-63682
-                    // * Assert channel status private
-                    getOverviewEntry('channel').contains('Private');
+                    // * Assert channel status shows deleted
+                    getOverviewEntry('channel').contains('Channel deleted');
                 });
             });
         });

--- a/e2e-tests/tests/support/api/cloud_default_config.json
+++ b/e2e-tests/tests/support/api/cloud_default_config.json
@@ -48,7 +48,6 @@
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
         "TeammateNameDisplay": "username",
-        "ExperimentalViewArchivedChannels": false,
         "ExperimentalEnableAutomaticReplies": false,
         "LockTeammateNameDisplay": false,
         "ExperimentalPrimaryTeam": "",

--- a/e2e-tests/tests/support/api/on_prem_default_config.json
+++ b/e2e-tests/tests/support/api/on_prem_default_config.json
@@ -96,7 +96,6 @@
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
         "TeammateNameDisplay": "username",
-        "ExperimentalViewArchivedChannels": false,
         "ExperimentalEnableAutomaticReplies": false,
         "LockTeammateNameDisplay": false,
         "ExperimentalPrimaryTeam": "",


### PR DESCRIPTION
## Summary
Remove deprecated `ExperimentalViewArchivedChannels` setting from e2e test configuration files. This setting has been deprecated by Mattermost and should no longer be used. This will fix the CI.

## Ticket Link
No ticket - cleanup of deprecated configuration setting

## Checklist
- [x] ~~Telemetry updated~~ - Not applicable
- [x] ~~Gated by experimental feature flag~~ - Not applicable  
- [x] ~~Unit tests updated~~ - Not applicable for config file changes