### PR TITLE
MM-69322: send single Content-Type header on /query

### DIFF
--- a/e2e-tests/tests/integration/playbooks/api/graphql_request_headers_spec.js
+++ b/e2e-tests/tests/integration/playbooks/api/graphql_request_headers_spec.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+// Stage: @prod
+// Group: @playbooks
+
+describe('api > graphql_request_headers', {testIsolation: true}, () => {
+    let testTeam;
+    let testUser;
+    let testPublicPlaybook;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Create a public playbook to run
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Public Playbook',
+                memberIDs: [],
+            }).then((playbook) => {
+                testPublicPlaybook = playbook;
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Size the viewport so the run details page renders fully.
+        cy.viewport('macbook-13');
+
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    // Regression for MM-69322: Apollo's HttpLink set a lowercase `content-type` that
+    // collided with the capitalized `Content-Type` added by Client4.getOptions, so the
+    // request went out as `Content-Type: application/json, application/json` and tripped
+    // WAF rules that flag multiple Content-Type headers. The endpoint must send one value.
+    it('sends a single Content-Type header on the browser GraphQL /query request', () => {
+        // # Capture the browser-issued GraphQL request (this is the Apollo path; cy.request
+        // # would bypass it and cannot reproduce the bug).
+        cy.intercept('POST', '**/plugins/playbooks/api/v0/query').as('graphqlQuery');
+
+        cy.apiRunPlaybook({
+            teamId: testTeam.id,
+            playbookId: testPublicPlaybook.id,
+            playbookRunName: 'graphql header run',
+            ownerUserId: testUser.id,
+        }).then((playbookRun) => {
+            // # Visit a GraphQL-backed page so the browser issues a /query through Apollo
+            cy.visit(`/playbooks/runs/${playbookRun.id}`);
+            cy.assertRunDetailsPageRenderComplete(testUser.username);
+        });
+
+        // * The request must carry exactly one Content-Type value, not a duplicated pair
+        cy.wait('@graphqlQuery').then(({request}) => {
+            expect(request.headers['content-type']).to.equal('application/json');
+        });
+    });
+});

--- a/webapp/src/graphql/apollo.test.ts
+++ b/webapp/src/graphql/apollo.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from 'mattermost-redux/client';
+
+import {buildQueryFetchOptions} from './apollo';
+
+describe('graphql fetch options (MM-69322)', () => {
+    // Mimics the options Apollo's HttpLink passes to our fetch wrapper: a POST with a
+    // body and a lowercase `content-type` header.
+    const apolloOptions = () => ({
+        method: 'POST',
+        body: JSON.stringify({query: '{ runs { edges { node { id } } } }'}),
+        headers: {accept: '*/*', 'content-type': 'application/json'},
+    });
+
+    const contentTypeKeys = (headers: Record<string, string>) =>
+        Object.keys(headers).filter((k) => k.toLowerCase() === 'content-type');
+
+    it('documents the upstream bug: Client4.getOptions alone duplicates the content-type header', () => {
+        const raw = Client4.getOptions(apolloOptions());
+
+        // Both a capitalized `Content-Type` (set by Client4) and Apollo's lowercase
+        // `content-type` survive Object.assign, which fetch() later joins with ", ".
+        expect(contentTypeKeys(raw.headers).length).toBeGreaterThan(1);
+    });
+
+    it('buildQueryFetchOptions yields exactly one content-type header', () => {
+        const result = buildQueryFetchOptions(apolloOptions());
+
+        expect(contentTypeKeys(result.headers)).toHaveLength(1);
+    });
+
+    it('collapses any case-insensitively duplicated header, not just content-type', () => {
+        // The real defect is the case-sensitive merge, so the dedup must be general.
+        // X-Requested-With is set canonically by Client4; a lowercase variant must not
+        // produce a second key.
+        const result = buildQueryFetchOptions({
+            ...apolloOptions(),
+            headers: {'content-type': 'application/json', 'x-requested-with': 'fetch'},
+        });
+
+        const names = Object.keys(result.headers).map((k) => k.toLowerCase());
+        const dupes = names.filter((k, i) => names.indexOf(k) !== i);
+        expect(dupes).toEqual([]);
+    });
+});

--- a/webapp/src/graphql/apollo.tsx
+++ b/webapp/src/graphql/apollo.tsx
@@ -29,9 +29,22 @@ export const ApolloWrapper = (props: ApolloWrapperProps) => {
     );
 };
 
+// Lowercase header names so case-variant duplicates collapse into one. Header names are
+// case-insensitive, so this is wire-equivalent.
+function dedupeHeaders(headers: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(
+        Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+}
+
+export function buildQueryFetchOptions(options: any) {
+    const result = Client4.getOptions(options);
+    return {...result, headers: dedupeHeaders(result.headers)};
+}
+
 export function makeGraphqlClient(isDevelopment: boolean) {
     const graphqlFetch = (_: RequestInfo, options: any) => {
-        return fetch(`${getApiUrl()}/query`, Client4.getOptions(options));
+        return fetch(`${getApiUrl()}/query`, buildQueryFetchOptions(options));
     };
     const graphqlClient = new ApolloClient({
         link: new HttpLink({fetch: graphqlFetch}),


### PR DESCRIPTION
## Summary
Apollo's `HttpLink` sets a lowercase `content-type`; `Client4.getOptions` adds a capitalized `Content-Type` and merges headers case-sensitively, so the GraphQL `/query` request went out as `Content-Type: application/json, application/json`. That trips WAF rules flagging multiple Content-Type headers (CVE-2023-38199 detection), forcing customers to whitelist us or weaken the rule.

This dedupes headers case-insensitively in the GraphQL fetch wrapper (`buildQueryFetchOptions`) so exactly one `Content-Type` is sent. Only the browser GraphQL path was affected; REST `doPost/doPut` pass no headers, so they were already fine.

_Note: the underlying cause is the case-sensitive header merge in `Client4.getOptions` (upstream `@mattermost/client`). This is a local unblock; an upstream fix would make the shared client correct for any future caller._

## Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-69322

## Test Plan
- Unit (`webapp/src/graphql/apollo.test.ts`): documents the raw duplicate from `Client4.getOptions`, asserts a single `content-type` after the fix, and verifies the dedup is general (not content-type-specific).
- E2E (`e2e-tests/tests/integration/playbooks/api/graphql_request_headers_spec.js`): intercepts a real browser-issued `/query` and asserts a single `Content-Type` value.


|  before  |  after  |
|----|----|
| <img width="500" alt="CleanShot 2026-06-16 at 16 03 41@2x" src="https://github.com/user-attachments/assets/d4b9b2d1-f640-49ee-bb1e-e3b84f1b02bd" /> | <img width="500" alt="CleanShot 2026-06-16 at 16 03 14" src="https://github.com/user-attachments/assets/b3b2b1d9-e6e9-4363-b53e-510431aba202" /> |

## Checklist
- [x] Unit tests updated (`webapp/src/graphql/apollo.test.ts`)
- [x] E2E test added (`e2e-tests/tests/integration/playbooks/api/graphql_request_headers_spec.js`)
- ~~Gated by experimental feature flag~~ (N/A)