### PR TITLE
Cherry-pick: MM-67867 Enforce target team permission check on cross-team run creation (#2212) to release-2.4

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -461,7 +461,7 @@ func (h *PlaybookRunHandler) createPlaybookRun(playbookRun app.PlaybookRun, user
 			return nil, errors.New("playbook is archived, cannot create a new run using an archived playbook")
 		}
 
-		if err = h.permissions.RunCreate(userID, *playbook); err != nil {
+		if err = h.permissions.RunCreate(userID, *playbook, playbookRun.TeamID); err != nil {
 			return nil, err
 		}
 

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -2568,3 +2568,85 @@ func TestMemberCannotCreateRunWithoutPlaybookIDToBypassPermissions(t *testing.T)
 		require.NoError(t, err, "Playbook-level permissions should still allow run creation")
 	})
 }
+
+// TestCrossTeamRunCreationPermission verifies that a user cannot bypass team-level
+// run_create permissions by referencing a playbook from a different team.
+// MM-67867
+func TestCrossTeamRunCreationPermission(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	// Remove run_create from the default team_user role so that team-level
+	// permission is absent; only playbook-level membership grants run_create.
+	roles, _, err := e.ServerAdminClient.GetRolesByNames(context.Background(), []string{model.TeamUserRoleId})
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	memberRole := roles[0]
+	originalPermissions := memberRole.Permissions
+
+	updatedPermissions := []string{}
+	for _, perm := range memberRole.Permissions {
+		if perm != model.PermissionRunCreate.Id {
+			updatedPermissions = append(updatedPermissions, perm)
+		}
+	}
+	_, _, err = e.ServerAdminClient.PatchRole(context.Background(), memberRole.Id, &model.RolePatch{
+		Permissions: &updatedPermissions,
+	})
+	require.NoError(t, err)
+	defer func() {
+		_, _, _ = e.ServerAdminClient.PatchRole(context.Background(), memberRole.Id, &model.RolePatch{
+			Permissions: &originalPermissions,
+		})
+	}()
+
+	t.Run("same-team run creation still works via playbook membership", func(t *testing.T) {
+		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+			Name:        "Same-team run",
+			OwnerUserID: e.RegularUser.Id,
+			TeamID:      e.BasicTeam.Id,
+			PlaybookID:  e.BasicPlaybook.ID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, run)
+	})
+
+	t.Run("cross-team run creation is blocked without target team permission", func(t *testing.T) {
+		// BasicPlaybook belongs to BasicTeam. RegularUser has playbook-level
+		// run_create via membership. But BasicTeam2 has no team-level run_create
+		// (removed above) and no playbook-level grant, so this must fail.
+		_, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+			Name:        "Cross-team run",
+			OwnerUserID: e.RegularUser.Id,
+			TeamID:      e.BasicTeam2.Id,
+			PlaybookID:  e.BasicPlaybook.ID,
+		})
+		require.Error(t, err, "should not be able to create a run in a team where user lacks run_create permission")
+	})
+}
+
+// TestCrossTeamRunCreationWithPermission verifies that cross-team run creation
+// succeeds when the user has run_create permission in the target team.
+// By default team_user does not have run_create (it lives on playbook_member),
+// so we grant it before any run creation to avoid role-cache timing issues.
+// MM-67867
+func TestCrossTeamRunCreationWithPermission(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	// Grant run_create at the team level before any run operations so the
+	// server's role cache is primed before the plugin checks permissions.
+	defaultRolePermissions := e.Permissions.SaveDefaultRolePermissions()
+	defer e.Permissions.RestoreDefaultRolePermissions(defaultRolePermissions)
+	e.Permissions.AddPermissionToRole(model.PermissionRunCreate.Id, model.TeamUserRoleId)
+
+	run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+		Name:        "Cross-team run with team-level permission",
+		OwnerUserID: e.RegularUser.Id,
+		TeamID:      e.BasicTeam2.Id,
+		PlaybookID:  e.BasicPlaybook.ID,
+	})
+	require.NoError(t, err, "cross-team run creation should succeed when user has run_create in the target team")
+	require.NotNil(t, run)
+	assert.Equal(t, e.BasicTeam2.Id, run.TeamID)
+}

--- a/server/app/permissions_service.go
+++ b/server/app/permissions_service.go
@@ -398,12 +398,18 @@ func (p *PermissionsService) PlaybookMakePublic(userID string, playbook Playbook
 	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to make playbook `%s` public", userID, playbook.ID)
 }
 
-func (p *PermissionsService) RunCreate(userID string, playbook Playbook) error {
-	if p.hasPermissionsToPlaybook(userID, playbook, model.PermissionRunCreate) {
-		return nil
+func (p *PermissionsService) RunCreate(userID string, playbook Playbook, targetTeamID string) error {
+	if !p.hasPermissionsToPlaybook(userID, playbook, model.PermissionRunCreate) {
+		return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to run playbook `%s`", userID, playbook.ID)
 	}
 
-	return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to run playbook `%s`", userID, playbook.ID)
+	if targetTeamID != "" && targetTeamID != playbook.TeamID {
+		if !p.pluginAPI.User.HasPermissionToTeam(userID, targetTeamID, model.PermissionRunCreate) {
+			return errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to create a run in team `%s`", userID, targetTeamID)
+		}
+	}
+
+	return nil
 }
 
 func (p *PermissionsService) RunManageProperties(userID, runID string) error {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -581,7 +581,7 @@ func (s *PlaybookRunServiceImpl) OpenCreatePlaybookRunDialog(teamID, requesterID
 
 	filteredPlaybooks := make([]Playbook, 0, len(playbooks))
 	for _, playbook := range playbooks {
-		if err := s.permissions.RunCreate(requesterID, playbook); err == nil {
+		if err := s.permissions.RunCreate(requesterID, playbook, ""); err == nil {
 			filteredPlaybooks = append(filteredPlaybooks, playbook)
 		}
 	}


### PR DESCRIPTION
## Summary

Cherry-pick of #2212 ([MM-67867](https://mattermost.atlassian.net/browse/MM-67867)) onto `release-2.4` for a backport release intended for Mattermost v10.11 ESR.

Security fix: an authenticated member who has `run_create` in one team can create a run in another team where they lack the permission, by referencing a cross-team playbook in `POST /plugins/playbooks/api/v0/runs`. The original handler only checked `RunCreate` against `playbook.TeamID`, not `playbookRun.TeamID`. The fix adds an explicit target-team check.

### Backport notes
- The cherry-pick from `master` (`705f54a8`) auto-merged across `server/api/playbook_runs.go`, `server/api_runs_test.go`, `server/app/permissions_service.go`, and `server/app/playbook_run_service.go`.
- One test-only adjustment was needed: `PermissionsHelper.{SaveDefaultRolePermissions,RestoreDefaultRolePermissions,AddPermissionToRole}` does not take `*testing.T` on `release-2.4` (those `tb`-accepting overloads were introduced later upstream). The new `TestCrossTeamRunCreationWithPermission` was adapted to the v2.4 signatures.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-67867

## Checklist

- ~~Gated by experimental feature flag~~
- [x] Unit tests updated (cherry-picked from #2212)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MM-67867]: https://mattermost.atlassian.net/browse/MM-67867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