### PR TITLE
[MM-69405] Add inter-plugin client constructor for the Playbooks API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,13 @@ const (
 	apiVersion = "v0"
 	manifestID = "playbooks"
 	userAgent  = "go-client/" + apiVersion
+
+	// externalAPIURLPrefix is the API path prefix for requests made over regular HTTP, where the
+	// Mattermost server routes /plugins/<id>/* to the plugin.
+	externalAPIURLPrefix = "plugins/" + manifestID + "/api/" + apiVersion + "/"
+	// interPluginAPIURLPrefix is the API path prefix for inter-plugin requests, where PluginHTTP
+	// routes by the first path segment (/<id>/*) instead.
+	interPluginAPIURLPrefix = manifestID + "/api/" + apiVersion + "/"
 )
 
 // Client manages communication with the Playbooks API.
@@ -36,6 +43,9 @@ type Client struct {
 	BaseURL *url.URL
 	// User agent used when communicating with the Playbooks API.
 	UserAgent string
+	// apiURLPrefix is the path prefix prepended to API endpoints. It differs between regular HTTP
+	// and inter-plugin requests; see externalAPIURLPrefix and interPluginAPIURLPrefix.
+	apiURLPrefix string
 
 	// PlaybookRuns is a collection of methods used to interact with playbook runs.
 	PlaybookRuns *PlaybookRunService
@@ -78,7 +88,7 @@ func newClient(mattermostSiteURL string, httpClient *http.Client) (*Client, erro
 		return nil, err
 	}
 
-	c := &Client{client: httpClient, BaseURL: siteURL, UserAgent: userAgent}
+	c := &Client{client: httpClient, BaseURL: siteURL, UserAgent: userAgent, apiURLPrefix: externalAPIURLPrefix}
 	c.PlaybookRuns = &PlaybookRunService{c}
 	c.Playbooks = &PlaybooksService{c}
 	c.Settings = &SettingsService{c}
@@ -127,12 +137,12 @@ func (c *Client) newRequest(method, endpoint string, body interface{}) (*http.Re
 
 // newAPIRequest creates an API request, JSON-encoding any given body parameter.
 func (c *Client) newAPIRequest(method, endpoint string, body interface{}) (*http.Request, error) {
-	return c.newRequest(method, buildAPIURL(endpoint), body)
+	return c.newRequest(method, c.buildAPIURL(endpoint), body)
 }
 
 // buildAPIURL constructs the path to the given endpoint.
-func buildAPIURL(endpoint string) string {
-	return fmt.Sprintf("plugins/%s/api/%s/%s", manifestID, apiVersion, endpoint)
+func (c *Client) buildAPIURL(endpoint string) string {
+	return c.apiURLPrefix + endpoint
 }
 
 // do sends an API request and returns the API response.

--- a/client/doc.go
+++ b/client/doc.go
@@ -2,4 +2,21 @@
 // See LICENSE.txt for license information.
 
 // Package client provides an HTTP client for using the Playbooks API.
+//
+// External callers authenticate as a Mattermost user and construct a client with New:
+//
+//	pb, err := client.New(client4)
+//
+// Other plugins can reach the Playbooks API over inter-plugin HTTP with
+// NewInterPluginClient, acting on behalf of a given user. Requests are dispatched through the
+// caller's PluginHTTP entrypoint and authorized with that user's permissions:
+//
+//	pb, err := client.NewInterPluginClient(p.API.PluginHTTP, userID)
+//	if err != nil {
+//	    return err
+//	}
+//	run, err := pb.PlaybookRuns.Get(ctx, runID)
+//
+// This requires the Playbooks server to honor the acting-user header, so it returns 401 against
+// servers that predate that support.
 package client

--- a/client/interplugin.go
+++ b/client/interplugin.go
@@ -62,9 +62,20 @@ type interPluginTransport struct {
 }
 
 func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set(actingUserIDHeader, t.actingUserID)
+	// RoundTrip must not modify the original request, so operate on a clone. The clone shares the
+	// original's Body, so closing it below also discharges RoundTrip's duty to close req.Body.
+	outReq := req.Clone(req.Context())
+	outReq.Header.Set(actingUserIDHeader, t.actingUserID)
 
-	resp := t.do(req)
+	// RoundTrip must always close the request body. PluginHTTP's buffered path closes and nils the
+	// body itself, but its streaming path does not, so close whatever remains once the call returns.
+	defer func() {
+		if outReq.Body != nil {
+			outReq.Body.Close()
+		}
+	}()
+
+	resp := t.do(outReq)
 	if resp == nil {
 		return nil, errors.Errorf("no response from the %s plugin; is it installed and enabled?", manifestID)
 	}
@@ -73,7 +84,7 @@ func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// error responses for non-2xx replies. Set it as net/http's Transport does for real network
 	// requests, so a non-2xx response yields an error rather than a nil-pointer panic.
 	if resp.Request == nil {
-		resp.Request = req
+		resp.Request = outReq
 	}
 
 	return resp, nil

--- a/client/interplugin.go
+++ b/client/interplugin.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// actingUserIDHeader names the user a calling plugin is acting on behalf of. The Playbooks server
+// promotes it into the authenticated user for trusted inter-plugin requests, so the request is
+// authorized with that user's permissions.
+const actingUserIDHeader = "Mattermost-Plugin-Acting-User-Id"
+
+// PluginHTTPFunc performs an inter-plugin HTTP request. It matches the signature of both
+// pluginapi.Client's Plugin.HTTP method and plugin.API's PluginHTTP method, so a caller can pass
+// either without this package depending on them.
+type PluginHTTPFunc func(*http.Request) *http.Response
+
+// NewInterPluginClient creates a Client that reaches the Playbooks plugin over inter-plugin HTTP,
+// acting on behalf of the given user. Every request is authorized with that user's permissions, so
+// the client only ever sees what actingUserID is allowed to see.
+//
+// do is the calling plugin's inter-plugin HTTP entrypoint, e.g. pluginAPI.Plugin.HTTP or
+// API.PluginHTTP. Example:
+//
+//	pb, err := client.NewInterPluginClient(p.API.PluginHTTP, userID)
+//	if err != nil {
+//	    return err
+//	}
+//	run, err := pb.PlaybookRuns.Get(ctx, runID)
+func NewInterPluginClient(do PluginHTTPFunc, actingUserID string) (*Client, error) {
+	if do == nil {
+		return nil, errors.New("a PluginHTTP function is required")
+	}
+	if actingUserID == "" {
+		return nil, errors.New("an acting user ID is required")
+	}
+
+	httpClient := &http.Client{
+		Transport: &interPluginTransport{do: do, actingUserID: actingUserID},
+	}
+
+	// The host is irrelevant: PluginHTTP routes by the request path's first segment, which is
+	// supplied by interPluginAPIURLPrefix. Only a syntactically valid base URL is needed.
+	c, err := newClient("http://playbooks.local", httpClient)
+	if err != nil {
+		return nil, err
+	}
+	c.apiURLPrefix = interPluginAPIURLPrefix
+
+	return c, nil
+}
+
+// interPluginTransport is an http.RoundTripper that dispatches requests through the calling
+// plugin's inter-plugin HTTP entrypoint, asserting the acting user on each request.
+type interPluginTransport struct {
+	do           PluginHTTPFunc
+	actingUserID string
+}
+
+func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(actingUserIDHeader, t.actingUserID)
+
+	resp := t.do(req)
+	if resp == nil {
+		return nil, errors.Errorf("no response from the %s plugin; is it installed and enabled?", manifestID)
+	}
+
+	return resp, nil
+}

--- a/client/interplugin.go
+++ b/client/interplugin.go
@@ -69,5 +69,12 @@ func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, err
 		return nil, errors.Errorf("no response from the %s plugin; is it installed and enabled?", manifestID)
 	}
 
+	// PluginHTTP does not populate Response.Request, but the client dereferences it when building
+	// error responses for non-2xx replies. Set it as net/http's Transport does for real network
+	// requests, so a non-2xx response yields an error rather than a nil-pointer panic.
+	if resp.Request == nil {
+		resp.Request = req
+	}
+
 	return resp, nil
 }

