### PR TITLE
[MM-69404] Allow inter-plugin API calls on behalf of a user

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -10,8 +10,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/config"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
@@ -33,20 +35,22 @@ type Handler struct {
 	APIRouter *mux.Router
 	root      *mux.Router
 	config    config.Service
+	auditor   app.Auditor
 }
 
 // NewHandler constructs a new handler.
-func NewHandler(pluginAPI *pluginapi.Client, config config.Service) *Handler {
+func NewHandler(pluginAPI *pluginapi.Client, config config.Service, auditor app.Auditor) *Handler {
 	handler := &Handler{
 		ErrorHandler: &ErrorHandler{},
 		pluginAPI:    pluginAPI,
 		config:       config,
+		auditor:      auditor,
 	}
 
 	root := mux.NewRouter()
 	root.Use(LogRequest)
 	api := root.PathPrefix("/api/v0").Subrouter()
-	api.Use(MattermostAuthorizationRequired)
+	api.Use(handler.MattermostAuthorizationRequired)
 
 	api.Handle("{anything:.*}", http.NotFoundHandler())
 	api.NotFoundHandler = http.NotFoundHandler()
@@ -126,7 +130,7 @@ const (
 // user it is acting on behalf of via the Mattermost-Plugin-Acting-User-Id header; that user is then
 // promoted into Mattermost-User-Id so every downstream per-user permission check applies to the
 // asserted user unchanged.
-func MattermostAuthorizationRequired(next http.Handler) http.Handler {
+func (h *Handler) MattermostAuthorizationRequired(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Normal authenticated user request -- unchanged behavior.
 		if r.Header.Get(userIDHeader) != "" {
@@ -136,15 +140,17 @@ func MattermostAuthorizationRequired(next http.Handler) http.Handler {
 
 		// Trusted inter-plugin request asserting an acting user.
 		if actingUserID := resolveInterPluginUser(r); actingUserID != "" {
-			// Record the privileged acting-as-user grant for auditing: the upstream LogRequest
-			// middleware runs before promotion, so it would otherwise log a blank user and never
-			// the calling plugin.
-			logrus.WithFields(logrus.Fields{
-				"caller_plugin_id": r.Header.Get(pluginIDHeader),
-				"acting_user_id":   actingUserID,
-				"method":           r.Method,
-				"url":              r.URL.String(),
-			}).Info("Authorized inter-plugin API request on behalf of user")
+			// Record the privileged acting-as-user grant in the audit log. The upstream
+			// LogRequest middleware runs before promotion, so the application log would
+			// otherwise record a blank user and never the calling plugin. The record
+			// documents the grant itself, not the eventual request outcome.
+			auditRec := h.auditor.MakeAuditRecord("interPluginActAsUser", model.AuditStatusSuccess)
+			auditRec.Actor.UserId = actingUserID
+			model.AddEventParameterToAuditRec(auditRec, "caller_plugin_id", r.Header.Get(pluginIDHeader))
+			model.AddEventParameterToAuditRec(auditRec, "acting_user_id", actingUserID)
+			model.AddEventParameterToAuditRec(auditRec, "method", r.Method)
+			model.AddEventParameterToAuditRec(auditRec, "url", r.URL.String())
+			h.auditor.LogAuditRec(auditRec)
 
 			r.Header.Set(userIDHeader, actingUserID)
 			next.ServeHTTP(w, r)

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -104,15 +104,70 @@ func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}, httpStatus i
 	}
 }
 
-// MattermostAuthorizationRequired checks if request is authorized.
+// Header names used to authorize requests. HTTP headers are case-insensitive; both spellings of
+// the user header in use throughout the handlers (Mattermost-User-Id / Mattermost-User-ID)
+// canonicalize to the same key, so promoting the acting user under this name is visible to all of
+// them.
+const (
+	userIDHeader = "Mattermost-User-Id"
+	// pluginIDHeader is set by the Mattermost server on inter-plugin/internal requests to identify
+	// the calling plugin. The server deletes it from externally-originated requests, so it cannot
+	// be spoofed by an external client -- it is the trust anchor for inter-plugin authorization.
+	pluginIDHeader = "Mattermost-Plugin-ID"
+	// actingUserIDHeader is set by the calling plugin to name the user it is acting on behalf of.
+	// It is only honored when the request is a trusted inter-plugin call from an allowed caller.
+	actingUserIDHeader = "Mattermost-Plugin-Acting-User-Id"
+)
+
+// MattermostAuthorizationRequired checks if a request is authorized.
+//
+// A request is authorized when it carries an authenticated user (the Mattermost-User-Id header set
+// by the server for user sessions). Additionally, a trusted inter-plugin request may assert the
+// user it is acting on behalf of via the Mattermost-Plugin-Acting-User-Id header; that user is then
+// promoted into Mattermost-User-Id so every downstream per-user permission check applies to the
+// asserted user unchanged.
 func MattermostAuthorizationRequired(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID := r.Header.Get("Mattermost-User-Id")
-		if userID != "" {
+		// Normal authenticated user request -- unchanged behavior.
+		if r.Header.Get(userIDHeader) != "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Trusted inter-plugin request asserting an acting user.
+		if actingUserID := resolveInterPluginUser(r); actingUserID != "" {
+			// Record the privileged acting-as-user grant for auditing: the upstream LogRequest
+			// middleware runs before promotion, so it would otherwise log a blank user and never
+			// the calling plugin.
+			logrus.WithFields(logrus.Fields{
+				"caller_plugin_id": r.Header.Get(pluginIDHeader),
+				"acting_user_id":   actingUserID,
+				"method":           r.Method,
+				"url":              r.URL.String(),
+			}).Info("Authorized inter-plugin API request on behalf of user")
+
+			r.Header.Set(userIDHeader, actingUserID)
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
 	})
+}
+
+// resolveInterPluginUser returns the user ID an inter-plugin request is acting on behalf of, or an
+// empty string if the request is not a trusted inter-plugin call asserting a user.
+//
+// This relies on the Mattermost-Plugin-ID header being set only by the server on genuine
+// inter-plugin/internal requests (and stripped from external requests), so an external client
+// cannot reach this branch by forging the headers. The calling plugin is trusted to name the user
+// it acts for; the asserted user's own permissions are still fully enforced downstream.
+func resolveInterPluginUser(r *http.Request) string {
+	callerPluginID := r.Header.Get(pluginIDHeader)
+	actingUserID := r.Header.Get(actingUserIDHeader)
+	if callerPluginID == "" || actingUserID == "" {
+		return ""
+	}
+
+	return actingUserID
 }

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -149,7 +149,8 @@ func (h *Handler) MattermostAuthorizationRequired(next http.Handler) http.Handle
 			model.AddEventParameterToAuditRec(auditRec, "caller_plugin_id", r.Header.Get(pluginIDHeader))
 			model.AddEventParameterToAuditRec(auditRec, "acting_user_id", actingUserID)
 			model.AddEventParameterToAuditRec(auditRec, "method", r.Method)
-			model.AddEventParameterToAuditRec(auditRec, "url", r.URL.String())
+			// Path only. The query string is caller-controlled and may carry sensitive values.
+			model.AddEventParameterToAuditRec(auditRec, "url", r.URL.EscapedPath())
 			h.auditor.LogAuditRec(auditRec)
 
 			r.Header.Set(userIDHeader, actingUserID)

--- a/server/api/playbook_runs_middleware_test.go
+++ b/server/api/playbook_runs_middleware_test.go
@@ -12,6 +12,92 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMattermostAuthorizationRequired(t *testing.T) {
+	const (
+		userID       = "user_abc123"
+		callerPlugin = "com.example.caller"
+	)
+
+	for _, tc := range []struct {
+		name             string
+		userHeader       string
+		pluginHeader     string
+		actingUserHeader string
+		expectStatus     int
+		expectUserID     string // the Mattermost-User-Id the downstream handler should observe
+	}{
+		{
+			name:         "authenticated user request passes unchanged",
+			userHeader:   userID,
+			expectStatus: http.StatusOK,
+			expectUserID: userID,
+		},
+		{
+			name:             "authenticated user request ignores plugin headers",
+			userHeader:       userID,
+			pluginHeader:     callerPlugin,
+			actingUserHeader: "someone_else",
+			expectStatus:     http.StatusOK,
+			expectUserID:     userID,
+		},
+		{
+			name:         "no headers at all is rejected",
+			expectStatus: http.StatusUnauthorized,
+		},
+		{
+			name:             "inter-plugin call promotes the acting user",
+			pluginHeader:     callerPlugin,
+			actingUserHeader: userID,
+			expectStatus:     http.StatusOK,
+			expectUserID:     userID,
+		},
+		{
+			name:             "inter-plugin call without an acting user is rejected",
+			pluginHeader:     callerPlugin,
+			actingUserHeader: "",
+			expectStatus:     http.StatusUnauthorized,
+		},
+		{
+			name:             "acting-user header without a plugin header is rejected (external spoof guard)",
+			pluginHeader:     "",
+			actingUserHeader: userID,
+			expectStatus:     http.StatusUnauthorized,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var observedUserID string
+			handlerCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				observedUserID = r.Header.Get("Mattermost-User-Id")
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/plugins/playbooks/api/v0/runs/runid", nil)
+			if tc.userHeader != "" {
+				req.Header.Set("Mattermost-User-Id", tc.userHeader)
+			}
+			if tc.pluginHeader != "" {
+				req.Header.Set("Mattermost-Plugin-ID", tc.pluginHeader)
+			}
+			if tc.actingUserHeader != "" {
+				req.Header.Set("Mattermost-Plugin-Acting-User-Id", tc.actingUserHeader)
+			}
+
+			rec := httptest.NewRecorder()
+			MattermostAuthorizationRequired(next).ServeHTTP(rec, req)
+
+			require.Equal(t, tc.expectStatus, rec.Code)
+			if tc.expectStatus == http.StatusOK {
+				require.True(t, handlerCalled, "downstream handler should have been called")
+				require.Equal(t, tc.expectUserID, observedUserID, "downstream handler saw the wrong user")
+			} else {
+				require.False(t, handlerCalled, "downstream handler must not be called on rejection")
+			}
+		})
+	}
+}
+
 func TestIsRunRestoreRequest(t *testing.T) {
 	t.Run("run restore", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/plugins/playbooks/api/v0/runs/runid/restore", nil)

--- a/server/api/playbook_runs_middleware_test.go
+++ b/server/api/playbook_runs_middleware_test.go
@@ -8,8 +8,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
+
+	mock_app "github.com/mattermost/mattermost-plugin-playbooks/server/app/mocks"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 func TestMattermostAuthorizationRequired(t *testing.T) {
@@ -25,6 +29,7 @@ func TestMattermostAuthorizationRequired(t *testing.T) {
 		actingUserHeader string
 		expectStatus     int
 		expectUserID     string // the Mattermost-User-Id the downstream handler should observe
+		expectAudit      bool   // whether the acting-as-user grant should be recorded
 	}{
 		{
 			name:         "authenticated user request passes unchanged",
@@ -50,6 +55,7 @@ func TestMattermostAuthorizationRequired(t *testing.T) {
 			actingUserHeader: userID,
 			expectStatus:     http.StatusOK,
 			expectUserID:     userID,
+			expectAudit:      true,
 		},
 		{
 			name:             "inter-plugin call without an acting user is rejected",
@@ -65,6 +71,22 @@ func TestMattermostAuthorizationRequired(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// gomock fails the test on any unexpected call, so paths that must NOT audit
+			// (normal user requests, rejections) are verified by setting no expectations.
+			mockAuditor := mock_app.NewMockAuditor(ctrl)
+			if tc.expectAudit {
+				auditRec := &model.AuditRecord{}
+				mockAuditor.EXPECT().
+					MakeAuditRecord("interPluginActAsUser", model.AuditStatusSuccess).
+					Return(auditRec)
+				mockAuditor.EXPECT().LogAuditRec(auditRec)
+			}
+
+			h := &Handler{auditor: mockAuditor}
+
 			var observedUserID string
 			handlerCalled := false
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +107,7 @@ func TestMattermostAuthorizationRequired(t *testing.T) {
 			}
 
 			rec := httptest.NewRecorder()
-			MattermostAuthorizationRequired(next).ServeHTTP(rec, req)
+			h.MattermostAuthorizationRequired(next).ServeHTTP(rec, req)
 
 			require.Equal(t, tc.expectStatus, rec.Code)
 			if tc.expectStatus == http.StatusOK {

--- a/server/app/auditor_service.go
+++ b/server/app/auditor_service.go
@@ -6,17 +6,18 @@ package app
 import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
 // AuditorService implements the Auditor interface
 type AuditorService struct {
-	pluginAPI plugin.API
+	pluginAPI pluginapi.Client
 }
 
 // NewAuditorService creates a new auditor service
-func NewAuditorService(pluginAPI plugin.API) Auditor {
+func NewAuditorService(api pluginapi.Client) Auditor {
 	return &AuditorService{
-		pluginAPI: pluginAPI,
+		pluginAPI: api,
 	}
 }
 
@@ -27,5 +28,5 @@ func (a *AuditorService) MakeAuditRecord(event string, initialStatus string) *mo
 
 // LogAuditRec logs an audit record
 func (a *AuditorService) LogAuditRec(auditRec *model.AuditRecord) {
-	a.pluginAPI.LogAuditRec(auditRec)
+	a.pluginAPI.Audit.Record(auditRec)
 }

--- a/server/app/auditor_service.go
+++ b/server/app/auditor_service.go
@@ -11,11 +11,11 @@ import (
 
 // AuditorService implements the Auditor interface
 type AuditorService struct {
-	pluginAPI pluginapi.Client
+	pluginAPI *pluginapi.Client
 }
 
 // NewAuditorService creates a new auditor service
-func NewAuditorService(api pluginapi.Client) Auditor {
+func NewAuditorService(api *pluginapi.Client) Auditor {
 	return &AuditorService{
 		pluginAPI: api,
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -167,7 +167,9 @@ func (p *Plugin) OnActivate() error {
 	categoryStore := sqlstore.NewCategoryStore(apiClient, sqlStore)
 	conditionStore := sqlstore.NewConditionStore(apiClient, sqlStore)
 
-	p.handler = api.NewHandler(pluginAPIClient, p.config)
+	auditorService := app.NewAuditorService(p.API)
+
+	p.handler = api.NewHandler(pluginAPIClient, p.config, auditorService)
 
 	p.categoryService = app.NewCategoryService(categoryStore, pluginAPIClient)
 	propertyService, err := app.NewPropertyService(pluginAPIClient, conditionStore)
@@ -176,7 +178,6 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.propertyService = propertyService
 
-	auditorService := app.NewAuditorService(p.API)
 	p.conditionService = app.NewConditionService(conditionStore, propertyService, p.bot, auditorService)
 
 	p.playbookService = app.NewPlaybookService(playbookStore, p.bot, pluginAPIClient, auditorService, p.metricsService, propertyService, p.conditionService)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -167,7 +167,7 @@ func (p *Plugin) OnActivate() error {
 	categoryStore := sqlstore.NewCategoryStore(apiClient, sqlStore)
 	conditionStore := sqlstore.NewConditionStore(apiClient, sqlStore)
 
-	auditorService := app.NewAuditorService(p.API)
+	auditorService := app.NewAuditorService(pluginAPIClient)
 
 	p.handler = api.NewHandler(pluginAPIClient, p.config, auditorService)
 


### PR DESCRIPTION
## Summary

Other Mattermost plugins cannot call the Playbooks REST/GraphQL API today. When a plugin issues a request via `PluginHTTP` / `client.Plugin.HTTP`, the server routes it through `ServeInterPluginRequest`, which blanks `Mattermost-User-Id`. Our `MattermostAuthorizationRequired` middleware requires that header, so every inter-plugin call gets a 401. The request reaches us; it just has no user identity to authorize against.

This is needed for a custom customer integration (itself a plugin) that needs to read and act on Playbooks data as a specific user.

### What this changes

Extend `MattermostAuthorizationRequired` so that, when there is no authenticated user but the request is a trusted inter-plugin call, it promotes the asserted acting-user into `Mattermost-User-Id` and lets the request proceed. The calling plugin names the user via a custom `Mattermost-Plugin-Acting-User-Id` header.

Because every downstream handler already reads `Mattermost-User-Id` and runs per-user permission checks (`RunView`, etc.), **no handler changes are required** and the call is scoped to exactly what the asserted user can see. The change is ~2 files (`server/api/api.go` plus a middleware test). GraphQL is mounted under the same subrouter, so it is covered too.

### Trust model / security

- **Trust anchor:** the design relies on `Mattermost-Plugin-ID` being unforgeable by external clients. The server deletes it from the public request path and only sets it on genuine inter-plugin/internal paths (verified against the server version we depend on). If a future server change stops stripping it, the trust boundary moves, so this dependency is called out explicitly here.
- **Least privilege preserved:** every call is still authorized as the asserted user via the unchanged permission checks. The feature does not grant a plugin read access beyond what some user already has.
- **No anonymous access:** an inter-plugin request without an acting-user header is rejected.
- **Auditing:** the privileged acting-as-user grant is logged (caller plugin ID + acting user + method/url). `LogRequest` runs before promotion, so it would otherwise record a blank user and never the calling plugin.


### Example logs
```jsonl
{"timestamp":"2026-06-22 09:51:54.702 +02:00","level":"debug","msg":"Received HTTP request","caller":"app/plugin_api.go:1160","plugin_id":"playbooks","user_id":"","request_id":"4hbmhi8ybfrdubeirdiwoq4fsw","user_agent":"","method":"GET","url":"/api/v0/runs/re1x94mc1pnzbpphofgp5thqpe","plugin_caller":"github.com/mattermost/mattermost-plugin-playbooks/server/api/logger.go:48"}
{"timestamp":"2026-06-22 09:51:54.702 +02:00","level":"info","msg":"Authorized inter-plugin API request on behalf of user","caller":"app/plugin_api.go:1164","plugin_id":"playbooks","url":"/api/v0/runs/re1x94mc1pnzbpphofgp5thqpe","caller_plugin_id":"com.mattermost.plugin-starter-template","acting_user_id":"nswgu3thqtyq3fp6hkwn8xuk7a","method":"GET","plugin_caller":"github.com/mattermost/mattermost-plugin-playbooks/server/api/api.go:147"}
{"timestamp":"2026-06-22 09:51:54.725 +02:00","level":"debug","msg":"Handled HTTP request","caller":"app/plugin_api.go:1160","plugin_id":"playbooks","time":"22","status":"200","user_agent":"","method":"GET","url":"/api/v0/runs/re1x94mc1pnzbpphofgp5thqpe","user_id":"","request_id":"4hbmhi8ybfrdubeirdiwoq4fsw","plugin_caller":"github.com/mattermost/mattermost-plugin-playbooks/server/api/logger.go:61"}
```

## Ticket Link

https://mattermost.atlassian.net/browse/MM-69404


🤖 Generated with [Claude Code](https://claude.com/claude-code)