### PR TITLE
CI: LPT-balance e2e shards from cached per-spec durations

### DIFF
--- a/.github/actions/aggregate-durations/aggregate.go
+++ b/.github/actions/aggregate-durations/aggregate.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// aggregate.go merges per-spec durations recorded by Cypress's after:spec
+// hook (results/durations.jsonl) across all e2e shards into a single
+// durations.json keyed by spec path with values in seconds.
+//
+// Inputs:
+//   -artifacts: directory containing downloaded shard artifacts; the tool
+//               recursively finds any "durations.jsonl" within.
+//   -prior:     optional existing durations.json to merge with; values from
+//               the current run overwrite, but specs not seen in this run
+//               keep their prior value so a single skipped/quarantined spec
+//               doesn't lose its baseline.
+//   -out:       output path (default durations.json).
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type record struct {
+	Spec       string  `json:"spec"`
+	DurationMs float64 `json:"durationMs"`
+}
+
+func main() {
+	artifacts := flag.String("artifacts", "", "directory containing downloaded shard artifacts")
+	prior := flag.String("prior", "", "optional path to prior durations.json")
+	out := flag.String("out", "durations.json", "output path for merged durations.json")
+	flag.Parse()
+
+	merged := map[string]float64{}
+
+	if *prior != "" {
+		if b, err := os.ReadFile(*prior); err == nil && len(b) > 0 {
+			if err := json.Unmarshal(b, &merged); err != nil {
+				fmt.Fprintf(os.Stderr, "aggregate: ignoring unreadable prior durations: %v\n", err)
+				merged = map[string]float64{}
+			}
+		}
+	}
+
+	thisRun := map[string]float64{}
+	if *artifacts != "" {
+		err := filepath.WalkDir(*artifacts, func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(p, "durations.jsonl") {
+				return nil
+			}
+			f, err := os.Open(p)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "aggregate: skipping %s: %v\n", p, err)
+				return nil
+			}
+			defer f.Close()
+
+			sc := bufio.NewScanner(f)
+			sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+			for sc.Scan() {
+				line := strings.TrimSpace(sc.Text())
+				if line == "" {
+					continue
+				}
+				var r record
+				if err := json.Unmarshal([]byte(line), &r); err != nil {
+					continue
+				}
+				if r.Spec == "" || r.DurationMs <= 0 {
+					continue
+				}
+				// Last-write wins per spec within a run (retries reuse the
+				// final value emitted by Cypress's after:spec).
+				thisRun[r.Spec] = r.DurationMs / 1000.0
+			}
+			return nil
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "aggregate: walk error:", err)
+		}
+	}
+
+	for spec, v := range thisRun {
+		merged[spec] = v
+	}
+
+	if len(merged) == 0 {
+		fmt.Fprintln(os.Stderr, "aggregate: no durations gathered; refusing to write empty durations.json")
+		os.Exit(1)
+	}
+
+	b, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(*out, b, 0o644); err != nil {
+		panic(err)
+	}
+	fmt.Fprintf(os.Stderr, "aggregate: wrote %s (%d specs, %d updated this run)\n", *out, len(merged), len(thisRun))
+}

--- a/.github/actions/e2e-test/action.yaml
+++ b/.github/actions/e2e-test/action.yaml
@@ -107,5 +107,6 @@ runs:
         name: cypress-test-results-${{ matrix.runId }}${{ inputs.ARTIFACT_SUFFIX }}
         path: |
           e2e-tests/results/junit
+          e2e-tests/results/durations.jsonl
           e2e-tests/tests/screenshots
         retention-days: 14 ## No need to keep test results more than 14 days

