### PR TITLE
MM-69465: Fix non-deterministic plugin config keys from serialize() casing

### DIFF
--- a/server/api_tabapp_test.go
+++ b/server/api_tabapp_test.go
@@ -29,7 +29,7 @@ func TestTabAppGetRuns(t *testing.T) {
 
 	setTabApp := func(t *testing.T, enable bool) {
 		cfg := e.Srv.Config()
-		cfg.PluginSettings.Plugins["playbooks"]["EnableTeamsTabApp"] = enable
+		cfg.PluginSettings.Plugins["playbooks"]["enableTeamsTabApp"] = enable
 
 		var patchedConfig model.Config
 

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -44,13 +44,16 @@ func (c *Configuration) Clone() *Configuration {
 	return &clone
 }
 
-func (c *Configuration) serialize() map[string]interface{} {
-	ret := make(map[string]interface{})
+func (c *Configuration) serialize() map[string]any {
+	ret := make(map[string]any)
+	// Keys with a plugin.json settings_schema entry MUST match that key exactly,
+	// or the console's copy and this one become duplicate keys. See
+	// reconcileLegacyConfigKeys. BotUserID/TeamsTabAppBotUserID have no schema entry.
 	ret["BotUserID"] = c.BotUserID
-	ret["EnableTeamsTabApp"] = c.EnableTeamsTabApp
-	ret["TeamsTabAppTenantIDs"] = c.TeamsTabAppTenantIDs
+	ret["enableTeamsTabApp"] = c.EnableTeamsTabApp
+	ret["teamsTabAppTenantIDs"] = c.TeamsTabAppTenantIDs
 	ret["TeamsTabAppBotUserID"] = c.TeamsTabAppBotUserID
-	ret["EnableIncrementalUpdates"] = c.EnableIncrementalUpdates
+	ret["enableincrementalupdates"] = c.EnableIncrementalUpdates
 	ret["EnableExperimentalFeatures"] = c.EnableExperimentalFeatures
 	ret["ExposeMCPExternal"] = c.ExposeMCPExternal
 	return ret

--- a/server/config/configuration_test.go
+++ b/server/config/configuration_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeKeysMatchPluginManifest guards against the casing mismatch that
+// caused MM-69465. The System Console persists a setting under its plugin.json
+// settings_schema key, while serialize() writes the plugin's own copy. If the two
+// disagree (even only in case), they become distinct keys that LoadPluginConfiguration
+// collapses non-deterministically. This test fails if serialize() can produce a
+// duplicate, either on its own or relative to the manifest.
+func TestSerializeKeysMatchPluginManifest(t *testing.T) {
+	serialized := (&Configuration{}).serialize()
+
+	t.Run("serialize() keys never collide case-insensitively", func(t *testing.T) {
+		seen := make(map[string]string, len(serialized))
+		for key := range serialized {
+			lower := strings.ToLower(key)
+			assert.NotContainsf(t, seen, lower,
+				"serialize() emits %q which collapses to the same config key as %q", key, seen[lower])
+			seen[lower] = key
+		}
+	})
+
+	t.Run("every plugin.json settings_schema key is written verbatim by serialize()", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join("..", "..", "plugin.json"))
+		require.NoError(t, err)
+
+		var manifest struct {
+			SettingsSchema struct {
+				Settings []struct {
+					Key string `json:"key"`
+				} `json:"settings"`
+			} `json:"settings_schema"`
+		}
+		require.NoError(t, json.Unmarshal(data, &manifest))
+		require.NotEmpty(t, manifest.SettingsSchema.Settings, "plugin.json should declare settings")
+
+		for _, setting := range manifest.SettingsSchema.Settings {
+			_, ok := serialized[setting.Key]
+			assert.Truef(t, ok,
+				"plugin.json settings_schema key %q is not written verbatim by serialize(); "+
+					"the console writes under that key, so a differently cased serialize() key would create a duplicate",
+				setting.Key)
+		}
+	})
+}

--- a/server/config/service.go
+++ b/server/config/service.go
@@ -17,12 +17,12 @@ import (
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
-// legacyConfigKeyAliases maps a canonical settings_schema key to the differently
-// cased key older plugin versions wrote via serialize(). See reconcileLegacyConfigKeys.
+// legacyConfigKeyAliases maps a legacy key older plugin versions wrote via
+// serialize() to its canonical settings_schema key. See reconcileLegacyConfigKeys.
 var legacyConfigKeyAliases = map[string]string{
-	"enableTeamsTabApp":        "EnableTeamsTabApp",
-	"teamsTabAppTenantIDs":     "TeamsTabAppTenantIDs",
-	"enableincrementalupdates": "EnableIncrementalUpdates",
+	"EnableTeamsTabApp":        "enableTeamsTabApp",
+	"TeamsTabAppTenantIDs":     "teamsTabAppTenantIDs",
+	"EnableIncrementalUpdates": "enableincrementalupdates",
 }
 
 // WebsocketPublisher defines interface for publishing websocket events
@@ -90,7 +90,7 @@ func (c *ServiceImpl) reconcileLegacyConfigKeys() error {
 	maps.Copy(cleaned, raw)
 
 	dirty := false
-	for canonical, legacy := range legacyConfigKeyAliases {
+	for legacy, canonical := range legacyConfigKeyAliases {
 		legacyVal, hasLegacy := cleaned[legacy]
 		if !hasLegacy {
 			continue

--- a/server/config/service.go
+++ b/server/config/service.go
@@ -5,19 +5,29 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/mattermost/mattermost/server/public/model"
 
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
+// legacyConfigKeyAliases maps a canonical settings_schema key to the differently
+// cased key older plugin versions wrote via serialize(). See reconcileLegacyConfigKeys.
+var legacyConfigKeyAliases = map[string]string{
+	"enableTeamsTabApp":        "EnableTeamsTabApp",
+	"teamsTabAppTenantIDs":     "TeamsTabAppTenantIDs",
+	"enableincrementalupdates": "EnableIncrementalUpdates",
+}
+
 // WebsocketPublisher defines interface for publishing websocket events
 type WebsocketPublisher interface {
-	PublishWebsocketEventGlobal(event string, payload interface{})
+	PublishWebsocketEventGlobal(event string, payload any)
 }
 
 const (
@@ -57,10 +67,47 @@ func NewConfigService(api *pluginapi.Client, manifest *model.Manifest) *ServiceI
 	c.configuration = new(Configuration)
 	c.configChangeListeners = make(map[string]func())
 
+	if err := c.reconcileLegacyConfigKeys(); err != nil {
+		logrus.WithError(err).Warn("failed to reconcile legacy plugin config keys")
+	}
+
 	// api.LoadPluginConfiguration never returns an error, so ignore it.
 	_ = api.Configuration.LoadPluginConfiguration(c.configuration)
 
 	return c
+}
+
+// reconcileLegacyConfigKeys reads the raw stored config (where case-duplicate
+// keys are still distinct, before LoadPluginConfiguration lowercases them) and
+// folds each legacy key into its canonical key, preferring the canonical (console)
+// value, then drops the legacy key. It only persists when something changed.
+// Idempotent, and runs before p.config is set, so it is safe under concurrent
+// cluster activation and does not recurse via OnConfigurationChange.
+func (c *ServiceImpl) reconcileLegacyConfigKeys() error {
+	raw := c.api.Configuration.GetPluginConfig()
+
+	cleaned := make(map[string]any, len(raw))
+	maps.Copy(cleaned, raw)
+
+	dirty := false
+	for canonical, legacy := range legacyConfigKeyAliases {
+		legacyVal, hasLegacy := cleaned[legacy]
+		if !hasLegacy {
+			continue
+		}
+
+		if _, hasCanonical := cleaned[canonical]; !hasCanonical {
+			cleaned[canonical] = legacyVal
+		}
+		delete(cleaned, legacy)
+		dirty = true
+	}
+
+	if !dirty {
+		return nil
+	}
+
+	return c.api.Configuration.SavePluginConfig(cleaned)
 }
 
 // SetWebsocketPublisher sets the websocket publisher for broadcasting config changes
@@ -146,7 +193,7 @@ func (c *ServiceImpl) OnConfigurationChange() error {
 	configuration.TeamsTabAppBotUserID = c.configuration.TeamsTabAppBotUserID
 
 	oldConfig := c.configuration
-	settingsPayload := make(map[string]interface{})
+	settingsPayload := make(map[string]any)
 
 	if oldConfig != nil {
 		if oldConfig.EnableExperimentalFeatures != configuration.EnableExperimentalFeatures {

--- a/server/config/service_test.go
+++ b/server/config/service_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+)
+
+func newServiceWithAPI(api *plugintest.API) *ServiceImpl {
+	return &ServiceImpl{api: pluginapi.NewClient(api, nil)}
+}
+
+func TestReconcileLegacyConfigKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keeps the console value when both keys are present", func(t *testing.T) {
+		t.Parallel()
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		api.On("GetPluginConfig").Return(map[string]any{
+			"BotUserID":                "bot1",
+			"enableincrementalupdates": true,
+			"EnableIncrementalUpdates": false,
+		})
+
+		var saved map[string]any
+		api.On("SavePluginConfig", mock.Anything).Run(func(args mock.Arguments) {
+			saved = args.Get(0).(map[string]any)
+		}).Return((*model.AppError)(nil))
+
+		require.NoError(t, newServiceWithAPI(api).reconcileLegacyConfigKeys())
+
+		assert.Equal(t, true, saved["enableincrementalupdates"])
+		assert.NotContains(t, saved, "EnableIncrementalUpdates")
+		assert.Equal(t, "bot1", saved["BotUserID"])
+	})
+
+	t.Run("folds a legacy-only value into its canonical key", func(t *testing.T) {
+		t.Parallel()
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		api.On("GetPluginConfig").Return(map[string]any{
+			"EnableIncrementalUpdates": true,
+		})
+
+		var saved map[string]any
+		api.On("SavePluginConfig", mock.Anything).Run(func(args mock.Arguments) {
+			saved = args.Get(0).(map[string]any)
+		}).Return((*model.AppError)(nil))
+
+		require.NoError(t, newServiceWithAPI(api).reconcileLegacyConfigKeys())
+
+		assert.Equal(t, true, saved["enableincrementalupdates"])
+		assert.NotContains(t, saved, "EnableIncrementalUpdates")
+	})
+
+	t.Run("resolves every aliased setting at once", func(t *testing.T) {
+		t.Parallel()
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		api.On("GetPluginConfig").Return(map[string]any{
+			"EnableTeamsTabApp":        true,
+			"teamsTabAppTenantIDs":     "tenant-a",
+			"TeamsTabAppTenantIDs":     "stale-tenant",
+			"EnableIncrementalUpdates": false,
+		})
+
+		var saved map[string]any
+		api.On("SavePluginConfig", mock.Anything).Run(func(args mock.Arguments) {
+			saved = args.Get(0).(map[string]any)
+		}).Return((*model.AppError)(nil))
+
+		require.NoError(t, newServiceWithAPI(api).reconcileLegacyConfigKeys())
+
+		assert.Equal(t, true, saved["enableTeamsTabApp"])
+		assert.NotContains(t, saved, "EnableTeamsTabApp")
+		assert.Equal(t, "tenant-a", saved["teamsTabAppTenantIDs"])
+		assert.NotContains(t, saved, "TeamsTabAppTenantIDs")
+		assert.Equal(t, false, saved["enableincrementalupdates"])
+		assert.NotContains(t, saved, "EnableIncrementalUpdates")
+	})
+
+	t.Run("does not persist when there is nothing to reconcile", func(t *testing.T) {
+		t.Parallel()
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		api.On("GetPluginConfig").Return(map[string]any{
+			"BotUserID":                "bot1",
+			"enableincrementalupdates": true,
+		})
+
+		require.NoError(t, newServiceWithAPI(api).reconcileLegacyConfigKeys())
+
+		api.AssertNotCalled(t, "SavePluginConfig", mock.Anything)
+	})
+}


### PR DESCRIPTION
## Summary

Three Playbooks plugin settings (`EnableIncrementalUpdates`, `EnableTeamsTabApp`, `TeamsTabAppTenantIDs`) could silently fail to take effect because the plugin persisted them under a different key casing than the System Console writes.

The System Console saves a setting under its `plugin.json` `settings_schema` key, while `Configuration.serialize()` wrote some of them under CamelCase keys. Since the server's `LoadPluginConfiguration` lowercases every key before unmarshaling, the two variants collapsed into one struct field, and Go's randomized map iteration order made the surviving value **non-deterministic**. A stale value could clobber the admin's choice — e.g. `EnableIncrementalUpdates` set `true` in the console but read as `false` — which also produced repeated `cluster.SendBestEffort failed … message too long` errors and broke cross-device run sync.

**Fix:**
- `serialize()` now emits the exact `settings_schema` keys, so the console's copy and the plugin's copy always coincide and no duplicate is ever created.
- New `reconcileLegacyConfigKeys()` runs once at plugin activation: it reads the raw stored config (where the duplicate keys are still distinct), folds any pre-existing duplicate into the canonical key — keeping the console value — and deletes the stale key. Idempotent and safe under concurrent cluster activation.
- Added unit tests for the reconcile behavior plus a guard test that fails if `serialize()` keys ever collide case-insensitively or drift from `plugin.json`.

Verified end-to-end against a live local instance: recreated the duplicate (`enableincrementalupdates: true` + stale `EnableIncrementalUpdates: false`), re-activated the plugin, and confirmed the duplicate was removed and the console value (`true`) preserved.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-69465

## Checklist
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
