### PR TITLE
Cherry-pick: MM-68372 Scope metric updates to playbook; strip import metric IDs (#2246) to release-2.4

### DIFF
--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -62,6 +62,11 @@ func (s *playbookService) Create(playbook Playbook, userID string) (string, erro
 }
 
 func (s *playbookService) Import(playbook Playbook, userID string) (string, error) {
+	// Strip metric IDs on import (export omits them); prevents treating foreign IDs as in-playbook updates.
+	for i := range playbook.Metrics {
+		playbook.Metrics[i].ID = ""
+	}
+
 	newID, err := s.Create(playbook, userID)
 	if err != nil {
 		return "", err

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -908,7 +908,7 @@ func (p *playbookStore) replacePlaybookMetrics(q queryExecer, playbook app.Playb
 					"Ordering":    i,
 					"DeleteAt":    0,
 				}).
-				Where(sq.Eq{"ID": m.ID}),
+				Where(sq.Eq{"ID": m.ID, "PlaybookID": playbook.ID}),
 			)
 		}
 		if err != nil {

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -1215,6 +1215,61 @@ func TestUpdatePlaybook(t *testing.T) {
 	}
 }
 
+func TestUpdatePlaybook_DoesNotModifyOtherPlaybookMetrics(t *testing.T) {
+	db := setupTestDB(t)
+	playbookStore := setupPlaybookStore(t, db)
+	teamID := model.NewId()
+
+	victim := NewPBBuilder().
+		WithTitle("victim pb").
+		WithTeamID(teamID).
+		WithChecklists([]int{1}).
+		WithMetrics([]string{"victim-metric"}).
+		ToPlaybook()
+
+	attacker := NewPBBuilder().
+		WithTitle("attacker pb").
+		WithTeamID(teamID).
+		WithChecklists([]int{1}).
+		WithMetrics([]string{"attacker-metric"}).
+		ToPlaybook()
+
+	victimID, err := playbookStore.Create(victim)
+	require.NoError(t, err)
+	attackerID, err := playbookStore.Create(attacker)
+	require.NoError(t, err)
+
+	victimPB, err := playbookStore.Get(victimID)
+	require.NoError(t, err)
+	require.Len(t, victimPB.Metrics, 1)
+	originalVictimTitle := victimPB.Metrics[0].Title
+
+	attackerPB, err := playbookStore.Get(attackerID)
+	require.NoError(t, err)
+	require.Len(t, attackerPB.Metrics, 1)
+	victimMetricID := victimPB.Metrics[0].ID
+
+	// Simulates an import/update payload that supplies another playbook's metric ID (MM-68372).
+	attackerPB.Metrics = []app.PlaybookMetricConfig{
+		{
+			ID:          victimMetricID,
+			Title:       "MODIFIED_BY_ATTACKER",
+			Description: attackerPB.Metrics[0].Description,
+			Type:        attackerPB.Metrics[0].Type,
+			Target:      attackerPB.Metrics[0].Target,
+		},
+	}
+
+	err = playbookStore.Update(attackerPB)
+	require.NoError(t, err)
+
+	victimAfter, err := playbookStore.Get(victimID)
+	require.NoError(t, err)
+	require.Len(t, victimAfter.Metrics, 1)
+	require.Equal(t, originalVictimTitle, victimAfter.Metrics[0].Title,
+		"victim metric must not change when a different playbook update references its metric ID")
+}
+
 func TestDeletePlaybook(t *testing.T) {
 	team1id := model.NewId()
 


### PR DESCRIPTION
## Summary

Cherry-pick of #2246 ([MM-68372](https://mattermost.atlassian.net/browse/MM-68372)) onto `release-2.4` for a backport release intended for Mattermost v10.11 ESR.

Security fix: the playbook import endpoint accepts `metrics[].id` values from the request body. When `replacePlaybookMetrics` is called, the update branch only filters by metric `ID`, with no `PlaybookID` scope. An authenticated user could therefore overwrite metric titles/descriptions/targets on playbooks owned by others by supplying foreign metric IDs in an import payload.

The fix has two layers:
1. **App layer**: strip metric IDs in `playbookService.Import` so imports always insert new metrics.
2. **SQL layer**: defense in depth — `replacePlaybookMetrics` `UPDATE` now filters by `ID` *and* `PlaybookID`, so even if a foreign ID slips through it cannot mutate a metric outside the current playbook.

### Backport notes
- Conflict in `server/app/playbook_service.go`: master's `Import` takes a `PlaybookImportData` (added in #2229) and emits audit records. On `release-2.4`, `Import` still takes a `Playbook` directly and there is no audit infrastructure. The backport keeps the v2.4 signature and only applies the metric-ID strip — the actual security fix.
- `server/app/playbook_service_test.go` exists on master but was deleted on v2.4; the master-side test changes rely on `PlaybookImportData`/audit fields that don't exist here, so the file is left removed.
- `server/sqlstore/playbook.go` and `server/sqlstore/playbook_test.go` cherry-picked cleanly.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-68372

## Checklist

- ~~Gated by experimental feature flag~~
- [x] Unit tests updated (sqlstore tests cherry-picked from #2246)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MM-68372]: https://mattermost.atlassian.net/browse/MM-68372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