--- a/.github/actions/generate-specs/action.yaml
+++ b/.github/actions/generate-specs/action.yaml
@@ -19,12 +19,25 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Best-effort restore of per-spec runtimes recorded by prior runs on the
+    # default branch. A miss is fine — split-tests.go falls back to
+    # round-robin assignment when DURATIONS_FILE is missing/empty/invalid.
+    - name: ci/restore-durations
+      id: restore-durations
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: ${{ github.action_path }}/durations.json
+        key: e2e-durations-v1-${{ github.run_id }}
+        restore-keys: |
+          e2e-durations-v1-
+
     - name: ci/generate-specs
       id: generate-specs
       env:
         PARALLELISM: ${{ inputs.parallelism }}
         SEARCH_PATH: ${{ inputs.search_path }}
         DIRECTORY: ${{ inputs.directory }}
+        DURATIONS_FILE: ${{ github.action_path }}/durations.json
       run: |
         go run ${{ github.action_path }}/split-tests.go > output.json
         echo "specs=$(cat output.json)" >> $GITHUB_OUTPUT

--- a/.github/actions/generate-specs/split-tests.go
+++ b/.github/actions/generate-specs/split-tests.go
@@ -10,16 +10,18 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
 
 type Specs struct {
-	searchPath   string
-	directory    string
-	parallelism  int
-	rawFiles     []string
-	groupedFiles []SpecGroup
+	searchPath    string
+	directory     string
+	parallelism   int
+	durationsFile string
+	rawFiles      []string
+	groupedFiles  []SpecGroup
 }
 
 type SpecGroup struct {
@@ -38,23 +40,23 @@ func newSpecGroup(runId string, specs string) *SpecGroup {
 	}
 }
 
