### PR TITLE
MM-65008: migrate post menu to registerPostDropdownMenuAction

### DIFF
--- a/e2e-tests/tests/support/ui/playbooks.js
+++ b/e2e-tests/tests/support/ui/playbooks.js
@@ -75,7 +75,7 @@ Cypress.Commands.add('startPlaybookRunFromPostMenu', (playbookName, playbookRunN
     // post a second message because cypress has trouble finding latest post when there's only one message
     cy.findByTestId('post_textbox').clear().type('another new message here{enter}');
     cy.clickPostActionsMenu();
-    cy.findByTestId('playbookRunPostMenuIcon').click();
+    cy.findByTestId('PlaybookRunPostMenuIcon').click();
     cy.startPlaybookRun(playbookName, playbookRunName);
 });
 

--- a/e2e-tests/tests/support/ui/playbooks.js
+++ b/e2e-tests/tests/support/ui/playbooks.js
@@ -75,7 +75,7 @@ Cypress.Commands.add('startPlaybookRunFromPostMenu', (playbookName, playbookRunN
     // post a second message because cypress has trouble finding latest post when there's only one message
     cy.findByTestId('post_textbox').clear().type('another new message here{enter}');
     cy.clickPostActionsMenu();
-    cy.findByTestId('playbookRunPostMenuIcon').click();
+    cy.findByRole('menuitem', {name: 'Run playbook'}).click();
     cy.startPlaybookRun(playbookName, playbookRunName);
 });
 

--- a/e2e-tests/tests/support/ui/playbooks.js
+++ b/e2e-tests/tests/support/ui/playbooks.js
@@ -75,7 +75,7 @@ Cypress.Commands.add('startPlaybookRunFromPostMenu', (playbookName, playbookRunN
     // post a second message because cypress has trouble finding latest post when there's only one message
     cy.findByTestId('post_textbox').clear().type('another new message here{enter}');
     cy.clickPostActionsMenu();
-    cy.findByTestId('PlaybookRunPostMenuIcon').click();
+    cy.findByTestId('playbookRunPostMenuIcon').click();
     cy.startPlaybookRun(playbookName, playbookRunName);
 });
 

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
   "icon_path": "assets/plugin_icon.svg",
-  "min_server_version": "7.6.0",
+  "min_server_version": "7.10.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/components/post_menu.tsx
+++ b/webapp/src/components/post_menu.tsx
@@ -22,14 +22,10 @@ import {addToTimeline, showPostMenuModal, startPlaybookRun} from 'src/actions';
 import {useAllowAddMessageToTimelineInCurrentTeam} from 'src/hooks';
 import {isProfessionalLicensedOrDevelopment} from 'src/license';
 
-interface Props {
-    postId: string;
-}
-
 function shouldShowPostMenuForPost(store: Store, postId: string) {
     const state = store.getState() as GlobalState;
     const post = getPost(state, postId);
-    return !!post && !isSystemMessage(post);
+    return Boolean(post) && !isSystemMessage(post);
 }
 
 export const StartPlaybookRunPostMenuText = () => {

--- a/webapp/src/components/post_menu.tsx
+++ b/webapp/src/components/post_menu.tsx
@@ -2,16 +2,14 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {Store} from 'redux';
 
 import styled from 'styled-components';
 
 import {GlobalState} from '@mattermost/types/store';
-import {Post} from '@mattermost/types/posts';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {Channel} from '@mattermost/types/channels';
 
 import {FormattedMessage} from 'react-intl';
 
@@ -22,83 +20,24 @@ import PlaybookRunPostMenuIcon from 'src/components/assets/icons/post_menu_icon'
 import {addToTimeline, showPostMenuModal, startPlaybookRun} from 'src/actions';
 
 import {useAllowAddMessageToTimelineInCurrentTeam} from 'src/hooks';
+import {isProfessionalLicensedOrDevelopment} from 'src/license';
 
 interface Props {
     postId: string;
 }
 
-export const StartPlaybookRunPostMenu = (props: Props) => {
-    const dispatch = useDispatch();
-    const channel = useSelector<GlobalState, Channel | undefined>((state) => {
-        const post = getPost(state, props.postId);
-        if (!post || isSystemMessage(post)) {
-            return undefined;
-        }
-        return getChannel(state, post.channel_id);
-    });
-    if (!channel) {
-        return null;
-    }
+function shouldShowPostMenuForPost(store: Store, postId: string) {
+    const state = store.getState() as GlobalState;
+    const post = getPost(state, postId);
+    return !!post && !isSystemMessage(post);
+}
 
-    const handleClick = () => {
-        dispatch(startPlaybookRun(channel.team_id, props.postId));
-    };
-
+export const StartPlaybookRunPostMenuText = () => {
     return (
-        <React.Fragment>
-            <li
-                className='MenuItem'
-                role='menuitem'
-                onClick={handleClick}
-            >
-                <button
-                    data-testid='playbookRunPostMenuIcon'
-                    className='style--none'
-                    role='presentation'
-                >
-                    <PlaybookRunPostMenuIcon/>
-                    <FormattedMessage defaultMessage='Run playbook'/>
-                </button>
-            </li>
-        </React.Fragment>
-    );
-};
-
-export const AttachToPlaybookRunPostMenu = (props: Props) => {
-    const dispatch = useDispatch();
-    const allowMessage = useAllowAddMessageToTimelineInCurrentTeam();
-
-    const post = useSelector<GlobalState, Post>((state) => getPost(state, props.postId));
-    if (!post || isSystemMessage(post)) {
-        return null;
-    }
-
-    const handleClick = () => {
-        if (allowMessage) {
-            dispatch(addToTimeline(props.postId));
-        } else {
-            dispatch(showPostMenuModal());
-        }
-    };
-
-    return (
-        <React.Fragment>
-            <li
-                className='MenuItem'
-                role='menuitem'
-                onClick={handleClick}
-            >
-                <button
-                    data-testid='playbookRunAddToTimeline'
-                    className='style--none'
-                    role='presentation'
-                >
-                    <PlaybookRunPostMenuIcon/>
-                    <FormattedMessage defaultMessage='Add to run timeline'/>
-                    {!allowMessage && <PositionedKeyVariantCircleIcon/>}
-                </button>
-            </li>
-        </React.Fragment>
+        <>
+            <PlaybookRunPostMenuIcon/>
+            <FormattedMessage defaultMessage='Run playbook'/>
+        </>
     );
 };
 
@@ -107,3 +46,56 @@ const PositionedKeyVariantCircleIcon = styled(KeyVariantCircleIcon)`
     margin-left: 16px;
     color: var(--online-indicator);
 `;
+
+export const AttachToPlaybookRunPostMenuText = () => {
+    const allowMessage = useAllowAddMessageToTimelineInCurrentTeam();
+    return (
+        <>
+            <PlaybookRunPostMenuIcon/>
+            <FormattedMessage defaultMessage='Add to run timeline'/>
+            {!allowMessage && <PositionedKeyVariantCircleIcon/>}
+        </>
+    );
+};
+
+export function makeStartPlaybookRunAction(store: Store) {
+    return {
+        text: StartPlaybookRunPostMenuText,
+        action: (postId: string) => {
+            const state = store.getState() as GlobalState;
+            const post = getPost(state, postId);
+            if (!post || isSystemMessage(post)) {
+                return;
+            }
+            const channel = getChannel(state, post.channel_id);
+            if (!channel) {
+                return;
+            }
+            store.dispatch(startPlaybookRun(channel.team_id, postId) as any);
+        },
+        filter: (postId: string) => {
+            return shouldShowPostMenuForPost(store, postId);
+        },
+    };
+}
+
+export function makeAttachToPlaybookRunAction(store: Store) {
+    return {
+        text: AttachToPlaybookRunPostMenuText,
+        action: (postId: string) => {
+            const state = store.getState() as GlobalState;
+            const post = getPost(state, postId);
+            if (!post || isSystemMessage(post)) {
+                return;
+            }
+            if (isProfessionalLicensedOrDevelopment(state)) {
+                store.dispatch(addToTimeline(postId) as any);
+            } else {
+                store.dispatch(showPostMenuModal() as any);
+            }
+        },
+        filter: (postId: string) => {
+            return shouldShowPostMenuForPost(store, postId);
+        },
+    };
+}

--- a/webapp/src/components/post_menu.tsx
+++ b/webapp/src/components/post_menu.tsx
@@ -60,7 +60,7 @@ export function makeStartPlaybookRunAction(store: Store) {
         action: (postId: string) => {
             const state = store.getState() as GlobalState;
             const post = getPost(state, postId);
-            if (!post || isSystemMessage(post)) {
+            if (!post) {
                 return;
             }
             const channel = getChannel(state, post.channel_id);
@@ -80,10 +80,6 @@ export function makeAttachToPlaybookRunAction(store: Store) {
         text: AttachToPlaybookRunPostMenuText,
         action: (postId: string) => {
             const state = store.getState() as GlobalState;
-            const post = getPost(state, postId);
-            if (!post || isSystemMessage(post)) {
-                return;
-            }
             if (isProfessionalLicensedOrDevelopment(state)) {
                 store.dispatch(addToTimeline(postId) as any);
             } else {

--- a/webapp/src/components/post_menu.tsx
+++ b/webapp/src/components/post_menu.tsx
@@ -31,7 +31,7 @@ function shouldShowPostMenuForPost(store: Store, postId: string) {
 export const StartPlaybookRunPostMenuText = () => {
     return (
         <>
-            <PlaybookRunPostMenuIcon/>
+            <PlaybookRunPostMenuIcon data-testid={'playbookRunPostMenuIcon'}/>
             <FormattedMessage defaultMessage='Run playbook'/>
         </>
     );

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -25,7 +25,7 @@ import {RetrospectiveFirstReminder, RetrospectiveReminder} from 'src/components/
 import manifest from 'src/manifest';
 import {ChannelHeaderButton, ChannelHeaderText, ChannelHeaderTooltip} from 'src/components/channel_header';
 import RightHandSidebar from 'src/components/rhs/rhs_main';
-import {AttachToPlaybookRunPostMenu, StartPlaybookRunPostMenu} from 'src/components/post_menu';
+import {makeAttachToPlaybookRunAction, makeStartPlaybookRunAction} from 'src/components/post_menu';
 import Backstage from 'src/components/backstage/backstage';
 import PostMenuModal from 'src/components/post_menu_modal';
 import ChannelActionsModal from 'src/components/channel_actions_modal';
@@ -200,8 +200,8 @@ export default class Plugin {
         };
         registry.registerChannelHeaderButtonAction(ChannelHeaderButton, boundToggleRHSAction, ChannelHeaderText, ChannelHeaderTooltip);
         registry.registerChannelHeaderMenuAction('Channel Actions', () => store.dispatch(showChannelActionsModal()), shouldRender);
-        registry.registerPostDropdownMenuComponent(StartPlaybookRunPostMenu);
-        registry.registerPostDropdownMenuComponent(AttachToPlaybookRunPostMenu);
+        registry.registerPostDropdownMenuAction(makeStartPlaybookRunAction(store));
+        registry.registerPostDropdownMenuAction(makeAttachToPlaybookRunAction(store));
         registry.registerRootComponent(PostMenuModal);
         registry.registerRootComponent(ChannelActionsModal);
         registry.registerRootComponent(LoginHook);


### PR DESCRIPTION
## Summary

- Replace deprecated `registerPostDropdownMenuComponent` with `registerPostDropdownMenuAction`
- Move text labels and action/filter into webapp/src/components/post_menu.tsx
- Add `makeStartPlaybookRunAction` and `makeAttachToPlaybookRunAction`
- DRY filter with `shouldShowPostMenuForPost` returning strict boolean
- Simplify webapp/src/index.tsx to always register actions (min server bumped)
- Remove deprecated component-based post menu items
- Cleanup unused imports

**Note* this also bumps `min_server_version` to 7.10 to ensure we have `registerPostDropdownMenuAction`

## Ticket Link

https://mattermost.atlassian.net/browse/MM-65008
