### PR TITLE
ci: align lint-go with mattermost/ image org

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -434,7 +434,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermostdevelopment/mattermost-enterprise-edition:master
+        image: mattermost/mattermost-enterprise-edition:master
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432
@@ -542,7 +542,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermostdevelopment/mattermost-enterprise-fips-edition:master
+        image: mattermost/mattermost-enterprise-fips-edition:master
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -434,7 +434,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermost/mattermost-enterprise-edition:master
+        image: mattermostdevelopment/mattermost-enterprise-edition:master
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432
@@ -542,7 +542,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermost/mattermost-enterprise-fips-edition:master
+        image: mattermostdevelopment/mattermost-enterprise-fips-edition:master
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
     needs:
       - go
     container:
-      image: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+      image: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- The `lint-go` job (added in #2269) still references the old `mattermostdevelopment/mattermost-build-server` image because #2267 (Go toolchain bump + org rename) was branched before the lint-split landed and didn't get rebased before merge. Bring it in line with the rest of the workflow.

I also tried renaming the two enterprise-edition references used by the cypress e2e jobs, but CI confirmed those need to stay on `mattermostdevelopment/` — the `:master` tag is only published to the dev registry; `mattermost/mattermost-enterprise-edition` only carries release tags. Reverted in the second commit.

## Test plan
- [ ] lint-go pulls the renamed image and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)