### PR TITLE
MM-69385 - Restrict run management actions for non-members

### DIFF
--- a/e2e-tests/tests/integration/playbooks/runs/owner_only_finish_spec.js
+++ b/e2e-tests/tests/integration/playbooks/runs/owner_only_finish_spec.js
@@ -366,6 +366,41 @@ describe('runs > owner only finish', {testIsolation: true}, () => {
                 });
             });
         });
+
+        // --- Post update modal: "Also mark the run as finished" checkbox ---
+
+        it('hides the "mark as finished" checkbox in the post update modal from a non-owner participant', () => {
+            // # Login as the non-owner participant and visit the run channel
+            cy.apiLogin(testParticipant);
+            cy.playbooksVisitRunChannel(testTeam.name, testPlaybookRun);
+
+            // # Open the post update modal (non-owners are allowed to post updates)
+            cy.uiPostMessageQuickly('/playbook update');
+
+            cy.getStatusUpdateDialog().within(() => {
+                // * The modal has rendered (textbox is present)
+                cy.findByTestId('update_run_status_textbox').should('be.visible');
+
+                // * The "Also mark the run as finished" checkbox is hidden — owner-only
+                // actions restrict finish to the run owner + system admin, so a non-owner
+                // cannot trigger a finish that the server would reject.
+                cy.findByTestId('mark-run-as-finished').should('not.exist');
+            });
+        });
+
+        it('shows the "mark as finished" checkbox in the post update modal to the run owner', () => {
+            // # Login as the run owner and visit the run channel
+            cy.apiLogin(testOwner);
+            cy.playbooksVisitRunChannel(testTeam.name, testPlaybookRun);
+
+            // # Open the post update modal
+            cy.uiPostMessageQuickly('/playbook update');
+
+            cy.getStatusUpdateDialog().within(() => {
+                // * The run owner can finish, so the checkbox is offered
+                cy.findByTestId('mark-run-as-finished').should('exist');
+            });
+        });
     });
 
     describe('restore is owner-restricted', () => {

--- a/webapp/src/components/modals/update_run_status_modal.finish_gating.test.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.finish_gating.test.tsx
@@ -1,0 +1,196 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import {UpdateRunStatusModal} from './update_run_status_modal';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+//
+// The modal pulls in Apollo, the datetime input, Redux and a number of
+// presentational widgets. We only care about whether the "Also mark the run as
+// finished" checkbox is rendered, so everything else is stubbed out and the
+// footer (which holds the checkbox) is rendered verbatim by a GenericModal mock.
+// ---------------------------------------------------------------------------
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    Link: ({children}: {children: React.ReactNode}) => <span>{children}</span>,
+}));
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en', defaultLocale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('@apollo/client', () => ({
+    ApolloProvider: ({children}: {children: React.ReactNode}) => children,
+    useQuery: () => ({
+        data: {
+            run: {
+                id: 'run-1',
+                name: 'Test Run',
+                teamID: 'team-1',
+                broadcastChannelIDs: [],
+                statusUpdateBroadcastChannelsEnabled: false,
+                checklists: [],
+                followers: [],
+                reminderMessageTemplate: '',
+                statusPosts: [],
+                previousReminder: 0,
+                reminderTimerDefaultSeconds: 0,
+            },
+        },
+    }),
+}));
+
+jest.mock('src/graphql/generated', () => ({
+    graphql: (s: string) => s,
+    getFragmentData: (_fragment: unknown, data: unknown) => data,
+}));
+
+jest.mock('src/hooks/redux', () => ({
+    useAppDispatch: () => jest.fn(),
+    useAppSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('mattermost-redux/selectors/entities/users', () => ({
+    ...jest.requireActual('mattermost-redux/selectors/entities/users'),
+    getCurrentUserId: () => 'current-user',
+}));
+
+jest.mock('mattermost-redux/selectors/entities/channels', () => ({
+    ...jest.requireActual('mattermost-redux/selectors/entities/channels'),
+    getChannel: () => undefined,
+}));
+
+const mockUseRun = jest.fn();
+const mockUsePlaybook = jest.fn();
+jest.mock('src/hooks/general', () => ({
+    useRun: (...args: unknown[]) => mockUseRun(...args),
+    useUserDisplayNameMap: () => ({}),
+}));
+jest.mock('src/hooks/crud', () => ({
+    usePlaybook: (...args: unknown[]) => mockUsePlaybook(...args),
+}));
+
+const mockIsBlockedByOwnerOnly = jest.fn();
+jest.mock('src/hooks/permissions', () => ({
+    useIsBlockedByOwnerOnlyForFinishRestore: (...args: [boolean | undefined, boolean | undefined]) =>
+        mockIsBlockedByOwnerOnly(...args),
+}));
+
+jest.mock('src/hooks', () => ({
+    useFormattedUsernames: () => [],
+    usePost: () => [undefined],
+}));
+
+jest.mock('src/components/datetime_input', () => ({
+    Mode: {DurationValue: 0, DateTimeValue: 1},
+    ms: () => 0,
+    useMakeOption: () => () => ({value: {}}),
+    useDateTimeInput: () => ({input: null, value: undefined}),
+}));
+
+jest.mock('src/components/markdown_textbox', () => () => null);
+jest.mock('src/components/assets/icons/warning_icon', () => () => null);
+jest.mock('src/components/widgets/unsaved_changes_modal', () => () => null);
+jest.mock('src/components/backstage/route_leaving_guard', () => () => null);
+jest.mock('src/components/widgets/tooltip', () => () => null);
+
+jest.mock('src/components/backstage/runs_list/checkbox_input', () => ({testId}: {testId: string}) => (
+    <div data-testid={testId}/>
+));
+
+jest.mock('src/components/backstage/playbook_runs/playbook_run/finish_run', () => ({
+    useFinishRunConfirmationMessage: () => '',
+}));
+
+jest.mock('src/components/widgets/generic_modal', () => {
+    const actual = jest.requireActual('src/components/widgets/generic_modal');
+    const GenericModal = ({children, footer}: {children: React.ReactNode; footer?: React.ReactNode}) => (
+        <div>
+            <div data-testid='modal-body'>{children}</div>
+            <div data-testid='modal-footer'>{footer}</div>
+        </div>
+    );
+    return {
+        ...actual,
+        __esModule: true,
+        default: GenericModal,
+    };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const baseProps = {
+    playbookRunId: 'run-1',
+    channelId: 'channel-1',
+    hasPermission: true,
+};
+
+const renderModal = () => renderer.create(<UpdateRunStatusModal {...baseProps}/>);
+
+describe('UpdateRunStatusModal — finish checkbox gating', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseRun.mockReturnValue([{owner_user_id: 'owner-1', playbook_id: 'playbook-1'}]);
+        mockUsePlaybook.mockReturnValue([{owner_group_only_actions: true}]);
+    });
+
+    it('hides the "mark as finished" checkbox when the user is blocked by the owner-only restriction', () => {
+        mockIsBlockedByOwnerOnly.mockReturnValue(true);
+
+        const json = JSON.stringify(renderModal().toJSON());
+
+        expect(json).not.toContain('mark-run-as-finished');
+    });
+
+    it('shows the "mark as finished" checkbox when the user is not blocked', () => {
+        mockIsBlockedByOwnerOnly.mockReturnValue(false);
+
+        const json = JSON.stringify(renderModal().toJSON());
+
+        expect(json).toContain('mark-run-as-finished');
+    });
+
+    it('derives ownerGroupOnlyActions and isOwner from the run and playbook for the restriction check', () => {
+        mockUseRun.mockReturnValue([{owner_user_id: 'current-user', playbook_id: 'playbook-1'}]);
+        mockUsePlaybook.mockReturnValue([{owner_group_only_actions: true}]);
+        mockIsBlockedByOwnerOnly.mockReturnValue(false);
+
+        renderModal();
+
+        // ownerGroupOnlyActions = true (from playbook), isOwner = true (owner === current user)
+        expect(mockIsBlockedByOwnerOnly).toHaveBeenCalledWith(true, true);
+    });
+
+    it('passes undefined ownerGroupOnlyActions while the playbook is still loading', () => {
+        mockUsePlaybook.mockReturnValue([undefined]);
+        mockIsBlockedByOwnerOnly.mockReturnValue(true);
+
+        renderModal();
+
+        expect(mockIsBlockedByOwnerOnly).toHaveBeenCalledWith(undefined, false);
+    });
+
+    it('treats a null playbook (run still loading) as not-yet-known so the checkbox stays hidden', () => {
+        // useThing resolves usePlaybook(undefined) to null while the run loads — null must be
+        // treated like undefined, otherwise a blocked user briefly sees the checkbox.
+        mockUseRun.mockReturnValue([undefined]);
+        mockUsePlaybook.mockReturnValue([null]);
+        mockIsBlockedByOwnerOnly.mockReturnValue(true);
+
+        renderModal();
+
+        expect(mockIsBlockedByOwnerOnly).toHaveBeenCalledWith(undefined, false);
+    });
+});

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -33,6 +33,8 @@ import {
 
 import {useFormattedUsernames, usePost} from 'src/hooks';
 import {useRun, useUserDisplayNameMap} from 'src/hooks/general';
+import {usePlaybook} from 'src/hooks/crud';
+import {useIsBlockedByOwnerOnlyForFinishRestore} from 'src/hooks/permissions';
 
 import MarkdownTextbox from 'src/components/markdown_textbox';
 
@@ -156,7 +158,7 @@ function useStatusMessagePreview(playbookRunId: string, message: string | undefi
     }, [message, derived, userMap]);
 }
 
-const UpdateRunStatusModal = ({
+export const UpdateRunStatusModal = ({
     playbookRunId,
     channelId,
     hasPermission,
@@ -168,6 +170,19 @@ const UpdateRunStatusModal = ({
     const dispatch = useAppDispatch();
     const {formatMessage, formatList} = useIntl();
     const currentUserId = useAppSelector(getCurrentUserId);
+
+    // Determine whether the OwnerGroupOnlyActions restriction blocks this user from finishing
+    // the run, mirroring the gating used by the standalone Finish controls. When blocked we hide
+    // the "Also mark the run as finished" checkbox so the user cannot trigger a finish that the
+    // server would reject.
+    const [restRun] = useRun(playbookRunId);
+    const [playbook] = usePlaybook(restRun?.playbook_id);
+    // `usePlaybook(undefined)` resolves to null while the run is still loading, so treat both
+    // null and undefined as "not yet known" — passing undefined keeps the checkbox hidden during
+    // load (the hook blocks on undefined) and prevents a flash of the checkbox for a blocked user.
+    const ownerGroupOnlyActions = playbook == null ? undefined : (playbook.owner_group_only_actions ?? false);
+    const isOwner = restRun?.owner_user_id === currentUserId;
+    const blockedByOwnerOnly = useIsBlockedByOwnerOnlyForFinishRestore(ownerGroupOnlyActions, isOwner);
     const {data} = useQuery(runStatusModalQueryDocument, {
         variables: {
             runID: playbookRunId,
@@ -392,7 +407,7 @@ const UpdateRunStatusModal = ({
                 autoCloseOnConfirmButton={false}
                 isConfirmDisabled={!(hasPermission && message?.trim() && currentUserId && channelId && isReminderValid)}
                 id={ID}
-                footer={footer}
+                footer={blockedByOwnerOnly ? undefined : footer}
                 components={{FooterContainer}}
             >
                 {hasPermission ? form : warning}

--- a/webapp/src/components/modals/update_run_status_modal.tsx
+++ b/webapp/src/components/modals/update_run_status_modal.tsx
@@ -177,6 +177,7 @@ export const UpdateRunStatusModal = ({
     // server would reject.
     const [restRun] = useRun(playbookRunId);
     const [playbook] = usePlaybook(restRun?.playbook_id);
+
     // `usePlaybook(undefined)` resolves to null while the run is still loading, so treat both
     // null and undefined as "not yet known" — passing undefined keeps the checkbox hidden during
     // load (the hook blocks on undefined) and prevents a flash of the checkbox for a blocked user.
@@ -204,8 +205,13 @@ export const UpdateRunStatusModal = ({
     const [showUnsavedRoute, setShowUnsaveRoute] = useState(false);
     const [finishRun, setFinishRun] = useState(providedFinishRunChecked || false);
 
-    const {input: reminderInput, reminder} = useReminderTimerOption(getFragmentData(ReminderTimer, run), finishRun, providedReminder);
-    const isReminderValid = finishRun || (reminder && reminder > 0);
+    // Enforce the owner-only gate at the logic level, not just by hiding the checkbox: a blocked
+    // user must never reach the finish path even if `finishRun` was seeded from props or the
+    // cancel-reopen round trip.
+    const effectiveFinishRun = !blockedByOwnerOnly && finishRun;
+
+    const {input: reminderInput, reminder} = useReminderTimerOption(getFragmentData(ReminderTimer, run), effectiveFinishRun, providedReminder);
+    const isReminderValid = effectiveFinishRun || (reminder && reminder > 0);
     let warningMessage = formatMessage({defaultMessage: 'Date must be in the future.'});
     if (!reminder || reminder === 0) {
         warningMessage = formatMessage({defaultMessage: 'Please specify a future date/time for the update reminder.'});
@@ -259,7 +265,7 @@ export const UpdateRunStatusModal = ({
         if (hasPermission && message?.trim() && currentUserId && channelId) {
             postStatusUpdate(
                 playbookRunId,
-                {message, reminder, finishRun},
+                {message, reminder, finishRun: effectiveFinishRun},
                 {user_id: currentUserId, channel_id: channelId, team_id: run?.teamID ?? ''}
             );
             onActualHide();
@@ -267,7 +273,7 @@ export const UpdateRunStatusModal = ({
     };
 
     const onSubmit = () => {
-        if (finishRun) {
+        if (effectiveFinishRun) {
             onActualHide();
 
             dispatch(modals.openModal(makeUncontrolledConfirmModalDefinition({
@@ -277,7 +283,7 @@ export const UpdateRunStatusModal = ({
                 confirmButtonText: formatMessage({defaultMessage: 'Finish run'}),
                 onConfirm,
                 onCancel: () => {
-                    dispatch(openUpdateRunStatusModal(playbookRunId, channelId, hasPermission, message, reminder, finishRun));
+                    dispatch(openUpdateRunStatusModal(playbookRunId, channelId, hasPermission, message, reminder, effectiveFinishRun));
                     setShowModal(true);
                 },
             })));


### PR DESCRIPTION
## Summary

On playbooks with **Restrict run management actions for non-owners** enabled, a non-owner could tick **Also mark the run as finished** when posting a status update. The update posted but the finish was silently rejected by the server — with no error or feedback.

This hides the *Also mark the run as finished* checkbox for users blocked by the owner-only restriction (reusing `useIsBlockedByOwnerOnlyForFinishRestore`), and enforces the gate in the submit logic so a blocked user can never reach the finish path. Owners and system admins are unaffected. Covered by new Jest and Cypress tests.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69385
