### PR TITLE
[MM-65159] Add UI support for hiding checklist items with condition

### DIFF
--- a/server/api/graphql_run.go
+++ b/server/api/graphql_run.go
@@ -21,7 +21,12 @@ type RunResolver struct {
 func (r *RunResolver) NumTasks() int32 {
 	total := 0
 	for _, checklist := range r.PlaybookRun.Checklists {
-		total += len(checklist.Items)
+		for _, item := range checklist.Items {
+			if item.ConditionAction == app.ConditionActionHidden {
+				continue
+			}
+			total++
+		}
 	}
 	return int32(total)
 }
@@ -32,6 +37,9 @@ func (r *RunResolver) NumTasksClosed() int32 {
 	closed := 0
 	for _, checklist := range r.PlaybookRun.Checklists {
 		for _, item := range checklist.Items {
+			if item.ConditionAction == app.ConditionActionHidden {
+				continue
+			}
 			if item.State == app.ChecklistItemStateClosed || item.State == app.ChecklistItemStateSkipped {
 				closed++
 			}

--- a/server/api/graphql_run_test.go
+++ b/server/api/graphql_run_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
+)
+
+func TestRunResolver_NumTasks(t *testing.T) {
+	t.Run("excludes hidden items from count", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Visible 1", ConditionAction: app.ConditionActionNone},
+							{Title: "Hidden 1", ConditionAction: app.ConditionActionHidden},
+							{Title: "Visible 2", ConditionAction: app.ConditionActionNone},
+							{Title: "Hidden 2", ConditionAction: app.ConditionActionHidden},
+							{Title: "Shown Modified", ConditionAction: app.ConditionActionShownBecauseModified},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasks()
+		// 5 total items - 2 hidden = 3 visible
+		assert.Equal(t, int32(3), result)
+	})
+
+	t.Run("returns 0 when all items are hidden", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Hidden 1", ConditionAction: app.ConditionActionHidden},
+							{Title: "Hidden 2", ConditionAction: app.ConditionActionHidden},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasks()
+		assert.Equal(t, int32(0), result)
+	})
+
+	t.Run("counts all items when none are hidden", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Task 1", ConditionAction: app.ConditionActionNone},
+							{Title: "Task 2", ConditionAction: ""},
+							{Title: "Task 3", ConditionAction: app.ConditionActionShownBecauseModified},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasks()
+		assert.Equal(t, int32(3), result)
+	})
+
+	t.Run("works across multiple checklists", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Visible 1", ConditionAction: ""},
+							{Title: "Hidden 1", ConditionAction: app.ConditionActionHidden},
+						},
+					},
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Visible 2", ConditionAction: ""},
+							{Title: "Hidden 2", ConditionAction: app.ConditionActionHidden},
+							{Title: "Visible 3", ConditionAction: ""},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasks()
+		// 5 total - 2 hidden = 3 visible
+		assert.Equal(t, int32(3), result)
+	})
+
+	t.Run("returns 0 for empty checklists", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{},
+			},
+		}
+
+		result := resolver.NumTasks()
+		assert.Equal(t, int32(0), result)
+	})
+}
+
+func TestRunResolver_NumTasksClosed(t *testing.T) {
+	t.Run("excludes hidden items from count", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Open", State: app.ChecklistItemStateOpen, ConditionAction: ""},
+							{Title: "Closed Visible", State: app.ChecklistItemStateClosed, ConditionAction: ""},
+							{Title: "Closed Hidden", State: app.ChecklistItemStateClosed, ConditionAction: app.ConditionActionHidden},
+							{Title: "Skipped Visible", State: app.ChecklistItemStateSkipped, ConditionAction: ""},
+							{Title: "Skipped Hidden", State: app.ChecklistItemStateSkipped, ConditionAction: app.ConditionActionHidden},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasksClosed()
+		// 2 closed/skipped items that are visible (excludes 2 hidden closed/skipped)
+		assert.Equal(t, int32(2), result)
+	})
+
+	t.Run("returns 0 when all closed items are hidden", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Open", State: app.ChecklistItemStateOpen, ConditionAction: ""},
+							{Title: "Closed Hidden", State: app.ChecklistItemStateClosed, ConditionAction: app.ConditionActionHidden},
+							{Title: "Skipped Hidden", State: app.ChecklistItemStateSkipped, ConditionAction: app.ConditionActionHidden},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasksClosed()
+		assert.Equal(t, int32(0), result)
+	})
+
+	t.Run("counts closed and skipped items when not hidden", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Closed 1", State: app.ChecklistItemStateClosed, ConditionAction: ""},
+							{Title: "Closed 2", State: app.ChecklistItemStateClosed, ConditionAction: app.ConditionActionNone},
+							{Title: "Skipped", State: app.ChecklistItemStateSkipped, ConditionAction: ""},
+							{Title: "Open", State: app.ChecklistItemStateOpen, ConditionAction: ""},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasksClosed()
+		assert.Equal(t, int32(3), result) // 2 closed + 1 skipped
+	})
+
+	t.Run("shown_because_modified items are counted when closed", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Closed Modified", State: app.ChecklistItemStateClosed, ConditionAction: app.ConditionActionShownBecauseModified},
+							{Title: "Open Modified", State: app.ChecklistItemStateOpen, ConditionAction: app.ConditionActionShownBecauseModified},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasksClosed()
+		assert.Equal(t, int32(1), result) // Only the closed one
+	})
+
+	t.Run("works across multiple checklists", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Closed 1", State: app.ChecklistItemStateClosed, ConditionAction: ""},
+							{Title: "Hidden Closed", State: app.ChecklistItemStateClosed, ConditionAction: app.ConditionActionHidden},
+						},
+					},
+					{
+						Items: []app.ChecklistItem{
+							{Title: "Closed 2", State: app.ChecklistItemStateClosed, ConditionAction: ""},
+							{Title: "Skipped", State: app.ChecklistItemStateSkipped, ConditionAction: ""},
+						},
+					},
+				},
+			},
+		}
+
+		result := resolver.NumTasksClosed()
+		// 3 closed/skipped visible (excludes 1 hidden)
+		assert.Equal(t, int32(3), result)
+	})
+
+	t.Run("returns 0 for empty checklists", func(t *testing.T) {
+		resolver := &RunResolver{
+			PlaybookRun: app.PlaybookRun{
+				Checklists: []app.Checklist{},
+			},
+		}
+
+		result := resolver.NumTasksClosed()
+		assert.Equal(t, int32(0), result)
+	})
+}

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -527,6 +527,7 @@
   "mw9jVA": "Add a title",
   "n1SlGq": "Attach Checklist Items to Condition",
   "nc8QpJ": "Recent Activity",