-func newSpecs(directory string, searchPath string, parallelism int) *Specs {
+func newSpecs(directory, searchPath string, parallelism int, durationsFile string) *Specs {
 	return &Specs{
-		directory:   directory,
-		searchPath:  searchPath,
-		parallelism: parallelism,
+		directory:     directory,
+		searchPath:    searchPath,
+		parallelism:   parallelism,
+		durationsFile: durationsFile,
 	}
 }
 
 func (s *Specs) findFiles() {
 	fileSystem := os.DirFS(filepath.Join(s.directory, s.searchPath))
 
+	r := regexp.MustCompile(`.*_spec\.(js|ts)$`)
 	err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		// Find all files matching _spec.(js|ts)
-		r := regexp.MustCompile(".*_spec.(js|ts)$")
 		if r.MatchString(path) {
 			s.rawFiles = append(s.rawFiles, filepath.Join(s.searchPath, path))
 		}
@@ -65,10 +67,72 @@ func (s *Specs) findFiles() {
 	}
 }
 
+// loadDurations returns the per-spec runtime map (seconds) from the cached
+// durations file, or nil if the file is missing/empty/invalid. Any of those
+// outcomes cause a fallback to round-robin splitting.
+func (s *Specs) loadDurations() map[string]float64 {
+	if s.durationsFile == "" {
+		return nil
+	}
+	b, err := os.ReadFile(s.durationsFile)
+	if err != nil || len(b) == 0 {
+		fmt.Fprintf(os.Stderr, "split-tests: durations file unavailable (%v); using round-robin\n", err)
+		return nil
+	}
+	d := map[string]float64{}
+	if err := json.Unmarshal(b, &d); err != nil || len(d) == 0 {
+		fmt.Fprintf(os.Stderr, "split-tests: durations file invalid or empty; using round-robin\n")
+		return nil
+	}
+	return d
+}
+
+func median(d map[string]float64) float64 {
+	if len(d) == 0 {
+		return 0
+	}
+	vs := make([]float64, 0, len(d))
+	for _, v := range d {
+		if v > 0 {
+			vs = append(vs, v)
+		}
+	}
+	if len(vs) == 0 {
+		return 0
+	}
+	sort.Float64s(vs)
+	mid := len(vs) / 2
+	if len(vs)%2 == 0 {
+		return (vs[mid-1] + vs[mid]) / 2
+	}
+	return vs[mid]
+}
+
 func (s *Specs) generateSplits() {
-	// Round-robin: spec i goes to shard (i % parallelism). Spreads
-	// alphabetically-clustered heavy specs (e.g. runs/rdp_*) across shards
-	// so no single shard inherits the entire slow cluster.
+	// Guard against zero/negative parallelism: degrade to a single shard.
+	if s.parallelism < 1 {
+		fmt.Fprintf(os.Stderr, "split-tests: parallelism %d invalid; coercing to 1\n", s.parallelism)
+		s.parallelism = 1
+	}
+
+	if len(s.rawFiles) == 0 {
+		for i := 0; i < s.parallelism; i++ {
+			s.groupedFiles = append(s.groupedFiles, *newSpecGroup(fmt.Sprintf("%d", i+1), ""))
+		}
+		return
+	}
+
+	if d := s.loadDurations(); len(d) > 0 {
+		s.lpt(d)
+		return
+	}
+	s.roundRobin()
+}
+
+// roundRobin assigns spec i to shard (i % parallelism). It spreads
+// alphabetically-clustered specs across shards without needing duration data,
+// and is the fallback when no durations cache is available.
+func (s *Specs) roundRobin() {
 	buckets := make([][]string, s.parallelism)
 	for i, f := range s.rawFiles {
 		shard := i % s.parallelism
@@ -82,8 +146,59 @@ func (s *Specs) generateSplits() {
 	}
 }
 
+// lpt packs specs into shards using Longest-Processing-Time-first: sort
+// descending by recorded cost, then repeatedly assign the next spec to the
+// currently-lightest shard. Specs with no recorded duration (new files,
+// renames) get the median cost so they don't pile onto one shard.
+func (s *Specs) lpt(durations map[string]float64) {
+	defaultCost := median(durations)
+	if defaultCost <= 0 {
+		defaultCost = 1
+	}
+
+	type spec struct {
+		path string
+		cost float64
+	}
+	specs := make([]spec, len(s.rawFiles))
+	unknown := 0
+	for i, f := range s.rawFiles {
+		c, ok := durations[f]
+		if !ok || c <= 0 {
+			c = defaultCost
+			unknown++
+		}
+		specs[i] = spec{f, c}
+	}
+
+	sort.SliceStable(specs, func(i, j int) bool { return specs[i].cost > specs[j].cost })
+
+	loads := make([]float64, s.parallelism)
+	buckets := make([][]string, s.parallelism)
+	for _, sp := range specs {
+		min := 0
+		for i := 1; i < s.parallelism; i++ {
+			if loads[i] < loads[min] {
+				min = i
+			}
+		}
+		buckets[min] = append(buckets[min], sp.path)
+		loads[min] += sp.cost
+	}
+
+	fmt.Fprintf(os.Stderr, "split-tests: LPT split (%d known, %d defaulted to median=%.1fs)\n",
+		len(specs)-unknown, unknown, defaultCost)
+	for i, b := range buckets {
+		sort.Strings(b)
+		s.groupedFiles = append(s.groupedFiles, *newSpecGroup(
+			fmt.Sprintf("%d", i+1),
+			strings.Join(b, ","),
+		))
+		fmt.Fprintf(os.Stderr, "split-tests: shard %d -> %.1fs across %d specs\n", i+1, loads[i], len(b))
+	}
+}
+
 func (s *Specs) dumpSplits() {
-	// Dump json format for GitHub actions
 	o := &Output{
 		Include: s.groupedFiles,
 	}
@@ -98,8 +213,9 @@ func main() {
 	searchPath := os.Getenv("SEARCH_PATH")
 	directory := os.Getenv("DIRECTORY")
 	parallelism, _ := strconv.Atoi(os.Getenv("PARALLELISM"))
+	durationsFile := os.Getenv("DURATIONS_FILE")
 
-	specs := newSpecs(directory, searchPath, parallelism)
+	specs := newSpecs(directory, searchPath, parallelism, durationsFile)
 	specs.findFiles()
 	specs.generateSplits()
 	specs.dumpSplits()

--- a/.github/actions/generate-specs/split-tests.go
+++ b/.github/actions/generate-specs/split-tests.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -67,28 +66,19 @@ func (s *Specs) findFiles() {
 }
 
 func (s *Specs) generateSplits() {
-	// Split to chunks based on the parallelism provided
-	chunkSize := int(math.Ceil(float64(len(s.rawFiles)) / float64(s.parallelism)))
-	runNo := 1
-	// We can figure out a more sophisticated way to split the tests
-	// We can use metadata in order to group them manually
-	for i := 0; i <= len(s.rawFiles); i += chunkSize {
-		end := i + chunkSize
-		if end > len(s.rawFiles) {
-			end = len(s.rawFiles)
-		}
-
-		fileGroup := strings.Join(s.rawFiles[i:end], ",")
-
-		specGroup := newSpecGroup(fmt.Sprintf("%d", runNo), fileGroup)
-		s.groupedFiles = append(s.groupedFiles, *specGroup)
-
-		// Break when we reach the end to avoid duplicate groups
-		if end == len(s.rawFiles) {
-			break
-		}
-
-		runNo++
+	// Round-robin: spec i goes to shard (i % parallelism). Spreads
+	// alphabetically-clustered heavy specs (e.g. runs/rdp_*) across shards
+	// so no single shard inherits the entire slow cluster.
+	buckets := make([][]string, s.parallelism)
+	for i, f := range s.rawFiles {
+		shard := i % s.parallelism
+		buckets[shard] = append(buckets[shard], f)
+	}
+	for i, b := range buckets {
+		s.groupedFiles = append(s.groupedFiles, *newSpecGroup(
+			fmt.Sprintf("%d", i+1),
+			strings.Join(b, ","),
+		))
 	}
 }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
         run: echo GO_VERSION=$(grep -E '^go [0-9]+\.[0-9]+' go.mod | cut -d' ' -f2) >> "${GITHUB_OUTPUT}"
 
   lint:
+    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - go
@@ -101,8 +102,7 @@ jobs:
   dist:
     runs-on: ubuntu-22.04
     needs:
-      - go
-      - lint
+      - go # TEMP: dropped `lint` while iterating on e2e LPT sharding
     container:
       image: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     steps:
@@ -128,8 +128,7 @@ jobs:
         run: make dist
 
   dist-fips:
-    # Skip FIPS testing for forks, which won't have docker login credentials.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: false # TEMP: skipping FIPS pipeline while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - go
@@ -164,7 +163,7 @@ jobs:
         run: make dist
 
   upload:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - dist
@@ -192,7 +191,7 @@ jobs:
           aws s3 cp dist/playbooks-*.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/mattermost-plugin-playbooks/mattermost-plugin-playbooks-${{ steps.short-sha.outputs.sha }}.tar.gz
 
   upload-fips:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - dist-fips
@@ -220,6 +219,7 @@ jobs:
           aws s3 cp dist-fips/playbooks-*.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/mattermost-plugin-playbooks/mattermost-plugin-playbooks-fips-${{ steps.short-sha.outputs.sha }}.tar.gz
 
   test:
+    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - lint
@@ -253,8 +253,7 @@ jobs:
         uses: ./.github/actions/test-with-db
 
   test-fips:
-    # Skip FIPS testing for forks, which won't have docker login credentials.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - lint
@@ -309,8 +308,8 @@ jobs:
   e2e-cypress-tests:
     runs-on: ubuntu-22.04
     needs:
+      # TEMP: dropped `lint` while iterating on e2e LPT sharding
       - go
-      - lint
       - generate-specs
       - dist
     name: e2e-cypress-tests-run-${{ matrix.runId }}
@@ -412,7 +411,7 @@ jobs:
           SPECS: ${{ matrix.specs }}
 
   e2e-cypress-tests-fips:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: false # TEMP: skipping FIPS pipeline while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - go
@@ -569,7 +568,7 @@ jobs:
           key: e2e-durations-v1-${{ github.run_id }}
 
   report-test-results:
-    if: always() && github.event.pull_request.head.repo.full_name == github.repository
+    if: false # TEMP: skipping while iterating on e2e LPT sharding
     needs:
       - e2e-cypress-tests
       - e2e-cypress-tests-fips

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -518,11 +518,15 @@ jobs:
           SPECS: ${{ matrix.specs }}
           ARTIFACT_SUFFIX: -fips
 
-  # Refresh the per-spec duration cache after a green default-branch run so
-  # subsequent runs (including PRs) can LPT-pack the shards. Runs only on
-  # push to the default branch; PRs read the cache but never write to it.
+  # Refresh the per-spec duration cache after a green e2e run so subsequent
+  # runs can LPT-pack the shards. Runs on default-branch pushes (populating
+  # the cache all PRs inherit on first run) and on same-repo PR pushes
+  # (populating that PR's branch-scoped cache so reruns benefit). Fork PRs
+  # are excluded — they can't write to the upstream cache anyway.
   update-durations:
-    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: |
+      (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     needs:
       - e2e-cypress-tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,6 @@ jobs:
         run: echo GO_VERSION=$(grep -E '^go [0-9]+\.[0-9]+' go.mod | cut -d' ' -f2) >> "${GITHUB_OUTPUT}"
 
   lint:
-    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - go
@@ -102,7 +101,8 @@ jobs:
   dist:
     runs-on: ubuntu-22.04
     needs:
-      - go # TEMP: dropped `lint` while iterating on e2e LPT sharding
+      - go
+      - lint
     container:
       image: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     steps:
@@ -128,7 +128,8 @@ jobs:
         run: make dist
 
   dist-fips:
-    if: false # TEMP: skipping FIPS pipeline while iterating on e2e LPT sharding
+    # Skip FIPS testing for forks, which won't have docker login credentials.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs:
       - go
@@ -163,7 +164,7 @@ jobs:
         run: make dist
 
   upload:
-    if: false # TEMP: skipping while iterating on e2e LPT sharding
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs:
       - dist
@@ -191,7 +192,7 @@ jobs:
           aws s3 cp dist/playbooks-*.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/mattermost-plugin-playbooks/mattermost-plugin-playbooks-${{ steps.short-sha.outputs.sha }}.tar.gz
 
   upload-fips:
-    if: false # TEMP: skipping while iterating on e2e LPT sharding
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs:
       - dist-fips
@@ -219,7 +220,6 @@ jobs:
           aws s3 cp dist-fips/playbooks-*.tar.gz s3://${{ secrets.AWS_S3_BUCKET }}/mattermost-plugin-playbooks/mattermost-plugin-playbooks-fips-${{ steps.short-sha.outputs.sha }}.tar.gz
 
   test:
-    if: false # TEMP: skipping while iterating on e2e LPT sharding
     runs-on: ubuntu-22.04
     needs:
       - lint
@@ -253,7 +253,8 @@ jobs:
         uses: ./.github/actions/test-with-db
 
   test-fips:
-    if: false # TEMP: skipping while iterating on e2e LPT sharding
+    # Skip FIPS testing for forks, which won't have docker login credentials.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs:
       - lint
@@ -308,8 +309,8 @@ jobs:
   e2e-cypress-tests:
     runs-on: ubuntu-22.04
     needs:
-      # TEMP: dropped `lint` while iterating on e2e LPT sharding
       - go
+      - lint
       - generate-specs
       - dist
     name: e2e-cypress-tests-run-${{ matrix.runId }}
@@ -411,7 +412,7 @@ jobs:
           SPECS: ${{ matrix.specs }}
 
   e2e-cypress-tests-fips:
-    if: false # TEMP: skipping FIPS pipeline while iterating on e2e LPT sharding
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs:
       - go
@@ -517,15 +518,11 @@ jobs:
           SPECS: ${{ matrix.specs }}
           ARTIFACT_SUFFIX: -fips
 
-  # Refresh the per-spec duration cache after a green e2e run so subsequent
-  # runs can LPT-pack the shards. Runs on default-branch pushes (populating
-  # the cache all PRs inherit on first run) and on same-repo PR pushes
-  # (populating that PR's branch-scoped cache so reruns benefit). Fork PRs
-  # are excluded — they can't write to the upstream cache anyway.
+  # Refresh the per-spec duration cache after a green default-branch run so
+  # subsequent runs (including PRs) can LPT-pack the shards. Runs only on
+  # push to the default branch; PRs read the cache but never write to it.
   update-durations:
-    if: |
-      (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     needs:
       - e2e-cypress-tests
     runs-on: ubuntu-22.04
@@ -568,7 +565,7 @@ jobs:
           key: e2e-durations-v1-${{ github.run_id }}
 
   report-test-results:
-    if: false # TEMP: skipping while iterating on e2e LPT sharding
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs:
       - e2e-cypress-tests
       - e2e-cypress-tests-fips

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -518,6 +518,52 @@ jobs:
           SPECS: ${{ matrix.specs }}
           ARTIFACT_SUFFIX: -fips
 
+  # Refresh the per-spec duration cache after a green default-branch run so
+  # subsequent runs (including PRs) can LPT-pack the shards. Runs only on
+  # push to the default branch; PRs read the cache but never write to it.
+  update-durations:
+    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs:
+      - e2e-cypress-tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: ci/setup-go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: ci/download-shard-artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: cypress-test-results-*
+          path: artifacts
+          merge-multiple: false
+
+      - name: ci/restore-prior-durations
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: durations.json
+          key: e2e-durations-v1-${{ github.run_id }}
+          restore-keys: |
+            e2e-durations-v1-
+
+      - name: ci/aggregate-durations
+        run: |
+          go run ./.github/actions/aggregate-durations/aggregate.go \
+            -artifacts=artifacts \
+            -prior=durations.json \
+            -out=durations.json
+
+      - name: ci/save-durations
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: durations.json
+          key: e2e-durations-v1-${{ github.run_id }}
+
   report-test-results:
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/e2e-tests/tests/plugins/index.js
+++ b/e2e-tests/tests/plugins/index.js
@@ -3,6 +3,9 @@
 
 /* eslint-disable no-console */
 
+const fs = require('fs');
+const path = require('path');
+
 const clientRequest = require('./client_request');
 const {
     dbGetActiveUserSessions,
@@ -70,6 +73,23 @@ module.exports = (on, config) => {
         }
 
         return launchOptions;
+    });
+
+    // Record per-spec runtime to results/durations.jsonl. The CI aggregator
+    // merges these across shards on default-branch runs to feed LPT-based
+    // sharding on subsequent runs (see .github/actions/generate-specs/).
+    on('after:spec', (spec, results) => {
+        try {
+            const outDir = path.resolve(__dirname, '..', '..', 'results');
+            fs.mkdirSync(outDir, {recursive: true});
+            const line = JSON.stringify({
+                spec: spec.relative,
+                durationMs: results && results.stats ? results.stats.duration : 0,
+            });
+            fs.appendFileSync(path.join(outDir, 'durations.jsonl'), line + '\n');
+        } catch (e) {
+            console.warn('after:spec duration record failed:', e);
+        }
     });
 
     return config;


### PR DESCRIPTION
## Summary
Replaces the e2e shard splitter's sequential alphabetical chunking with **Longest-Processing-Time-first (LPT)** bin-packing, fed by a per-spec duration cache that the default branch maintains. Falls back to round-robin if the cache is missing/empty/invalid, so cold-start runs and fork PRs still work.

### Why
Baseline across the prior 10 PR runs: shards 1/2/3 averaged 19.7 / 23.4 / 33.6 min (critical path 33.6 min). The slowest shard inherited the entire `runs/rdp_*` cluster because it sorts last alphabetically.

An earlier round-robin-only experiment on this branch confirmed that spreading spec **count** alone isn't enough — whichever shard ends up with the costliest cluster still pins the critical path (measured: 33.4 min, ~12 s improvement). Real balance needs per-spec **cost**.

### How it works
- Cypress's `after:spec` hook (in `e2e-tests/tests/plugins/index.js`) records each spec's duration to `e2e-tests/results/durations.jsonl` per shard.
- Each shard's artifact now includes that file.
- A new `update-durations` job (only on push to the default branch) downloads all shard artifacts, merges them into `durations.json` (prior values are preserved for specs not measured this run), and saves the file to the GHA cache under `e2e-durations-v1-${{ github.run_id }}`.
- `generate-specs` does a best-effort `actions/cache/restore` for `e2e-durations-v1-*` before running the splitter. PRs read the cache from the default branch scope; fork PRs can also read it.
- `split-tests.go` runs LPT: sort specs descending by recorded cost, then repeatedly assign the next spec to the currently-lightest shard. Specs with no recorded duration (new files, renames) get the median cost so they enter the pack realistically.

### Resilience
- **Cold cache / missing / unparseable durations file** → splitter logs the reason and uses round-robin (i.e. spec `i` → shard `i % parallelism`). The earlier round-robin commit on this PR is preserved as the fallback path.
- **New / renamed / unmeasured specs** → median-default cost. One green default-branch run later, the cache has real numbers for them.
- **`parallelism <= 0`** → coerced to 1 with a stderr warning. No div-by-zero.
- **Empty spec list** → emits empty shard groups; no panic.
- **Fork PRs / untrusted writers** → `update-durations` gated on `push` to the default branch, so fork code can't poison durations. Fork PRs still read the cache.
- **Cache key versioning** → `e2e-durations-v1-` prefix. Bump on schema changes; old readers won't pick up incompatible new caches.

### Expected impact
Simulating LPT against the durations gathered from an earlier shard run on this PR:
```
split-tests: LPT split (70 known, 0 defaulted to median=40.6s)
split-tests: shard 1 -> 1315.0s across 23 specs
split-tests: shard 2 -> 1316.6s across 22 specs
split-tests: shard 3 -> 1315.5s across 25 specs
```
All three shards within 1.6 seconds. Real-world wall-clock projection: ~27 min per shard (~22 min cypress + ~5 min postgres/deps/plugin boot), down from 33.6 min. **~6–7 min saved per PR.**

### Rollout
The first push to the default branch after merge populates the cache. The first PR run *after that* is the first to LPT-pack. PR runs before that fall back to round-robin (still spreads heavy clusters by count, just doesn't balance by cost).

### Files
- `.github/actions/generate-specs/split-tests.go` — LPT + median-default + round-robin fallback + div-by-zero guard.
- `.github/actions/aggregate-durations/aggregate.go` (new) — merges per-shard JSONL into `durations.json`, preserves prior values for unmeasured specs.
- `.github/actions/generate-specs/action.yaml` — restore cache, pass `DURATIONS_FILE`.
- `.github/actions/e2e-test/action.yaml` — include `durations.jsonl` in artifact.
- `e2e-tests/tests/plugins/index.js` — `after:spec` recorder.
- `.github/workflows/ci.yaml` — `update-durations` job.

## Ticket Link
N/A — CI infrastructure change.

## Checklist
- ~~Gated by experimental feature flag~~
- ~~Unit tests updated~~ — splitter and aggregator smoke-tested locally and verified end-to-end on this PR: each shard wrote a 24/23/23-entry `durations.jsonl`; aggregator merged into a 70-spec `durations.json`; LPT against that file produced 1315/1317/1316 s shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)