### PR TITLE
[MM-68372] Scope metric updates to playbook; strip import metric IDs

### DIFF
--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -92,6 +92,11 @@ func (s *playbookService) Import(data PlaybookImportData, userID string) (string
 	model.AddEventParameterToAuditRec(auditRec, "numConditions", len(data.Conditions))
 	model.AddEventParameterAuditableToAuditRec(auditRec, "playbook", playbook)
 
+	// Strip metric IDs on import (export omits them); prevents treating foreign IDs as in-playbook updates.
+	for i := range playbook.Metrics {
+		playbook.Metrics[i].ID = ""
+	}
+
 	condRefs := saveAndClearConditionRefs(&playbook)
 
 	newPlaybookID, err := s.Create(playbook, userID)

--- a/server/app/playbook_service_test.go
+++ b/server/app/playbook_service_test.go
@@ -17,6 +17,7 @@ import (
 	mock_app "github.com/mattermost/mattermost-plugin-playbooks/server/app/mocks"
 	mock_bot "github.com/mattermost/mattermost-plugin-playbooks/server/bot/mocks"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/metrics"
+	"gopkg.in/guregu/null.v4"
 )
 
 func TestPlaybookService_CreatePropertyField(t *testing.T) {
@@ -807,6 +808,54 @@ func TestPlaybookService_Import(t *testing.T) {
 			}},
 		}, userID)
 
+		require.NoError(t, err)
+		assert.Equal(t, newPlaybookID, resultID)
+	})
+
+	t.Run("strips metric IDs before create", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStore := mock_app.NewMockPlaybookStore(ctrl)
+		mockPropertyService := mock_app.NewMockPropertyService(ctrl)
+		mockConditionService := mock_app.NewMockConditionService(ctrl)
+		mockPoster := mock_bot.NewMockPoster(ctrl)
+		mockAuditor := mock_app.NewMockAuditor(ctrl)
+
+		mockAuditor.EXPECT().
+			MakeAuditRecord(gomock.Any(), gomock.Any()).
+			Return(&model.AuditRecord{}).
+			AnyTimes()
+
+		mockAuditor.EXPECT().
+			LogAuditRec(gomock.Any()).
+			AnyTimes()
+
+		service := app.NewPlaybookService(
+			mockStore,
+			mockPoster,
+			nil,
+			mockAuditor,
+			nil,
+			mockPropertyService,
+			mockConditionService,
+		)
+
+		foreignID := "metric_id_from_another_playbook"
+		pb := basePlaybook
+		pb.Metrics = []app.PlaybookMetricConfig{
+			{ID: foreignID, Title: "m1", Type: app.MetricTypeInteger, Description: "d", Target: null.IntFrom(1)},
+		}
+
+		mockStore.EXPECT().
+			Create(gomock.Any()).
+			DoAndReturn(func(created app.Playbook) (string, error) {
+				require.Empty(t, created.Metrics[0].ID, "import must strip metric IDs so Create only inserts new metrics")
+				return newPlaybookID, nil
+			})
+		mockPoster.EXPECT().PublishWebsocketEventToTeam(gomock.Any(), gomock.Any(), basePlaybook.TeamID)
+
+		resultID, err := service.Import(app.PlaybookImportData{Playbook: pb}, userID)
 		require.NoError(t, err)
 		assert.Equal(t, newPlaybookID, resultID)
 	})

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -895,7 +895,7 @@ func (p *playbookStore) replacePlaybookMetrics(q queryExecer, playbook app.Playb
 					"Ordering":    i,
 					"DeleteAt":    0,
 				}).
-				Where(sq.Eq{"ID": m.ID}),
+				Where(sq.Eq{"ID": m.ID, "PlaybookID": playbook.ID}),
 			)
 		}
 		if err != nil {

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -1215,6 +1215,61 @@ func TestUpdatePlaybook(t *testing.T) {
 	}
 }
 
+func TestUpdatePlaybook_DoesNotModifyOtherPlaybookMetrics(t *testing.T) {
+	db := setupTestDB(t)
+	playbookStore := setupPlaybookStore(t, db)
+	teamID := model.NewId()
+
+	victim := NewPBBuilder().
+		WithTitle("victim pb").
+		WithTeamID(teamID).
+		WithChecklists([]int{1}).
+		WithMetrics([]string{"victim-metric"}).
+		ToPlaybook()
+
+	attacker := NewPBBuilder().
+		WithTitle("attacker pb").
+		WithTeamID(teamID).
+		WithChecklists([]int{1}).
+		WithMetrics([]string{"attacker-metric"}).
+		ToPlaybook()
+
+	victimID, err := playbookStore.Create(victim)
+	require.NoError(t, err)
+	attackerID, err := playbookStore.Create(attacker)
+	require.NoError(t, err)
+
+	victimPB, err := playbookStore.Get(victimID)
+	require.NoError(t, err)
+	require.Len(t, victimPB.Metrics, 1)
+	originalVictimTitle := victimPB.Metrics[0].Title
+
+	attackerPB, err := playbookStore.Get(attackerID)
+	require.NoError(t, err)
+	require.Len(t, attackerPB.Metrics, 1)
+	victimMetricID := victimPB.Metrics[0].ID
+
+	// Simulates an import/update payload that supplies another playbook's metric ID (MM-68372).
+	attackerPB.Metrics = []app.PlaybookMetricConfig{
+		{
+			ID:          victimMetricID,
+			Title:       "MODIFIED_BY_ATTACKER",
+			Description: attackerPB.Metrics[0].Description,
+			Type:        attackerPB.Metrics[0].Type,
+			Target:      attackerPB.Metrics[0].Target,
+		},
+	}
+
+	err = playbookStore.Update(attackerPB)
+	require.NoError(t, err)
+
+	victimAfter, err := playbookStore.Get(victimID)
+	require.NoError(t, err)
+	require.Len(t, victimAfter.Metrics, 1)
+	require.Equal(t, originalVictimTitle, victimAfter.Metrics[0].Title,
+		"victim metric must not change when a different playbook update references its metric ID")
+}
+
 func TestDeletePlaybook(t *testing.T) {
 	team1id := model.NewId()
 


### PR DESCRIPTION
## Summary

This change ensures playbook metric configuration updates only apply to rows for the same playbook, and that imported playbooks do not carry forward metric database IDs (consistent with export).

- **Store:** When updating an existing `IR_MetricConfig` row by ID, the query also requires the row's `PlaybookID` to match the playbook being saved.
- **Service:** `Import` clears `Metrics[].ID` before `Create` so new playbooks always get new metric rows.
- **Tests:** Store and app unit tests for the above. Regression test for the store path was confirmed to fail when the extra `PlaybookID` condition is removed.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-68372

## Checklist
- [ ] Gated by experimental feature flag
- [x] Unit tests updated
