### PR TITLE
Exclude conditionally hidden tasks from finish-run outstanding count

### DIFF
--- a/e2e-tests/tests/integration/playbooks/runs/rdp_main_finish_spec.js
+++ b/e2e-tests/tests/integration/playbooks/runs/rdp_main_finish_spec.js
@@ -231,4 +231,15 @@ describe('runs > run details page > finish with conditional hidden tasks', {test
         cy.get('#confirmModal').should('not.contain.text', 'outstanding task');
         cy.get('#confirmModal').should('contain.text', 'Are you sure');
     });
+
+    it('still warns about outstanding tasks when a visible task is not complete', () => {
+        cy.findByText('Conditional hidden 1').should('not.exist');
+
+        cy.findByText('Always visible task').should('be.visible');
+
+        cy.findByTestId('run-finish-section').find('button').click();
+
+        cy.get('#confirmModal').should('be.visible');
+        cy.get('#confirmModal').should('contain.text', 'outstanding task');
+    });
 });

--- a/e2e-tests/tests/integration/playbooks/runs/rdp_main_finish_spec.js
+++ b/e2e-tests/tests/integration/playbooks/runs/rdp_main_finish_spec.js
@@ -132,3 +132,103 @@ describe('runs > run details page > finish', {testIsolation: true}, () => {
         });
     });
 });
+
+describe('runs > run details page > finish with conditional hidden tasks', {testIsolation: true}, () => {
+    let testTeam;
+    let testUser;
+    let testPlaybook;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+        });
+    });
+
+    beforeEach(() => {
+        cy.viewport('macbook-13');
+        cy.apiLogin(testUser);
+
+        cy.apiCreateTestPlaybook({
+            teamId: testTeam.id,
+            title: 'Finish hidden conditional tasks ' + Date.now(),
+            userId: testUser.id,
+            checklists: [{
+                title: 'Stage 1',
+                items: [
+                    {title: 'Always visible task'},
+                    {title: 'Conditional hidden 1'},
+                    {title: 'Conditional hidden 2'},
+                    {title: 'Conditional hidden 3'},
+                    {title: 'Conditional hidden 4'},
+                    {title: 'Conditional hidden 5'},
+                ],
+            }],
+        }).then((playbook) => {
+            testPlaybook = playbook;
+        });
+
+        cy.then(() => {
+            cy.apiAddPropertyField(testPlaybook.id, {
+                name: 'Priority',
+                type: 'select',
+                attrs: {
+                    visibility: 'always',
+                    sortOrder: 1,
+                    options: [
+                        {name: 'High'},
+                        {name: 'Low'},
+                    ],
+                },
+            });
+        });
+
+        cy.then(() => {
+            cy.apiGetPropertyFields(testPlaybook.id).then((fields) => {
+                const priorityField = fields.find((f) => f.name === 'Priority');
+                const highOptionId = priorityField.attrs.options.find((o) => o.name === 'High').id;
+
+                cy.apiCreatePlaybookCondition(testPlaybook.id, {
+                    is: {
+                        field_id: priorityField.id,
+                        value: [highOptionId],
+                    },
+                }).then((condition) => {
+                    cy.apiGetPlaybook(testPlaybook.id).then((playbook) => {
+                        for (let i = 1; i <= 5; i++) {
+                            playbook.checklists[0].items[i].condition_id = condition.id;
+                        }
+                        return cy.apiUpdatePlaybook(playbook);
+                    });
+                });
+            });
+        });
+
+        cy.then(() => {
+            cy.apiRunPlaybook({
+                teamId: testTeam.id,
+                playbookId: testPlaybook.id,
+                playbookRunName: 'conditional hidden run ' + Date.now(),
+                ownerUserId: testUser.id,
+            }).then((run) => {
+                cy.visit(`/playbooks/runs/${run.id}`);
+            });
+        });
+    });
+
+    it('does not count conditionally hidden tasks as outstanding when finishing', () => {
+        cy.findByText('Conditional hidden 1').should('not.exist');
+
+        cy.findByText('Always visible task').closest('[data-testid="checkbox-item-container"]').within(() => {
+            cy.get('input[type="checkbox"]').check();
+        });
+
+        cy.wait(500);
+
+        cy.findByTestId('run-finish-section').find('button').click();
+
+        cy.get('#confirmModal').should('be.visible');
+        cy.get('#confirmModal').should('not.contain.text', 'outstanding task');
+        cy.get('#confirmModal').should('contain.text', 'Are you sure');
+    });
+});

