### PR TITLE
ci: switch enterprise-edition images to mattermost/ org

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -434,7 +434,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermostdevelopment/mattermost-enterprise-edition:master
+        image: mattermost/mattermost-enterprise-edition:master
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432
@@ -542,7 +542,7 @@ jobs:
         ports:
           - 9200:9200
       mattermost-server:
-        image: mattermostdevelopment/mattermost-enterprise-fips-edition:master
+        image: mattermost/mattermost-enterprise-fips-edition:master
         env:
           DB_HOST: postgres
           DB_PORT_NUMBER: 5432


### PR DESCRIPTION
## Summary
- Mirrors the org rename done in #2267 for the two remaining `mattermostdevelopment/` image refs (the cypress e2e `mattermost-server` services for the EE and EE-FIPS jobs).
- Stacked on top of #2272 — merge that first.

## Risk
The cypress e2e jobs pull these images without credentials today. If `mattermost/mattermost-enterprise-edition` / `mattermost/mattermost-enterprise-fips-edition` aren't publicly pullable, CI will fail at the service-start step and we can either add `credentials:` (DOCKERHUB_USERNAME/TOKEN) or revert.

## Test plan
- [ ] cypress-e2e and cypress-e2e-fips jobs pull the renamed images and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)