### PR TITLE
Gray out and explain read-only run name field in run playbook modal

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -608,6 +608,7 @@
   "mm5vL8": "Only invited members",
   "mw9jVA": "Add a title",
   "n70CD4": "Are you sure you want to resume {name}?",
+  "nGnueQ": "The run name is set automatically from this playbook's channel name template and can't be edited here.",
   "nR9VfG": "Failed to save run number prefix. Please try again.",
   "nc8QpJ": "Recent Activity",
   "nkCCM2": "You will not be reminded again.",

--- a/webapp/src/components/assets/inputs.tsx
+++ b/webapp/src/components/assets/inputs.tsx
@@ -17,6 +17,16 @@ export const BaseInput = styled.input<{$invalid?: boolean; $readOnly?: boolean}>
     &:focus {
         box-shadow: ${(props) => (props.$invalid ? 'inset 0 0 0 2px var(--error-text)' : 'inset 0 0 0 2px var(--button-bg)')};
     }
+
+    ${(props) => props.$readOnly && `
+        background-color: rgba(var(--center-channel-color-rgb), 0.04);
+        color: rgba(var(--center-channel-color-rgb), 0.56);
+        cursor: not-allowed;
+
+        &:focus {
+            box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
+        }
+    `}
 `;
 
 export const BaseTextArea = styled.textarea`

--- a/webapp/src/components/assets/inputs.tsx
+++ b/webapp/src/components/assets/inputs.tsx
@@ -22,10 +22,6 @@ export const BaseInput = styled.input<{$invalid?: boolean; $readOnly?: boolean}>
         background-color: rgba(var(--center-channel-color-rgb), 0.04);
         color: rgba(var(--center-channel-color-rgb), 0.56);
         cursor: not-allowed;
-
-        &:focus {
-            box-shadow: inset 0 0 0 1px rgba(var(--center-channel-color-rgb), 0.16);
-        }
     `}
 `;
 

--- a/webapp/src/components/modals/run_playbook_modal.test.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.test.tsx
@@ -222,6 +222,7 @@ import {createPlaybookRun} from 'src/client';
 import {useUserDisplayNameMap} from 'src/hooks/general';
 import {findNodeByTestId} from 'src/utils/test_helpers';
 import {RUN_NAME_MAX_LENGTH} from 'src/constants';
+import Tooltip from 'src/components/widgets/tooltip';
 
 import {RunPlaybookModal} from './run_playbook_modal';
 