--- a/e2e-tests/tests/integration/playbooks/runs/rdp_main_finish_spec.js
+++ b/e2e-tests/tests/integration/playbooks/runs/rdp_main_finish_spec.js
@@ -139,6 +139,7 @@ describe('runs > run details page > finish with conditional hidden tasks', {test
     let testPlaybook;
 
     before(() => {
+        cy.apiAdminLogin();
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
             testUser = user;
@@ -219,11 +220,13 @@ describe('runs > run details page > finish with conditional hidden tasks', {test
     it('does not count conditionally hidden tasks as outstanding when finishing', () => {
         cy.findByText('Conditional hidden 1').should('not.exist');
 
+        cy.intercept('PUT', '/plugins/playbooks/api/v0/runs/*/checklists/*/item/*/state').as('setItemState');
+
         cy.findByText('Always visible task').closest('[data-testid="checkbox-item-container"]').within(() => {
             cy.get('input[type="checkbox"]').check();
         });
 
-        cy.wait(500);
+        cy.wait('@setItemState').its('response.statusCode').should('eq', 200);
 
         cy.findByTestId('run-finish-section').find('button').click();
 

--- a/server/app/finish_outstanding_checklist_items.go
+++ b/server/app/finish_outstanding_checklist_items.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+// CountOutstandingChecklistItemsForFinishRun returns how many checklist items are still
+// incomplete for finish-run confirmation. Items hidden by run conditions (condition_action
+// hidden) are excluded so the count matches visible checklist UX.
+func CountOutstandingChecklistItemsForFinishRun(checklists []Checklist) int {
+	n := 0
+	for _, c := range checklists {
+		for _, item := range c.Items {
+			if item.ConditionAction == ConditionActionHidden {
+				continue
+			}
+			if item.State == ChecklistItemStateOpen || item.State == ChecklistItemStateInProgress {
+				n++
+			}
+		}
+	}
+	return n
+}

--- a/server/app/finish_outstanding_checklist_items_test.go
+++ b/server/app/finish_outstanding_checklist_items_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import "testing"
+
+func TestCountOutstandingChecklistItemsForFinishRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		if got := CountOutstandingChecklistItemsForFinishRun(nil); got != 0 {
+			t.Fatalf("nil checklists: got %d want 0", got)
+		}
+		if got := CountOutstandingChecklistItemsForFinishRun([]Checklist{}); got != 0 {
+			t.Fatalf("empty slice: got %d want 0", got)
+		}
+	})
+
+	t.Run("open visible counts", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{{State: ChecklistItemStateOpen}},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 1 {
+			t.Fatalf("got %d want 1", got)
+		}
+	})
+
+	t.Run("in progress visible counts", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{{State: ChecklistItemStateInProgress}},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 1 {
+			t.Fatalf("got %d want 1", got)
+		}
+	})
+
+	t.Run("open hidden does not count", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{{
+				State:           ChecklistItemStateOpen,
+				ConditionAction: ConditionActionHidden,
+			}},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 0 {
+			t.Fatalf("got %d want 0", got)
+		}
+	})
+
+	t.Run("in progress hidden does not count", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{{
+				State:           ChecklistItemStateInProgress,
+				ConditionAction: ConditionActionHidden,
+			}},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 0 {
+			t.Fatalf("got %d want 0", got)
+		}
+	})
+
+	t.Run("many hidden open plus one open visible", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{
+				{State: ChecklistItemStateOpen},
+				{State: ChecklistItemStateOpen, ConditionAction: ConditionActionHidden},
+				{State: ChecklistItemStateOpen, ConditionAction: ConditionActionHidden},
+				{State: ChecklistItemStateOpen, ConditionAction: ConditionActionHidden},
+				{State: ChecklistItemStateOpen, ConditionAction: ConditionActionHidden},
+				{State: ChecklistItemStateOpen, ConditionAction: ConditionActionHidden},
+			},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 1 {
+			t.Fatalf("got %d want 1", got)
+		}
+	})
+
+	t.Run("closed and skipped visible do not count", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{
+				{State: ChecklistItemStateClosed},
+				{State: ChecklistItemStateSkipped},
+			},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 0 {
+			t.Fatalf("got %d want 0", got)
+		}
+	})
+
+	t.Run("shown because modified still open counts", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{{
+			Items: []ChecklistItem{{
+				State:           ChecklistItemStateOpen,
+				ConditionAction: ConditionActionShownBecauseModified,
+			}},
+		}}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 1 {
+			t.Fatalf("got %d want 1", got)
+		}
+	})
+
+	t.Run("aggregates multiple checklists", func(t *testing.T) {
+		t.Parallel()
+		checklists := []Checklist{
+			{Items: []ChecklistItem{{State: ChecklistItemStateOpen}}},
+			{Items: []ChecklistItem{{State: ChecklistItemStateInProgress}}},
+		}
+		if got := CountOutstandingChecklistItemsForFinishRun(checklists); got != 2 {
+			t.Fatalf("got %d want 2", got)
+		}
+	})
+}

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1159,6 +1159,9 @@ func (s *PlaybookRunServiceImpl) OpenFinishPlaybookRunDialog(playbookRunID, user
 	numOutstanding := 0
 	for _, c := range currentPlaybookRun.Checklists {
 		for _, item := range c.Items {
+			if item.ConditionAction == ConditionActionHidden {
+				continue
+			}
 			if item.State == ChecklistItemStateOpen || item.State == ChecklistItemStateInProgress {
 				numOutstanding++
 			}

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -1156,17 +1156,7 @@ func (s *PlaybookRunServiceImpl) OpenFinishPlaybookRunDialog(playbookRunID, user
 		return errors.Wrapf(err, "failed to to resolve user %s", userID)
 	}
 
-	numOutstanding := 0
-	for _, c := range currentPlaybookRun.Checklists {
-		for _, item := range c.Items {
-			if item.ConditionAction == ConditionActionHidden {
-				continue
-			}
-			if item.State == ChecklistItemStateOpen || item.State == ChecklistItemStateInProgress {
-				numOutstanding++
-			}
-		}
-	}
+	numOutstanding := CountOutstandingChecklistItemsForFinishRun(currentPlaybookRun.Checklists)
 
 	dialogRequest := model.OpenDialogRequest{
 		URL: fmt.Sprintf("/plugins/%s/api/v0/runs/%s/finish-dialog",

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/finish_run.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/finish_run.tsx
@@ -21,6 +21,7 @@ import {ChecklistItemState} from 'src/types/playbook';
 interface ChecklistsSubset {
     items: {
         state: string
+        condition_action?: string
     }[]
 }
 
@@ -28,6 +29,9 @@ const outstandingTasks = (checklists: ChecklistsSubset[]) => {
     let count = 0;
     for (const list of checklists) {
         for (const item of list.items) {
+            if (item.condition_action === 'hidden') {
+                continue;
+            }
             if (item.state === ChecklistItemState.Open || item.state === ChecklistItemState.InProgress) {
                 count++;
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When finishing a playbook run, the confirmation dialog counted every checklist item that was still open or in progress, including tasks hidden by run conditions (`condition_action: hidden`). The run details UI and RHS already omit those tasks from visible progress, so users saw all visible work complete but still got a warning about outstanding tasks.

This change aligns the outstanding-task count with that behavior in:

- The webapp finish confirmation (`finish_run.tsx`, also used by the status-update modal).
- The server-side finish dialog opened by the `/playbook finish` slash command (`OpenFinishPlaybookRunDialog`).

E2E coverage:

- With only visible work complete (one checked task; five hidden conditional tasks still open), the modal must **not** mention outstanding tasks.
- With the same run but the visible task **left open**, the modal **must** mention outstanding tasks so the copy cannot be removed without breaking tests.

## QA

### Setup

A playbook with a Priority (Low/High) property attribute and a checklist with :

- [ ] Always visible task
- [ ] Conditional task A — shown only when Priority = High
- [ ] Conditional task B — shown only when Priority = High

### Tests

1. Start a run, leave Priority unset → only **Always visible task shows**. Check it off → click Finish.
  - Before the fix: modal warned about 2 outstanding tasks (the hidden ones) 
  - After the fix: modal should not mention outstanding tasks 
2. Start a run, leave Priority unset → only **Always visible task shows**. Leave it unchecked → click Finish.
  - Before the fix: modal warned about 3 outstanding tasks (1 visible + 2 hidden) 
  - After the fix: modal should warn about 1 outstanding task 
3. Start a run, leave Priority unset → check off **Always visible task**. Then set Priority = High so **Conditional task A and B** appear unchecked → click Finish.
  - Before and after the fix: modal warns about 2 outstanding tasks (sanity check — once tasks are visible they should still count)

And just a sanity check: runs without any conditions should still warn about unchecked items like before.

## Ticket Link

[MM-68795](https://mattermost.atlassian.net/browse/MM-68795)

## Checklist

- [ ] Gated by experimental feature flag
- [x] Unit tests updated (E2E added; no new unit tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34f0fcd7-91b9-4353-8483-95558e1cdbfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34f0fcd7-91b9-4353-8483-95558e1cdbfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





[MM-68795]: https://mattermost.atlassian.net/browse/MM-68795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