### PR TITLE
bump minimum mattermost version to 11.0.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
   "icon_path": "assets/plugin_icon.svg",
-  "min_server_version": "7.10.0",
+  "min_server_version": "11.0.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
## Summary
Updates the minimum required Mattermost server version from 7.10.0 to 11.0.0 in plugin.json.

This is required because of the new plugin apis we use for properties.

## Ticket Link
Part of the Mattermost version requirement update initiative.

## Checklist
- [x] ~~Unit tests updated~~ (no tests needed for version requirement change)
- [x] ~~Gated by experimental feature flag~~ (not applicable)