@@ -318,6 +319,17 @@ describe('RunPlaybookModal — template mode', () => {
         it('marks name field as read-only when template is set', () => {
             const component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
             expect(toJson(component)).toContain('"$readOnly":true');
+        });
+
+        it('wraps the read-only name field in an explanatory tooltip when template is set', () => {
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            const tooltip = component!.root.findByType(Tooltip);
+            expect(tooltip.props.id).toBe('run-name-readonly-tooltip');
+            expect(tooltip.props.content).toContain('channel name template');
         });
 
         it('reinitializes same-id playbook refetches when template fields change', () => {
@@ -839,5 +851,14 @@ describe('RunPlaybookModal — no template (free-text mode)', () => {
     it('does not mark name as optional', () => {
         const component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
         expect(toJson(component)).not.toContain('optional');
+    });
+
+    it('does not wrap the editable name field in a tooltip', () => {
+        let component: renderer.ReactTestRenderer;
+        act(() => {
+            component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+        });
+
+        expect(component!.root.findAllByType(Tooltip)).toHaveLength(0);
     });
 });

--- a/webapp/src/components/modals/run_playbook_modal.test.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.test.tsx
@@ -332,6 +332,21 @@ describe('RunPlaybookModal — template mode', () => {
             expect(tooltip.props.content).toContain('channel name template');
         });
 
+        it('exposes the read-only reason to screen readers via aria-describedby', () => {
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            const tree = component!.toJSON();
+            const nameInput = findNodeByTestId(tree, 'run-name-input');
+            expect(nameInput.props['aria-describedby']).toBe('run-name-readonly-desc');
+
+            const description = findNodeByTestId(tree, 'run-name-readonly-desc');
+            expect(description.props.id).toBe('run-name-readonly-desc');
+            expect(JSON.stringify(description)).toContain('channel name template');
+        });
+
         it('reinitializes same-id playbook refetches when template fields change', () => {
             let component: renderer.ReactTestRenderer;
             act(() => {
@@ -860,5 +875,14 @@ describe('RunPlaybookModal — no template (free-text mode)', () => {
         });
 
         expect(component!.root.findAllByType(Tooltip)).toHaveLength(0);
+    });
+
+    it('does not set aria-describedby or a hidden description on the editable name field', () => {
+        const component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+        const tree = component.toJSON();
+
+        const nameInput = findNodeByTestId(tree, 'run-name-input');
+        expect(nameInput.props['aria-describedby']).toBeUndefined();
+        expect(toJson(component)).not.toContain('run-name-readonly-desc');
     });
 });

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -30,7 +30,7 @@ import {getPlaybooksGraphQLClient} from 'src/graphql_client';
 import {useCanCreatePlaybooksInTeam, usePlaybook, usePlaybookAttributes} from 'src/hooks';
 import {usePlaybook as useRestPlaybook} from 'src/hooks/crud';
 import {BaseInput, BaseTextArea} from 'src/components/assets/inputs';
-import Tooltip from 'src/components/widgets/tooltip';
+import ConditionalTooltip from 'src/components/widgets/conditional_tooltip';
 import GenericModal, {InlineLabel, ModalSideheading} from 'src/components/widgets/generic_modal';
 import {createPlaybookRun} from 'src/client';
 import {ButtonLabel, StyledChannelSelector, VerticalSplit} from 'src/components/backstage/playbook_edit/automation/channel_access';
@@ -574,19 +574,6 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
         suffix = ' ' + formatMessage({defaultMessage: '(optional)'});
     }
 
-    const input = (
-        <BaseInput
-            $invalid={Boolean(error)}
-            $readOnly={readOnly}
-            data-testid={'run-name-input'}
-            autoFocus={!readOnly}
-            type={'text'}
-            value={runName}
-            readOnly={readOnly}
-            onChange={readOnly ? undefined : onRunNameChange}
-        />
-    );
-
     return (<>
         <RunNameLabel invalid={Boolean(error)}>
             {formatMessage(
@@ -597,14 +584,22 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
                 {suffix},
             )}
         </RunNameLabel>
-        {readOnly ? (
-            <Tooltip
-                id={'run-name-readonly-tooltip'}
-                content={formatMessage({defaultMessage: 'The run name is set automatically from this playbook\'s channel name template and can\'t be edited here.'})}
-            >
-                {input}
-            </Tooltip>
-        ) : input}
+        <ConditionalTooltip
+            show={Boolean(readOnly)}
+            id={'run-name-readonly-tooltip'}
+            content={formatMessage({defaultMessage: 'The run name is set automatically from this playbook\'s channel name template and can\'t be edited here.'})}
+        >
+            <BaseInput
+                $invalid={Boolean(error)}
+                $readOnly={readOnly}
+                data-testid={'run-name-input'}
+                autoFocus={!readOnly}
+                type={'text'}
+                value={runName}
+                readOnly={readOnly}
+                onChange={readOnly ? undefined : onRunNameChange}
+            />
+        </ConditionalTooltip>
         {error && <ErrorMessage data-testid={'run-name-error'}>{error}</ErrorMessage>}
     </>);
 };

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -574,6 +574,8 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
         suffix = ' ' + formatMessage({defaultMessage: '(optional)'});
     }
 
+    const readOnlyExplanation = formatMessage({defaultMessage: 'The run name is set automatically from this playbook\'s channel name template and can\'t be edited here.'});
+
     return (<>
         <RunNameLabel invalid={Boolean(error)}>
             {formatMessage(
@@ -587,7 +589,7 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
         <ConditionalTooltip
             show={Boolean(readOnly)}
             id={'run-name-readonly-tooltip'}
-            content={formatMessage({defaultMessage: 'The run name is set automatically from this playbook\'s channel name template and can\'t be edited here.'})}
+            content={readOnlyExplanation}
         >
             <BaseInput
                 $invalid={Boolean(error)}
@@ -597,9 +599,18 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
                 type={'text'}
                 value={runName}
                 readOnly={readOnly}
+                aria-describedby={readOnly ? 'run-name-readonly-desc' : undefined}
                 onChange={readOnly ? undefined : onRunNameChange}
             />
         </ConditionalTooltip>
+        {readOnly && (
+            <VisuallyHidden
+                id={'run-name-readonly-desc'}
+                data-testid={'run-name-readonly-desc'}
+            >
+                {readOnlyExplanation}
+            </VisuallyHidden>
+        )}
         {error && <ErrorMessage data-testid={'run-name-error'}>{error}</ErrorMessage>}
     </>);
 };
@@ -842,6 +853,20 @@ const CreatePlaybookButton = styled.button`
 
 const RunNameLabel = styled(InlineLabel)<{invalid?: boolean}>`
     color: ${(props) => (props.invalid ? 'var(--error-text)' : 'rgba(var(--center-channel-color-rgb), 0.64)')};
+`;
+
+// Visually hidden but available to screen readers, so the reason a field is
+// read-only (otherwise only shown in the hover tooltip) is in the a11y tree.
+const VisuallyHidden = styled.span`
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 `;
 
 const ErrorMessage = styled.div`

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -30,6 +30,7 @@ import {getPlaybooksGraphQLClient} from 'src/graphql_client';
 import {useCanCreatePlaybooksInTeam, usePlaybook, usePlaybookAttributes} from 'src/hooks';
 import {usePlaybook as useRestPlaybook} from 'src/hooks/crud';
 import {BaseInput, BaseTextArea} from 'src/components/assets/inputs';
+import Tooltip from 'src/components/widgets/tooltip';
 import GenericModal, {InlineLabel, ModalSideheading} from 'src/components/widgets/generic_modal';
 import {createPlaybookRun} from 'src/client';
 import {ButtonLabel, StyledChannelSelector, VerticalSplit} from 'src/components/backstage/playbook_edit/automation/channel_access';
@@ -573,16 +574,7 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
         suffix = ' ' + formatMessage({defaultMessage: '(optional)'});
     }
 
-    return (<>
-        <RunNameLabel invalid={Boolean(error)}>
-            {formatMessage(
-                {
-                    id: 'playbooks.run_playbook_modal.run_name_label',
-                    defaultMessage: 'Run name{suffix}',
-                },
-                {suffix},
-            )}
-        </RunNameLabel>
+    const input = (
         <BaseInput
             $invalid={Boolean(error)}
             $readOnly={readOnly}
@@ -593,6 +585,26 @@ const RunNameSection = ({runName, onSetRunName, readOnly}: RunNameProps) => {
             readOnly={readOnly}
             onChange={readOnly ? undefined : onRunNameChange}
         />
+    );
+
+    return (<>
+        <RunNameLabel invalid={Boolean(error)}>
+            {formatMessage(
+                {
+                    id: 'playbooks.run_playbook_modal.run_name_label',
+                    defaultMessage: 'Run name{suffix}',
+                },
+                {suffix},
+            )}
+        </RunNameLabel>
+        {readOnly ? (
+            <Tooltip
+                id={'run-name-readonly-tooltip'}
+                content={formatMessage({defaultMessage: 'The run name is set automatically from this playbook\'s channel name template and can\'t be edited here.'})}
+            >
+                {input}
+            </Tooltip>
+        ) : input}
         {error && <ErrorMessage data-testid={'run-name-error'}>{error}</ErrorMessage>}
     </>);
 };


### PR DESCRIPTION
## Summary
When a playbook has a channel name template configured, the **Run name** field in the run playbook modal is read-only (the name is generated from the template). Previously the field still looked editable, which was confusing.

This PR:
- Styles the field with a disabled/grayed-out appearance when it's read-only (muted background and text, `not-allowed` cursor, no focus highlight).
- Adds a tooltip explaining *why* it can't be edited: the run name comes from the playbook's channel name template.

<img width="1210" height="368" alt="image" src="https://github.com/user-attachments/assets/bf3abe40-3925-4912-bef8-37a3e905b994" />

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69402

## Checklist
- [ ] Gated by experimental feature flag
- [ ] Unit tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)