### PR TITLE
[MM-69462] Disable editing attributes and adding participants on finished runs

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_properties.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_properties.tsx
@@ -37,6 +37,7 @@ const RHSInfoProperties = (props: Props) => {
                 propertyFields={props.run.property_fields}
                 propertyValues={props.run.property_values}
                 runID={props.run.id}
+                readOnly={!props.editable}
             />
         </Section>
     );

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
@@ -26,7 +26,7 @@ import {useManageRunMembership} from 'src/graphql/hooks';
 
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
 
 import {SendMessageButton} from './send_message_button';
 import AddParticipantsModal from './add_participant_modal';
@@ -74,6 +74,8 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
         }
         return true;
     };
+
+    const isFinished = playbookRun.current_status === PlaybookRunStatus.Finished;
 
     const manageParticipantsSection = () => {
         if (manageMode) {
@@ -126,7 +128,7 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
                     )}
                 </ParticipantsNumber>
 
-                {role === Role.Participant && manageParticipantsSection()}
+                {role === Role.Participant && !isFinished && manageParticipantsSection()}
 
             </HeaderSection>
 

--- a/webapp/src/components/rhs/properties/property_date.test.tsx
+++ b/webapp/src/components/rhs/properties/property_date.test.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import DateProperty from './property_date';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('src/components/datetime_selector', () => ({
+    DateTimeSelector: () => <div data-testid='edit-mode'/>,
+    optionFromMillis: () => ({}),
+}));
+
+jest.mock('src/components/datetime_parsing', () => ({
+    Mode: {DateTimeValue: 'datetime_value'},
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Due date',
+    type: 'date',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const value: PropertyValue = {field_id: 'field-1', value: '2026-01-01'} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+const triggerEnterKey = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onKeyDown?.({key: 'Enter', preventDefault: jest.fn()});
+    });
+};
+
+describe('DateProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <DateProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('does not enter edit mode on Enter key when readOnly', () => {
+        const component = create(
+            <DateProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerEnterKey(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <DateProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_date.tsx
+++ b/webapp/src/components/rhs/properties/property_date.tsx
@@ -88,11 +88,14 @@ const DateProperty = (props: Props) => {
     }, [props.value?.value]);
 
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
+        if (props.readOnly) {
+            return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsEditing(true);
         }
-    }, []);
+    }, [props.readOnly]);
 
     const handleSelectedChange = useCallback((option: DateTimeOption | undefined | null) => {
         const seq = ++callSeqRef.current;
@@ -145,8 +148,9 @@ const DateProperty = (props: Props) => {
 
     return (
         <PropertyDisplayContainer
-            onClick={() => setIsEditing(true)}
-            onKeyDown={handleActivateKey}
+            $readOnly={props.readOnly}
+            onClick={props.readOnly ? undefined : () => setIsEditing(true)}
+            onKeyDown={props.readOnly ? undefined : handleActivateKey}
             data-testid='property-value'
         >
             {formatted ?? <EmptyState/>}

--- a/webapp/src/components/rhs/properties/property_date.tsx
+++ b/webapp/src/components/rhs/properties/property_date.tsx
@@ -87,6 +87,13 @@ const DateProperty = (props: Props) => {
         setDisplayMillis(newMillis);
     }, [props.value?.value]);
 
+    const handleClick = useCallback(() => {
+        if (props.readOnly) {
+            return;
+        }
+        setIsEditing(true);
+    }, [props.readOnly]);
+
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
         if (props.readOnly) {
             return;
@@ -149,8 +156,8 @@ const DateProperty = (props: Props) => {
     return (
         <PropertyDisplayContainer
             $readOnly={props.readOnly}
-            onClick={props.readOnly ? undefined : () => setIsEditing(true)}
-            onKeyDown={props.readOnly ? undefined : handleActivateKey}
+            onClick={handleClick}
+            onKeyDown={handleActivateKey}
             data-testid='property-value'
         >
             {formatted ?? <EmptyState/>}

--- a/webapp/src/components/rhs/properties/property_multiselect.test.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import MultiselectProperty from './property_multiselect';
+
+jest.mock('./property_select_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Tags',
+    type: 'multiselect',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const emptyValue: PropertyValue = {field_id: 'field-1', value: []} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('MultiselectProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_multiselect.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.tsx
@@ -5,17 +5,14 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useUpdateEffect} from 'react-use';
 
-import {PropertyField, PropertyValue} from 'src/types/properties';
+import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
 
-interface Props {
-    field: PropertyField;
-    value?: PropertyValue;
-    runID: string;
+interface Props extends PropertyComponentProps {
     onValueChange: (value: string[] | null) => void;
 }
 
@@ -36,6 +33,9 @@ const MultiselectProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
         setTempValue(displayValue ?? null);
     };
@@ -71,7 +71,8 @@ const MultiselectProperty = (props: Props) => {
     if (!displayValue || !Array.isArray(displayValue) || displayValue.length === 0) {
         return (
             <EmptyMultiselectDisplay
-                onClick={handleStartEdit}
+                onClick={props.readOnly ? undefined : handleStartEdit}
+                $readOnly={props.readOnly}
                 data-testid='property-value'
             >
                 <EmptyState/>
@@ -89,7 +90,7 @@ const MultiselectProperty = (props: Props) => {
                 <PropertyChip
                     key={index}
                     label={label!}
-                    onClick={handleStartEdit}
+                    onClick={props.readOnly ? undefined : handleStartEdit}
                 />
             ))}
         </ChipsContainer>
@@ -102,17 +103,19 @@ const ChipsContainer = styled.div`
     gap: 4px;
 `;
 
-const EmptyMultiselectDisplay = styled.div`
+const EmptyMultiselectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: pointer;
+    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
     &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
+        ${({$readOnly}) => !$readOnly && `
+            background-color: rgba(var(--center-channel-color-rgb), 0.04);
+            border-radius: 4px;
+            margin: 0 -4px;
+            padding: 4px;
+        `}
     }
 `;
 

--- a/webapp/src/components/rhs/properties/property_multiselect.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.tsx
@@ -11,6 +11,7 @@ import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
 interface Props extends PropertyComponentProps {
     onValueChange: (value: string[] | null) => void;
@@ -71,7 +72,7 @@ const MultiselectProperty = (props: Props) => {
     if (!displayValue || !Array.isArray(displayValue) || displayValue.length === 0) {
         return (
             <EmptyMultiselectDisplay
-                onClick={props.readOnly ? undefined : handleStartEdit}
+                onClick={handleStartEdit}
                 $readOnly={props.readOnly}
                 data-testid='property-value'
             >
@@ -105,18 +106,10 @@ const ChipsContainer = styled.div`
 
 const EmptyMultiselectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        ${({$readOnly}) => !$readOnly && `
-            background-color: rgba(var(--center-channel-color-rgb), 0.04);
-            border-radius: 4px;
-            margin: 0 -4px;
-            padding: 4px;
-        `}
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 export default MultiselectProperty;

--- a/webapp/src/components/rhs/properties/property_select.test.tsx
+++ b/webapp/src/components/rhs/properties/property_select.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import SelectProperty from './property_select';
+
+jest.mock('./property_select_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Priority',
+    type: 'select',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const emptyValue: PropertyValue = {field_id: 'field-1', value: ''} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('SelectProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_select.tsx
+++ b/webapp/src/components/rhs/properties/property_select.tsx
@@ -5,17 +5,14 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useUpdateEffect} from 'react-use';
 
-import {PropertyField, PropertyValue} from 'src/types/properties';
+import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
 
-interface Props {
-    field: PropertyField;
-    value?: PropertyValue;
-    runID: string;
+interface Props extends PropertyComponentProps {
     onValueChange: (value: string | null) => void;
 }
 
@@ -36,6 +33,9 @@ const SelectProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
     };
 
@@ -72,7 +72,8 @@ const SelectProperty = (props: Props) => {
     if (!displayLabel) {
         return (
             <EmptySelectDisplay
-                onClick={handleStartEdit}
+                onClick={props.readOnly ? undefined : handleStartEdit}
+                $readOnly={props.readOnly}
                 data-testid='property-value'
             >
                 <EmptyState/>
@@ -83,23 +84,25 @@ const SelectProperty = (props: Props) => {
     return (
         <PropertyChip
             label={displayLabel}
-            onClick={handleStartEdit}
+            onClick={props.readOnly ? undefined : handleStartEdit}
             data-testid='property-value'
         />
     );
 };
 
-const EmptySelectDisplay = styled.div`
+const EmptySelectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: pointer;
+    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
     &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
+        ${({$readOnly}) => !$readOnly && `
+            background-color: rgba(var(--center-channel-color-rgb), 0.04);
+            border-radius: 4px;
+            margin: 0 -4px;
+            padding: 4px;
+        `}
     }
 `;
 

--- a/webapp/src/components/rhs/properties/property_select.tsx
+++ b/webapp/src/components/rhs/properties/property_select.tsx
@@ -11,6 +11,7 @@ import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
 interface Props extends PropertyComponentProps {
     onValueChange: (value: string | null) => void;
@@ -72,7 +73,7 @@ const SelectProperty = (props: Props) => {
     if (!displayLabel) {
         return (
             <EmptySelectDisplay
-                onClick={props.readOnly ? undefined : handleStartEdit}
+                onClick={handleStartEdit}
                 $readOnly={props.readOnly}
                 data-testid='property-value'
             >
@@ -92,18 +93,10 @@ const SelectProperty = (props: Props) => {
 
 const EmptySelectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        ${({$readOnly}) => !$readOnly && `
-            background-color: rgba(var(--center-channel-color-rgb), 0.04);
-            border-radius: 4px;
-            margin: 0 -4px;
-            padding: 4px;
-        `}
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 export default SelectProperty;

--- a/webapp/src/components/rhs/properties/property_styles.ts
+++ b/webapp/src/components/rhs/properties/property_styles.ts
@@ -4,34 +4,38 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export const PropertyDisplayContainer = styled.div.attrs(() => ({
-    role: 'button',
-    tabIndex: 0,
-    onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+export const PropertyDisplayContainer = styled.div.attrs<{$readOnly?: boolean}>(({$readOnly}) => ({
+    role: $readOnly ? undefined : 'button',
+    tabIndex: $readOnly ? undefined : 0,
+    onKeyDown: $readOnly ? undefined : (e: React.KeyboardEvent<HTMLDivElement>) => {
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             (e.currentTarget as HTMLElement).click();
         }
     },
-}))`
+}))<{$readOnly?: boolean}>`
     flex: 1;
     color: var(--center-channel-color);
     font-size: 14px;
     line-height: 20px;
-    cursor: pointer;
+    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
     &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
+        ${({$readOnly}) => !$readOnly && `
+            background-color: rgba(var(--center-channel-color-rgb), 0.04);
+            border-radius: 4px;
+            margin: 0 -4px;
+            padding: 4px;
+        `}
     }
 
     &:focus-visible {
-        outline: 2px solid var(--button-bg);
-        outline-offset: 2px;
-        border-radius: 4px;
+        ${({$readOnly}) => !$readOnly && `
+            outline: 2px solid var(--button-bg);
+            outline-offset: 2px;
+            border-radius: 4px;
+        `}
     }
 `;

--- a/webapp/src/components/rhs/properties/property_styles.ts
+++ b/webapp/src/components/rhs/properties/property_styles.ts
@@ -1,26 +1,12 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
-export const PropertyDisplayContainer = styled.div.attrs<{$readOnly?: boolean}>(({$readOnly}) => ({
-    role: $readOnly ? undefined : 'button',
-    tabIndex: $readOnly ? undefined : 0,
-    onKeyDown: $readOnly ? undefined : (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            (e.currentTarget as HTMLElement).click();
-        }
-    },
-}))<{$readOnly?: boolean}>`
-    flex: 1;
-    color: var(--center-channel-color);
-    font-size: 14px;
-    line-height: 20px;
+// Shared cursor/hover affordance for editable property displays. When $readOnly
+// is set the pointer cursor and hover highlight are suppressed.
+export const readOnlyInteractiveStyles = css<{$readOnly?: boolean}>`
     cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
-    padding: 4px 0;
-    min-height: 20px;
 
     &:hover {
         ${({$readOnly}) => !$readOnly && `
@@ -30,6 +16,20 @@ export const PropertyDisplayContainer = styled.div.attrs<{$readOnly?: boolean}>(
             padding: 4px;
         `}
     }
+`;
+
+export const PropertyDisplayContainer = styled.div.attrs<{$readOnly?: boolean}>(({$readOnly}) => ({
+    role: $readOnly ? undefined : 'button',
+    tabIndex: $readOnly ? undefined : 0,
+}))<{$readOnly?: boolean}>`
+    flex: 1;
+    color: var(--center-channel-color);
+    font-size: 14px;
+    line-height: 20px;
+    padding: 4px 0;
+    min-height: 20px;
+
+    ${readOnlyInteractiveStyles}
 
     &:focus-visible {
         ${({$readOnly}) => !$readOnly && `

--- a/webapp/src/components/rhs/properties/property_text.test.tsx
+++ b/webapp/src/components/rhs/properties/property_text.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import TextProperty from './property_text';
+
+jest.mock('./property_text_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Summary',
+    type: 'text',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const value: PropertyValue = {field_id: 'field-1', value: 'hello'} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('TextProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <TextProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <TextProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_text.tsx
+++ b/webapp/src/components/rhs/properties/property_text.tsx
@@ -5,15 +5,12 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useUpdateEffect} from 'react-use';
 
-import {PropertyField, PropertyValue} from 'src/types/properties';
+import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertyTextInput from './property_text_input';
 import EmptyState from './empty_state';
 
-interface Props {
-    field: PropertyField;
-    value?: PropertyValue;
-    runID: string;
+interface Props extends PropertyComponentProps {
     onValueChange: (value: string | null) => void;
 }
 
@@ -34,6 +31,9 @@ const TextProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
     };
 
@@ -72,7 +72,8 @@ const TextProperty = (props: Props) => {
 
     return (
         <TextDisplay
-            onClick={handleStartEdit}
+            onClick={props.readOnly ? undefined : handleStartEdit}
+            $readOnly={props.readOnly}
             data-testid='property-value'
         >
             {content}
@@ -80,20 +81,22 @@ const TextProperty = (props: Props) => {
     );
 };
 
-const TextDisplay = styled.div`
+const TextDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
     color: var(--center-channel-color);
     font-size: 14px;
     line-height: 20px;
-    cursor: pointer;
+    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
     &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
+        ${({$readOnly}) => !$readOnly && `
+            background-color: rgba(var(--center-channel-color-rgb), 0.04);
+            border-radius: 4px;
+            margin: 0 -4px;
+            padding: 4px;
+        `}
     }
 `;
 

--- a/webapp/src/components/rhs/properties/property_text.tsx
+++ b/webapp/src/components/rhs/properties/property_text.tsx
@@ -9,6 +9,7 @@ import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertyTextInput from './property_text_input';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
 interface Props extends PropertyComponentProps {
     onValueChange: (value: string | null) => void;
@@ -72,7 +73,7 @@ const TextProperty = (props: Props) => {
 
     return (
         <TextDisplay
-            onClick={props.readOnly ? undefined : handleStartEdit}
+            onClick={handleStartEdit}
             $readOnly={props.readOnly}
             data-testid='property-value'
         >
@@ -86,18 +87,10 @@ const TextDisplay = styled.div<{$readOnly?: boolean}>`
     color: var(--center-channel-color);
     font-size: 14px;
     line-height: 20px;
-    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        ${({$readOnly}) => !$readOnly && `
-            background-color: rgba(var(--center-channel-color-rgb), 0.04);
-            border-radius: 4px;
-            margin: 0 -4px;
-            padding: 4px;
-        `}
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 const URLLink = styled.a`

--- a/webapp/src/components/rhs/properties/property_user.test.tsx
+++ b/webapp/src/components/rhs/properties/property_user.test.tsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import UserProperty, {MultiuserProperty} from './property_user';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('src/hooks', () => ({
+    useProfilesInTeam: () => [],
+}));
+
+jest.mock('src/components/profile/profile', () => ({
+    __esModule: true,
+    default: () => <div data-testid='profile'/>,
+}));
+
+jest.mock('src/components/profile/profile_selector', () => ({
+    __esModule: true,
+    default: () => <div data-testid='profile-selector'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Owner',
+    type: 'user',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const makeValue = (value: string | string[]): PropertyValue => ({
+    field_id: 'field-1',
+    value,
+} as unknown as PropertyValue);
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'profile-selector'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+const triggerEnterKey = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onKeyDown?.({key: 'Enter', preventDefault: jest.fn()});
+    });
+};
+
+describe('UserProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <UserProperty
+                field={field}
+                value={makeValue('user-1')}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('does not enter edit mode on Enter key when readOnly', () => {
+        const component = create(
+            <UserProperty
+                field={field}
+                value={makeValue('user-1')}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerEnterKey(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <UserProperty
+                field={field}
+                value={makeValue('user-1')}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});
+
+describe('MultiuserProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <MultiuserProperty
+                field={field}
+                value={makeValue(['user-1'])}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('does not enter edit mode on Enter key when readOnly', () => {
+        const component = create(
+            <MultiuserProperty
+                field={field}
+                value={makeValue(['user-1'])}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerEnterKey(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <MultiuserProperty
+                field={field}
+                value={makeValue(['user-1'])}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_user.tsx
+++ b/webapp/src/components/rhs/properties/property_user.tsx
@@ -49,11 +49,14 @@ const UserProperty = (props: Props) => {
     const fetchUsersInTeam = useCallback(async () => profilesInTeam, [profilesInTeam]);
 
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
+        if (props.readOnly) {
+            return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsEditing(true);
         }
-    }, []);
+    }, [props.readOnly]);
 
     const handleSelectedChange = useCallback((user?: UserProfile) => {
         const newValue = user?.id ?? null;
@@ -96,8 +99,9 @@ const UserProperty = (props: Props) => {
 
     return (
         <PropertyDisplayContainer
-            onClick={() => setIsEditing(true)}
-            onKeyDown={handleActivateKey}
+            $readOnly={props.readOnly}
+            onClick={props.readOnly ? undefined : () => setIsEditing(true)}
+            onKeyDown={props.readOnly ? undefined : handleActivateKey}
             data-testid='property-value'
         >
             {displayValue ? <Profile userId={displayValue}/> : <EmptyState/>}
@@ -132,11 +136,14 @@ export const MultiuserProperty = (props: Props) => {
     const fetchUsersInTeam = useCallback(async () => profilesInTeam, [profilesInTeam]);
 
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
+        if (props.readOnly) {
+            return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsEditing(true);
         }
-    }, []);
+    }, [props.readOnly]);
 
     const applyNewValues = useCallback((newValues: string[]) => {
         const seq = ++callSeqRef.current;
@@ -209,8 +216,9 @@ export const MultiuserProperty = (props: Props) => {
 
     return (
         <PropertyDisplayContainer
-            onClick={() => setIsEditing(true)}
-            onKeyDown={handleActivateKey}
+            $readOnly={props.readOnly}
+            onClick={props.readOnly ? undefined : () => setIsEditing(true)}
+            onKeyDown={props.readOnly ? undefined : handleActivateKey}
             data-testid='property-value'
         >
             {displayValues.length === 0 ? <EmptyState/> : (

--- a/webapp/src/components/rhs/properties/property_user.tsx
+++ b/webapp/src/components/rhs/properties/property_user.tsx
@@ -48,6 +48,13 @@ const UserProperty = (props: Props) => {
 
     const fetchUsersInTeam = useCallback(async () => profilesInTeam, [profilesInTeam]);
 
+    const handleClick = useCallback(() => {
+        if (props.readOnly) {
+            return;
+        }
+        setIsEditing(true);
+    }, [props.readOnly]);
+
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
         if (props.readOnly) {
             return;
@@ -100,8 +107,8 @@ const UserProperty = (props: Props) => {
     return (
         <PropertyDisplayContainer
             $readOnly={props.readOnly}
-            onClick={props.readOnly ? undefined : () => setIsEditing(true)}
-            onKeyDown={props.readOnly ? undefined : handleActivateKey}
+            onClick={handleClick}
+            onKeyDown={handleActivateKey}
             data-testid='property-value'
         >
             {displayValue ? <Profile userId={displayValue}/> : <EmptyState/>}
@@ -134,6 +141,13 @@ export const MultiuserProperty = (props: Props) => {
     }, [props.value?.value]);
 
     const fetchUsersInTeam = useCallback(async () => profilesInTeam, [profilesInTeam]);
+
+    const handleClick = useCallback(() => {
+        if (props.readOnly) {
+            return;
+        }
+        setIsEditing(true);
+    }, [props.readOnly]);
 
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
         if (props.readOnly) {
@@ -217,8 +231,8 @@ export const MultiuserProperty = (props: Props) => {
     return (
         <PropertyDisplayContainer
             $readOnly={props.readOnly}
-            onClick={props.readOnly ? undefined : () => setIsEditing(true)}
-            onKeyDown={props.readOnly ? undefined : handleActivateKey}
+            onClick={handleClick}
+            onKeyDown={handleActivateKey}
             data-testid='property-value'
         >
             {displayValues.length === 0 ? <EmptyState/> : (

--- a/webapp/src/components/rhs/properties_list.tsx
+++ b/webapp/src/components/rhs/properties_list.tsx
@@ -13,6 +13,7 @@ interface Props {
     propertyValues?: PropertyValue[];
     runID: string;
     className?: string;
+    readOnly?: boolean;
 }
 
 const PropertiesList = (props: Props) => {
@@ -47,6 +48,7 @@ const PropertiesList = (props: Props) => {
                     field={field}
                     value={value}
                     runID={props.runID}
+                    readOnly={props.readOnly}
                 />
             ))}
         </div>

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -198,8 +198,9 @@ const RHSAbout = (props: Props) => {
                                 <MemberSectionTitle>{formatMessage({defaultMessage: 'Participants'})}</MemberSectionTitle>
                                 <RHSParticipants
                                     userIds={props.playbookRun.participant_ids.filter((id) => id !== props.playbookRun.owner_user_id)}
-                                    onParticipate={shouldShowParticipate ? showParticipateConfirm : undefined}
+                                    onParticipate={!isFinished && shouldShowParticipate ? showParticipateConfirm : undefined}
                                     setShowParticipants={props.setShowParticipants}
+                                    canAddParticipants={!isFinished}
                                 />
                             </ParticipantsSection>
                         </Row>
@@ -207,6 +208,7 @@ const RHSAbout = (props: Props) => {
                             propertyFields={props.playbookRun.property_fields}
                             propertyValues={props.playbookRun.property_values}
                             runID={props.playbookRun.id}
+                            readOnly={isFinished || props.readOnly}
                         />
                     </>
                 }

--- a/webapp/src/components/rhs/rhs_participants.test.tsx
+++ b/webapp/src/components/rhs/rhs_participants.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import RHSParticipants from './rhs_participants';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('src/hooks/redux', () => ({
+    useAppDispatch: () => jest.fn(),
+    useAppSelector: () => null,
+}));
+
+jest.mock('src/components/rhs/rhs_participant', () => ({
+    RHSParticipant: () => null,
+    Rest: () => null,
+}));
+
+describe('RHSParticipants', () => {
+    it('hides add participant controls when canAddParticipants is false', () => {
+        const component = renderer.create(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={false}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'})).toHaveLength(0);
+    });
+
+    it('shows add participant controls when canAddParticipants is true', () => {
+        const component = renderer.create(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={true}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'}).length).toBeGreaterThan(0);
+    });
+});

--- a/webapp/src/components/rhs/rhs_participants.tsx
+++ b/webapp/src/components/rhs/rhs_participants.tsx
@@ -19,11 +19,13 @@ interface Props {
     userIds: string[];
     onParticipate?: () => void;
     setShowParticipants: React.Dispatch<React.SetStateAction<boolean>>
+    canAddParticipants?: boolean;
 }
 
 const RHSParticipants = (props: Props) => {
     const {formatMessage} = useIntl();
     const openMembersModal = useOpenMembersModalIfPresent();
+    const canAddParticipants = props.canAddParticipants ?? true;
 
     const showParticipants = () => {
         props.setShowParticipants(true);
@@ -45,6 +47,29 @@ const RHSParticipants = (props: Props) => {
         </WithTooltip>
     );
 
+    const addParticipantControl = (() => {
+        if (props.onParticipate) {
+            return becomeParticipant;
+        }
+        if (!canAddParticipants) {
+            return null;
+        }
+        return (
+            <WithTooltip
+                id={'rhs-add-participant'}
+                title={formatMessage({defaultMessage: 'Add participant'})}
+            >
+                <AddParticipantIconButton
+                    onClick={showParticipants}
+                    data-testid={'rhs-add-participant-icon'}
+                    $format={'icon'}
+                >
+                    <AccountMultiplePlusOutlineIcon size={20}/>
+                </AddParticipantIconButton>
+            </WithTooltip>
+        );
+    })();
+
     if (props.userIds.length === 0) {
         return (
             <Container>
@@ -52,7 +77,7 @@ const RHSParticipants = (props: Props) => {
                     <FormattedMessage defaultMessage='Nobody yet.'/>
                     {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
                     {' '}
-                    {props.onParticipate ? null : (
+                    {canAddParticipants && !props.onParticipate ? (
                         <LinkAddParticipants
                             to={'#'}
                             onClick={showParticipants}
@@ -60,7 +85,7 @@ const RHSParticipants = (props: Props) => {
                             {formatMessage({defaultMessage: 'Add participant'})}
                             <OpenInNewIcon size={11}/>
                         </LinkAddParticipants>
-                    )}
+                    ) : null}
                 </NoParticipants>
                 {props.onParticipate ? becomeParticipant : null}
             </Container>
@@ -87,20 +112,7 @@ const RHSParticipants = (props: Props) => {
                     sizeInPx={height}
                 />
             </UserRow>
-            {props.onParticipate ? becomeParticipant : (
-                <WithTooltip
-                    id={'rhs-add-participant'}
-                    title={formatMessage({defaultMessage: 'Add participant'})}
-                >
-                    <AddParticipantIconButton
-                        onClick={showParticipants}
-                        data-testid={'rhs-add-participant-icon'}
-                        $format={'icon'}
-                    >
-                        <AccountMultiplePlusOutlineIcon size={20}/>
-                    </AddParticipantIconButton>
-                </WithTooltip>
-            )}
+            {addParticipantControl}
         </Container>
     );
 };

--- a/webapp/src/components/rhs/rhs_property.test.tsx
+++ b/webapp/src/components/rhs/rhs_property.test.tsx
@@ -29,7 +29,12 @@ jest.mock('react-intl', () => {
 
 jest.mock('./properties/property_text', () => ({
     __esModule: true,
-    default: () => <div data-testid='mock-text-property'/>,
+    default: (props: {readOnly?: boolean}) => (
+        <div
+            data-testid='mock-text-property'
+            data-readonly={props.readOnly}
+        />
+    ),
 }));
 
 jest.mock('./properties/property_select', () => ({
@@ -149,5 +154,17 @@ describe('RHSProperty', () => {
                 'mock-user-property', 'mock-multiuser-property', 'mock-date-property'].includes(n.props['data-testid']),
         );
         expect(valueComponents.length).toBe(0);
+    });
+
+    it('passes readOnly to property components', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('text')}
+                runID='run-1'
+                readOnly={true}
+            />,
+        );
+        const instance = component.root;
+        expect(instance.findByProps({'data-testid': 'mock-text-property'}).props['data-readonly']).toBe(true);
     });
 });

--- a/webapp/src/components/rhs/rhs_property.tsx
+++ b/webapp/src/components/rhs/rhs_property.tsx
@@ -21,6 +21,7 @@ interface Props {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
 }
 
 const RHSProperty = (props: Props) => {
@@ -48,6 +49,7 @@ const RHSProperty = (props: Props) => {
             field: props.field,
             value: props.value,
             runID: props.runID,
+            readOnly: props.readOnly,
         };
 
         switch (props.field.type) {

--- a/webapp/src/types/properties.ts
+++ b/webapp/src/types/properties.ts
@@ -58,4 +58,5 @@ export interface PropertyComponentProps {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
 }


### PR DESCRIPTION
## Summary
- Disable click-to-edit affordances for run attributes when a playbook run is finished
- Hide "Add participant" and Manage controls in the RHS and participants view for finished runs
- Wire the existing backstage `editable` prop through to `PropertiesList` (was previously unused)

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69462

## Test plan
- [x] Open a finished playbook run in the RHS
- [x] Confirm run attributes are read-only (no hover/edit affordance, no "Failed to update property value" toast)
- [x] Confirm "Add participant" link/icon is hidden in the about section
- [x] Open the participants list for a finished run and confirm Manage/Add buttons are hidden
- [x] Open an in-progress run and confirm attributes and add-participant controls still work as before

## Checklist
- [ ] Gated by experimental feature flag
- [x] Unit tests updated