### PR TITLE
Bump minimum server version to 11.7.3

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
   "icon_path": "assets/plugin_icon.svg",
-  "min_server_version": "11.1.0",
+  "min_server_version": "11.7.3",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
## Summary

Raise the plugin's `min_server_version` from 11.1.0 to 11.7.3 so Playbooks only installs on Mattermost 11.7.3 and later.

## Ticket Link
N/A

## Checklist
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated

Made with [Cursor](https://cursor.com)