### PR TITLE
Update interactive dialog label to fit mobile better

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -201,7 +201,7 @@
   },
   {
     "id": "app.user.run.update_status.submit_label",
-    "translation": "Update status"
+    "translation": "Post"
   },
   {
     "id": "app.user.run.update_status.title",


### PR DESCRIPTION
## Summary
The interactive dialog submit labels appear at the top of the navigation bar on mobile. Long names in the header can create not great looking buttons.

This reduces the size of the button.

## Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-65046