--- a/client/interplugin_test.go
+++ b/client/interplugin_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-playbooks/client"
+)
+
+func TestNewInterPluginClient(t *testing.T) {
+	noopDo := func(*http.Request) *http.Response { return nil }
+
+	t.Run("requires a PluginHTTP function", func(t *testing.T) {
+		c, err := client.NewInterPluginClient(nil, "user_abc")
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
+
+	t.Run("requires an acting user ID", func(t *testing.T) {
+		c, err := client.NewInterPluginClient(noopDo, "")
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
+
+	t.Run("routes through PluginHTTP and asserts the acting user", func(t *testing.T) {
+		var gotReq *http.Request
+		do := func(req *http.Request) *http.Response {
+			gotReq = req
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"id":"run123"}`)),
+			}
+		}
+
+		c, err := client.NewInterPluginClient(do, "user_abc")
+		require.NoError(t, err)
+
+		run, err := c.PlaybookRuns.Get(context.Background(), "run123")
+		require.NoError(t, err)
+		require.Equal(t, "run123", run.ID)
+
+		// The path must be /<pluginid>/api/v0/... so PluginHTTP routes it to Playbooks.
+		require.Equal(t, "/playbooks/api/v0/runs/run123", gotReq.URL.Path)
+		require.Equal(t, "user_abc", gotReq.Header.Get("Mattermost-Plugin-Acting-User-Id"))
+	})
+
+	t.Run("surfaces a nil response as an error", func(t *testing.T) {
+		c, err := client.NewInterPluginClient(noopDo, "user_abc")
+		require.NoError(t, err)
+
+		_, err = c.PlaybookRuns.Get(context.Background(), "run123")
+		require.Error(t, err)
+	})
+}

--- a/client/interplugin_test.go
+++ b/client/interplugin_test.go
@@ -53,6 +53,24 @@ func TestNewInterPluginClient(t *testing.T) {
 		require.Equal(t, "user_abc", gotReq.Header.Get("Mattermost-Plugin-Acting-User-Id"))
 	})
 
+	t.Run("non-2xx response is returned as an error, not a panic", func(t *testing.T) {
+		// PluginHTTP leaves Response.Request nil; the transport must set it so checkResponse
+		// does not dereference a nil pointer when building the error for a non-2xx reply.
+		do := func(*http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":"forbidden"}`)),
+			}
+		}
+
+		c, err := client.NewInterPluginClient(do, "user_abc")
+		require.NoError(t, err)
+
+		_, err = c.PlaybookRuns.Get(context.Background(), "run123")
+		require.Error(t, err)
+	})
+
 	t.Run("surfaces a nil response as an error", func(t *testing.T) {
 		c, err := client.NewInterPluginClient(noopDo, "user_abc")
 		require.NoError(t, err)

--- a/client/playbooks.go
+++ b/client/playbooks.go
@@ -180,7 +180,7 @@ func (s *PlaybooksService) Duplicate(ctx context.Context, playbookID string) (st
 // Imports a playbook. Returns the id of the newly created playbook
 func (s *PlaybooksService) Import(ctx context.Context, toImport []byte, team string) (string, error) {
 	url := "playbooks/import?team_id=" + team
-	u, err := s.client.BaseURL.Parse(buildAPIURL(url))
+	u, err := s.client.BaseURL.Parse(s.client.buildAPIURL(url))
 	if err != nil {
 		return "", errors.Wrapf(err, "invalid endpoint %s", url)
 	}

--- a/client/unexport_test.go
+++ b/client/unexport_test.go
@@ -3,5 +3,4 @@
 
 package client
 
-var BuildAPIURL = buildAPIURL
 var NewClient = newClient


### PR DESCRIPTION
## Summary

Client-side companion to #2316. Lets other plugins call the Playbooks API over inter-plugin HTTP using the existing typed `client.Client`, instead of hand-rolling `*http.Request`s.

```go
pb, err := client.NewInterPluginClient(p.API.PluginHTTP, userID)
if err != nil {
    return err
}
run, err := pb.PlaybookRuns.Get(ctx, runID) // authorized as userID
```

`do` accepts anything with the `func(*http.Request) *http.Response` shape, so both `p.API.PluginHTTP` and `pluginClient.Plugin.HTTP` work without this package depending on the plugin API. The client is scoped to a single acting user for its lifetime (build one per user).

### What changed

Two adjustments make the existing client usable over inter-plugin HTTP:

- **API URL prefix is now a `Client` field.** Regular HTTP uses `plugins/playbooks/api/v0/`; inter-plugin requests use `playbooks/api/v0/`, because `PluginHTTP` routes by the first path segment (`/<pluginid>/*`) rather than the `/plugins/<id>/*` route the server uses for external HTTP.
- **A small `RoundTripper`** (`interPluginTransport`) injects the `Mattermost-Plugin-Acting-User-Id` header on every request and turns a nil `PluginHTTP` response (plugin not installed/enabled) into a clear error.

`NewInterPluginClient` fails closed: it errors if `do` is nil or `actingUserID` is empty, so a request can never go out without an asserted user.

### Dependency

This is inert until the server-side change (#2316) that promotes the acting-user header lands; until then these requests get a 401. No new module dependency: `client/go.mod` already requires `mattermost/server/public`, and the constructor takes a plain func rather than importing the plugin API.


## Ticket Link

https://mattermost.atlassian.net/browse/MM-69405


🤖 Generated with [Claude Code](https://claude.com/claude-code)