### PR TITLE
MM-69021: Validate property field ownership when setting a run property value

### DIFF
--- a/server/app/errors.go
+++ b/server/app/errors.go
@@ -29,6 +29,9 @@ var ErrDuplicateEntry = errors.New("duplicate entry")
 // ErrPropertyFieldInUse occurs when trying to delete a property field that is referenced by conditions.
 var ErrPropertyFieldInUse = errors.New("property field is in use")
 
+// ErrPropertyFieldNotOnRun occurs when a property field does not belong to the specified run.
+var ErrPropertyFieldNotOnRun = errors.New("property field does not belong to run")
+
 // ErrPropertyOptionsInUse occurs when trying to remove property options that are referenced by conditions.
 var ErrPropertyOptionsInUse = errors.New("property options are in use")
 

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -4804,6 +4804,10 @@ func (s *PlaybookRunServiceImpl) SetRunPropertyValue(userID, playbookRunID, prop
 		}
 	}
 
+	if propertyField == nil {
+		return nil, errors.Wrap(ErrPropertyFieldNotOnRun, "property field does not belong to this run")
+	}
+
 	var currentValue json.RawMessage
 	for _, pfv := range run.PropertyValues {
 		if pfv.FieldID == propertyFieldID {

--- a/server/app/set_run_property_value_test.go
+++ b/server/app/set_run_property_value_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// stubRunStore embeds PlaybookRunStore so only the method exercised here needs
+// an implementation; any other call would nil-panic and surface immediately.
+type stubRunStore struct {
+	PlaybookRunStore
+	run *PlaybookRun
+	err error
+}
+
+func (s *stubRunStore) GetPlaybookRun(string) (*PlaybookRun, error) {
+	return s.run, s.err
+}
+
+// stubLicenseChecker reports that premium run attributes are disabled, so
+// GetPlaybookRun leaves PropertyFields empty and the stubbed run controls the test.
+type stubLicenseChecker struct {
+	LicenseChecker
+}
+
+func (stubLicenseChecker) PlaybookAttributesAllowed() bool { return false }
+
+// TestSetRunPropertyValue_FieldOwnershipValidation covers the guard in
+// SetRunPropertyValue: when the supplied field is not one of the run's fields,
+// it must return ErrPropertyFieldNotOnRun instead of dereferencing a nil field
+// (which previously panicked the plugin for a cross-run field ID).
+func TestSetRunPropertyValue_FieldOwnershipValidation(t *testing.T) {
+	runID := model.NewId()
+
+	newService := func(run *PlaybookRun, storeErr error) *PlaybookRunServiceImpl {
+		return &PlaybookRunServiceImpl{
+			store:          &stubRunStore{run: run, err: storeErr},
+			licenseChecker: stubLicenseChecker{},
+		}
+	}
+
+	t.Run("field not on run is rejected without panicking", func(t *testing.T) {
+		svc := newService(&PlaybookRun{ID: runID}, nil)
+
+		_, err := svc.SetRunPropertyValue("user1", runID, model.NewId(), json.RawMessage(`"high"`))
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not belong to run")
+	})
+
+	t.Run("store error on lookup propagates", func(t *testing.T) {
+		svc := newService(nil, errors.New("db unavailable"))
+
+		_, err := svc.SetRunPropertyValue("user1", runID, model.NewId(), json.RawMessage(`"high"`))
+
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
Backport of the property field ownership guard in `SetRunPropertyValue` added in
c245f3a1 ("CF-5: Create Placeholder for Task Assignment", #2256), already present
on `master` and `release-2.10`. The guard verifies that the requested property
field belongs to the run before reading or writing its value, returning
`ErrPropertyFieldNotOnRun` otherwise — aligning the REST endpoint with the
equivalent GraphQL mutation that already performs this check.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69021

## Checklist
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
