### PR TITLE
Add server/AGENTS.md clarifying testify usage in Go tests

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions (server/)
+
+## Go Testing
+
+- Use the `testify` library (`require`/`assert`) for all assertions in Go tests.
+- Never use the Go standard library testing assertions (`t.Fatal`, `t.Fatalf`, `t.Error`, `t.Errorf`) to check expected values — use `require.NoError`, `require.Equal`, `assert.True`, etc. instead.


### PR DESCRIPTION
## Summary
Adds `server/AGENTS.md` documenting that Go tests must use `testify` (`require`/`assert`) for assertions, never the standard library's `t.Fatal`/`t.Error`/etc.

## Ticket Link
N/A — documentation-only change, no Jira ticket.

## Checklist
- ~~Gated by experimental feature flag~~
- ~~Unit tests updated~~