### PR TITLE
Update minimum server version to 11.8.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
   "icon_path": "assets/plugin_icon.svg",
-  "min_server_version": "11.1.0",
+  "min_server_version": "11.8.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
## Summary
- Updates the Playbooks plugin `min_server_version` from `11.1.0` to `11.8.0`.

## Ticket Link
N/A

## Checklist
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated

## Test plan
- `make check-style` passed.
- `make test` was run and failed because the local test Mattermost instance rejected the plugin after the minimum server version bump: `plugin requires Mattermost 11.8.0: playbooks`.

Made with [Cursor](https://cursor.com)