### PR TITLE
fix(cypress): match password reqs for fips build

### DIFF
--- a/e2e-tests/tests/fixtures/ldap-add-user.ldif
+++ b/e2e-tests/tests/fixtures/ldap-add-user.ldif
@@ -5,4 +5,4 @@ sn: FourLDAP
 cn: TestLDAP
 uid: e2etest.four
 mail: e2etest.four@mmtest.com
-userPassword: Password1
+userPassword: Passwd4Testing!

--- a/e2e-tests/tests/fixtures/ldap-reset-data.ldif
+++ b/e2e-tests/tests/fixtures/ldap-reset-data.ldif
@@ -22,7 +22,7 @@ sn: OneLDAP
 cn: TestLDAP
 uid: e2etest.one
 mail: e2etest.one@mmtest.com
-userPassword: Password1
+userPassword: Passwd4Testing!
 
 dn: uid=e2etest.two,ou=e2etest,dc=mm,dc=test,dc=com
 changetype: add
@@ -31,7 +31,7 @@ sn: TwoLDAP
 cn: TestLDAP
 uid: e2etest.two
 mail: e2etest.two@mmtest.com
-userPassword: Password1
+userPassword: Passwd4Testing!
 
 dn: uid=e2etest.three,ou=e2etest,dc=mm,dc=test,dc=com
 changetype: add
@@ -40,4 +40,4 @@ sn: ThreeLDAP
 cn: TestLDAP
 uid: e2etest.three.ldap
 mail: e2etest.three@mmtest.com
-userPassword: Password1
+userPassword: Passwd4Testing!

