### PR TITLE
chore(ci): pin build/test Node to .nvmrc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,11 @@ jobs:
       - name: ci/configure-git-safe-directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
+      - name: ci/setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+
       - name: ci/cache-node-modules
         id: cache-node-modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -186,6 +191,10 @@ jobs:
           fetch-depth: "0"
       - name: ci/configure-git-safe-directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: ci/setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
       - name: ci/get-short-sha
         id: short-sha
         run: echo "sha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
@@ -325,6 +334,11 @@ jobs:
       - name: ci/configure-git-safe-directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
+      - name: ci/setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+
       - name: ci/test-with-db
         uses: ./.github/actions/test-with-db
 
@@ -362,6 +376,11 @@ jobs:
 
       - name: ci/configure-git-safe-directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: ci/setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
 
       - name: ci/test-with-db
         uses: ./.github/actions/test-with-db


### PR DESCRIPTION
## Summary
`dist`, `lint-web`, and `test` run inside `mattermost/mattermost-build-server:<.go-version>` with no `setup-node` step, so they build/test on the image's bundled Node — **v20.11.1** (EOL April 2026), diverging from `.nvmrc` (**24.11**). `dist-fips` already pins `.nvmrc`; the others didn't.

This adds `actions/setup-node` (`node-version-file: .nvmrc`) to `dist`, `lint-web`, `test`, and `test-fips` so the standard path matches `dist-fips`. Building on 24.11 is already proven — `dist-fips` does it and is green.

No Jira ticket — CI hygiene found while triaging a transient `dist` failure on #2302.

## Upstream SITREP — interim fix
Root cause is upstream: `server/build/Dockerfile.buildenv` pins `NODE_VERSION=20.11.1`, and image tags track Go only (`:1.26.3`), hiding the Node version.

- Tracked by [MM-67040](https://mattermost.atlassian.net/browse/MM-67040) (In Progress) — Go+Node combined tags (e.g. `…:go-1.26.3-node-24.11.1`).
- Both implementation PRs (mattermost/mattermost **#34913**, **#34914**) are **closed unmerged**; `Dockerfile.buildenv` is still on 20.11.1 — not landed.
- Related Node-24 tickets, all closed, deferred the build-image piece here: [MM-65801](https://mattermost.atlassian.net/browse/MM-65801), [MM-67168](https://mattermost.atlassian.net/browse/MM-67168), [MM-66972](https://mattermost.atlassian.net/browse/MM-66972), [MM-67924](https://mattermost.atlassian.net/browse/MM-67924).

**Follow-up:** when MM-67040 lands, point the container at a go+node tag and drop these `setup-node` steps.

## Notes
- Config-only; CI is the verification.
- Distinct from the [GH Actions Node-20 *runtime* deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) — this is the *build toolchain* Node.
- Doesn't touch `webapp/package.json` engines (`20.x || 22.x || >=24.0.0`).


[MM-67040]: https://mattermost.atlassian.net/browse/MM-67040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MM-65801]: https://mattermost.atlassian.net/browse/MM-65801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