### PR TITLE
Fix double websocket when changing owner or assignee

### DIFF
--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -265,7 +265,7 @@ func (r *RunRootResolver) AddRunParticipants(ctx context.Context, args struct {
 		}
 	}
 
-	if err := c.playbookRunService.AddParticipants(args.RunID, args.UserIDs, userID, args.ForceAddToChannel, false); err != nil {
+	if err := c.playbookRunService.AddParticipants(args.RunID, args.UserIDs, userID, args.ForceAddToChannel, true); err != nil {
 		return "", errors.Wrap(err, "failed to add participant from run")
 	}
 

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -265,7 +265,7 @@ func (r *RunRootResolver) AddRunParticipants(ctx context.Context, args struct {
 		}
 	}
 
-	if err := c.playbookRunService.AddParticipants(args.RunID, args.UserIDs, userID, args.ForceAddToChannel); err != nil {
+	if err := c.playbookRunService.AddParticipants(args.RunID, args.UserIDs, userID, args.ForceAddToChannel, false); err != nil {
 		return "", errors.Wrap(err, "failed to add participant from run")
 	}
 

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -1312,7 +1312,7 @@ type PlaybookRunService interface {
 	RemoveParticipants(playbookRunID string, userIDs []string, requesterUserID string) error
 
 	// AddParticipants adds users to the participants list
-	AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool) error
+	AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, omitWebsocket bool) error
 
 	// GetPlaybookRunIDsForUser returns run ids where user is a participant or is following
 	GetPlaybookRunIDsForUser(userID string) ([]string, error)

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -457,7 +457,7 @@ func (s *PlaybookRunServiceImpl) CreatePlaybookRun(playbookRun *PlaybookRun, pb 
 		}
 	}
 
-	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false)
+	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false, false)
 	if err != nil {
 		logrus.WithError(err).WithFields(map[string]any{
 			"playbookRunId":  playbookRun.ID,
@@ -1574,7 +1574,7 @@ func (s *PlaybookRunServiceImpl) ChangeOwner(playbookRunID, userID, ownerID stri
 	}
 
 	// add owner as user
-	err = s.AddParticipants(playbookRunID, []string{ownerID}, userID, false)
+	err = s.AddParticipants(playbookRunID, []string{ownerID}, userID, false, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to add owner as a participant")
 	}
@@ -1781,7 +1781,7 @@ func (s *PlaybookRunServiceImpl) SetAssignee(playbookRunID, userID, assigneeID s
 			}
 		}
 		if !isParticipant {
-			err = s.AddParticipants(playbookRunID, []string{assigneeID}, userID, false)
+			err = s.AddParticipants(playbookRunID, []string{assigneeID}, userID, false, true)
 			if err != nil {
 				return errors.Wrapf(err, "failed to add assignee to run")
 			}
@@ -2791,7 +2791,7 @@ func (s *PlaybookRunServiceImpl) addPlaybookRunInitialMemberships(playbookRun *P
 	if playbookRun.OwnerUserID != playbookRun.ReporterUserID {
 		participants = append(participants, playbookRun.ReporterUserID)
 	}
-	err := s.AddParticipants(playbookRun.ID, participants, playbookRun.ReporterUserID, false)
+	err := s.AddParticipants(playbookRun.ID, participants, playbookRun.ReporterUserID, false, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to add owner/reporter as a participant")
 	}
@@ -3465,7 +3465,7 @@ func (s *PlaybookRunServiceImpl) leaveActions(playbookRun *PlaybookRun, userID s
 	}
 }
 
-func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool) error {
+func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, omitWebsocket bool) error {
 	usersFailedToInvite := make([]string, 0)
 	usersToInvite := make([]string, 0)
 
@@ -3536,7 +3536,7 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 	}
 
 	// ws send run
-	if len(usersToInvite) > 0 {
+	if len(usersToInvite) > 0 && !omitWebsocket {
 		playbookRun, err = s.store.GetPlaybookRun(playbookRunID)
 		if err != nil {
 			return errors.Wrap(err, "failed to refresh playbook run after timeline event creation")

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -457,7 +457,7 @@ func (s *PlaybookRunServiceImpl) CreatePlaybookRun(playbookRun *PlaybookRun, pb 
 		}
 	}
 
-	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false, false)
+	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false, true)
 	if err != nil {
 		logrus.WithError(err).WithFields(map[string]any{
 			"playbookRunId":  playbookRun.ID,
@@ -1574,7 +1574,7 @@ func (s *PlaybookRunServiceImpl) ChangeOwner(playbookRunID, userID, ownerID stri
 	}
 
 	// add owner as user
-	err = s.AddParticipants(playbookRunID, []string{ownerID}, userID, false, true)
+	err = s.AddParticipants(playbookRunID, []string{ownerID}, userID, false, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to add owner as a participant")
 	}
@@ -1781,7 +1781,7 @@ func (s *PlaybookRunServiceImpl) SetAssignee(playbookRunID, userID, assigneeID s
 			}
 		}
 		if !isParticipant {
-			err = s.AddParticipants(playbookRunID, []string{assigneeID}, userID, false, true)
+			err = s.AddParticipants(playbookRunID, []string{assigneeID}, userID, false, false)
 			if err != nil {
 				return errors.Wrapf(err, "failed to add assignee to run")
 			}
@@ -2791,7 +2791,7 @@ func (s *PlaybookRunServiceImpl) addPlaybookRunInitialMemberships(playbookRun *P
 	if playbookRun.OwnerUserID != playbookRun.ReporterUserID {
 		participants = append(participants, playbookRun.ReporterUserID)
 	}
-	err := s.AddParticipants(playbookRun.ID, participants, playbookRun.ReporterUserID, false, false)
+	err := s.AddParticipants(playbookRun.ID, participants, playbookRun.ReporterUserID, false, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to add owner/reporter as a participant")
 	}
@@ -3465,7 +3465,7 @@ func (s *PlaybookRunServiceImpl) leaveActions(playbookRun *PlaybookRun, userID s
 	}
 }
 
-func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, omitWebsocket bool) error {
+func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, sendWebsocket bool) error {
 	usersFailedToInvite := make([]string, 0)
 	usersToInvite := make([]string, 0)
 
@@ -3536,7 +3536,7 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 	}
 
 	// ws send run
-	if len(usersToInvite) > 0 && !omitWebsocket {
+	if len(usersToInvite) > 0 && sendWebsocket {
 		playbookRun, err = s.store.GetPlaybookRun(playbookRunID)
 		if err != nil {
 			return errors.Wrap(err, "failed to refresh playbook run after timeline event creation")


### PR DESCRIPTION
## Summary
When we add a new participant because we added a owner or assignee from outside of the run, we were sending two different websocket events with the same update at:
- One for adding the participant
- One for setting the assignee

This makes sure only one websocket is sent in this scenario.

## Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-65176