### PR TITLE
Fix app__body cleanup on release-2.9

### DIFF
--- a/webapp/src/components/backstage/backstage.test.tsx
+++ b/webapp/src/components/backstage/backstage.test.tsx
@@ -1,0 +1,114 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import renderer, {act} from 'react-test-renderer';
+
+const mockApplyTheme = jest.fn();
+let mockCurrentTheme = {type: 'initial-theme'};
+
+jest.mock('mattermost-redux/selectors/entities/preferences', () => ({
+    getTheme: () => mockCurrentTheme,
+}));
+
+jest.mock('src/hooks/redux', () => ({
+    useAppSelector: (selector: any) => selector({}),
+}));
+
+jest.mock('src/components/backstage/css_utils', () => ({
+    applyTheme: (theme: any) => mockApplyTheme(theme),
+}));
+
+jest.mock('react-router-dom', () => {
+    const actual = jest.requireActual('react-router-dom');
+    return {
+        ...actual,
+        useLocation: () => ({pathname: '/playbooks'}),
+        useRouteMatch: () => ({url: '/playbooks'}),
+    };
+});
+
+jest.mock('src/hooks', () => ({
+    useForceDocumentTitle: jest.fn(),
+}));
+
+jest.mock('./toast_banner', () => ({
+    ToastProvider: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}));
+
+jest.mock('./lhs_navigation', () => ({
+    __esModule: true,
+    default: () => <nav data-testid='lhs-navigation'/>,
+}));
+
+jest.mock('./main_body', () => ({
+    __esModule: true,
+    default: () => <main data-testid='main-body'/>,
+}));
+
+jest.mock('src/components/backstage/rhs/rhs', () => ({
+    __esModule: true,
+    default: () => <aside data-testid='backstage-rhs'/>,
+}));
+
+import Backstage from './backstage';
+
+describe('Backstage', () => {
+    let rootElement: HTMLDivElement;
+
+    beforeEach(() => {
+        mockApplyTheme.mockClear();
+        mockCurrentTheme = {type: 'initial-theme'};
+        document.body.classList.remove('app__body');
+
+        rootElement = document.createElement('div');
+        rootElement.id = 'root';
+        document.body.appendChild(rootElement);
+    });
+
+    afterEach(() => {
+        document.body.classList.remove('app__body');
+        rootElement.remove();
+    });
+
+    it('adds app__body on mount and leaves it on unmount', () => {
+        let component!: ReturnType<typeof renderer.create>;
+
+        expect(document.body.classList.contains('app__body')).toBe(false);
+        expect(rootElement.classList.contains('channel-view')).toBe(false);
+
+        act(() => {
+            component = renderer.create(<Backstage/>);
+        });
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+        expect(rootElement.classList.contains('channel-view')).toBe(true);
+
+        act(() => {
+            component.unmount();
+        });
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+    });
+
+    it('applies the selected theme on mount and when the current theme changes', () => {
+        let component!: ReturnType<typeof renderer.create>;
+
+        act(() => {
+            component = renderer.create(<Backstage/>);
+        });
+
+        expect(mockApplyTheme).toHaveBeenCalledTimes(1);
+        expect(mockApplyTheme).toHaveBeenCalledWith(mockCurrentTheme);
+
+        const updatedTheme = {type: 'updated-theme'};
+        mockCurrentTheme = updatedTheme;
+
+        act(() => {
+            component.update(<Backstage/>);
+        });
+
+        expect(mockApplyTheme).toHaveBeenCalledWith(updatedTheme);
+        expect(mockApplyTheme).toHaveBeenCalledTimes(2);
+    });
+});

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -34,18 +34,17 @@ const Backstage = () => {
 
     const currentTheme = useAppSelector(getTheme);
     useEffect(() => {
-        // This class, critical for all the styling to work, is added by ChannelController,
-        // which is not loaded when rendering this root component.
+        // Pre-11.8 servers need Playbooks to add this; do not remove on unmount.
         document.body.classList.add('app__body');
+
         const root = document.getElementById('root');
         if (root) {
-            root.className += ' channel-view';
+            root.classList.add('channel-view');
         }
+    }, []);
 
+    useEffect(() => {
         applyTheme(currentTheme);
-        return function cleanUp() {
-            document.body.classList.remove('app__body');
-        };
     }, [currentTheme]);
 
     useForceDocumentTitle('Playbooks');


### PR DESCRIPTION
## Summary
- Prevents Playbooks Backstage cleanup from removing `app__body` after unmount on release-2.9.
- Preserves release-2.9's `#root.channel-view` setup while adding the class idempotently.
- Adds regression coverage for preserving `app__body` after Backstage unmounts.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-67913

## Checklist
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated

## Validation
- `npm ci`
- `npm test -- --runTestsByPath src/components/backstage/backstage.test.tsx`
- `npx eslint --quiet src/components/backstage/backstage.tsx src/components/backstage/backstage.test.tsx`

Made with [Cursor](https://cursor.com)