### PR TITLE
MM-65685: fix undefined pollution in myPlaybookRuns

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -11,7 +11,7 @@ import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {makeModalDefinition as makeUpdateRunNameModalDefinition} from 'src/components/modals/run_update_name';
 import {makeModalDefinition as makeUpdateRunChannelModalDefinition} from 'src/components/modals/run_update_channel';
 import {makeModalDefinition as makePlaybookRunModalDefinition} from 'src/components/modals/run_playbook_modal';
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunConnection} from 'src/types/playbook_run';
 import {canIPostUpdateForRun, selectToggleRHS} from 'src/selectors';
 import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 import {
@@ -42,10 +42,12 @@ import {
     RECEIVED_GLOBAL_SETTINGS,
     RECEIVED_PLAYBOOK_RUNS,
     RECEIVED_TEAM_PLAYBOOK_RUNS,
+    RECEIVED_TEAM_PLAYBOOK_RUN_CONNECTIONS,
     RECEIVED_TOGGLE_RHS_ACTION,
     REMOVED_FROM_CHANNEL,
     ReceivedGlobalSettings,
     ReceivedPlaybookRuns,
+    ReceivedTeamPlaybookRunConnections,
     ReceivedTeamPlaybookRuns,
     ReceivedToggleRHSAction,
     RemovedFromChannel,
@@ -271,6 +273,11 @@ export const receivedPlaybookRuns = (playbookRuns: PlaybookRun[]): ReceivedPlayb
 
 export const receivedTeamPlaybookRuns = (playbookRuns: PlaybookRun[]): ReceivedTeamPlaybookRuns => ({
     type: RECEIVED_TEAM_PLAYBOOK_RUNS,
+    playbookRuns,
+});
+
+export const receivedTeamPlaybookRunConnections = (playbookRuns: PlaybookRunConnection[]): ReceivedTeamPlaybookRunConnections => ({
+    type: RECEIVED_TEAM_PLAYBOOK_RUN_CONNECTIONS,
     playbookRuns,
 });
 

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -6,7 +6,7 @@ import {combineReducers} from 'redux';
 import {Team} from '@mattermost/types/teams';
 import {Channel} from '@mattermost/types/channels';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, isRun} from 'src/types/playbook_run';
 import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 import {
     CLOSE_BACKSTAGE_RHS,
@@ -27,10 +27,12 @@ import {
     RECEIVED_GLOBAL_SETTINGS,
     RECEIVED_PLAYBOOK_RUNS,
     RECEIVED_TEAM_PLAYBOOK_RUNS,
+    RECEIVED_TEAM_PLAYBOOK_RUN_CONNECTIONS,
     RECEIVED_TOGGLE_RHS_ACTION,
     REMOVED_FROM_CHANNEL,
     ReceivedGlobalSettings,
     ReceivedPlaybookRuns,
+    ReceivedTeamPlaybookRunConnections,
     ReceivedTeamPlaybookRuns,
     ReceivedToggleRHSAction,
     RemovedFromChannel,
@@ -190,7 +192,13 @@ type TStateMyPlaybookRunsByTeam = Record<Team['id'], null | Record<Channel['id']
  */
 const myPlaybookRunsByTeam = (
     state: TStateMyPlaybookRunsByTeam = {},
-    action: PlaybookRunCreated | PlaybookRunUpdated | ReceivedTeamPlaybookRuns | RemovedFromChannel | WebsocketPlaybookRunIncrementalUpdateReceived
+    action:
+        PlaybookRunCreated |
+        PlaybookRunUpdated |
+        ReceivedTeamPlaybookRuns |
+        ReceivedTeamPlaybookRunConnections |
+        RemovedFromChannel |
+        WebsocketPlaybookRunIncrementalUpdateReceived
 ): TStateMyPlaybookRunsByTeam => {
     switch (action.type) {
     case PLAYBOOK_RUN_CREATED: {
@@ -217,6 +225,9 @@ const myPlaybookRunsByTeam = (
             },
         };
     }
+
+    // TODO https://mattermost.atlassian.net/browse/MM-65733
+    case RECEIVED_TEAM_PLAYBOOK_RUN_CONNECTIONS:
     case RECEIVED_TEAM_PLAYBOOK_RUNS: {
         const receivedTeamPlaybookRunsAction = action as ReceivedTeamPlaybookRuns;
         const playbookRuns = receivedTeamPlaybookRunsAction.playbookRuns;
@@ -288,7 +299,7 @@ const myPlaybookRunsByTeam = (
         }
 
         const currentRun = state[targetTeamId]?.[targetChannelId];
-        if (!currentRun) {
+        if (!isRun(currentRun)) {
             return state;
         }
 

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -13,7 +13,7 @@ import {matchPath} from 'react-router-dom';
 import {currentPlaybookRun, inPlaybookRunChannel, isPlaybookRunRHSOpen} from 'src/selectors';
 import {PlaybookRunStatus} from 'src/types/playbook_run';
 
-import {receivedTeamPlaybookRuns, toggleRHS} from 'src/actions';
+import {receivedTeamPlaybookRunConnections, toggleRHS} from 'src/actions';
 import {browserHistory} from 'src/webapp_globals';
 
 const RunsOnTeamQuery = gql`
@@ -73,7 +73,7 @@ export function makeRHSOpener(store: Store<GlobalState>, graphqlClient: ApolloCl
             });
 
             const runs = fetched.data.runs.edges.map((edge: any) => edge.node);
-            store.dispatch(receivedTeamPlaybookRuns(runs));
+            store.dispatch(receivedTeamPlaybookRunConnections(runs));
         }
 
         const searchParams = new URLSearchParams(url.searchParams);

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -3,7 +3,7 @@
 
 import Integrations from 'mattermost-redux/action_types/integrations';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunConnection} from 'src/types/playbook_run';
 import {BackstageRHSSection, BackstageRHSViewMode} from 'src/types/backstage_rhs';
 import manifest from 'src/manifest';
 import {GlobalSettings} from 'src/types/settings';
@@ -20,6 +20,7 @@ export const PLAYBOOK_ARCHIVED = manifest.id + '_playbook_archived';
 export const PLAYBOOK_RESTORED = manifest.id + '_playbook_restored';
 export const RECEIVED_PLAYBOOK_RUNS = manifest.id + '_received_playbook_runs';
 export const RECEIVED_TEAM_PLAYBOOK_RUNS = manifest.id + '_received_team_playbook_run_channels';
+export const RECEIVED_TEAM_PLAYBOOK_RUN_CONNECTIONS = manifest.id + '_received_team_playbook_run_connections';
 export const REMOVED_FROM_CHANNEL = manifest.id + '_removed_from_playbook_run_channel';
 export const RECEIVED_GLOBAL_SETTINGS = manifest.id + '_received_global_settings';
 export const SHOW_POST_MENU_MODAL = manifest.id + '_show_post_menu_modal';
@@ -103,6 +104,11 @@ export interface ReceivedPlaybookRuns {
 export interface ReceivedTeamPlaybookRuns {
     type: typeof RECEIVED_TEAM_PLAYBOOK_RUNS;
     playbookRuns: PlaybookRun[];
+}
+
+export interface ReceivedTeamPlaybookRunConnections{
+    type: typeof RECEIVED_TEAM_PLAYBOOK_RUN_CONNECTIONS;
+    playbookRuns: PlaybookRunConnection[];
 }
 
 export interface RemovedFromChannel {

--- a/webapp/src/types/playbook_run.ts
+++ b/webapp/src/types/playbook_run.ts
@@ -57,6 +57,11 @@ export interface PlaybookRun {
     type: PlaybookRunType
 }
 
+export interface PlaybookRunConnection extends Partial<PlaybookRun> {
+    team_id: string;
+    channel_id: string;
+}
+
 export interface StatusPost {
     id: string;
     create_at: number;
@@ -151,4 +156,16 @@ export interface PlaybookRunChecklistItem extends ChecklistItem {
     playbook_run_create_at: number;
     checklist_title: string;
     checklist_num: number;
+}
+
+export function isRun(run: undefined | null | PlaybookRun | PlaybookRunConnection): run is PlaybookRun {
+    if (run) {
+        const {id} = run;
+        return id != null && id.length > 0;
+    }
+    return false;
+}
+
+export function isRunConnection(run: PlaybookRun | PlaybookRunConnection): run is PlaybookRunConnection {
+    return isRun(run) === false;
 }


### PR DESCRIPTION
## Summary
Fixes an error where the `myPlaybookRuns` reducer store was polluted with an `undefined` entry, which would cause HTTP-Fetch errors. `ReceivedTeamPlaybookRunConnections` is added so `myPlaybookRuns` doesn't hook into it. 

## Ticket Link
https://mattermost.atlassian.net/browse/MM-65685

## Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
~~- [ ] Gated by experimental feature flag~~
- [ ] Unit tests updated
