### PR TITLE
Fix master lint: run_playbook_modal test imports deleted Tooltip widget

### DIFF
--- a/webapp/src/components/modals/run_playbook_modal.test.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.test.tsx
@@ -222,7 +222,7 @@ import {createPlaybookRun} from 'src/client';
 import {useUserDisplayNameMap} from 'src/hooks/general';
 import {findNodeByTestId} from 'src/utils/test_helpers';
 import {RUN_NAME_MAX_LENGTH} from 'src/constants';
-import Tooltip from 'src/components/widgets/tooltip';
+import ConditionalTooltip from 'src/components/widgets/conditional_tooltip';
 
 import {RunPlaybookModal} from './run_playbook_modal';
 
@@ -327,7 +327,8 @@ describe('RunPlaybookModal — template mode', () => {
                 component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
             });
 
-            const tooltip = component!.root.findByType(Tooltip);
+            const tooltip = component!.root.findByType(ConditionalTooltip);
+            expect(tooltip.props.show).toBe(true);
             expect(tooltip.props.id).toBe('run-name-readonly-tooltip');
             expect(tooltip.props.content).toContain('channel name template');
         });
@@ -874,7 +875,8 @@ describe('RunPlaybookModal — no template (free-text mode)', () => {
             component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
         });
 
-        expect(component!.root.findAllByType(Tooltip)).toHaveLength(0);
+        const tooltip = component!.root.findByType(ConditionalTooltip);
+        expect(tooltip.props.show).toBe(false);
     });
 
     it('does not set aria-describedby or a hidden description on the editable name field', () => {


### PR DESCRIPTION
## Summary

`lint-web` is failing on `master` (`import/order`, see [failed run](https://github.com/mattermost/mattermost-plugin-playbooks/actions/runs/28031016038)).

`webapp/src/components/modals/run_playbook_modal.test.tsx` (added in #2314) imports the old `src/components/widgets/tooltip` widget, which was deleted in #2236 ("MM-68333 Use WithTooltip shared from web app"). The two PRs were in flight simultaneously, so master ended up with a test importing a now-deleted module — breaking lint.

This switches the test to the `ConditionalTooltip` widget the component actually renders. Since `ConditionalTooltip` is always present in the tree and toggles via its `show` prop, the assertions now check `show` (true for the read-only template case, false for the editable case) instead of the presence/absence of a tooltip element.

Verified locally:
- `npm run lint:eslint` → clean (exit 0)
- `jest run_playbook_modal.test.tsx` → 34/34 passing

## Ticket Link

N/A — CI fix.

## Checklist
- ~~Gated by experimental feature flag~~
- [x] Unit tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)