### PR TITLE
Fix app__body compatibility for Playbooks

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-playbooks/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-playbooks/issues",
   "icon_path": "assets/plugin_icon.svg",
-  "min_server_version": "11.8.0",
+  "min_server_version": "11.1.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/components/backstage/backstage.test.tsx
+++ b/webapp/src/components/backstage/backstage.test.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import renderer, {act} from 'react-test-renderer';
+
+const mockApplyTheme = jest.fn();
+let mockCurrentTheme = {type: 'initial-theme'};
+
+jest.mock('mattermost-redux/selectors/entities/preferences', () => ({
+    getTheme: () => mockCurrentTheme,
+}));
+
+jest.mock('src/hooks/redux', () => ({
+    useAppSelector: (selector: any) => selector({}),
+}));
+
+jest.mock('src/components/backstage/css_utils', () => ({
+    applyTheme: (theme: any) => mockApplyTheme(theme),
+}));
+
+jest.mock('react-router-dom', () => {
+    const actual = jest.requireActual('react-router-dom');
+    return {
+        ...actual,
+        useLocation: () => ({pathname: '/playbooks'}),
+        useRouteMatch: () => ({url: '/playbooks'}),
+    };
+});
+
+jest.mock('src/hooks', () => ({
+    useForceDocumentTitle: jest.fn(),
+}));
+
+jest.mock('./toast_banner', () => ({
+    ToastProvider: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}));
+
+jest.mock('./lhs_navigation', () => ({
+    __esModule: true,
+    default: () => <nav data-testid='lhs-navigation'/>,
+}));
+
+jest.mock('./main_body', () => ({
+    __esModule: true,
+    default: () => <main data-testid='main-body'/>,
+}));
+
+jest.mock('src/components/backstage/rhs/rhs', () => ({
+    __esModule: true,
+    default: () => <aside data-testid='backstage-rhs'/>,
+}));
+
+import Backstage from './backstage';
+
+describe('Backstage', () => {
+    beforeEach(() => {
+        mockApplyTheme.mockClear();
+        mockCurrentTheme = {type: 'initial-theme'};
+        document.body.classList.remove('app__body');
+    });
+
+    afterEach(() => {
+        document.body.classList.remove('app__body');
+    });
+
+    it('adds app__body on mount and leaves it on unmount', () => {
+        let component!: ReturnType<typeof renderer.create>;
+
+        expect(document.body.classList.contains('app__body')).toBe(false);
+
+        act(() => {
+            component = renderer.create(<Backstage/>);
+        });
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+
+        act(() => {
+            component.unmount();
+        });
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+    });
+
+    it('applies the selected theme on mount and when the current theme changes', () => {
+        let component!: ReturnType<typeof renderer.create>;
+
+        act(() => {
+            component = renderer.create(<Backstage/>);
+        });
+
+        expect(mockApplyTheme).toHaveBeenCalledTimes(1);
+        expect(mockApplyTheme).toHaveBeenCalledWith(mockCurrentTheme);
+
+        const updatedTheme = {type: 'updated-theme'};
+        mockCurrentTheme = updatedTheme;
+
+        act(() => {
+            component.update(<Backstage/>);
+        });
+
+        expect(mockApplyTheme).toHaveBeenCalledWith(updatedTheme);
+        expect(mockApplyTheme).toHaveBeenCalledTimes(2);
+    });
+});

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -34,11 +34,11 @@ const Backstage = () => {
 
     const currentTheme = useAppSelector(getTheme);
     useEffect(() => {
-        // Note: previously this effect also toggled the `app__body` class on `document.body` and appended
-        // `channel-view` to `#root`. Both of those are now owned by the host webapp (`WithUserTheme` owns
-        // `app__body`; `LoggedIn` adds `channel-view` to `#root`). Duplicating them here caused a momentary
-        // white flash on Playbooks → Channels navigation because Playbooks' cleanup removed `app__body`
-        // before the deeply-nested ChannelController had a chance to re-add it (MM-67913).
+        // Pre-11.8 servers need Playbooks to add this; 11.8+ core also owns it. Do not remove on unmount.
+        document.body.classList.add('app__body');
+    }, []);
+
+    useEffect(() => {
         applyTheme(currentTheme);
     }, [currentTheme]);
 


### PR DESCRIPTION
## Summary
- Restores Playbooks compatibility with supported older servers by setting `min_server_version` back to `11.1.0` on master.
- Adds `app__body` when the Backstage view mounts and intentionally leaves cleanup to the host webapp.
- Adds regression coverage for preserving `app__body` after Backstage unmounts.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-67913

## Checklist
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated

## Validation
- `npm test -- --runTestsByPath src/components/backstage/backstage.test.tsx`
- `npx eslint --quiet src/components/backstage/backstage.tsx src/components/backstage/backstage.test.tsx`

Made with [Cursor](https://cursor.com)