+  "nfdxZY": "conditionally rendered: {reason}",
   "ngjbAO": "Edit property type",
   "nkCCM2": "You will not be reminded again.",
   "nqVby7": "<b>{numTasksChecked, number}</b> of <b>{numTasks, number}</b> {numTasks, plural, =1 {task} other {tasks}} checked",

--- a/webapp/src/components/checklist/collapsible_checklist.tsx
+++ b/webapp/src/components/checklist/collapsible_checklist.tsx
@@ -262,6 +262,11 @@ const tasksCompleted = (items: ChecklistItem[]) => {
     let total = 0;
 
     for (const item of items) {
+        // Exclude hidden items from all counts
+        if (item.condition_action === 'hidden') {
+            continue;
+        }
+
         if (item.state !== ChecklistItemState.Skip) {
             total++;
         }

--- a/webapp/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/src/components/checklist_item/checklist_item.tsx
@@ -32,6 +32,7 @@ import AssignTo from './assign_to';
 import Command from './command';
 import {CancelSaveButtons, CheckBoxButton} from './inputs';
 import {DueDateButton} from './duedate';
+import ConditionIndicator from './condition_indicator';
 
 import TaskActions from './task_actions';
 import {haveAtleastOneEnabledAction} from './task_actions_modal';
@@ -330,6 +331,7 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
                     onChange={(item: ChecklistItemState) => props.onChange?.(item)}
                     onReadOnlyInteract={props.onReadOnlyInteract}
                 />
+                <ConditionIndicator checklistItem={props.checklistItem}/>
                 <ChecklistItemTitleWrapper
                     onClick={() => props.collapsibleDescription && props.checklistItem.description !== '' && toggleDescription()}
                 >
@@ -484,7 +486,7 @@ export const CheckboxContainer = styled.div`
 
 const ChecklistItemTitleWrapper = styled.div`
     display: flex;
-    width: 100%;
+    flex: 1;
     flex-direction: column;
 `;
 

--- a/webapp/src/components/checklist_item/condition_indicator.test.tsx
+++ b/webapp/src/components/checklist_item/condition_indicator.test.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import {emptyChecklistItem} from 'src/types/playbook';
+
+import ConditionIndicator from './condition_indicator';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('src/components/widgets/tooltip', () => ({
+    __esModule: true,
+    default: ({children, content}: any) => (
+        <div data-tooltip={content}>{children}</div>
+    ),
+}));
+
+jest.mock('@mattermost/compass-icons/components', () => ({
+    SourceBranchIcon: ({size, color}: any) => (
+        <svg
+            data-size={size}
+            data-color={color}
+        />
+    ),
+}));
+
+describe('ConditionIndicator', () => {
+    it('should return null when no condition_id', () => {
+        const item = emptyChecklistItem();
+        const component = renderer.create(
+            <ConditionIndicator checklistItem={item}/>,
+        );
+        expect(component.toJSON()).toBeNull();
+    });
+
+    it('should render gray icon for normal condition', () => {
+        const item = {
+            ...emptyChecklistItem(),
+            id: 'test-123',
+            condition_id: 'cond-456',
+            condition_action: '',
+            condition_reason: 'Priority is "High"',
+        };
+        const component = renderer.create(
+            <ConditionIndicator checklistItem={item}/>,
+        );
+        const tree = component.toJSON();
+
+        expect(tree).toBeTruthy();
+        expect(tree?.props['data-tooltip']).toBe('conditionally rendered: Priority is "High"');
+        expect(tree?.children[0].children[0].props['data-color']).toBe('rgba(var(--center-channel-color-rgb), 0.56)');
+        expect(tree?.children[0].children[0].props['data-size']).toBe(14);
+    });
+
+    it('should render red icon for shown_because_modified', () => {
+        const item = {
+            ...emptyChecklistItem(),
+            id: 'test-789',
+            condition_id: 'cond-012',
+            condition_action: 'shown_because_modified',
+            condition_reason: 'Item modified by user',
+        };
+        const component = renderer.create(
+            <ConditionIndicator checklistItem={item}/>,
+        );
+        const tree = component.toJSON();
+
+        expect(tree).toBeTruthy();
+        expect(tree?.props['data-tooltip']).toBe('conditionally rendered: Item modified by user');
+        expect(tree?.children[0].children[0].props['data-color']).toBe('var(--error-text)');
+        expect(tree?.children[0].children[0].props['data-size']).toBe(14);
+    });
+});

--- a/webapp/src/components/checklist_item/condition_indicator.test.tsx
+++ b/webapp/src/components/checklist_item/condition_indicator.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import renderer from 'react-test-renderer';
+import renderer, {ReactTestRendererJSON} from 'react-test-renderer';
 
 import {emptyChecklistItem} from 'src/types/playbook';
 
@@ -56,9 +56,16 @@ describe('ConditionIndicator', () => {
         const tree = component.toJSON();
 
         expect(tree).toBeTruthy();
-        expect(tree?.props['data-tooltip']).toBe('conditionally rendered: Priority is "High"');
-        expect(tree?.children[0].children[0].props['data-color']).toBe('rgba(var(--center-channel-color-rgb), 0.56)');
-        expect(tree?.children[0].children[0].props['data-size']).toBe(14);
+        expect(Array.isArray(tree)).toBe(false);
+        if (tree && !Array.isArray(tree) && tree.children) {
+            expect(tree.props['data-tooltip']).toBe('conditionally rendered: Priority is "High"');
+            const child = tree.children[0] as ReactTestRendererJSON;
+            if (child.children) {
+                const grandchild = child.children[0] as ReactTestRendererJSON;
+                expect(grandchild.props['data-color']).toBe('rgba(var(--center-channel-color-rgb), 0.56)');
+                expect(grandchild.props['data-size']).toBe(14);
+            }
+        }
     });
 
     it('should render red icon for shown_because_modified', () => {
@@ -75,8 +82,15 @@ describe('ConditionIndicator', () => {
         const tree = component.toJSON();
 
         expect(tree).toBeTruthy();
-        expect(tree?.props['data-tooltip']).toBe('conditionally rendered: Item modified by user');
-        expect(tree?.children[0].children[0].props['data-color']).toBe('var(--error-text)');
-        expect(tree?.children[0].children[0].props['data-size']).toBe(14);
+        expect(Array.isArray(tree)).toBe(false);
+        if (tree && !Array.isArray(tree) && tree.children) {
+            expect(tree.props['data-tooltip']).toBe('conditionally rendered: Item modified by user');
+            const child = tree.children[0] as ReactTestRendererJSON;
+            if (child.children) {
+                const grandchild = child.children[0] as ReactTestRendererJSON;
+                expect(grandchild.props['data-color']).toBe('var(--error-text)');
+                expect(grandchild.props['data-size']).toBe(14);
+            }
+        }
     });
 });

--- a/webapp/src/components/checklist_item/condition_indicator.tsx
+++ b/webapp/src/components/checklist_item/condition_indicator.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+import {useIntl} from 'react-intl';
+import {SourceBranchIcon} from '@mattermost/compass-icons/components';
+
+import Tooltip from 'src/components/widgets/tooltip';
+import {ChecklistItem} from 'src/types/playbook';
+
+interface ConditionIndicatorProps {
+    checklistItem: ChecklistItem;
+}
+
+const ConditionIndicator = ({checklistItem}: ConditionIndicatorProps) => {
+    const {formatMessage} = useIntl();
+
+    if (!checklistItem.condition_id) {
+        return null;
+    }
+
+    const useErrorColor = checklistItem.condition_action === 'shown_because_modified';
+    const tooltipId = `condition-indicator-${checklistItem.id || 'new'}`;
+    const iconColor = useErrorColor ? 'var(--error-text)' : 'rgba(var(--center-channel-color-rgb), 0.56)';
+
+    const tooltipContent = formatMessage(
+        {defaultMessage: 'conditionally rendered: {reason}'},
+        {reason: checklistItem.condition_reason},
+    );
+
+    return (
+        <Tooltip
+            id={tooltipId}
+            content={tooltipContent}
+        >
+            <IconWrapper>
+                <SourceBranchIcon
+                    size={14}
+                    color={iconColor}
+                />
+            </IconWrapper>
+        </Tooltip>
+    );
+};
+
+const IconWrapper = styled.span`
+    margin-top: 4px;
+    margin-right: 2px;
+`;
+
+export default ConditionIndicator;

--- a/webapp/src/components/rhs/rhs_checklist_list.tsx
+++ b/webapp/src/components/rhs/rhs_checklist_list.tsx
@@ -117,6 +117,13 @@ const RHSChecklistList = ({id, playbookRun, parentContainer, readOnly, onReadOnl
     };
 
     const showItem = (checklistItem: ChecklistItem, myId: string) => {
+        // Hide items with condition_action = "hidden"
+        // This check must come FIRST to ensure hidden items stay hidden
+        // regardless of other filter settings
+        if (checklistItem.condition_action === 'hidden') {
+            return false;
+        }
+
         if (checklistItemsFilter.all) {
             return true;
         }


### PR DESCRIPTION
## Summary

Adds UI support for conditional checklist items by filtering out hidden items from display and adding visual indicators to show when items have conditions applied.

Blocked by #2089 

## Ticket Link

https://mattermost.atlassian.net/browse/MM-65159

## Checklist
  - [x] Gated by experimental feature flag
  - [x] Unit tests updated