### PR TITLE
[MM-68190] Support export and import of attributes and conditionals

### DIFF
--- a/e2e-tests/tests/integration/playbooks/playbooks/export_import_spec.js
+++ b/e2e-tests/tests/integration/playbooks/playbooks/export_import_spec.js
@@ -1,0 +1,455 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+// Stage: @prod
+// Group: @playbooks
+
+describe('playbooks > export and import with attributes and conditions', {testIsolation: true}, () => {
+    let testTeam;
+    let testUser;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+        });
+    });
+
+    beforeEach(() => {
+        cy.apiLogin(testUser);
+    });
+
+    describe('API export', () => {
+        it('exports playbook without attributes or conditions', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Export Plain Playbook',
+                userId: testUser.id,
+            }).then((playbook) => {
+                cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                    // * Verify basic export structure
+                    expect(exportData.version).to.equal(1);
+                    expect(exportData.title).to.equal('Export Plain Playbook');
+                    expect(exportData.checklists).to.have.length.at.least(1);
+
+                    // * Verify sensitive fields are excluded
+                    expect(exportData.id).to.not.exist;
+                    expect(exportData.team_id).to.not.exist;
+
+                    // * Verify properties and conditions are omitted when not present
+                    expect(exportData.properties).to.not.exist;
+                    expect(exportData.conditions).to.not.exist;
+                });
+            });
+        });
+
+        it('exports playbook with attributes included', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Export With Attributes',
+                userId: testUser.id,
+            }).then((playbook) => {
+                // # Add a text attribute
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Environment',
+                    type: 'text',
+                    attrs: {visibility: 'always', sortOrder: 0},
+                });
+
+                // # Add a select attribute with options
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Severity',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 1,
+                        options: [
+                            {name: 'Critical'},
+                            {name: 'Major'},
+                            {name: 'Minor'},
+                        ],
+                    },
+                });
+
+                cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                    // * Verify properties are present in export
+                    expect(exportData.properties).to.have.length(2);
+
+                    const envProp = exportData.properties.find((p) => p.name === 'Environment');
+                    expect(envProp).to.exist;
+                    expect(envProp.type).to.equal('text');
+                    expect(envProp.id).to.be.a('string').and.not.be.empty;
+
+                    const sevProp = exportData.properties.find((p) => p.name === 'Severity');
+                    expect(sevProp).to.exist;
+                    expect(sevProp.type).to.equal('select');
+                    expect(sevProp.attrs.options).to.have.length(3);
+                });
+            });
+        });
+
+        it('exports playbook with attributes and conditions', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Export Full',
+                userId: testUser.id,
+            }).then((playbook) => {
+                // # Add a select attribute
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Priority',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 0,
+                        options: [{name: 'High'}, {name: 'Low'}],
+                    },
+                });
+
+                cy.apiGetPropertyFields(playbook.id).then((fields) => {
+                    const priorityField = fields.find((f) => f.name === 'Priority');
+                    const highOptionId = priorityField.attrs.options.find((o) => o.name === 'High').id;
+
+                    // # Create a condition referencing the attribute
+                    cy.apiCreatePlaybookCondition(playbook.id, {
+                        is: {field_id: priorityField.id, value: [highOptionId]},
+                    }).then((condition) => {
+                        // # Attach condition to a checklist item
+                        cy.apiAttachConditionToTask(playbook.id, 0, 0, condition.id);
+
+                        cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                            // * Verify properties are in export
+                            expect(exportData.properties).to.have.length(1);
+                            expect(exportData.properties[0].name).to.equal('Priority');
+
+                            // * Verify conditions are in export
+                            expect(exportData.conditions).to.have.length(1);
+                            expect(exportData.conditions[0].version).to.equal(1);
+                            expect(exportData.conditions[0].condition_expr).to.exist;
+
+                            // * Verify checklist item has condition_id in export
+                            const firstItem = exportData.checklists[0].items[0];
+                            expect(firstItem.condition_id).to.equal(condition.id);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('API import', () => {
+        it('round-trip: export then import preserves attributes', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Round Trip Source',
+                userId: testUser.id,
+            }).then((playbook) => {
+                // # Add attributes
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Customer',
+                    type: 'text',
+                    attrs: {visibility: 'always', sortOrder: 0},
+                });
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Impact',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 1,
+                        options: [{name: 'High'}, {name: 'Medium'}, {name: 'Low'}],
+                    },
+                });
+
+                // # Export the playbook
+                cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                    // # Import into the same team
+                    cy.apiImportPlaybook(exportData, testTeam.id).then((importResult) => {
+                        expect(importResult.id).to.be.a('string').and.not.be.empty;
+                        expect(importResult.id).to.not.equal(playbook.id);
+
+                        // * Verify imported playbook has the same title
+                        cy.apiGetPlaybook(importResult.id).then((imported) => {
+                            expect(imported.title).to.equal('Round Trip Source');
+                        });
+
+                        // * Verify property fields were recreated with new IDs
+                        cy.apiGetPropertyFields(importResult.id).then((importedFields) => {
+                            expect(importedFields).to.have.length(2);
+
+                            const customer = importedFields.find((f) => f.name === 'Customer');
+                            expect(customer).to.exist;
+                            expect(customer.type).to.equal('text');
+
+                            const impact = importedFields.find((f) => f.name === 'Impact');
+                            expect(impact).to.exist;
+                            expect(impact.type).to.equal('select');
+                            expect(impact.attrs.options).to.have.length(3);
+
+                            // * Verify new IDs were generated
+                            cy.apiGetPropertyFields(playbook.id).then((origFields) => {
+                                const origCustomer = origFields.find((f) => f.name === 'Customer');
+                                expect(customer.id).to.not.equal(origCustomer.id);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('round-trip: export then import preserves conditions and task linkage', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Round Trip Conditions',
+                userId: testUser.id,
+            }).then((playbook) => {
+                // # Add select attributes
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Status',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 0,
+                        options: [{name: 'Active'}, {name: 'Resolved'}],
+                    },
+                });
+
+                cy.apiGetPropertyFields(playbook.id).then((fields) => {
+                    const statusField = fields.find((f) => f.name === 'Status');
+                    const activeOptionId = statusField.attrs.options.find((o) => o.name === 'Active').id;
+
+                    // # Create a condition
+                    cy.apiCreatePlaybookCondition(playbook.id, {
+                        is: {field_id: statusField.id, value: [activeOptionId]},
+                    }).then((condition) => {
+                        // # Attach condition to first task
+                        cy.apiAttachConditionToTask(playbook.id, 0, 0, condition.id);
+
+                        // # Export and import
+                        cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                            cy.apiImportPlaybook(exportData, testTeam.id).then((importResult) => {
+                                // * Verify the imported playbook has a condition on the task
+                                cy.apiGetPlaybook(importResult.id).then((imported) => {
+                                    const firstItem = imported.checklists[0].items[0];
+                                    expect(firstItem.condition_id).to.be.a('string').and.not.be.empty;
+
+                                    // * Verify the condition_id was remapped (not the original)
+                                    expect(firstItem.condition_id).to.not.equal(condition.id);
+                                });
+
+                                // * Verify the imported property fields have new IDs referencing the import
+                                cy.apiGetPropertyFields(importResult.id).then((importedFields) => {
+                                    expect(importedFields).to.have.length(1);
+                                    expect(importedFields[0].name).to.equal('Status');
+                                    expect(importedFields[0].id).to.not.equal(statusField.id);
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('rejects import with unsupported version', () => {
+            const badExport = {
+                title: 'Bad Version Playbook',
+                version: 999,
+                checklists: [{title: 'Checklist', items: [{title: 'Task'}]}],
+                reminder_timer_default_seconds: 86400,
+                status_update_enabled: true,
+                retrospective_enabled: true,
+                create_channel_member_on_new_participant: true,
+                create_channel_member_on_removed_participant: true,
+            };
+
+            cy.request({
+                headers: {'X-Requested-With': 'XMLHttpRequest'},
+                url: `/plugins/playbooks/api/v0/playbooks/import?team_id=${testTeam.id}`,
+                method: 'POST',
+                body: badExport,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.equal(400);
+            });
+        });
+
+        it('rejects import with playbook ID set', () => {
+            const badExport = {
+                id: 'some-fake-id',
+                title: 'Has ID Playbook',
+                version: 1,
+                checklists: [{title: 'Checklist', items: [{title: 'Task'}]}],
+                reminder_timer_default_seconds: 86400,
+                status_update_enabled: true,
+                retrospective_enabled: true,
+                create_channel_member_on_new_participant: true,
+                create_channel_member_on_removed_participant: true,
+            };
+
+            cy.request({
+                headers: {'X-Requested-With': 'XMLHttpRequest'},
+                url: `/plugins/playbooks/api/v0/playbooks/import?team_id=${testTeam.id}`,
+                method: 'POST',
+                body: badExport,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.equal(400);
+            });
+        });
+    });
+
+    describe('UI import with attributes', () => {
+        it('imports playbook with attributes via drag-and-drop', () => {
+            // # First create and export a playbook with attributes to get a real fixture
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'UI Import Source',
+                userId: testUser.id,
+            }).then((playbook) => {
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Region',
+                    type: 'text',
+                    attrs: {visibility: 'always', sortOrder: 0},
+                });
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Tier',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 1,
+                        options: [{name: 'Gold'}, {name: 'Silver'}],
+                    },
+                });
+
+                cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                    const exportBuffer = Cypress.Buffer.from(JSON.stringify(exportData));
+
+                    // # Open the Playbooks list
+                    cy.visit('/playbooks');
+                    cy.findByTestId('playbooksLHSButton').click();
+
+                    // # Drag-and-drop the export file
+                    cy.findByTestId('playbook-list-scroll-container').selectFile(
+                        {contents: exportBuffer, fileName: 'export.json', mimeType: 'application/json'},
+                        {action: 'drag-drop'},
+                    );
+
+                    // * Verify the playbook editor opens with the correct title
+                    cy.findByTestId('playbook-editor-title').should('contain', 'UI Import Source');
+
+                    // # Navigate to attributes
+                    cy.findByText('Attributes').click();
+
+                    // * Verify attributes were imported
+                    cy.findAllByTestId('property-field-row').should('have.length', 2);
+                });
+            });
+        });
+
+        it('imports playbook with attributes via file input', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'UI Input Import Source',
+                userId: testUser.id,
+            }).then((playbook) => {
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Priority Level',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 0,
+                        options: [{name: 'P1'}, {name: 'P2'}, {name: 'P3'}],
+                    },
+                });
+
+                cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                    const exportBuffer = Cypress.Buffer.from(JSON.stringify(exportData));
+
+                    // # Open the Playbooks list
+                    cy.visit('/playbooks');
+                    cy.findByTestId('playbooksLHSButton').click();
+
+                    // # Use the file input to import
+                    cy.findByTestId('titlePlaybook').within(() => {
+                        cy.findByTestId('playbook-import-input').selectFile(
+                            {contents: exportBuffer, fileName: 'export.json', mimeType: 'application/json'},
+                            {force: true},
+                        );
+                    });
+
+                    // * Verify the playbook editor opens with the correct title
+                    cy.findByTestId('playbook-editor-title').should('contain', 'UI Input Import Source');
+
+                    // # Navigate to attributes
+                    cy.findByText('Attributes').click();
+
+                    // * Verify the select attribute was imported with its options
+                    cy.findAllByTestId('property-field-row').should('have.length', 1);
+                    cy.findAllByTestId('property-field-row').eq(0).within(() => {
+                        cy.findByText('P1').should('exist');
+                        cy.findByText('P2').should('exist');
+                        cy.findByText('P3').should('exist');
+                    });
+                });
+            });
+        });
+
+        it('imports playbook with conditions and verifies task linkage in UI', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'UI Condition Import',
+                userId: testUser.id,
+            }).then((playbook) => {
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Urgency',
+                    type: 'select',
+                    attrs: {
+                        visibility: 'always',
+                        sortOrder: 0,
+                        options: [{name: 'Urgent'}, {name: 'Normal'}],
+                    },
+                });
+
+                cy.apiGetPropertyFields(playbook.id).then((fields) => {
+                    const urgencyField = fields.find((f) => f.name === 'Urgency');
+                    const urgentOptionId = urgencyField.attrs.options.find((o) => o.name === 'Urgent').id;
+
+                    cy.apiCreatePlaybookCondition(playbook.id, {
+                        is: {field_id: urgencyField.id, value: [urgentOptionId]},
+                    }).then((condition) => {
+                        cy.apiAttachConditionToTask(playbook.id, 0, 0, condition.id);
+
+                        cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                            const exportBuffer = Cypress.Buffer.from(JSON.stringify(exportData));
+
+                            // # Open the Playbooks list
+                            cy.visit('/playbooks');
+                            cy.findByTestId('playbooksLHSButton').click();
+
+                            // # Import via drag-and-drop
+                            cy.findByTestId('playbook-list-scroll-container').selectFile(
+                                {contents: exportBuffer, fileName: 'export.json', mimeType: 'application/json'},
+                                {action: 'drag-drop'},
+                            );
+
+                            // * Verify the playbook editor opens
+                            cy.findByTestId('playbook-editor-title').should('contain', 'UI Condition Import');
+
+                            // # Navigate to Outline to check condition
+                            cy.findByText('Outline').click();
+
+                            // * Verify condition was imported and linked to task
+                            cy.findByTestId('condition-header').should('exist');
+                            cy.findByTestId('condition-header').within(() => {
+                                cy.findByText('Urgency').should('exist');
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/e2e-tests/tests/support/api/playbooks.js
+++ b/e2e-tests/tests/support/api/playbooks.js
@@ -585,6 +585,42 @@ Cypress.Commands.add('apiDeletePlaybookCondition', (playbookId, conditionId) => 
 });
 
 /**
+ * Export a playbook via REST API
+ * @param {String} playbookId - The playbook ID
+ * @returns {Object} The exported playbook JSON
+ */
+Cypress.Commands.add('apiExportPlaybook', (playbookId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: `/plugins/playbooks/api/v0/playbooks/${playbookId}/export`,
+        method: 'GET',
+    }).then((response) => {
+        expect(response.status).to.equal(StatusOK);
+        cy.wrap(response.body);
+    });
+});
+
+/**
+ * Import a playbook via REST API
+ * @param {Object} exportData - The playbook export JSON to import
+ * @param {String} [teamId] - Optional team ID to assign the imported playbook to
+ * @returns {Object} The response body with the new playbook ID
+ */
+Cypress.Commands.add('apiImportPlaybook', (exportData, teamId) => {
+    const qs = teamId ? {team_id: teamId} : {};
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/plugins/playbooks/api/v0/playbooks/import',
+        method: 'POST',
+        body: exportData,
+        qs,
+    }).then((response) => {
+        expect(response.status).to.equal(StatusCreated);
+        cy.wrap(response.body);
+    });
+});
+
+/**
  * Attach a condition to a checklist item
  * @param {String} playbookId - The playbook ID
  * @param {Number} checklistIndex - The checklist index (0-based)

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -609,7 +609,21 @@ func (h *PlaybookHandler) exportPlaybook(c *Context, w http.ResponseWriter, r *h
 		return
 	}
 
-	export, err := app.GeneratePlaybookExport(playbook)
+	// Fetch properties and conditions for the playbook
+	properties, err := h.propertyService.GetPropertyFields(playbookID)
+	if err != nil {
+		h.HandleError(w, c.logger, err)
+		return
+	}
+
+	// Fetch conditions through the playbook service which manages the export
+	conditions, err := h.playbookService.GetPlaybookConditionsForExport(playbookID)
+	if err != nil {
+		h.HandleError(w, c.logger, err)
+		return
+	}
+
+	export, err := app.GeneratePlaybookExport(playbook, properties, conditions)
 	if err != nil {
 		h.HandleError(w, c.logger, err)
 		return
@@ -659,7 +673,9 @@ func (h *PlaybookHandler) importPlaybook(c *Context, w http.ResponseWriter, r *h
 	userID := r.Header.Get("Mattermost-User-ID")
 	var importBlock struct {
 		app.Playbook
-		Version int `json:"version"`
+		Version    int                    `json:"version"`
+		Properties []app.ExportPropertyField `json:"properties,omitempty"`
+		Conditions []app.ExportCondition   `json:"conditions,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&importBlock); err != nil {
 		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "unable to decode playbook import", err)
@@ -700,7 +716,7 @@ func (h *PlaybookHandler) importPlaybook(c *Context, w http.ResponseWriter, r *h
 		return
 	}
 
-	id, err := h.playbookService.Import(playbook, userID)
+	id, err := h.playbookService.ImportWithProperties(playbook, userID, importBlock.Properties, importBlock.Conditions)
 	if err != nil {
 		h.HandleError(w, c.logger, err)
 		return

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -609,14 +609,12 @@ func (h *PlaybookHandler) exportPlaybook(c *Context, w http.ResponseWriter, r *h
 		return
 	}
 
-	// Fetch properties and conditions for the playbook
 	properties, err := h.propertyService.GetPropertyFields(playbookID)
 	if err != nil {
 		h.HandleError(w, c.logger, err)
 		return
 	}
 
-	// Fetch conditions through the playbook service which manages the export
 	conditions, err := h.playbookService.GetPlaybookConditionsForExport(playbookID)
 	if err != nil {
 		h.HandleError(w, c.logger, err)
@@ -716,7 +714,12 @@ func (h *PlaybookHandler) importPlaybook(c *Context, w http.ResponseWriter, r *h
 		return
 	}
 
-	id, err := h.playbookService.ImportWithProperties(playbook, userID, importBlock.Properties, importBlock.Conditions)
+	id, err := h.playbookService.Import(app.PlaybookImportData{
+		Playbook:   playbook,
+		Version:    importBlock.Version,
+		Properties: importBlock.Properties,
+		Conditions: importBlock.Conditions,
+	}, userID)
 	if err != nil {
 		h.HandleError(w, c.logger, err)
 		return

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -673,9 +673,9 @@ func (h *PlaybookHandler) importPlaybook(c *Context, w http.ResponseWriter, r *h
 	userID := r.Header.Get("Mattermost-User-ID")
 	var importBlock struct {
 		app.Playbook
-		Version    int                    `json:"version"`
+		Version    int                       `json:"version"`
 		Properties []app.ExportPropertyField `json:"properties,omitempty"`
-		Conditions []app.ExportCondition   `json:"conditions,omitempty"`
+		Conditions []app.ExportCondition     `json:"conditions,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&importBlock); err != nil {
 		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "unable to decode playbook import", err)

--- a/server/api_playbooks_test.go
+++ b/server/api_playbooks_test.go
@@ -1430,6 +1430,171 @@ func TestPlaybooksImportExport(t *testing.T) {
 		assert.Equal(t, e.BasicPlaybook.Title, newPlaybook.Title)
 		assert.NotEqual(t, e.BasicPlaybook.ID, newPlaybook.ID)
 	})
+
+	t.Run("Export and import with properties", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip()
+		}
+
+		e.SetEnterpriseLicence() // properties require license
+
+		// Create a fresh playbook to avoid state from prior subtests
+		freshPlaybookID, err := e.PlaybooksClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
+			Title:  "Fresh Playbook for Properties Test",
+			TeamID: e.BasicTeam.Id,
+			Public: true,
+		})
+		require.NoError(t, err)
+
+		// Create a property field on the playbook via the API
+		createdField, err := e.PlaybooksClient.Playbooks.CreatePropertyField(
+			context.Background(),
+			freshPlaybookID,
+			client.PropertyFieldRequest{
+				Name: "Status",
+				Type: "select",
+				Attrs: &client.PropertyFieldAttrsInput{
+					Options: &[]client.PropertyOptionInput{
+						{Name: "Active"},
+						{Name: "Inactive"},
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		// Export
+		result, err := e.PlaybooksClient.Playbooks.Export(context.Background(), freshPlaybookID)
+		require.NoError(t, err)
+
+		// Verify properties key exists in export JSON
+		var exportData map[string]interface{}
+		err = json.Unmarshal(result, &exportData)
+		require.NoError(t, err)
+		props, ok := exportData["properties"].([]interface{})
+		require.True(t, ok, "export should contain properties")
+		require.Len(t, props, 1)
+
+		// Import into a new playbook
+		newPlaybookID, err := e.PlaybooksClient.Playbooks.Import(context.Background(), result, e.BasicTeam.Id)
+		require.NoError(t, err)
+
+		// Fetch new playbook's properties and verify
+		newFields, err := e.PlaybooksClient.Playbooks.GetPropertyFields(context.Background(), newPlaybookID)
+		require.NoError(t, err)
+		require.Len(t, newFields, 1)
+
+		assert.Equal(t, createdField.Name, newFields[0].Name)
+		assert.NotEqual(t, createdField.ID, newFields[0].ID, "imported property should have a new ID")
+
+		// Extract and verify options from Attrs
+		rawOptions, ok := newFields[0].Attrs["options"].([]interface{})
+		require.True(t, ok, "options should be present in attrs")
+		assert.Len(t, rawOptions, 2, "options should be preserved")
+	})
+
+	t.Run("Export and import with conditions", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip()
+		}
+
+		e.SetEnterpriseLicence() // properties and conditions require license
+
+		// Use a fresh playbook to avoid state from prior subtests
+		freshPlaybookID, err := e.PlaybooksClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
+			Title:  "Conditions Test Playbook",
+			TeamID: e.BasicTeam.Id,
+			Public: true,
+			Checklists: []client.Checklist{{
+				Title: "CL1",
+				Items: []client.ChecklistItem{{Title: "task1"}},
+			}},
+		})
+		require.NoError(t, err)
+
+		// Create a property field
+		createdField, err := e.PlaybooksClient.Playbooks.CreatePropertyField(
+			context.Background(),
+			freshPlaybookID,
+			client.PropertyFieldRequest{
+				Name: "Priority",
+				Type: "select",
+				Attrs: &client.PropertyFieldAttrsInput{
+					Options: &[]client.PropertyOptionInput{
+						{Name: "High"},
+						{Name: "Low"},
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		// Extract the first option ID from Attrs
+		rawOptions, ok := createdField.Attrs["options"].([]interface{})
+		require.True(t, ok)
+		firstOpt, ok := rawOptions[0].(map[string]interface{})
+		require.True(t, ok)
+		optionID, ok := firstOpt["id"].(string)
+		require.True(t, ok)
+
+		// Create a condition referencing the property field
+		createdCondition, err := e.PlaybooksClient.PlaybookConditions.Create(
+			context.Background(),
+			freshPlaybookID,
+			client.Condition{
+				Version: 1,
+				ConditionExpr: client.ConditionExprV1{
+					Is: &client.ComparisonCondition{
+						FieldID: createdField.ID,
+						Value:   json.RawMessage(`["` + optionID + `"]`),
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		// Export
+		result, err := e.PlaybooksClient.Playbooks.Export(context.Background(), freshPlaybookID)
+		require.NoError(t, err)
+
+		// Verify export has both properties and conditions
+		var exportData map[string]interface{}
+		err = json.Unmarshal(result, &exportData)
+		require.NoError(t, err)
+
+		props, ok := exportData["properties"].([]interface{})
+		require.True(t, ok, "export should contain properties")
+		require.Len(t, props, 1)
+
+		conds, ok := exportData["conditions"].([]interface{})
+		require.True(t, ok, "export should contain conditions")
+		require.Len(t, conds, 1)
+
+		// Import
+		newPlaybookID, err := e.PlaybooksClient.Playbooks.Import(context.Background(), result, e.BasicTeam.Id)
+		require.NoError(t, err)
+
+		// Verify new playbook has properties with new IDs
+		newFields, err := e.PlaybooksClient.Playbooks.GetPropertyFields(context.Background(), newPlaybookID)
+		require.NoError(t, err)
+		require.Len(t, newFields, 1)
+		assert.Equal(t, createdField.Name, newFields[0].Name)
+		assert.NotEqual(t, createdField.ID, newFields[0].ID, "imported property should have new ID")
+
+		// Verify conditions were imported on the new playbook with new IDs
+		importedConditions, err := e.PlaybooksClient.PlaybookConditions.List(
+			context.Background(), newPlaybookID, 0, 100, client.PlaybookConditionListOptions{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, importedConditions.TotalCount, "imported playbook should have one condition")
+		require.Len(t, importedConditions.Items, 1)
+		assert.NotEqual(t, createdCondition.ID, importedConditions.Items[0].ID, "imported condition should have a new ID")
+
+		// Verify the condition expression references the new property field ID (not the old one)
+		assert.NotNil(t, importedConditions.Items[0].ConditionExpr.Is)
+		assert.Equal(t, newFields[0].ID, importedConditions.Items[0].ConditionExpr.Is.FieldID,
+			"imported condition should reference the new property field ID")
+	})
 }
 
 func TestPlaybooksDuplicate(t *testing.T) {

--- a/server/app/condition.go
+++ b/server/app/condition.go
@@ -791,9 +791,6 @@ type ConditionService interface {
 	// Create conditions from exported data with property ID remapping, returns old condition ID to new condition mapping
 	CreateConditionsFromExport(playbookID string, exportConditions []ExportCondition, propertyMappings *PropertyCopyResult) (map[string]*Condition, error)
 
-	// GetPlaybookConditionsForExport retrieves all conditions for a playbook without auth overhead
-	GetPlaybookConditionsForExport(playbookID string) ([]Condition, error)
-
 	// Evaluate conditions for a run when a property field changes
 	EvaluateConditionsOnValueChanged(playbookRun *PlaybookRun, changedFieldID string) (*ConditionEvaluationResult, error)
 

--- a/server/app/condition.go
+++ b/server/app/condition.go
@@ -788,6 +788,12 @@ type ConditionService interface {
 	// Copy conditions from playbook to playbook with field ID mappings, returns old condition ID to new condition mapping
 	CopyPlaybookConditionsToPlaybook(sourcePlaybookID, targetPlaybookID string, propertyMappings *PropertyCopyResult) (map[string]*Condition, error)
 
+	// Create conditions from exported data with property ID remapping, returns old condition ID to new condition mapping
+	CreateConditionsFromExport(playbookID string, exportConditions []ExportCondition, propertyMappings *PropertyCopyResult) (map[string]*Condition, error)
+
+	// GetPlaybookConditionsForExport retrieves all conditions for a playbook without auth overhead
+	GetPlaybookConditionsForExport(playbookID string) ([]Condition, error)
+
 	// Evaluate conditions for a run when a property field changes
 	EvaluateConditionsOnValueChanged(playbookRun *PlaybookRun, changedFieldID string) (*ConditionEvaluationResult, error)
 

--- a/server/app/condition_service.go
+++ b/server/app/condition_service.go
@@ -232,11 +232,6 @@ func (s *conditionService) CreateConditionsFromExport(playbookID string, exportC
 	return conditionMapping, nil
 }
 
-// GetPlaybookConditionsForExport retrieves all conditions for a playbook without auth overhead.
-func (s *conditionService) GetPlaybookConditionsForExport(playbookID string) ([]Condition, error) {
-	return s.store.GetPlaybookConditions(playbookID, 0, MaxConditionsPerPlaybook)
-}
-
 // CreatePlaybookCondition creates a new stored condition for a playbook
 func (s *conditionService) CreatePlaybookCondition(userID string, condition Condition, teamID string) (*Condition, error) {
 	auditRec := s.auditor.MakeAuditRecord("createCondition", model.AuditStatusFail)

--- a/server/app/condition_service.go
+++ b/server/app/condition_service.go
@@ -141,6 +141,84 @@ func (s *conditionService) CopyPlaybookConditionsToPlaybook(sourcePlaybookID, ta
 	return conditionMapping, nil
 }
 
+// CreateConditionsFromExport creates conditions from exported data with property ID remapping.
+// This parallels CopyPlaybookConditionsToPlaybook but starts from deserialized export data
+// rather than from conditions already in the database.
+func (s *conditionService) CreateConditionsFromExport(playbookID string, exportConditions []ExportCondition, propertyMappings *PropertyCopyResult) (map[string]*Condition, error) {
+	conditionMapping := make(map[string]*Condition)
+	if len(exportConditions) == 0 {
+		return conditionMapping, nil
+	}
+
+	newProperties, err := s.propertyService.GetPropertyFields(playbookID)
+	if err != nil {
+		logrus.WithError(err).WithField("playbook_id", playbookID).Warn("failed to fetch property fields for validation during import")
+		newProperties = []PropertyField{}
+	}
+
+	for _, exportCondition := range exportConditions {
+		if exportCondition.ConditionExpr == nil {
+			logrus.WithFields(logrus.Fields{
+				"playbook_id":  playbookID,
+				"condition_id": exportCondition.ID,
+				"version":      exportCondition.Version,
+			}).Warn("condition expression is nil after deserialization during import, skipping")
+			continue
+		}
+
+		// Remap field and option IDs in-place
+		if err := exportCondition.ConditionExpr.SwapPropertyIDs(propertyMappings); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"playbook_id":  playbookID,
+				"condition_id": exportCondition.ID,
+				"version":      exportCondition.Version,
+			}).Warn("failed to remap property IDs in condition during import, skipping")
+			continue
+		}
+
+		newCondition := Condition{
+			ConditionExpr: exportCondition.ConditionExpr,
+			Version:       exportCondition.Version,
+			PlaybookID:    playbookID,
+			CreateAt:      model.GetMillis(),
+			UpdateAt:      model.GetMillis(),
+		}
+
+		if err := newCondition.IsValid(true, newProperties); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"playbook_id":  playbookID,
+				"condition_id": exportCondition.ID,
+				"version":      exportCondition.Version,
+			}).Warn("condition validation failed during import, skipping")
+			continue
+		}
+
+		createdCondition, err := s.store.CreateCondition(playbookID, newCondition)
+		if err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"playbook_id":  playbookID,
+				"condition_id": exportCondition.ID,
+				"version":      exportCondition.Version,
+			}).Warn("failed to create condition during import, skipping")
+			continue
+		}
+
+		conditionMapping[exportCondition.ID] = createdCondition
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"playbook_id":       playbookID,
+		"conditions_created": len(conditionMapping),
+	}).Info("created conditions from export")
+
+	return conditionMapping, nil
+}
+
+// GetPlaybookConditionsForExport retrieves all conditions for a playbook without auth overhead.
+func (s *conditionService) GetPlaybookConditionsForExport(playbookID string) ([]Condition, error) {
+	return s.store.GetPlaybookConditions(playbookID, 0, MaxConditionsPerPlaybook)
+}
+
 // CreatePlaybookCondition creates a new stored condition for a playbook
 func (s *conditionService) CreatePlaybookCondition(userID string, condition Condition, teamID string) (*Condition, error) {
 	auditRec := s.auditor.MakeAuditRecord("createCondition", model.AuditStatusFail)

--- a/server/app/condition_service.go
+++ b/server/app/condition_service.go
@@ -150,6 +150,11 @@ func (s *conditionService) CreateConditionsFromExport(playbookID string, exportC
 		return conditionMapping, nil
 	}
 
+	currentCount, err := s.store.GetPlaybookConditionCount(playbookID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get current condition count during import")
+	}
+
 	newProperties, err := s.propertyService.GetPropertyFields(playbookID)
 	if err != nil {
 		logrus.WithError(err).WithField("playbook_id", playbookID).Warn("failed to fetch property fields for validation during import")
@@ -157,6 +162,16 @@ func (s *conditionService) CreateConditionsFromExport(playbookID string, exportC
 	}
 
 	for _, exportCondition := range exportConditions {
+		if currentCount >= MaxConditionsPerPlaybook {
+			logrus.WithFields(logrus.Fields{
+				"playbook_id": playbookID,
+				"limit":       MaxConditionsPerPlaybook,
+				"created":     len(conditionMapping),
+				"skipped":     len(exportConditions) - len(conditionMapping),
+			}).Warn("reached maximum conditions per playbook during import, skipping remaining")
+			break
+		}
+
 		if exportCondition.ConditionExpr == nil {
 			logrus.WithFields(logrus.Fields{
 				"playbook_id":  playbookID,
@@ -193,6 +208,8 @@ func (s *conditionService) CreateConditionsFromExport(playbookID string, exportC
 			continue
 		}
 
+		newCondition.Sanitize()
+
 		createdCondition, err := s.store.CreateCondition(playbookID, newCondition)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
@@ -204,10 +221,11 @@ func (s *conditionService) CreateConditionsFromExport(playbookID string, exportC
 		}
 
 		conditionMapping[exportCondition.ID] = createdCondition
+		currentCount++
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"playbook_id":       playbookID,
+		"playbook_id":        playbookID,
 		"conditions_created": len(conditionMapping),
 	}).Info("created conditions from export")
 

--- a/server/app/export.go
+++ b/server/app/export.go
@@ -6,6 +6,8 @@ package app
 import (
 	"encoding/json"
 	"reflect"
+
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 const CurrentPlaybookExportVersion = 1
@@ -58,13 +60,116 @@ func generateMetricsExport(metrics []PlaybookMetricConfig) []interface{} {
 	return exported
 }
 
+// ExportPropertyField represents a property field in export format
+type ExportPropertyField struct {
+	ID   string                              `json:"id"`
+	Name string                              `json:"name"`
+	Type model.PropertyFieldType             `json:"type"`
+	Attrs Attrs                              `json:"attrs"`
+}
+
+// ExportCondition represents a condition in export format
+type ExportCondition struct {
+	ID            string              `json:"id"`
+	ConditionExpr ConditionExpression `json:"condition_expr"`
+	Version       int                 `json:"version"`
+}
+
+// UnmarshalJSON deserializes ExportCondition from JSON.
+// Since ConditionExpression is an interface, we need custom unmarshaling to properly
+// deserialize condition_expr based on the version field.
+func (ec *ExportCondition) UnmarshalJSON(data []byte) error {
+	type Alias ExportCondition
+	aux := &struct {
+		ConditionExpr json.RawMessage `json:"condition_expr"`
+		*Alias
+	}{
+		Alias: (*Alias)(ec),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Handle versioned condition expression deserialization
+	if aux.ConditionExpr == nil || string(aux.ConditionExpr) == "null" {
+		return nil // condition_expr is optional on export
+	}
+
+	switch ec.Version {
+	case 1:
+		var exprV1 ConditionExprV1
+		if err := json.Unmarshal(aux.ConditionExpr, &exprV1); err != nil {
+			return err
+		}
+		ec.ConditionExpr = &exprV1
+	default:
+		// Silently ignore unsupported versions during import (graceful degradation)
+		return nil
+	}
+
+	return nil
+}
+
+// NewExportPropertyField creates an ExportPropertyField from a PropertyField
+func NewExportPropertyField(pf PropertyField) ExportPropertyField {
+	return ExportPropertyField{
+		ID:    pf.ID,
+		Name:  pf.Name,
+		Type:  pf.Type,
+		Attrs: pf.Attrs,
+	}
+}
+
+// NewExportCondition creates an ExportCondition from a Condition
+func NewExportCondition(c Condition) ExportCondition {
+	return ExportCondition{
+		ID:            c.ID,
+		ConditionExpr: c.ConditionExpr,
+		Version:       c.Version,
+	}
+}
+
+func generatePropertiesExport(properties []PropertyField) []interface{} {
+	exported := make([]interface{}, 0, len(properties))
+	for _, property := range properties {
+		exportProperty := NewExportPropertyField(property)
+		exported = append(exported, exportProperty)
+	}
+	return exported
+}
+
+func generateConditionsExport(conditions []Condition) []interface{} {
+	exported := make([]interface{}, 0, len(conditions))
+	for _, condition := range conditions {
+		exportCondition := NewExportCondition(condition)
+		exported = append(exported, exportCondition)
+	}
+	return exported
+}
+
 // GeneratePlaybookExport returns a playbook in export format.
 // Fields marked with the stuct tag "export" are included using the given string.
-func GeneratePlaybookExport(playbook Playbook) ([]byte, error) {
+// If properties and conditions are provided, they are also included in the export.
+// Note: CurrentPlaybookExportVersion is kept at 1 to maintain backward compatibility.
+// This is intentional and safe because:
+// - Added "properties" and "conditions" keys are purely additive
+// - Go's json.Decoder silently ignores unknown keys on import
+// - Servers with old export versions will gracefully degrade (importing without attributes/conditionals)
+// - This avoids hard "Unsupported version" rejections for new exports
+func GeneratePlaybookExport(playbook Playbook, properties []PropertyField, conditions []Condition) ([]byte, error) {
 	export := getFieldsForExport(playbook)
 	export["version"] = CurrentPlaybookExportVersion
 	export["checklists"] = generateChecklistExport(playbook.Checklists)
 	export["metrics"] = generateMetricsExport(playbook.Metrics)
+
+	// Add properties and conditions if provided
+	if len(properties) > 0 {
+		export["properties"] = generatePropertiesExport(properties)
+	}
+	if len(conditions) > 0 {
+		export["conditions"] = generateConditionsExport(conditions)
+	}
 
 	result, err := json.MarshalIndent(export, "", "    ")
 	if err != nil {

--- a/server/app/export.go
+++ b/server/app/export.go
@@ -62,10 +62,10 @@ func generateMetricsExport(metrics []PlaybookMetricConfig) []interface{} {
 
 // ExportPropertyField represents a property field in export format
 type ExportPropertyField struct {
-	ID   string                              `json:"id"`
-	Name string                              `json:"name"`
-	Type model.PropertyFieldType             `json:"type"`
-	Attrs Attrs                              `json:"attrs"`
+	ID    string                  `json:"id"`
+	Name  string                  `json:"name"`
+	Type  model.PropertyFieldType `json:"type"`
+	Attrs Attrs                   `json:"attrs"`
 }
 
 // ExportCondition represents a condition in export format

--- a/server/app/export.go
+++ b/server/app/export.go
@@ -130,33 +130,33 @@ func NewExportCondition(c Condition) ExportCondition {
 	}
 }
 
-func generatePropertiesExport(properties []PropertyField) []interface{} {
-	exported := make([]interface{}, 0, len(properties))
+func generatePropertiesExport(properties []PropertyField) []ExportPropertyField {
+	exported := make([]ExportPropertyField, 0, len(properties))
 	for _, property := range properties {
-		exportProperty := NewExportPropertyField(property)
-		exported = append(exported, exportProperty)
+		exported = append(exported, NewExportPropertyField(property))
 	}
 	return exported
 }
 
-func generateConditionsExport(conditions []Condition) []interface{} {
-	exported := make([]interface{}, 0, len(conditions))
+func generateConditionsExport(conditions []Condition) []ExportCondition {
+	exported := make([]ExportCondition, 0, len(conditions))
 	for _, condition := range conditions {
-		exportCondition := NewExportCondition(condition)
-		exported = append(exported, exportCondition)
+		exported = append(exported, NewExportCondition(condition))
 	}
 	return exported
+}
+
+// PlaybookImportData contains all the data needed to import a playbook,
+// including optional properties and conditions.
+type PlaybookImportData struct {
+	Playbook   Playbook              `json:"playbook"`
+	Version    int                   `json:"version"`
+	Properties []ExportPropertyField `json:"properties,omitempty"`
+	Conditions []ExportCondition     `json:"conditions,omitempty"`
 }
 
 // GeneratePlaybookExport returns a playbook in export format.
 // Fields marked with the stuct tag "export" are included using the given string.
-// If properties and conditions are provided, they are also included in the export.
-// Note: CurrentPlaybookExportVersion is kept at 1 to maintain backward compatibility.
-// This is intentional and safe because:
-// - Added "properties" and "conditions" keys are purely additive
-// - Go's json.Decoder silently ignores unknown keys on import
-// - Servers with old export versions will gracefully degrade (importing without attributes/conditionals)
-// - This avoids hard "Unsupported version" rejections for new exports
 func GeneratePlaybookExport(playbook Playbook, properties []PropertyField, conditions []Condition) ([]byte, error) {
 	export := getFieldsForExport(playbook)
 	export["version"] = CurrentPlaybookExportVersion

--- a/server/app/export_test.go
+++ b/server/app/export_test.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestGeneratePlaybookExport(t *testing.T) {
 		},
 	}
 
-	output, err := GeneratePlaybookExport(pb)
+	output, err := GeneratePlaybookExport(pb, []PropertyField{}, []Condition{})
 	require.NoError(t, err)
 
 	result := Playbook{}
@@ -79,4 +80,123 @@ func TestPlaybookDefinesExports(t *testing.T) {
 	definesExports(t, Playbook{})
 	definesExports(t, Checklist{})
 	definesExports(t, ChecklistItem{})
+}
+
+func TestGeneratePlaybookExportWithProperties(t *testing.T) {
+	// Create a test playbook with properties and conditions
+	pb := Playbook{
+		Title:    "Testing with Properties",
+		CreateAt: 23423234,
+		Checklists: []Checklist{
+			{
+				Title: "checklist 1",
+				Items: []ChecklistItem{
+					{
+						Title:       "Conditional Item",
+						Description: "Item with condition",
+						ConditionID: "cond1",
+					},
+				},
+			},
+		},
+	}
+
+	// Create test properties
+	properties := []PropertyField{
+		{
+			PropertyField: model.PropertyField{
+				ID:   "prop1",
+				Name: "Status",
+				Type: model.PropertyFieldTypeSelect,
+			},
+			Attrs: Attrs{
+				Visibility: PropertyFieldVisibilityAlways,
+				SortOrder:  1,
+			},
+		},
+	}
+
+	// Create test conditions
+	conditions := []Condition{
+		{
+			ID:      "cond1",
+			Version: 1,
+			ConditionExpr: &ConditionExprV1{
+				Is: &ComparisonCondition{
+					FieldID: "prop1",
+					Value:   json.RawMessage(`["active"]`),
+				},
+			},
+		},
+	}
+
+	output, err := GeneratePlaybookExport(pb, properties, conditions)
+	require.NoError(t, err)
+
+	// Unmarshal to verify structure
+	var result map[string]interface{}
+	err = json.Unmarshal(output, &result)
+	require.NoError(t, err)
+
+	// Verify properties are present
+	props, ok := result["properties"].([]interface{})
+	require.True(t, ok, "properties should be present in export")
+	require.Len(t, props, 1)
+
+	// Verify conditions are present
+	conds, ok := result["conditions"].([]interface{})
+	require.True(t, ok, "conditions should be present in export")
+	require.Len(t, conds, 1)
+
+	// Verify checklist item has condition ID
+	checklists, ok := result["checklists"].([]interface{})
+	require.True(t, ok, "checklists should be present in export")
+	checklist := checklists[0].(map[string]interface{})
+	items := checklist["items"].([]interface{})
+	item := items[0].(map[string]interface{})
+	assert.Equal(t, "cond1", item["condition_id"])
+}
+
+func TestExportConditionRoundTrip(t *testing.T) {
+	original := ExportCondition{
+		ID:      "cond1",
+		Version: 1,
+		ConditionExpr: &ConditionExprV1{
+			Is: &ComparisonCondition{
+				FieldID: "field1",
+				Value:   json.RawMessage(`["opt1"]`),
+			},
+		},
+	}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded ExportCondition
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.NotNil(t, decoded.ConditionExpr)
+	expr, ok := decoded.ConditionExpr.(*ConditionExprV1)
+	require.True(t, ok, "should deserialize as *ConditionExprV1")
+	assert.Equal(t, "field1", expr.Is.FieldID)
+	assert.Equal(t, json.RawMessage(`["opt1"]`), expr.Is.Value)
+	assert.Equal(t, 1, decoded.Version)
+	assert.Equal(t, "cond1", decoded.ID)
+}
+
+func TestExportConditionUnmarshalUnsupportedVersion(t *testing.T) {
+	data := []byte(`{"id":"c1","version":99,"condition_expr":{"is":{"field_id":"f1","value":"x"}}}`)
+	var ec ExportCondition
+	err := json.Unmarshal(data, &ec)
+	require.NoError(t, err, "unsupported versions should not error")
+	assert.Nil(t, ec.ConditionExpr, "unsupported version should leave ConditionExpr nil")
+	assert.Equal(t, 99, ec.Version)
+}
+
+func TestExportConditionUnmarshalNullExpr(t *testing.T) {
+	data := []byte(`{"id":"c1","version":1,"condition_expr":null}`)
+	var ec ExportCondition
+	err := json.Unmarshal(data, &ec)
+	require.NoError(t, err)
+	assert.Nil(t, ec.ConditionExpr)
 }

--- a/server/app/mocks/mock_condition_service.go
+++ b/server/app/mocks/mock_condition_service.go
@@ -64,6 +64,36 @@ func (mr *MockConditionServiceMockRecorder) CopyPlaybookConditionsToRun(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyPlaybookConditionsToRun", reflect.TypeOf((*MockConditionService)(nil).CopyPlaybookConditionsToRun), arg0, arg1, arg2)
 }
 
+// CreateConditionsFromExport mocks base method.
+func (m *MockConditionService) CreateConditionsFromExport(arg0 string, arg1 []app.ExportCondition, arg2 *app.PropertyCopyResult) (map[string]*app.Condition, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConditionsFromExport", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]*app.Condition)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateConditionsFromExport indicates an expected call of CreateConditionsFromExport.
+func (mr *MockConditionServiceMockRecorder) CreateConditionsFromExport(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConditionsFromExport", reflect.TypeOf((*MockConditionService)(nil).CreateConditionsFromExport), arg0, arg1, arg2)
+}
+
+// GetPlaybookConditionsForExport mocks base method.
+func (m *MockConditionService) GetPlaybookConditionsForExport(arg0 string) ([]app.Condition, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlaybookConditionsForExport", arg0)
+	ret0, _ := ret[0].([]app.Condition)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPlaybookConditionsForExport indicates an expected call of GetPlaybookConditionsForExport.
+func (mr *MockConditionServiceMockRecorder) GetPlaybookConditionsForExport(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlaybookConditionsForExport", reflect.TypeOf((*MockConditionService)(nil).GetPlaybookConditionsForExport), arg0)
+}
+
 // CreatePlaybookCondition mocks base method.
 func (m *MockConditionService) CreatePlaybookCondition(arg0 string, arg1 app.Condition, arg2 string) (*app.Condition, error) {
 	m.ctrl.T.Helper()

--- a/server/app/mocks/mock_condition_service.go
+++ b/server/app/mocks/mock_condition_service.go
@@ -79,21 +79,6 @@ func (mr *MockConditionServiceMockRecorder) CreateConditionsFromExport(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConditionsFromExport", reflect.TypeOf((*MockConditionService)(nil).CreateConditionsFromExport), arg0, arg1, arg2)
 }
 
-// GetPlaybookConditionsForExport mocks base method.
-func (m *MockConditionService) GetPlaybookConditionsForExport(arg0 string) ([]app.Condition, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlaybookConditionsForExport", arg0)
-	ret0, _ := ret[0].([]app.Condition)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPlaybookConditionsForExport indicates an expected call of GetPlaybookConditionsForExport.
-func (mr *MockConditionServiceMockRecorder) GetPlaybookConditionsForExport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlaybookConditionsForExport", reflect.TypeOf((*MockConditionService)(nil).GetPlaybookConditionsForExport), arg0)
-}
-
 // CreatePlaybookCondition mocks base method.
 func (m *MockConditionService) CreatePlaybookCondition(arg0 string, arg1 app.Condition, arg2 string) (*app.Condition, error) {
 	m.ctrl.T.Helper()

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -328,10 +328,10 @@ type ChecklistItem struct {
 	UpdateAt int64 `json:"update_at" export:"-"`
 
 	// ConditionID is the ID of the condition that created this checklist item, if any
-	ConditionID string `json:"condition_id" export:"-"`
+	ConditionID string `json:"condition_id" export:"condition_id"`
 
 	// ConditionAction is a string that represents the action created as a result of a condition. For now, '' or 'hidden'
-	ConditionAction ConditionAction `json:"condition_action" export:"-"`
+	ConditionAction ConditionAction `json:"condition_action" export:"condition_action"`
 
 	// ConditionReason is a string representation of the condition.
 	ConditionReason string `json:"condition_reason" export:"-"`
@@ -397,6 +397,12 @@ type PlaybookService interface {
 
 	// Import imports a new playbook
 	Import(playbook Playbook, userID string) (string, error)
+
+	// ImportWithProperties imports a new playbook with its properties and conditions
+	ImportWithProperties(playbook Playbook, userID string, properties []ExportPropertyField, conditions []ExportCondition) (string, error)
+
+	// GetPlaybookConditionsForExport retrieves all conditions for a playbook for export purposes
+	GetPlaybookConditionsForExport(playbookID string) ([]Condition, error)
 
 	// GetPlaybooks retrieves all playbooks
 	GetPlaybooks() ([]Playbook, error)

--- a/server/app/playbook.go
+++ b/server/app/playbook.go
@@ -395,13 +395,10 @@ type PlaybookService interface {
 	// Create creates a new playbook
 	Create(playbook Playbook, userID string) (string, error)
 
-	// Import imports a new playbook
-	Import(playbook Playbook, userID string) (string, error)
+	// Import imports a playbook, optionally including properties and conditions.
+	Import(data PlaybookImportData, userID string) (string, error)
 
-	// ImportWithProperties imports a new playbook with its properties and conditions
-	ImportWithProperties(playbook Playbook, userID string, properties []ExportPropertyField, conditions []ExportCondition) (string, error)
-
-	// GetPlaybookConditionsForExport retrieves all conditions for a playbook for export purposes
+	// GetPlaybookConditionsForExport retrieves all conditions for a playbook for export purposes.
 	GetPlaybookConditionsForExport(playbookID string) ([]Condition, error)
 
 	// GetPlaybooks retrieves all playbooks

--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -82,63 +82,17 @@ func (s *playbookService) Create(playbook Playbook, userID string) (string, erro
 	return newID, nil
 }
 
-func (s *playbookService) Import(playbook Playbook, userID string) (string, error) {
+func (s *playbookService) Import(data PlaybookImportData, userID string) (string, error) {
 	auditRec := s.auditor.MakeAuditRecord("importPlaybook", model.AuditStatusFail)
 	defer s.auditor.LogAuditRec(auditRec)
 
+	playbook := data.Playbook
 	model.AddEventParameterToAuditRec(auditRec, "userID", userID)
+	model.AddEventParameterToAuditRec(auditRec, "numProperties", len(data.Properties))
+	model.AddEventParameterToAuditRec(auditRec, "numConditions", len(data.Conditions))
 	model.AddEventParameterAuditableToAuditRec(auditRec, "playbook", playbook)
 
-	// Perform the actual operation
-	newID, err := s.Create(playbook, userID)
-	if err != nil {
-		auditRec.AddErrorDesc(err.Error())
-		return "", err
-	}
-	playbook.ID = newID
-
-	// Mark success and add result state
-	auditRec.Success()
-	auditRec.AddEventResultState(playbook)
-
-	return newID, nil
-}
-
-// ImportWithProperties imports a playbook with its properties and conditions.
-// This calls Create directly (rather than Import) so a single audit record
-// covers the full operation including property/condition setup.
-func (s *playbookService) ImportWithProperties(playbook Playbook, userID string, properties []ExportPropertyField, conditions []ExportCondition) (string, error) {
-	auditRec := s.auditor.MakeAuditRecord("importPlaybookWithProperties", model.AuditStatusFail)
-	defer s.auditor.LogAuditRec(auditRec)
-
-	model.AddEventParameterToAuditRec(auditRec, "userID", userID)
-	model.AddEventParameterToAuditRec(auditRec, "numProperties", len(properties))
-	model.AddEventParameterToAuditRec(auditRec, "numConditions", len(conditions))
-	model.AddEventParameterAuditableToAuditRec(auditRec, "playbook", playbook)
-
-	// Save exported condition references before clearing them. These are needed
-	// later to remap old condition IDs to newly created ones.
-	type exportedCondRef struct {
-		checklistIdx    int
-		itemIdx         int
-		conditionID     string
-		conditionAction ConditionAction
-	}
-	var exportedCondRefs []exportedCondRef
-	for i := range playbook.Checklists {
-		for j := range playbook.Checklists[i].Items {
-			if playbook.Checklists[i].Items[j].ConditionID != "" {
-				exportedCondRefs = append(exportedCondRefs, exportedCondRef{
-					checklistIdx:    i,
-					itemIdx:         j,
-					conditionID:     playbook.Checklists[i].Items[j].ConditionID,
-					conditionAction: playbook.Checklists[i].Items[j].ConditionAction,
-				})
-			}
-			playbook.Checklists[i].Items[j].ConditionID = ""
-			playbook.Checklists[i].Items[j].ConditionAction = ""
-		}
-	}
+	condRefs := saveAndClearConditionRefs(&playbook)
 
 	newPlaybookID, err := s.Create(playbook, userID)
 	if err != nil {
@@ -147,111 +101,39 @@ func (s *playbookService) ImportWithProperties(playbook Playbook, userID string,
 	}
 	playbook.ID = newPlaybookID
 
-	if len(properties) == 0 && len(conditions) == 0 {
+	if len(data.Properties) == 0 && len(data.Conditions) == 0 {
 		auditRec.Success()
 		auditRec.AddEventResultState(playbook)
 		return newPlaybookID, nil
 	}
 
-	oldFieldIDToNewFieldID := make(map[string]string)
-	oldOptionIDToNewOptionID := make(map[string]string)
-	copiedFields := []PropertyField{}
+	propResult := s.createPropertiesFromExport(newPlaybookID, data.Properties)
 
-	for _, exportProperty := range properties {
-		newField := PropertyField{
-			PropertyField: model.PropertyField{
-				Name: exportProperty.Name,
-				Type: exportProperty.Type,
-			},
-			Attrs: exportProperty.Attrs,
-		}
-		createdField, err := s.propertyService.CreatePropertyField(newPlaybookID, newField)
-		if err != nil {
-			auditRec.AddErrorDesc("failed to create property field " + exportProperty.Name + ": " + err.Error())
-			logrus.WithError(err).WithFields(logrus.Fields{
-				"playbook_id":       newPlaybookID,
-				"property_name":     exportProperty.Name,
-				"original_field_id": exportProperty.ID,
-			}).Warn("failed to create property field during import, skipping")
-			continue
-		}
-		oldFieldIDToNewFieldID[exportProperty.ID] = createdField.ID
-		copiedFields = append(copiedFields, *createdField)
-
-		if createdField.SupportsOptions() {
-			for j, oldOption := range exportProperty.Attrs.Options {
-				if j < len(createdField.Attrs.Options) {
-					oldOptionIDToNewOptionID[oldOption.GetID()] = createdField.Attrs.Options[j].GetID()
-				}
-			}
-		}
-	}
-
-	// Second pass: remap ParentID on fields that reference other fields
-	for i, field := range copiedFields {
-		if field.Attrs.ParentID != "" {
-			if newParentID, ok := oldFieldIDToNewFieldID[field.Attrs.ParentID]; ok {
-				copiedFields[i].Attrs.ParentID = newParentID
-				updatedField := copiedFields[i]
-				if _, err := s.propertyService.UpdatePropertyField(newPlaybookID, updatedField); err != nil {
-					logrus.WithError(err).WithFields(logrus.Fields{
-						"playbook_id":   newPlaybookID,
-						"field_id":      field.ID,
-						"old_parent_id": field.Attrs.ParentID,
-						"new_parent_id": newParentID,
-					}).Warn("failed to remap ParentID on imported property field")
-				}
-			}
-		}
-	}
-
-	if len(conditions) > 0 && len(oldFieldIDToNewFieldID) > 0 {
+	if len(data.Conditions) > 0 && len(propResult.FieldMappings) > 0 {
 		propertyMappings := &PropertyCopyResult{
-			FieldMappings:  oldFieldIDToNewFieldID,
-			OptionMappings: oldOptionIDToNewOptionID,
-			CopiedFields:   copiedFields,
+			FieldMappings:  propResult.FieldMappings,
+			OptionMappings: propResult.OptionMappings,
+			CopiedFields:   propResult.CopiedFields,
 		}
 
-		conditionMapping, err := s.conditionService.CreateConditionsFromExport(newPlaybookID, conditions, propertyMappings)
+		conditionMapping, err := s.conditionService.CreateConditionsFromExport(newPlaybookID, data.Conditions, propertyMappings)
 		if err != nil {
 			auditRec.AddErrorDesc("failed to create conditions from export: " + err.Error())
-			logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to create conditions from export")
+			return "", errors.Wrap(err, "failed to create conditions from export")
 		}
 
-		if len(conditionMapping) > 0 && len(exportedCondRefs) > 0 {
-			oldConditionIDToNewConditionID := make(map[string]string)
-			for oldID, newCond := range conditionMapping {
-				oldConditionIDToNewConditionID[oldID] = newCond.ID
-			}
-
+		if len(conditionMapping) > 0 && len(condRefs) > 0 {
 			updatedPlaybook, err := s.Get(newPlaybookID)
 			if err != nil {
-				auditRec.AddErrorDesc("failed to get playbook for condition remapping: " + err.Error())
-				logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to get playbook for condition remapping")
-			} else {
-				// Write back only the condition IDs that were actually recreated,
-				// using the saved exported references (the stored items have empty IDs).
-				for _, ref := range exportedCondRefs {
-					if ref.checklistIdx >= len(updatedPlaybook.Checklists) ||
-						ref.itemIdx >= len(updatedPlaybook.Checklists[ref.checklistIdx].Items) {
-						logrus.WithFields(logrus.Fields{
-							"playbook_id":    newPlaybookID,
-							"checklist_idx":  ref.checklistIdx,
-							"item_idx":       ref.itemIdx,
-							"num_checklists": len(updatedPlaybook.Checklists),
-						}).Warn("checklist structure changed after create, skipping condition remap for item")
-						continue
-					}
-					if newConditionID, ok := oldConditionIDToNewConditionID[ref.conditionID]; ok {
-						updatedPlaybook.Checklists[ref.checklistIdx].Items[ref.itemIdx].ConditionID = newConditionID
-						updatedPlaybook.Checklists[ref.checklistIdx].Items[ref.itemIdx].ConditionAction = ref.conditionAction
-					}
-				}
+				auditRec.AddErrorDesc(err.Error())
+				return "", errors.Wrap(err, "failed to get playbook for condition remapping")
+			}
 
-				if err := s.store.Update(updatedPlaybook); err != nil {
-					auditRec.AddErrorDesc("failed to update playbook with remapped condition IDs: " + err.Error())
-					logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to update playbook with remapped condition IDs")
-				}
+			remapChecklistConditions(&updatedPlaybook, conditionMapping, condRefs)
+
+			if err := s.Update(updatedPlaybook, userID); err != nil {
+				auditRec.AddErrorDesc(err.Error())
+				return "", errors.Wrap(err, "failed to update playbook with remapped condition IDs")
 			}
 		}
 	}
@@ -262,10 +144,130 @@ func (s *playbookService) ImportWithProperties(playbook Playbook, userID string,
 	return newPlaybookID, nil
 }
 
-// GetPlaybookConditionsForExport delegates to the condition service to fetch conditions
-// for export without authentication overhead.
+// GetPlaybookConditionsForExport retrieves all conditions for a playbook for export purposes.
 func (s *playbookService) GetPlaybookConditionsForExport(playbookID string) ([]Condition, error) {
-	return s.conditionService.GetPlaybookConditionsForExport(playbookID)
+	result, err := s.conditionService.GetPlaybookConditions("", playbookID, 0, MaxConditionsPerPlaybook)
+	if err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+type exportedCondRef struct {
+	checklistIdx    int
+	itemIdx         int
+	conditionID     string
+	conditionAction ConditionAction
+}
+
+// saveAndClearConditionRefs extracts condition references from checklist items
+// and clears them so the playbook can be created without dangling IDs.
+func saveAndClearConditionRefs(playbook *Playbook) []exportedCondRef {
+	var refs []exportedCondRef
+	for i := range playbook.Checklists {
+		for j := range playbook.Checklists[i].Items {
+			if playbook.Checklists[i].Items[j].ConditionID != "" {
+				refs = append(refs, exportedCondRef{
+					checklistIdx:    i,
+					itemIdx:         j,
+					conditionID:     playbook.Checklists[i].Items[j].ConditionID,
+					conditionAction: playbook.Checklists[i].Items[j].ConditionAction,
+				})
+			}
+			playbook.Checklists[i].Items[j].ConditionID = ""
+			playbook.Checklists[i].Items[j].ConditionAction = ""
+		}
+	}
+	return refs
+}
+
+// remapChecklistConditions writes back condition IDs that were recreated during
+// import, using the saved references from the original export.
+func remapChecklistConditions(playbook *Playbook, conditionMapping map[string]*Condition, refs []exportedCondRef) {
+	oldToNew := make(map[string]string, len(conditionMapping))
+	for oldID, newCond := range conditionMapping {
+		oldToNew[oldID] = newCond.ID
+	}
+
+	for _, ref := range refs {
+		if ref.checklistIdx >= len(playbook.Checklists) ||
+			ref.itemIdx >= len(playbook.Checklists[ref.checklistIdx].Items) {
+			logrus.WithFields(logrus.Fields{
+				"checklist_idx":  ref.checklistIdx,
+				"item_idx":       ref.itemIdx,
+				"num_checklists": len(playbook.Checklists),
+			}).Warn("checklist structure changed after create, skipping condition remap for item")
+			continue
+		}
+		if newCondID, ok := oldToNew[ref.conditionID]; ok {
+			playbook.Checklists[ref.checklistIdx].Items[ref.itemIdx].ConditionID = newCondID
+			playbook.Checklists[ref.checklistIdx].Items[ref.itemIdx].ConditionAction = ref.conditionAction
+		}
+	}
+}
+
+type importPropertyResult struct {
+	FieldMappings  map[string]string
+	OptionMappings map[string]string
+	CopiedFields   []PropertyField
+}
+
+// createPropertiesFromExport creates property fields on the target playbook from
+// exported data, builds old->new ID mappings, and remaps ParentID references.
+func (s *playbookService) createPropertiesFromExport(playbookID string, properties []ExportPropertyField) importPropertyResult {
+	result := importPropertyResult{
+		FieldMappings:  make(map[string]string),
+		OptionMappings: make(map[string]string),
+	}
+
+	for _, exportProp := range properties {
+		newField := PropertyField{
+			PropertyField: model.PropertyField{
+				Name: exportProp.Name,
+				Type: exportProp.Type,
+			},
+			Attrs: exportProp.Attrs,
+		}
+		createdField, err := s.propertyService.CreatePropertyField(playbookID, newField)
+		if err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"playbook_id":       playbookID,
+				"property_name":     exportProp.Name,
+				"original_field_id": exportProp.ID,
+			}).Warn("failed to create property field during import, skipping")
+			continue
+		}
+		result.FieldMappings[exportProp.ID] = createdField.ID
+		result.CopiedFields = append(result.CopiedFields, *createdField)
+
+		if createdField.SupportsOptions() {
+			for j, oldOption := range exportProp.Attrs.Options {
+				if j < len(createdField.Attrs.Options) {
+					result.OptionMappings[oldOption.GetID()] = createdField.Attrs.Options[j].GetID()
+				}
+			}
+		}
+	}
+
+	for i, field := range result.CopiedFields {
+		if field.Attrs.ParentID != "" {
+			if newParentID, ok := result.FieldMappings[field.Attrs.ParentID]; ok {
+				result.CopiedFields[i].Attrs.ParentID = newParentID
+				updatedField := result.CopiedFields[i]
+				if _, err := s.propertyService.UpdatePropertyField(playbookID, updatedField); err != nil {
+					result.CopiedFields[i].Attrs.ParentID = ""
+					logrus.WithError(err).WithFields(logrus.Fields{
+						"playbook_id":   playbookID,
+						"field_id":      field.ID,
+						"old_parent_id": field.Attrs.ParentID,
+						"new_parent_id": newParentID,
+					}).Warn("failed to remap ParentID on imported property field, cleared to avoid dangling ref")
+				}
+			}
+		}
+	}
+
+	return result
 }
 
 func (s *playbookService) Get(id string) (Playbook, error) {

--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -116,6 +116,30 @@ func (s *playbookService) ImportWithProperties(playbook Playbook, userID string,
 	model.AddEventParameterToAuditRec(auditRec, "numConditions", len(conditions))
 	model.AddEventParameterAuditableToAuditRec(auditRec, "playbook", playbook)
 
+	// Save exported condition references before clearing them. These are needed
+	// later to remap old condition IDs to newly created ones.
+	type exportedCondRef struct {
+		checklistIdx    int
+		itemIdx         int
+		conditionID     string
+		conditionAction ConditionAction
+	}
+	var exportedCondRefs []exportedCondRef
+	for i := range playbook.Checklists {
+		for j := range playbook.Checklists[i].Items {
+			if playbook.Checklists[i].Items[j].ConditionID != "" {
+				exportedCondRefs = append(exportedCondRefs, exportedCondRef{
+					checklistIdx:    i,
+					itemIdx:         j,
+					conditionID:     playbook.Checklists[i].Items[j].ConditionID,
+					conditionAction: playbook.Checklists[i].Items[j].ConditionAction,
+				})
+			}
+			playbook.Checklists[i].Items[j].ConditionID = ""
+			playbook.Checklists[i].Items[j].ConditionAction = ""
+		}
+	}
+
 	newPlaybookID, err := s.Create(playbook, userID)
 	if err != nil {
 		auditRec.AddErrorDesc(err.Error())
@@ -163,6 +187,24 @@ func (s *playbookService) ImportWithProperties(playbook Playbook, userID string,
 		}
 	}
 
+	// Second pass: remap ParentID on fields that reference other fields
+	for i, field := range copiedFields {
+		if field.Attrs.ParentID != "" {
+			if newParentID, ok := oldFieldIDToNewFieldID[field.Attrs.ParentID]; ok {
+				copiedFields[i].Attrs.ParentID = newParentID
+				updatedField := copiedFields[i]
+				if _, err := s.propertyService.UpdatePropertyField(newPlaybookID, updatedField); err != nil {
+					logrus.WithError(err).WithFields(logrus.Fields{
+						"playbook_id":   newPlaybookID,
+						"field_id":      field.ID,
+						"old_parent_id": field.Attrs.ParentID,
+						"new_parent_id": newParentID,
+					}).Warn("failed to remap ParentID on imported property field")
+				}
+			}
+		}
+	}
+
 	if len(conditions) > 0 && len(oldFieldIDToNewFieldID) > 0 {
 		propertyMappings := &PropertyCopyResult{
 			FieldMappings:  oldFieldIDToNewFieldID,
@@ -176,7 +218,7 @@ func (s *playbookService) ImportWithProperties(playbook Playbook, userID string,
 			logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to create conditions from export")
 		}
 
-		if len(conditionMapping) > 0 {
+		if len(conditionMapping) > 0 && len(exportedCondRefs) > 0 {
 			oldConditionIDToNewConditionID := make(map[string]string)
 			for oldID, newCond := range conditionMapping {
 				oldConditionIDToNewConditionID[oldID] = newCond.ID
@@ -187,11 +229,22 @@ func (s *playbookService) ImportWithProperties(playbook Playbook, userID string,
 				auditRec.AddErrorDesc("failed to get playbook for condition remapping: " + err.Error())
 				logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to get playbook for condition remapping")
 			} else {
-				for i := range updatedPlaybook.Checklists {
-					for j := range updatedPlaybook.Checklists[i].Items {
-						if newConditionID, ok := oldConditionIDToNewConditionID[updatedPlaybook.Checklists[i].Items[j].ConditionID]; ok {
-							updatedPlaybook.Checklists[i].Items[j].ConditionID = newConditionID
-						}
+				// Write back only the condition IDs that were actually recreated,
+				// using the saved exported references (the stored items have empty IDs).
+				for _, ref := range exportedCondRefs {
+					if ref.checklistIdx >= len(updatedPlaybook.Checklists) ||
+						ref.itemIdx >= len(updatedPlaybook.Checklists[ref.checklistIdx].Items) {
+						logrus.WithFields(logrus.Fields{
+							"playbook_id":    newPlaybookID,
+							"checklist_idx":  ref.checklistIdx,
+							"item_idx":       ref.itemIdx,
+							"num_checklists": len(updatedPlaybook.Checklists),
+						}).Warn("checklist structure changed after create, skipping condition remap for item")
+						continue
+					}
+					if newConditionID, ok := oldConditionIDToNewConditionID[ref.conditionID]; ok {
+						updatedPlaybook.Checklists[ref.checklistIdx].Items[ref.itemIdx].ConditionID = newConditionID
+						updatedPlaybook.Checklists[ref.checklistIdx].Items[ref.itemIdx].ConditionAction = ref.conditionAction
 					}
 				}
 

--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -104,6 +104,117 @@ func (s *playbookService) Import(playbook Playbook, userID string) (string, erro
 	return newID, nil
 }
 
+// ImportWithProperties imports a playbook with its properties and conditions.
+// This calls Create directly (rather than Import) so a single audit record
+// covers the full operation including property/condition setup.
+func (s *playbookService) ImportWithProperties(playbook Playbook, userID string, properties []ExportPropertyField, conditions []ExportCondition) (string, error) {
+	auditRec := s.auditor.MakeAuditRecord("importPlaybookWithProperties", model.AuditStatusFail)
+	defer s.auditor.LogAuditRec(auditRec)
+
+	model.AddEventParameterToAuditRec(auditRec, "userID", userID)
+	model.AddEventParameterToAuditRec(auditRec, "numProperties", len(properties))
+	model.AddEventParameterToAuditRec(auditRec, "numConditions", len(conditions))
+	model.AddEventParameterAuditableToAuditRec(auditRec, "playbook", playbook)
+
+	newPlaybookID, err := s.Create(playbook, userID)
+	if err != nil {
+		auditRec.AddErrorDesc(err.Error())
+		return "", err
+	}
+	playbook.ID = newPlaybookID
+
+	if len(properties) == 0 && len(conditions) == 0 {
+		auditRec.Success()
+		auditRec.AddEventResultState(playbook)
+		return newPlaybookID, nil
+	}
+
+	oldFieldIDToNewFieldID := make(map[string]string)
+	oldOptionIDToNewOptionID := make(map[string]string)
+	copiedFields := []PropertyField{}
+
+	for _, exportProperty := range properties {
+		newField := PropertyField{
+			PropertyField: model.PropertyField{
+				Name: exportProperty.Name,
+				Type: exportProperty.Type,
+			},
+			Attrs: exportProperty.Attrs,
+		}
+		createdField, err := s.propertyService.CreatePropertyField(newPlaybookID, newField)
+		if err != nil {
+			auditRec.AddErrorDesc("failed to create property field " + exportProperty.Name + ": " + err.Error())
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"playbook_id":       newPlaybookID,
+				"property_name":     exportProperty.Name,
+				"original_field_id": exportProperty.ID,
+			}).Warn("failed to create property field during import, skipping")
+			continue
+		}
+		oldFieldIDToNewFieldID[exportProperty.ID] = createdField.ID
+		copiedFields = append(copiedFields, *createdField)
+
+		if createdField.SupportsOptions() {
+			for j, oldOption := range exportProperty.Attrs.Options {
+				if j < len(createdField.Attrs.Options) {
+					oldOptionIDToNewOptionID[oldOption.GetID()] = createdField.Attrs.Options[j].GetID()
+				}
+			}
+		}
+	}
+
+	if len(conditions) > 0 && len(oldFieldIDToNewFieldID) > 0 {
+		propertyMappings := &PropertyCopyResult{
+			FieldMappings:  oldFieldIDToNewFieldID,
+			OptionMappings: oldOptionIDToNewOptionID,
+			CopiedFields:   copiedFields,
+		}
+
+		conditionMapping, err := s.conditionService.CreateConditionsFromExport(newPlaybookID, conditions, propertyMappings)
+		if err != nil {
+			auditRec.AddErrorDesc("failed to create conditions from export: " + err.Error())
+			logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to create conditions from export")
+		}
+
+		if len(conditionMapping) > 0 {
+			oldConditionIDToNewConditionID := make(map[string]string)
+			for oldID, newCond := range conditionMapping {
+				oldConditionIDToNewConditionID[oldID] = newCond.ID
+			}
+
+			updatedPlaybook, err := s.Get(newPlaybookID)
+			if err != nil {
+				auditRec.AddErrorDesc("failed to get playbook for condition remapping: " + err.Error())
+				logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to get playbook for condition remapping")
+			} else {
+				for i := range updatedPlaybook.Checklists {
+					for j := range updatedPlaybook.Checklists[i].Items {
+						if newConditionID, ok := oldConditionIDToNewConditionID[updatedPlaybook.Checklists[i].Items[j].ConditionID]; ok {
+							updatedPlaybook.Checklists[i].Items[j].ConditionID = newConditionID
+						}
+					}
+				}
+
+				if err := s.store.Update(updatedPlaybook); err != nil {
+					auditRec.AddErrorDesc("failed to update playbook with remapped condition IDs: " + err.Error())
+					logrus.WithError(err).WithField("playbook_id", newPlaybookID).Warn("failed to update playbook with remapped condition IDs")
+				}
+			}
+		}
+	}
+
+	auditRec.Success()
+	auditRec.AddEventResultState(playbook)
+
+	return newPlaybookID, nil
+}
+
+// GetPlaybookConditionsForExport delegates to the condition service to fetch conditions
+// for export without authentication overhead.
+func (s *playbookService) GetPlaybookConditionsForExport(playbookID string) ([]Condition, error) {
+	return s.conditionService.GetPlaybookConditionsForExport(playbookID)
+}
+
 func (s *playbookService) Get(id string) (Playbook, error) {
 	return s.store.Get(id)
 }

--- a/server/app/playbook_service_test.go
+++ b/server/app/playbook_service_test.go
@@ -4,6 +4,7 @@
 package app_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -449,3 +450,252 @@ func TestPlaybookService_Duplicate(t *testing.T) {
 		assert.NotEmpty(t, resultID)
 	})
 }
+
+func TestPlaybookService_ImportWithProperties(t *testing.T) {
+	userID := model.NewId()
+	newPlaybookID := model.NewId()
+
+	basePlaybook := app.Playbook{
+		Title:       "Test Playbook",
+		Description: "Test Description",
+		Checklists: []app.Checklist{
+			{
+				Title: "Checklist 1",
+				Items: []app.ChecklistItem{
+					{
+						Title:       "Item with condition",
+						ConditionID: "old-cond-1",
+					},
+				},
+			},
+		},
+	}
+
+	baseExportProperty := app.ExportPropertyField{
+		ID:   "old-prop-1",
+		Name: "Status",
+		Type: model.PropertyFieldTypeSelect,
+		Attrs: app.Attrs{
+			Visibility: app.PropertyFieldVisibilityAlways,
+			Options: model.PropertyOptions[*model.PluginPropertyOption]{
+				model.NewPluginPropertyOption("opt-1", "Active"),
+				model.NewPluginPropertyOption("opt-2", "Inactive"),
+			},
+		},
+	}
+
+	t.Run("successfully imports playbook with properties and conditions", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStore := mock_app.NewMockPlaybookStore(ctrl)
+		mockPropertyService := mock_app.NewMockPropertyService(ctrl)
+		mockConditionService := mock_app.NewMockConditionService(ctrl)
+		mockPoster := mock_bot.NewMockPoster(ctrl)
+		mockAuditor := mock_app.NewMockAuditor(ctrl)
+
+		mockAuditor.EXPECT().
+			MakeAuditRecord(gomock.Any(), gomock.Any()).
+			Return(&model.AuditRecord{}).
+			AnyTimes()
+
+		mockAuditor.EXPECT().
+			LogAuditRec(gomock.Any()).
+			AnyTimes()
+
+		service := app.NewPlaybookService(
+			mockStore,
+			mockPoster,
+			nil,
+			mockAuditor,
+			nil, // metrics
+			mockPropertyService,
+			mockConditionService,
+		)
+
+		oldFieldID := "old-prop-1"
+		newFieldID := "new-prop-1"
+		oldOptionID := "old-opt-1"
+		newOptionID := "new-opt-1"
+		oldConditionID := "old-cond-1"
+		newConditionID := "new-cond-1"
+
+		exportProperties := []app.ExportPropertyField{{
+			ID:   oldFieldID,
+			Name: "Status",
+			Type: model.PropertyFieldTypeSelect,
+			Attrs: app.Attrs{
+				Visibility: app.PropertyFieldVisibilityAlways,
+				Options: model.PropertyOptions[*model.PluginPropertyOption]{
+					model.NewPluginPropertyOption(oldOptionID, "Active"),
+				},
+			},
+		}}
+
+		exportConditions := []app.ExportCondition{{
+			ID:      oldConditionID,
+			Version: 1,
+			ConditionExpr: &app.ConditionExprV1{
+				Is: &app.ComparisonCondition{
+					FieldID: oldFieldID,
+					Value:   json.RawMessage(`["` + oldOptionID + `"]`),
+				},
+			},
+		}}
+
+		playbook := app.Playbook{
+			Title: "Test",
+			Checklists: []app.Checklist{{
+				Title: "CL",
+				Items: []app.ChecklistItem{{
+					Title:       "Conditional task",
+					ConditionID: oldConditionID,
+				}},
+			}},
+		}
+
+		mockStore.EXPECT().Create(gomock.Any()).Return(newPlaybookID, nil)
+		mockPoster.EXPECT().PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), gomock.Any())
+
+		createdField := &app.PropertyField{
+			PropertyField: model.PropertyField{ID: newFieldID, Name: "Status", Type: model.PropertyFieldTypeSelect},
+			Attrs: app.Attrs{
+				Visibility: app.PropertyFieldVisibilityAlways,
+				Options: model.PropertyOptions[*model.PluginPropertyOption]{
+					model.NewPluginPropertyOption(newOptionID, "Active"),
+				},
+			},
+		}
+		mockPropertyService.EXPECT().CreatePropertyField(newPlaybookID, gomock.Any()).Return(createdField, nil)
+
+		mockConditionService.EXPECT().
+			CreateConditionsFromExport(newPlaybookID, exportConditions, gomock.Any()).
+			DoAndReturn(func(pbID string, conds []app.ExportCondition, mappings *app.PropertyCopyResult) (map[string]*app.Condition, error) {
+				assert.Contains(t, mappings.FieldMappings, oldFieldID, "field mappings should contain old field ID")
+				assert.Equal(t, newFieldID, mappings.FieldMappings[oldFieldID], "field mapping should be old->new")
+				assert.Contains(t, mappings.OptionMappings, oldOptionID, "option mappings should contain old option ID")
+				assert.Equal(t, newOptionID, mappings.OptionMappings[oldOptionID], "option mapping should be old->new")
+
+				return map[string]*app.Condition{
+					oldConditionID: {ID: newConditionID},
+				}, nil
+			})
+
+		mockStore.EXPECT().Get(newPlaybookID).Return(playbook, nil)
+
+		mockStore.EXPECT().
+			Update(gomock.Any()).
+			DoAndReturn(func(pb app.Playbook) error {
+				assert.Equal(t, newConditionID, pb.Checklists[0].Items[0].ConditionID,
+					"checklist item ConditionID should be remapped to new condition ID")
+				return nil
+			})
+
+		resultID, err := service.ImportWithProperties(playbook, userID, exportProperties, exportConditions)
+		require.NoError(t, err)
+		assert.Equal(t, newPlaybookID, resultID)
+	})
+
+	t.Run("returns early if no properties or conditions", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStore := mock_app.NewMockPlaybookStore(ctrl)
+		mockPropertyService := mock_app.NewMockPropertyService(ctrl)
+		mockConditionService := mock_app.NewMockConditionService(ctrl)
+		mockPoster := mock_bot.NewMockPoster(ctrl)
+		mockAuditor := mock_app.NewMockAuditor(ctrl)
+
+		mockAuditor.EXPECT().
+			MakeAuditRecord(gomock.Any(), gomock.Any()).
+			Return(&model.AuditRecord{}).
+			AnyTimes()
+
+		mockAuditor.EXPECT().
+			LogAuditRec(gomock.Any()).
+			AnyTimes()
+
+		service := app.NewPlaybookService(
+			mockStore,
+			mockPoster,
+			nil,
+			mockAuditor,
+			nil, // metrics
+			mockPropertyService,
+			mockConditionService,
+		)
+
+		mockStore.EXPECT().
+			Create(gomock.Any()).
+			DoAndReturn(func(pb app.Playbook) (string, error) {
+				return newPlaybookID, nil
+			})
+
+		mockPoster.EXPECT().
+			PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), basePlaybook.TeamID)
+
+		resultID, err := service.ImportWithProperties(
+			basePlaybook,
+			userID,
+			[]app.ExportPropertyField{},
+			[]app.ExportCondition{},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, newPlaybookID, resultID)
+	})
+
+	t.Run("gracefully handles property creation failure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStore := mock_app.NewMockPlaybookStore(ctrl)
+		mockPropertyService := mock_app.NewMockPropertyService(ctrl)
+		mockConditionService := mock_app.NewMockConditionService(ctrl)
+		mockPoster := mock_bot.NewMockPoster(ctrl)
+		mockAuditor := mock_app.NewMockAuditor(ctrl)
+
+		mockAuditor.EXPECT().
+			MakeAuditRecord(gomock.Any(), gomock.Any()).
+			Return(&model.AuditRecord{}).
+			AnyTimes()
+
+		mockAuditor.EXPECT().
+			LogAuditRec(gomock.Any()).
+			AnyTimes()
+
+		service := app.NewPlaybookService(
+			mockStore,
+			mockPoster,
+			nil,
+			mockAuditor,
+			nil, // metrics
+			mockPropertyService,
+			mockConditionService,
+		)
+
+		mockStore.EXPECT().
+			Create(gomock.Any()).
+			DoAndReturn(func(pb app.Playbook) (string, error) {
+				return newPlaybookID, nil
+			})
+
+		mockPoster.EXPECT().
+			PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), basePlaybook.TeamID)
+
+		mockPropertyService.EXPECT().
+			CreatePropertyField(newPlaybookID, gomock.Any()).
+			Return(nil, errors.New("property creation failed"))
+
+		resultID, err := service.ImportWithProperties(
+			basePlaybook,
+			userID,
+			[]app.ExportPropertyField{baseExportProperty},
+			[]app.ExportCondition{},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, newPlaybookID, resultID)
+	})
+}
+

--- a/server/app/playbook_service_test.go
+++ b/server/app/playbook_service_test.go
@@ -515,22 +515,35 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 
 		oldFieldID := "old-prop-1"
 		newFieldID := "new-prop-1"
+		oldChildFieldID := "old-prop-child"
+		newChildFieldID := "new-prop-child"
 		oldOptionID := "old-opt-1"
 		newOptionID := "new-opt-1"
 		oldConditionID := "old-cond-1"
 		newConditionID := "new-cond-1"
 
-		exportProperties := []app.ExportPropertyField{{
-			ID:   oldFieldID,
-			Name: "Status",
-			Type: model.PropertyFieldTypeSelect,
-			Attrs: app.Attrs{
-				Visibility: app.PropertyFieldVisibilityAlways,
-				Options: model.PropertyOptions[*model.PluginPropertyOption]{
-					model.NewPluginPropertyOption(oldOptionID, "Active"),
+		exportProperties := []app.ExportPropertyField{
+			{
+				ID:   oldFieldID,
+				Name: "Status",
+				Type: model.PropertyFieldTypeSelect,
+				Attrs: app.Attrs{
+					Visibility: app.PropertyFieldVisibilityAlways,
+					Options: model.PropertyOptions[*model.PluginPropertyOption]{
+						model.NewPluginPropertyOption(oldOptionID, "Active"),
+					},
 				},
 			},
-		}}
+			{
+				ID:   oldChildFieldID,
+				Name: "SubStatus",
+				Type: model.PropertyFieldTypeText,
+				Attrs: app.Attrs{
+					Visibility: app.PropertyFieldVisibilityAlways,
+					ParentID:   oldFieldID,
+				},
+			},
+		}
 
 		exportConditions := []app.ExportCondition{{
 			ID:      oldConditionID,
@@ -548,13 +561,22 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 			Checklists: []app.Checklist{{
 				Title: "CL",
 				Items: []app.ChecklistItem{{
-					Title:       "Conditional task",
-					ConditionID: oldConditionID,
+					Title:           "Conditional task",
+					ConditionID:     oldConditionID,
+					ConditionAction: app.ConditionActionHidden,
 				}},
 			}},
 		}
 
-		mockStore.EXPECT().Create(gomock.Any()).Return(newPlaybookID, nil)
+		mockStore.EXPECT().
+			Create(gomock.Any()).
+			DoAndReturn(func(pb app.Playbook) (string, error) {
+				assert.Empty(t, pb.Checklists[0].Items[0].ConditionID,
+					"ConditionID should be cleared before Create")
+				assert.Empty(t, pb.Checklists[0].Items[0].ConditionAction,
+					"ConditionAction should be cleared before Create")
+				return newPlaybookID, nil
+			})
 		mockPoster.EXPECT().PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), gomock.Any())
 
 		createdField := &app.PropertyField{
@@ -566,7 +588,24 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 				},
 			},
 		}
-		mockPropertyService.EXPECT().CreatePropertyField(newPlaybookID, gomock.Any()).Return(createdField, nil)
+		createdChildField := &app.PropertyField{
+			PropertyField: model.PropertyField{ID: newChildFieldID, Name: "SubStatus", Type: model.PropertyFieldTypeText},
+			Attrs: app.Attrs{
+				Visibility: app.PropertyFieldVisibilityAlways,
+				ParentID:   oldFieldID, // still has old parent ID before remap
+			},
+		}
+
+		firstCreate := mockPropertyService.EXPECT().CreatePropertyField(newPlaybookID, gomock.Any()).Return(createdField, nil)
+		mockPropertyService.EXPECT().CreatePropertyField(newPlaybookID, gomock.Any()).Return(createdChildField, nil).After(firstCreate)
+
+		mockPropertyService.EXPECT().
+			UpdatePropertyField(newPlaybookID, gomock.Any()).
+			DoAndReturn(func(pbID string, field app.PropertyField) (*app.PropertyField, error) {
+				assert.Equal(t, newChildFieldID, field.ID, "should update the child field")
+				assert.Equal(t, newFieldID, field.Attrs.ParentID, "ParentID should be remapped to new field ID")
+				return &field, nil
+			})
 
 		mockConditionService.EXPECT().
 			CreateConditionsFromExport(newPlaybookID, exportConditions, gomock.Any()).
@@ -581,13 +620,26 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 				}, nil
 			})
 
-		mockStore.EXPECT().Get(newPlaybookID).Return(playbook, nil)
+		// Get returns the playbook as stored (with cleared ConditionIDs)
+		storedPlaybook := app.Playbook{
+			Title: "Test",
+			Checklists: []app.Checklist{{
+				Title: "CL",
+				Items: []app.ChecklistItem{{
+					Title:       "Conditional task",
+					ConditionID: "",
+				}},
+			}},
+		}
+		mockStore.EXPECT().Get(newPlaybookID).Return(storedPlaybook, nil)
 
 		mockStore.EXPECT().
 			Update(gomock.Any()).
 			DoAndReturn(func(pb app.Playbook) error {
 				assert.Equal(t, newConditionID, pb.Checklists[0].Items[0].ConditionID,
 					"checklist item ConditionID should be remapped to new condition ID")
+				assert.Equal(t, app.ConditionActionHidden, pb.Checklists[0].Items[0].ConditionAction,
+					"checklist item ConditionAction should be restored after remap")
 				return nil
 			})
 
@@ -698,4 +750,3 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 		assert.Equal(t, newPlaybookID, resultID)
 	})
 }
-

--- a/server/app/playbook_service_test.go
+++ b/server/app/playbook_service_test.go
@@ -451,7 +451,7 @@ func TestPlaybookService_Duplicate(t *testing.T) {
 	})
 }
 
-func TestPlaybookService_ImportWithProperties(t *testing.T) {
+func TestPlaybookService_Import(t *testing.T) {
 	userID := model.NewId()
 	newPlaybookID := model.NewId()
 
@@ -643,7 +643,11 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 				return nil
 			})
 
-		resultID, err := service.ImportWithProperties(playbook, userID, exportProperties, exportConditions)
+		resultID, err := service.Import(app.PlaybookImportData{
+			Playbook:   playbook,
+			Properties: exportProperties,
+			Conditions: exportConditions,
+		}, userID)
 		require.NoError(t, err)
 		assert.Equal(t, newPlaybookID, resultID)
 	})
@@ -686,12 +690,11 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 		mockPoster.EXPECT().
 			PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), basePlaybook.TeamID)
 
-		resultID, err := service.ImportWithProperties(
-			basePlaybook,
-			userID,
-			[]app.ExportPropertyField{},
-			[]app.ExportCondition{},
-		)
+		resultID, err := service.Import(app.PlaybookImportData{
+			Playbook:   basePlaybook,
+			Properties: []app.ExportPropertyField{},
+			Conditions: []app.ExportCondition{},
+		}, userID)
 
 		require.NoError(t, err)
 		assert.Equal(t, newPlaybookID, resultID)
@@ -739,12 +742,70 @@ func TestPlaybookService_ImportWithProperties(t *testing.T) {
 			CreatePropertyField(newPlaybookID, gomock.Any()).
 			Return(nil, errors.New("property creation failed"))
 
-		resultID, err := service.ImportWithProperties(
-			basePlaybook,
-			userID,
-			[]app.ExportPropertyField{baseExportProperty},
-			[]app.ExportCondition{},
+		resultID, err := service.Import(app.PlaybookImportData{
+			Playbook:   basePlaybook,
+			Properties: []app.ExportPropertyField{baseExportProperty},
+			Conditions: []app.ExportCondition{},
+		}, userID)
+
+		require.NoError(t, err)
+		assert.Equal(t, newPlaybookID, resultID)
+	})
+
+	t.Run("skips conditions when all property creations fail", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStore := mock_app.NewMockPlaybookStore(ctrl)
+		mockPropertyService := mock_app.NewMockPropertyService(ctrl)
+		mockConditionService := mock_app.NewMockConditionService(ctrl)
+		mockPoster := mock_bot.NewMockPoster(ctrl)
+		mockAuditor := mock_app.NewMockAuditor(ctrl)
+
+		mockAuditor.EXPECT().
+			MakeAuditRecord(gomock.Any(), gomock.Any()).
+			Return(&model.AuditRecord{}).
+			AnyTimes()
+
+		mockAuditor.EXPECT().
+			LogAuditRec(gomock.Any()).
+			AnyTimes()
+
+		service := app.NewPlaybookService(
+			mockStore,
+			mockPoster,
+			nil,
+			mockAuditor,
+			nil,
+			mockPropertyService,
+			mockConditionService,
 		)
+
+		mockStore.EXPECT().
+			Create(gomock.Any()).
+			Return(newPlaybookID, nil)
+
+		mockPoster.EXPECT().
+			PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), gomock.Any())
+
+		mockPropertyService.EXPECT().
+			CreatePropertyField(newPlaybookID, gomock.Any()).
+			Return(nil, errors.New("property creation failed"))
+
+		resultID, err := service.Import(app.PlaybookImportData{
+			Playbook:   basePlaybook,
+			Properties: []app.ExportPropertyField{baseExportProperty},
+			Conditions: []app.ExportCondition{{
+				ID:      "cond-1",
+				Version: 1,
+				ConditionExpr: &app.ConditionExprV1{
+					Is: &app.ComparisonCondition{
+						FieldID: "old-prop-1",
+						Value:   json.RawMessage(`["opt-1"]`),
+					},
+				},
+			}},
+		}, userID)
 
 		require.NoError(t, err)
 		assert.Equal(t, newPlaybookID, resultID)

--- a/webapp/src/components/backstage/playbook_properties/property_values_input.tsx
+++ b/webapp/src/components/backstage/playbook_properties/property_values_input.tsx
@@ -120,12 +120,7 @@ const ClickableMultiValue = (props: {
     }, [props.data.label]);
 
     const onDropdownChange = (open: boolean) => {
-        if (open) {
-            setTimeout(() => {
-                inputRef.current?.focus();
-                inputRef.current?.select();
-            }, 50);
-        } else {
+        if (!open) {
             handleRename();
             setEditValue(props.data.label);
         }
@@ -191,6 +186,7 @@ const ClickableMultiValue = (props: {
                         ref={inputRef}
                         value={editValue}
                         onChange={(e) => setEditValue(e.target.value)}
+                        onFocus={(e) => e.target.select()}
                         onKeyDown={handleKeyDown}
                         onBlur={handleBlur}
                         maxLength={255}


### PR DESCRIPTION
## Summary

Extends playbook export/import to include **property field definitions** (attributes) and **conditions** (conditional tasks). Previously, exporting a playbook to JSON and reimporting it would lose these definitions.

- On **export**: properties and conditions are fetched separately and serialized as additive `"properties"` and `"conditions"` JSON keys. The export version is intentionally kept at 1 — Go's `json.Decoder` silently ignores unknown keys, so old servers importing new exports gracefully degrade (playbook imports without attributes/conditionals) rather than hard-rejecting with "Unsupported version".
- On **import**: property fields are recreated with new IDs, an `old_id → new_id` mapping is built (same pattern as `CopyPlaybookPropertiesToRun`), condition expressions are remapped via `SwapPropertyIDs`, conditions are created via the new `CreateConditionsFromExport` method on `ConditionService`, and checklist item `condition_id` references are updated on the playbook.

### Key changes

| File | Changes |
|------|---------|
| `server/app/export.go` | New `ExportPropertyField`/`ExportCondition` types, custom `UnmarshalJSON` for versioned condition deserialization, `generatePropertiesExport`/`generateConditionsExport` helpers, extended `GeneratePlaybookExport` signature |
| `server/app/playbook.go` | Changed `ConditionID`/`ConditionAction` export tags from `"-"` to key names; added `ImportWithProperties` and `GetPlaybookConditionsForExport` to `PlaybookService` interface |
| `server/app/playbook_service.go` | `ImportWithProperties` implementation with full audit trail, `GetPlaybookConditionsForExport` delegation |
| `server/app/condition.go` | Added `CreateConditionsFromExport` and `GetPlaybookConditionsForExport` to `ConditionService` interface |
| `server/app/condition_service.go` | Implementation of the two new methods (parallels `CopyPlaybookConditionsToPlaybook` pattern) |
| `server/api/playbooks.go` | Export handler fetches properties/conditions; import handler decodes and passes them through |
| `server/app/export_test.go` | Unit tests for export with properties, condition round-trip, unsupported version, null expression |
| `server/app/playbook_service_test.go` | Unit tests for `ImportWithProperties` ID remapping, early return, and error handling |
| `server/api_playbooks_test.go` | Integration tests for export→import with properties and conditions, verifying remapped IDs |

## Ticket Link

https://mattermost.atlassian.net/browse/MM-68190

## Checklist
- [x] ~~Gated by experimental feature flag~~ (additive change — purely new JSON keys, no feature flag needed)
- [x] Unit tests updated