--- a/e2e-tests/tests/fixtures/ldap_users.json
+++ b/e2e-tests/tests/fixtures/ldap_users.json
@@ -1,43 +1,43 @@
 {
     "dev-1": {
         "username": "dev.one",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+devone@simulator.amazonses.com",
         "userType": "Admin"
     },
     "dev-2": {
         "username": "dev.two",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+devtwo@simulator.amazonses.com",
         "userType": "Admin"
     },
     "test-1": {
         "username": "test.one",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+testone@simulator.amazonses.com",
         "userType": ""
     },
     "test-2": {
         "username": "test.two",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+testtwo@simulator.amazonses.com",
         "userType": ""
     },
     "test-3": {
         "username": "test.three",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+testthree@simulator.amazonses.com",
         "userType": ""
     },
     "board-1": {
         "username": "board.one",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+boardone@simulator.amazonses.com",
         "userType": ""
     },
     "board-2": {
         "username": "board.two",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "success+boardtwo@simulator.amazonses.com",
         "userType": ""
     }

--- a/e2e-tests/tests/fixtures/saml_ldap_users.json
+++ b/e2e-tests/tests/fixtures/saml_ldap_users.json
@@ -1,7 +1,7 @@
 {
     "user1": {
         "username": "e2etest.one",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "e2etest.one@mmtest.com",
         "firstname": "TestSaml",
         "lastname": "OneSaml",
@@ -11,7 +11,7 @@
     },
     "user2": {
         "username": "e2etest.two",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "e2etest.two@mmtest.com",
         "firstname": "TestSaml",
         "lastname": "TwoSaml",
@@ -21,7 +21,7 @@
     },
     "user3": {
         "username": "e2etest.three.saml",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "e2etest.three@mmtest.com",
         "firstname": "FirstSaml",
         "lastname": "ThreeSaml",
@@ -31,7 +31,7 @@
     },
     "user4": {
         "username": "e2etest.four",
-        "password": "Password1",
+        "password": "Passwd4Testing!",
         "email": "e2etest.four@mmtest.com",
         "firstname": "TestSaml",
         "lastname": "FourSaml",

--- a/e2e-tests/tests/fixtures/saml_users.json
+++ b/e2e-tests/tests/fixtures/saml_users.json
@@ -2,7 +2,7 @@
     "regulars": {
         "samluser-1": {
             "username": "samluser-1",
-            "password": "Password1",
+            "password": "Passwd4Testing!",
             "email": "samluser-1@test.com",
             "firstname": "saml1",
             "lastname": "user",
@@ -10,7 +10,7 @@
         },
         "samluser-2": {
             "username": "samluser-2",
-            "password": "Password1",
+            "password": "Passwd4Testing!",
             "email": "samluser-2@test.com",
             "firstname": "saml2",
             "lastname": "user",
@@ -20,7 +20,7 @@
     "admins": {
         "samladmin-1": {
             "username": "samladmin-1",
-            "password": "Password1",
+            "password": "Passwd4Testing!",
             "email": "samladmin-1@test.com",
             "firstname": "saml1",
             "lastname": "admin",
@@ -28,7 +28,7 @@
         },
         "samladmin-2": {
             "username": "samladmin-2",
-            "password": "Password1",
+            "password": "Passwd4Testing!",
             "email": "samladmin-2@test.com",
             "firstname": "saml2",
             "lastname": "admin",
@@ -39,7 +39,7 @@
     "guests": {
         "samlguest-1": {
             "username": "samlguest-1",
-            "password": "Password1",
+            "password": "Passwd4Testing!",
             "email": "samlguest-1@test.com",
             "firstname": "saml1",
             "lastname": "guest",
@@ -47,7 +47,7 @@
         },
         "samlguest-2": {
             "username": "samlguest-2",
-            "password": "Password1",
+            "password": "Passwd4Testing!",
             "email": "samlguest-2@test.com",
             "firstname": "saml2",
             "lastname": "guest",

--- a/e2e-tests/tests/support/api/cloud_default_config.json
+++ b/e2e-tests/tests/support/api/cloud_default_config.json
@@ -54,7 +54,7 @@
         "ExperimentalDefaultChannels": []
     },
     "PasswordSettings": {
-        "MinimumLength": 5,
+        "MinimumLength": 14,
         "Lowercase": false,
         "Number": false,
         "Uppercase": false,

--- a/e2e-tests/tests/support/api/on_prem_default_config.json
+++ b/e2e-tests/tests/support/api/on_prem_default_config.json
@@ -148,7 +148,7 @@
         "FileLocation": ""
     },
     "PasswordSettings": {
-        "MinimumLength": 5,
+        "MinimumLength": 14,
         "Lowercase": false,
         "Number": false,
         "Uppercase": false,

--- a/e2e-tests/tests/support/api/user.js
+++ b/e2e-tests/tests/support/api/user.js
@@ -222,7 +222,7 @@ function generateRandomUser(prefix = 'user', createAt = 0) {
     return {
         email: `${prefix}${randomId}@sample.mattermost.com`,
         username: `${prefix}${randomId}`,
-        password: 'passwd',
+        password: 'Passwd4Testing!',
         first_name: `First${randomId}`,
         last_name: `Last${randomId}`,
         nickname: `Nickname${randomId}`,

--- a/e2e-tests/tests/support/ldap_server_commands.js
+++ b/e2e-tests/tests/support/ldap_server_commands.js
@@ -74,7 +74,7 @@ export function generateLDAPUser(prefix = 'ldap') {
 
     return {
         username,
-        password: 'Password1',
+        password: 'Passwd4Testing!',
         email: `${username}@mmtest.com`,
         firstname: `Firstname-${randomId}`,
         lastname: `Lastname-${randomId}`,
@@ -107,6 +107,6 @@ cn: ${user.firstname}
 sn: ${user.lastname}
 uid: ${user.username}
 mail: ${user.email}
-userPassword: Password1
+userPassword: Passwd4Testing!
 `;
 }


### PR DESCRIPTION
#### Summary
Cypress E2E tests fail against test servers that enforce a minimum password length of 14 characters (FIPS builds). This PR updates all hardcoded test passwords and server default configs to meet that requirement.

- Set `PasswordSettings.MinimumLength` to `14` in both on-prem and cloud default configs
- Replace `passwd` (6 chars) with `Passwd4Testing!` (15 chars) in the default test user generator (`generateRandomUser`)
- Replace `Password1` (9 chars) with `Passwd4Testing!` (15 chars) across all LDAP, SAML, and SAML+LDAP fixture files and the LDAP user generator

#### Ticket Link
none
