### PR TITLE
Revert MM-67913 change from release-2.9

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -34,12 +34,18 @@ const Backstage = () => {
 
     const currentTheme = useAppSelector(getTheme);
     useEffect(() => {
-        // Note: previously this effect also toggled the `app__body` class on `document.body` and appended
-        // `channel-view` to `#root`. Both of those are now owned by the host webapp (`WithUserTheme` owns
-        // `app__body`; `LoggedIn` adds `channel-view` to `#root`). Duplicating them here caused a momentary
-        // white flash on Playbooks → Channels navigation because Playbooks' cleanup removed `app__body`
-        // before the deeply-nested ChannelController had a chance to re-add it (MM-67913).
+        // This class, critical for all the styling to work, is added by ChannelController,
+        // which is not loaded when rendering this root component.
+        document.body.classList.add('app__body');
+        const root = document.getElementById('root');
+        if (root) {
+            root.className += ' channel-view';
+        }
+
         applyTheme(currentTheme);
+        return function cleanUp() {
+            document.body.classList.remove('app__body');
+        };
     }, [currentTheme]);
 
     useForceDocumentTitle('Playbooks');


### PR DESCRIPTION
## Summary
Reverts https://github.com/mattermost/mattermost-plugin-playbooks/commit/933677328dd50e5a072346422e3ed5506085aa8d from the release-2.9 branch because it was intended for master only.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-67913

## Checklist
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated

Test plan: Not run; this is a direct revert of the unintended release-branch commit.

Made with [Cursor](https://cursor.com)