### PR TITLE
MM-65748: License validation missing support for 'entry' SKU type

### DIFF
--- a/webapp/src/license.test.ts
+++ b/webapp/src/license.test.ts
@@ -22,6 +22,7 @@ describe('license checks', () => {
 
     const withProfessionalName = withSkuName('professional');
     const withEnterpriseName = withSkuName('enterprise');
+    const withEntryName = withSkuName('entry');
     const withEnterpriseAdvancedName = withSkuName('advanced');
     const withUnknownName = withSkuName('unknown');
 
@@ -32,6 +33,7 @@ describe('license checks', () => {
 
     const professional = withProfessionalName(baseLicense);
     const enterprise = withEnterpriseName(baseLicense);
+    const entry = withEntryName(baseLicense);
     const enterpriseAdvanced = withEnterpriseAdvancedName(baseLicense);
     const unknownSku = withUnknownName(baseLicense);
 
@@ -70,6 +72,18 @@ describe('license checks', () => {
 
         it('Enterprise Advanced SKU name with LDAP disabled', () => {
             expect(checkProfessionalLicensed(withLDAPDisabled(enterpriseAdvanced))).toBe(true);
+        });
+
+        it('Entry SKU name', () => {
+            expect(checkProfessionalLicensed(entry)).toBe(true);
+        });
+
+        it('Entry SKU name with LDAP enabled', () => {
+            expect(checkProfessionalLicensed(withLDAPEnabled(entry))).toBe(true);
+        });
+
+        it('Entry SKU name with LDAP disabled', () => {
+            expect(checkProfessionalLicensed(withLDAPDisabled(entry))).toBe(true);
         });
 
         it('Unknown SKU name', () => {
@@ -120,6 +134,18 @@ describe('license checks', () => {
 
         it('Enterprise Advanced SKU name with Message Export disabled', () => {
             expect(checkEnterpriseLicensed(withMessageExportDisabled(enterpriseAdvanced))).toBe(true);
+        });
+
+        it('Entry SKU name', () => {
+            expect(checkEnterpriseLicensed(entry)).toBe(true);
+        });
+
+        it('Entry SKU name with Message Export enabled', () => {
+            expect(checkEnterpriseLicensed(withMessageExportEnabled(entry))).toBe(true);
+        });
+
+        it('Entry SKU name with Message Export disabled', () => {
+            expect(checkEnterpriseLicensed(withMessageExportDisabled(entry))).toBe(true);
         });
 
         it('Unknown SKU name', () => {

--- a/webapp/src/license.ts
+++ b/webapp/src/license.ts
@@ -7,11 +7,13 @@ import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general
 const professional = 'professional';
 const enterprise = 'enterprise';
 const enterpriseAdvanced = 'advanced';
+const entry = 'entry';
 
 // isValidSkuShortName returns whether the SKU short name is one of the known strings;
-// namely: professional, enterprise or enterprise advanced.
+// namely: entry, professional, enterprise or enterprise advanced.
 const isValidSkuShortName = (license: Record<string, string>) => {
     switch (license?.SkuShortName) {
+    case entry:
     case professional:
     case enterprise:
     case enterpriseAdvanced:
@@ -31,7 +33,7 @@ export const isEnterpriseLicensedOrDevelopment = (state: GlobalState): boolean =
 };
 
 export const checkEnterpriseLicensed = (license: Record<string, string>) => {
-    if (license?.SkuShortName === enterprise || license?.SkuShortName === enterpriseAdvanced) {
+    if ([enterprise, entry, enterpriseAdvanced].includes(license?.SkuShortName)) {
         return true;
     }
 
@@ -56,9 +58,7 @@ export const isProfessionalLicensedOrDevelopment = (state: GlobalState): boolean
 };
 
 export const checkProfessionalLicensed = (license: Record<string, string>) => {
-    if (license?.SkuShortName === professional ||
-        license?.SkuShortName === enterprise ||
-        license?.SkuShortName === enterpriseAdvanced) {
+    if ([professional, enterprise, entry, enterpriseAdvanced].includes(license?.SkuShortName)) {
         return true;
     }
 


### PR DESCRIPTION
## Summary

Fixes frontend license validation functions to properly support the 'entry' SKU type.

Note that the backend works as expected and relies on Mattermost's "number" for the license (0 for free, 10 for pro...); So we overlooked the fact that the frontend would use a different system: the SkuShortName.

And because playbooks works "as licensed" if your setup has dev mode and debug mode turned on (which we do locally and on test server), we missed this.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-65748

## Checklist

- [x] Unit tests updated
- [ ] Gated by experimental feature flag