### PR TITLE
[MM-69446] Fix run name precedence over literal channel template

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -6219,6 +6219,13 @@ func (s *PlaybookRunServiceImpl) resolveRunName(playbookRun *PlaybookRun, pb *Pl
 	seqID := FormatSequentialID(pb.RunNumberPrefix, runNumber)
 	playbookRun.SequentialID = seqID
 
+	if userSuppliedName != "" {
+		resolvedRunName := strings.TrimSpace(truncateRunes(userSuppliedName, MaxRunNameLength))
+		playbookRun.Name = resolvedRunName
+		resolvedChannelName := strings.Join(strings.Fields(truncateRunes(resolvedRunName, model.ChannelDisplayNameMaxRunes)), " ")
+		return resolvedChannelName, nil
+	}
+
 	if formatFunc == nil {
 		formatFunc = s.makeRunNameFormatFunc()
 	}
@@ -6247,8 +6254,6 @@ func (s *PlaybookRunServiceImpl) resolveRunName(playbookRun *PlaybookRun, pb *Pl
 
 	if resolvedRunName == "" {
 		switch {
-		case userSuppliedName != "":
-			resolvedRunName = userSuppliedName
 		case seqID != "":
 			resolvedRunName = seqID + " - Untitled"
 		default:

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -6219,7 +6219,7 @@ func (s *PlaybookRunServiceImpl) resolveRunName(playbookRun *PlaybookRun, pb *Pl
 	seqID := FormatSequentialID(pb.RunNumberPrefix, runNumber)
 	playbookRun.SequentialID = seqID
 
-	if userSuppliedName != "" {
+	if userSuppliedName != "" && template != "" && !strings.Contains(template, "{") {
 		resolvedRunName := strings.TrimSpace(truncateRunes(userSuppliedName, MaxRunNameLength))
 		playbookRun.Name = resolvedRunName
 		resolvedChannelName := strings.Join(strings.Fields(truncateRunes(resolvedRunName, model.ChannelDisplayNameMaxRunes)), " ")
@@ -6254,6 +6254,8 @@ func (s *PlaybookRunServiceImpl) resolveRunName(playbookRun *PlaybookRun, pb *Pl
 
 	if resolvedRunName == "" {
 		switch {
+		case userSuppliedName != "":
+			resolvedRunName = userSuppliedName
 		case seqID != "":
 			resolvedRunName = seqID + " - Untitled"
 		default:

--- a/server/app/resolve_and_allocate_test.go
+++ b/server/app/resolve_and_allocate_test.go
@@ -258,6 +258,41 @@ func TestResolveAndAllocate_IncrementNotFoundWrapsMalformedRun(t *testing.T) {
 //
 // This test deliberately exercises the licensed path because dry-run only validates
 // property-field placeholders when PlaybookAttributesAllowed() is true.
+func TestResolveAndAllocate_UserSuppliedNameOverridesLiteralTemplate(t *testing.T) {
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "JIRA_ID: TITLE",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 1}
+	svc := newAllocService(pbStub)
+
+	callerName := "MM-69439: OAuth token can revoke..."
+	run := &PlaybookRun{PlaybookID: pb.ID, Name: callerName}
+	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
+
+	require.NoError(t, err)
+	assert.Equal(t, callerName, run.Name, "caller-supplied name must override literal channel_name_template")
+	assert.Equal(t, callerName, channelName)
+}
+
+func TestResolveAndAllocate_LiteralTemplateUsedWhenNoUserName(t *testing.T) {
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "JIRA_ID: TITLE",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 1}
+	svc := newAllocService(pbStub)
+
+	run := &PlaybookRun{PlaybookID: pb.ID, Name: ""}
+	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
+
+	require.NoError(t, err)
+	assert.Equal(t, "JIRA_ID: TITLE", run.Name)
+	assert.Equal(t, "JIRA_ID: TITLE", channelName)
+}
+
 func TestResolveAndAllocate_DryRunFailureSkipsAllocation(t *testing.T) {
 	zoneField := PropertyField{
 		PropertyField: model.PropertyField{

--- a/server/app/resolve_and_allocate_test.go
+++ b/server/app/resolve_and_allocate_test.go
@@ -293,6 +293,23 @@ func TestResolveAndAllocate_LiteralTemplateUsedWhenNoUserName(t *testing.T) {
 	assert.Equal(t, "JIRA_ID: TITLE", channelName)
 }
 
+func TestResolveAndAllocate_UserSuppliedNameDoesNotOverrideTokenTemplate(t *testing.T) {
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "Incident {SEQ}",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 42}
+	svc := newAllocService(pbStub)
+
+	run := &PlaybookRun{PlaybookID: pb.ID, Name: "Caller Override Attempt"}
+	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Incident INC-00042", run.Name)
+	assert.Equal(t, "Incident INC-00042", channelName)
+}
+
 func TestResolveAndAllocate_DryRunFailureSkipsAllocation(t *testing.T) {
 	zoneField := PropertyField{
 		PropertyField: model.PropertyField{


### PR DESCRIPTION
## Summary
- Fix a v2.10.0 regression where a literal `channel_name_template` (e.g. `JIRA_ID: TITLE`) overrode a caller-supplied run `name` on `POST /api/v0/runs`
- Restore pre-CF-2 behavior: non-empty caller-supplied names take precedence over template resolution
- Add unit tests covering both the regression case and the no-name fallback

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69446

## Checklist
- [ ] Gated by experimental feature flag
- [x] Unit tests updated