### PR TITLE
MM-69384 - Disable toggles when "Only admins can edit this playbook" = true

### DIFF
--- a/e2e-tests/tests/integration/playbooks/playbooks/edit/admin_only_edit_spec.js
+++ b/e2e-tests/tests/integration/playbooks/playbooks/edit/admin_only_edit_spec.js
@@ -160,6 +160,12 @@ describe('playbooks > edit > admin only edit', {testIsolation: true}, () => {
         // * Retrospective toggle input is disabled
         cy.findByTestId('retrospective-toggle').find('input[type="checkbox"]').should('be.disabled');
 
+        // * "Require new channel for all runs" toggle input is disabled
+        cy.findByTestId('new-channel-only-toggle').find('input[type="checkbox"]').should('be.disabled');
+
+        // * "Auto-archive channel" toggle input is disabled
+        cy.findByTestId('auto-archive-channel-toggle').find('input[type="checkbox"]').should('be.disabled');
+
         // * Add-checklist button is not rendered (checklist is read-only)
         cy.get('#checklists').should('be.visible');
         cy.findByTestId('add-a-checklist-button').should('not.exist');
@@ -190,6 +196,12 @@ describe('playbooks > edit > admin only edit', {testIsolation: true}, () => {
 
         // * Status update toggle is not disabled
         cy.findByTestId('status-update-toggle').find('input[type="checkbox"]').should('not.be.disabled');
+
+        // * "Require new channel for all runs" toggle is not disabled
+        cy.findByTestId('new-channel-only-toggle').find('input[type="checkbox"]').should('not.be.disabled');
+
+        // * "Auto-archive channel" toggle is not disabled
+        cy.findByTestId('auto-archive-channel-toggle').find('input[type="checkbox"]').should('not.be.disabled');
 
         // * Add-checklist button is rendered
         cy.findByTestId('add-a-checklist-button').should('exist');

--- a/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
+++ b/webapp/src/components/backstage/playbook_editor/outline/section_actions.tsx
@@ -277,7 +277,7 @@ const LegacyActionsEdit = ({playbook, canEdit = true, newChannelOnly = false, on
                 <Setting id={'new-channel-only'}>
                     <NewChannelOnlyToggle
                         playbook={{new_channel_only: newChannelOnly}}
-                        disabled={archived || !onNewChannelOnlyChange}
+                        disabled={disabled || !onNewChannelOnlyChange}
                         onChange={onNewChannelOnlyChange}
                     />
                 </Setting>
@@ -388,7 +388,7 @@ const LegacyActionsEdit = ({playbook, canEdit = true, newChannelOnly = false, on
                                 <AutoArchiveToggle
                                     autoArchive={autoArchiveChannel}
                                     isLinkedChannel={playbookForCreateChannel.channel_mode === 'link_existing_channel'}
-                                    disabled={archived}
+                                    disabled={disabled}
                                     onChange={onAutoArchiveChange}
                                 />
                             </div>


### PR DESCRIPTION
## Summary

With **Only admins can edit this playbook** enabled, the *Require new channel for all runs* and *Auto-archive channel* toggles were still editable for ordinary users — toggling them just flashed a `Failed to save setting` error. Every other setting was already read-only.

These two toggles keyed their `disabled` state off `archived` alone, ignoring `!canEdit`. They now use the same `disabled` (`archived || !canEdit`) as the surrounding settings, so they are read-only for non-admins. Covered by updated Cypress tests.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69384
