### PR TITLE
MM-66406: Replace setTimeout with onFocus handler in property values input

### DIFF
--- a/webapp/src/components/backstage/playbook_properties/property_values_input.tsx
+++ b/webapp/src/components/backstage/playbook_properties/property_values_input.tsx
@@ -120,12 +120,7 @@ const ClickableMultiValue = (props: {
     }, [props.data.label]);
 
     const onDropdownChange = (open: boolean) => {
-        if (open) {
-            setTimeout(() => {
-                inputRef.current?.focus();
-                inputRef.current?.select();
-            }, 50);
-        } else {
+        if (!open) {
             handleRename();
             setEditValue(props.data.label);
         }
@@ -191,6 +186,7 @@ const ClickableMultiValue = (props: {
                         ref={inputRef}
                         value={editValue}
                         onChange={(e) => setEditValue(e.target.value)}
+                        onFocus={(e) => e.target.select()}
                         onKeyDown={handleKeyDown}
                         onBlur={handleBlur}
                         maxLength={255}


### PR DESCRIPTION
## Summary
- Replace timing-dependent `setTimeout` in `ClickableMultiValue` dropdown with a React-idiomatic `onFocus` handler
- The `Dropdown` component's `FloatingFocusManager` already auto-focuses the first tabbable element on open; the added `onFocus` handler selects the text, eliminating the 50ms timing hack
- Follows the same pattern established in #2168 for `playbook_properties.tsx`

## Ticket
https://mattermost.atlassian.net/browse/MM-66406

## Test plan
- [ ] Open a playbook's attributes page with a select/multiselect property that has existing options
- [ ] Click an option pill to open the rename dropdown
- [ ] Verify the rename input is focused and text is selected on open
- [ ] Rename the option and confirm the change persists on blur / Enter
- [ ] Press Escape and confirm the original value is restored

#### Release Note
```release-note
None
```
