### PR TITLE
Allow overriding the template-generated run name in the Start a run modal

### DIFF
--- a/client/playbook_run.go
+++ b/client/playbook_run.go
@@ -149,6 +149,11 @@ type PlaybookRunCreateOptions struct {
 	CreatePublicRun *bool                      `json:"create_public_run"`
 	Type            string                     `json:"type"`
 	PropertyValues  map[string]json.RawMessage `json:"property_values,omitempty"`
+
+	// NameTemplateOverride indicates the user chose to override the playbook's channel name
+	// template and supply Name manually. When true and Name is non-empty, the template is
+	// ignored for this run and Name is used verbatim.
+	NameTemplateOverride bool `json:"name_template_override,omitempty"`
 }
 
 // RunAction represents the run action settings. Frontend passes this struct to update settings.

--- a/client/playbook_run.go
+++ b/client/playbook_run.go
@@ -150,9 +150,8 @@ type PlaybookRunCreateOptions struct {
 	Type            string                     `json:"type"`
 	PropertyValues  map[string]json.RawMessage `json:"property_values,omitempty"`
 
-	// NameTemplateOverride indicates the user chose to override the playbook's channel name
-	// template and supply Name manually. When true and Name is non-empty, the template is
-	// ignored for this run and Name is used verbatim.
+	// NameTemplateOverride, when true and Name is non-empty, ignores the playbook's channel name
+	// template and uses Name verbatim.
 	NameTemplateOverride bool `json:"name_template_override,omitempty"`
 }
 

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
@@ -297,7 +297,8 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
                 cy.findByTestId('override-run-name-checkbox').check({force: true});
 
                 // * Name input is now editable (no readonly attr) and cleared
-                cy.findByTestId('run-name-input').should('not.have.attr', 'readonly').and('have.value', '');
+                cy.findByTestId('run-name-input').should('have.value', '');
+                cy.findByTestId('run-name-input').should('not.have.attr', 'readonly');
 
                 // * The template preview is hidden while overriding
                 cy.findByTestId('run-name-preview').should('not.exist');

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
@@ -297,7 +297,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
                 cy.findByTestId('override-run-name-checkbox').should('exist').and('not.be.checked');
 
                 // # Check the override option
-                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByTestId('override-run-name-checkbox').check();
 
                 // * Name input is now editable (no readonly attr) and cleared
                 cy.findByTestId('run-name-input').should('have.value', '');
@@ -307,7 +307,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
                 cy.findByTestId('run-name-preview').should('not.exist');
 
                 // # Uncheck the override option
-                cy.findByTestId('override-run-name-checkbox').uncheck({force: true});
+                cy.findByTestId('override-run-name-checkbox').uncheck();
 
                 // * The template is restored and the field is read-only again
                 cy.findByTestId('run-name-input').should('have.value', '{OWNER}').and('have.attr', 'readonly');
@@ -320,7 +320,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
 
             cy.get('#root-portal.modal-open').within(() => {
                 // # Enable override
-                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByTestId('override-run-name-checkbox').check();
 
                 // # Type only whitespace into the (now editable) name field
                 cy.findByTestId('run-name-input').clear().type('   ');
@@ -340,7 +340,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
 
             cy.get('#root-portal.modal-open').within(() => {
                 // # Enable override and type a manual name
-                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByTestId('override-run-name-checkbox').check();
                 cy.findByTestId('run-name-input').clear().type(overrideName);
 
                 // * Submit is enabled and start the run
@@ -374,7 +374,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
                 cy.findByTestId('modal-confirm-button').should('be.disabled');
 
                 // # Enable override
-                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByTestId('override-run-name-checkbox').check();
 
                 // * The Attributes section disappears — the template is no longer used
                 cy.findByText('Attributes').should('not.exist');
@@ -408,7 +408,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
                 cy.findByTestId(`property-field-${priorityFieldId}`).clear().type(typedPriority);
 
                 // # Enable override (hides the Attributes section) and type a manual name
-                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByTestId('override-run-name-checkbox').check();
                 cy.findByText('Attributes').should('not.exist');
                 cy.findByTestId('run-name-input').clear().type(overrideName);
 

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
@@ -311,6 +311,24 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
             });
         });
 
+        it('keeps the Start run button disabled when the override name is only whitespace', () => {
+            // # Open the modal for a template playbook
+            cy.playbooksOpenRunModal(seqTemplatePlaybook.id);
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // # Enable override
+                cy.findByTestId('override-run-name-checkbox').check({force: true});
+
+                // # Type only whitespace into the (now editable) name field
+                cy.findByTestId('run-name-input').clear().type('   ');
+
+                // * Start run stays disabled — a whitespace-only name is not a valid override.
+                // The server trims the name and would otherwise fall back to the template, so the
+                // client must not enable submission for whitespace-only input.
+                cy.findByTestId('modal-confirm-button').should('be.disabled');
+            });
+        });
+
         it('creates a run with the manually-entered name when overriding a template', () => {
             const overrideName = 'Manually named run ' + getRandomId();
 

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
@@ -216,6 +216,165 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
         });
     });
 
+    describe('override the template-generated name', () => {
+        let seqTemplatePlaybook;
+        let plainPlaybook;
+        let fieldTemplatePlaybook;
+
+        beforeEach(() => {
+            // # Playbook with a system-token-only template (no property fields required)
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Override SeqTemplate PB ' + getRandomId(),
+                makePublic: true,
+                memberIDs: [testUser.id],
+                createPublicPlaybookRun: true,
+            }).then((playbook) => {
+                cy.apiPatchPlaybook(playbook.id, {channel_name_template: '{OWNER}'}).then(() => {
+                    seqTemplatePlaybook = playbook;
+                });
+            });
+
+            // # Playbook WITHOUT a template (free-text mode)
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Override Plain PB ' + getRandomId(),
+                makePublic: true,
+                memberIDs: [testUser.id],
+                createPublicPlaybookRun: true,
+            }).then((playbook) => {
+                plainPlaybook = playbook;
+            });
+
+            // # Playbook with a template referencing a required property field
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Override FieldTemplate PB ' + getRandomId(),
+                makePublic: true,
+                memberIDs: [testUser.id],
+                createPublicPlaybookRun: true,
+            }).then((playbook) => {
+                fieldTemplatePlaybook = playbook;
+                cy.apiAddPropertyField(playbook.id, {
+                    name: 'Priority',
+                    type: 'text',
+                    attrs: {visibility: 'always', sortOrder: 0},
+                });
+                cy.apiPatchPlaybook(playbook.id, {channel_name_template: '{Priority} incident'});
+            });
+        });
+
+        afterEach(() => {
+            [seqTemplatePlaybook, plainPlaybook, fieldTemplatePlaybook].forEach((pb) => {
+                if (pb) {
+                    cy.apiArchivePlaybook(pb.id);
+                }
+            });
+        });
+
+        it('does not show the override checkbox when no template is set', () => {
+            // # Open the modal for a template-less playbook
+            cy.playbooksOpenRunModal(plainPlaybook.id);
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // * The override checkbox is not rendered without a template
+                cy.findByTestId('override-run-name-checkbox').should('not.exist');
+            });
+        });
+
+        it('shows the override checkbox and toggles the name field editability', () => {
+            // # Open the modal for a template playbook
+            cy.playbooksOpenRunModal(seqTemplatePlaybook.id);
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // * Name input is pre-filled with the template and read-only
+                cy.findByTestId('run-name-input').should('have.value', '{OWNER}').and('have.attr', 'readonly');
+
+                // * The override checkbox exists and starts unchecked
+                cy.findByTestId('override-run-name-checkbox').should('exist').and('not.be.checked');
+
+                // # Check the override option
+                cy.findByTestId('override-run-name-checkbox').check({force: true});
+
+                // * Name input is now editable (no readonly attr) and cleared
+                cy.findByTestId('run-name-input').should('not.have.attr', 'readonly').and('have.value', '');
+
+                // * The template preview is hidden while overriding
+                cy.findByTestId('run-name-preview').should('not.exist');
+
+                // # Uncheck the override option
+                cy.findByTestId('override-run-name-checkbox').uncheck({force: true});
+
+                // * The template is restored and the field is read-only again
+                cy.findByTestId('run-name-input').should('have.value', '{OWNER}').and('have.attr', 'readonly');
+            });
+        });
+
+        it('creates a run with the manually-entered name when overriding a template', () => {
+            const overrideName = 'Manually named run ' + getRandomId();
+
+            // # Open the modal for a template playbook
+            cy.playbooksOpenRunModal(seqTemplatePlaybook.id);
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // # Enable override and type a manual name
+                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByTestId('run-name-input').clear().type(overrideName);
+
+                // * Submit is enabled and start the run
+                cy.findByTestId('modal-confirm-button').should('not.be.disabled').click();
+            });
+
+            // * Landed on the run details page
+            cy.url().should('include', '/playbooks/runs/');
+
+            // * The run title matches the manually-entered name (not the {OWNER} template)
+            cy.get('h1').contains(overrideName);
+
+            // * Backend stored the overridden name verbatim and still assigned a sequential ID
+            cy.playbooksGetRunIdFromUrl().then((runId) => {
+                cy.apiGetPlaybookRun(runId).then(({body: run}) => {
+                    expect(run.name, 'run name should be the overridden value').to.equal(overrideName);
+                    expect(run.sequential_id, 'a sequential ID is still assigned').to.not.equal('');
+                });
+            });
+        });
+
+        it('bypasses required template property fields when overriding', () => {
+            const overrideName = 'Override skips fields ' + getRandomId();
+
+            // # Open the modal for a playbook whose template requires a property field
+            cy.playbooksOpenRunModal(fieldTemplatePlaybook.id);
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // * The Attributes section (required field) is shown and submit is disabled
+                cy.findByText('Attributes').should('be.visible');
+                cy.findByTestId('modal-confirm-button').should('be.disabled');
+
+                // # Enable override
+                cy.findByTestId('override-run-name-checkbox').check({force: true});
+
+                // * The Attributes section disappears — the template is no longer used
+                cy.findByText('Attributes').should('not.exist');
+
+                // # Type a manual name
+                cy.findByTestId('run-name-input').clear().type(overrideName);
+
+                // * Submit is enabled even though the required property field was never filled
+                cy.findByTestId('modal-confirm-button').should('not.be.disabled').click();
+            });
+
+            // * Run is created with the overridden name
+            cy.url().should('include', '/playbooks/runs/');
+            cy.get('h1').contains(overrideName);
+            cy.playbooksGetRunIdFromUrl().then((runId) => {
+                cy.apiGetPlaybookRun(runId).then(({body: run}) => {
+                    expect(run.name).to.equal(overrideName);
+                });
+            });
+        });
+    });
+
     describe('template name too long', () => {
         let longTemplatePlaybook;
 

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/start_run_template_spec.js
@@ -220,6 +220,7 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
         let seqTemplatePlaybook;
         let plainPlaybook;
         let fieldTemplatePlaybook;
+        let priorityFieldId;
 
         beforeEach(() => {
             // # Playbook with a system-token-only template (no property fields required)
@@ -259,6 +260,8 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
                     name: 'Priority',
                     type: 'text',
                     attrs: {visibility: 'always', sortOrder: 0},
+                }).then((fieldId) => {
+                    priorityFieldId = fieldId;
                 });
                 cy.apiPatchPlaybook(playbook.id, {channel_name_template: '{Priority} incident'});
             });
@@ -389,6 +392,39 @@ describe('playbooks > start a run > template mode (React modal)', {testIsolation
             cy.playbooksGetRunIdFromUrl().then((runId) => {
                 cy.apiGetPlaybookRun(runId).then(({body: run}) => {
                     expect(run.name).to.equal(overrideName);
+                });
+            });
+        });
+
+        it('does not persist attribute values typed before enabling override', () => {
+            const overrideName = 'Override drops fields ' + getRandomId();
+            const typedPriority = 'P1-' + getRandomId();
+
+            // # Open the modal for a playbook whose template references a property field
+            cy.playbooksOpenRunModal(fieldTemplatePlaybook.id);
+
+            cy.get('#root-portal.modal-open').within(() => {
+                // # Fill the Priority attribute BEFORE enabling override
+                cy.findByTestId(`property-field-${priorityFieldId}`).clear().type(typedPriority);
+
+                // # Enable override (hides the Attributes section) and type a manual name
+                cy.findByTestId('override-run-name-checkbox').check({force: true});
+                cy.findByText('Attributes').should('not.exist');
+                cy.findByTestId('run-name-input').clear().type(overrideName);
+
+                // # Start the run
+                cy.findByTestId('modal-confirm-button').should('not.be.disabled').click();
+            });
+
+            // * Run is created with the overridden name
+            cy.url().should('include', '/playbooks/runs/');
+            cy.get('h1').contains(overrideName);
+
+            // * The value typed before overriding must NOT be persisted to the run
+            cy.playbooksGetRunIdFromUrl().then((runId) => {
+                cy.apiGetPlaybookRun(runId).then(({body: run}) => {
+                    expect(run.name).to.equal(overrideName);
+                    expect(JSON.stringify(run.property_values || []), 'attribute value entered before override must not be persisted').to.not.contain(typedPriority);
                 });
             });
         });

--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -194,6 +194,10 @@ paths:
                   type: string
                   description: The identifier of the playbook with from which this playbook run was created.
                   example: 0y4a0ntte97cxvfont8y84wa7x
+                name_template_override:
+                  type: boolean
+                  description: When true and the playbook has a channel name template, the template is ignored for this run and the supplied name is used verbatim. Ignored when the name is blank.
+                  example: false
       x-codeSamples:
         - lang: curl
           source: |

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -232,6 +232,8 @@ func (h *PlaybookRunHandler) createPlaybookRunFromPost(c *Context, w http.Respon
 			PostID:      playbookRunCreateOptions.PostID,
 			PlaybookID:  playbookRunCreateOptions.PlaybookID,
 			Type:        runType,
+
+			NameTemplateOverride: playbookRunCreateOptions.NameTemplateOverride,
 		},
 		userID,
 		playbookRunCreateOptions.CreatePublicRun,

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -259,8 +259,7 @@ type PlaybookRun struct {
 	TaskTotal     int `json:"task_total"`
 	TaskCompleted int `json:"task_completed"`
 
-	// NameTemplateOverride is a transient, non-persisted flag set at creation time. When true and
-	// Name is non-empty, the playbook's channel name template is ignored and Name is used verbatim.
+	// NameTemplateOverride is a transient (non-persisted) creation flag; see HasNameOverride.
 	NameTemplateOverride bool `json:"-"`
 }
 

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -258,6 +258,10 @@ type PlaybookRun struct {
 	// excluded; Skipped items count as completed. See ComputeTaskProgress.
 	TaskTotal     int `json:"task_total"`
 	TaskCompleted int `json:"task_completed"`
+
+	// NameTemplateOverride is a transient, non-persisted flag set at creation time. When true and
+	// Name is non-empty, the playbook's channel name template is ignored and Name is used verbatim.
+	NameTemplateOverride bool `json:"-"`
 }
 
 func (r *PlaybookRun) ComputeTaskProgress() {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -264,6 +264,13 @@ type PlaybookRun struct {
 	NameTemplateOverride bool `json:"-"`
 }
 
+// HasNameOverride reports whether the run should ignore the playbook's channel name template and
+// use the user-supplied Name verbatim. The name must be non-blank after trimming; a whitespace-only
+// name is treated as no override so the template still drives naming.
+func (r *PlaybookRun) HasNameOverride() bool {
+	return r.NameTemplateOverride && strings.TrimSpace(r.Name) != ""
+}
+
 func (r *PlaybookRun) ComputeTaskProgress() {
 	total, completed := 0, 0
 	for _, cl := range r.Checklists {

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -6000,12 +6000,18 @@ func (s *PlaybookRunServiceImpl) ResolveRunCreationParams(playbookRun *PlaybookR
 		playbookRun.PlaybookID = pb.ID
 	}
 
+	s.resolveOwner(playbookRun, logger)
+
+	// When the user opts to override the template with a manually-supplied name, the template is
+	// not used for this run, so skip template preparation and validation entirely.
+	if playbookRun.NameTemplateOverride && strings.TrimSpace(playbookRun.Name) != "" {
+		return nil
+	}
+
 	fields, attributesLicensed, err := s.loadTemplateFields(pb)
 	if err != nil {
 		return err
 	}
-
-	s.resolveOwner(playbookRun, logger)
 
 	template, err := s.prepareTemplate(pb, source, fields, attributesLicensed, logger)
 	if err != nil {
@@ -6038,14 +6044,24 @@ func (s *PlaybookRunServiceImpl) resolveAndAllocate(playbookRun *PlaybookRun, pb
 	}
 	pb = &latestPb
 
-	fields, attributesLicensed, err := s.loadTemplateFields(pb)
-	if err != nil {
-		return "", err
-	}
+	// When the user opts to override the template with a manually-supplied name, ignore the
+	// playbook's channel name template for this run so the user-supplied name is used verbatim.
+	// A sequential ID is still allocated below.
+	overrideTemplate := playbookRun.NameTemplateOverride && userSuppliedName != ""
 
-	template, err := s.prepareTemplate(pb, source, fields, attributesLicensed, logger)
-	if err != nil {
-		return "", err
+	var fields []PropertyField
+	var template string
+	if !overrideTemplate {
+		var attributesLicensed bool
+		fields, attributesLicensed, err = s.loadTemplateFields(pb)
+		if err != nil {
+			return "", err
+		}
+
+		template, err = s.prepareTemplate(pb, source, fields, attributesLicensed, logger)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	sanitizedValues := s.sanitizePropertyValues(fields, initialValues, logger)

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -6004,7 +6004,7 @@ func (s *PlaybookRunServiceImpl) ResolveRunCreationParams(playbookRun *PlaybookR
 
 	// When the user opts to override the template with a manually-supplied name, the template is
 	// not used for this run, so skip template preparation and validation entirely.
-	if playbookRun.NameTemplateOverride && strings.TrimSpace(playbookRun.Name) != "" {
+	if playbookRun.HasNameOverride() {
 		return nil
 	}
 
@@ -6047,7 +6047,7 @@ func (s *PlaybookRunServiceImpl) resolveAndAllocate(playbookRun *PlaybookRun, pb
 	// When the user opts to override the template with a manually-supplied name, ignore the
 	// playbook's channel name template for this run so the user-supplied name is used verbatim.
 	// A sequential ID is still allocated below.
-	overrideTemplate := playbookRun.NameTemplateOverride && userSuppliedName != ""
+	overrideTemplate := playbookRun.HasNameOverride()
 
 	var fields []PropertyField
 	var template string

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -6002,8 +6002,7 @@ func (s *PlaybookRunServiceImpl) ResolveRunCreationParams(playbookRun *PlaybookR
 
 	s.resolveOwner(playbookRun, logger)
 
-	// When the user opts to override the template with a manually-supplied name, the template is
-	// not used for this run, so skip template preparation and validation entirely.
+	// The template is unused when overriding, so skip its validation.
 	if playbookRun.HasNameOverride() {
 		return nil
 	}
@@ -6044,9 +6043,7 @@ func (s *PlaybookRunServiceImpl) resolveAndAllocate(playbookRun *PlaybookRun, pb
 	}
 	pb = &latestPb
 
-	// When the user opts to override the template with a manually-supplied name, ignore the
-	// playbook's channel name template for this run so the user-supplied name is used verbatim.
-	// A sequential ID is still allocated below.
+	// When overriding, ignore the template; a sequential ID is still allocated below.
 	overrideTemplate := playbookRun.HasNameOverride()
 
 	var fields []PropertyField

--- a/server/app/playbook_run_test.go
+++ b/server/app/playbook_run_test.go
@@ -50,6 +50,33 @@ func TestFormatSequentialID(t *testing.T) {
 	})
 }
 
+func TestPlaybookRun_HasNameOverride(t *testing.T) {
+	t.Run("flag set with a real name overrides", func(t *testing.T) {
+		r := &PlaybookRun{NameTemplateOverride: true, Name: "My title"}
+		require.True(t, r.HasNameOverride())
+	})
+
+	t.Run("flag set with leading/trailing whitespace still overrides", func(t *testing.T) {
+		r := &PlaybookRun{NameTemplateOverride: true, Name: "  My title  "}
+		require.True(t, r.HasNameOverride())
+	})
+
+	t.Run("flag set with whitespace-only name does not override", func(t *testing.T) {
+		r := &PlaybookRun{NameTemplateOverride: true, Name: "   "}
+		require.False(t, r.HasNameOverride())
+	})
+
+	t.Run("flag set with empty name does not override", func(t *testing.T) {
+		r := &PlaybookRun{NameTemplateOverride: true, Name: ""}
+		require.False(t, r.HasNameOverride())
+	})
+
+	t.Run("flag unset never overrides", func(t *testing.T) {
+		r := &PlaybookRun{NameTemplateOverride: false, Name: "My title"}
+		require.False(t, r.HasNameOverride())
+	})
+}
+
 func TestPlaybookRun_MarshalJSON(t *testing.T) {
 	t.Run("marshal pointer", func(t *testing.T) {
 		testPlaybookRun := &PlaybookRun{}

--- a/server/app/resolve_and_allocate_test.go
+++ b/server/app/resolve_and_allocate_test.go
@@ -178,6 +178,31 @@ func newAllocService(pbStub *allocPlaybookServiceStub) *PlaybookRunServiceImpl {
 	}
 }
 
+// newAllocServiceWithZoneTemplate builds a service whose playbook uses the "{Zone}" channel-name
+// template (with the "Zone" property field defined) and the attributes license enabled. It returns
+// the service, the playbook stub (to assert allocation side effects), and the playbook to pass in.
+func newAllocServiceWithZoneTemplate(incrementResult int64) (*PlaybookRunServiceImpl, *allocPlaybookServiceStub, Playbook) {
+	zoneField := PropertyField{
+		PropertyField: model.PropertyField{
+			ID:   "fld_zone",
+			Name: "Zone",
+			Type: model.PropertyFieldTypeText,
+		},
+	}
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "{Zone}",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: incrementResult}
+	svc := &PlaybookRunServiceImpl{
+		playbookService: pbStub,
+		propertyService: &allocPropertyServiceStub{fields: []PropertyField{zoneField}},
+		licenseChecker:  &allocLicenseCheckerWithAttributes{},
+	}
+	return svc, pbStub, pb
+}
+
 func TestResolveAndAllocate_HappyPathPrefixed(t *testing.T) {
 	pb := Playbook{ID: "pb_1", RunNumberPrefix: "INC"}
 	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 42}
@@ -259,24 +284,7 @@ func TestResolveAndAllocate_IncrementNotFoundWrapsMalformedRun(t *testing.T) {
 // This test deliberately exercises the licensed path because dry-run only validates
 // property-field placeholders when PlaybookAttributesAllowed() is true.
 func TestResolveAndAllocate_DryRunFailureSkipsAllocation(t *testing.T) {
-	zoneField := PropertyField{
-		PropertyField: model.PropertyField{
-			ID:   "fld_zone",
-			Name: "Zone",
-			Type: model.PropertyFieldTypeText,
-		},
-	}
-	pb := Playbook{
-		ID:                  "pb_1",
-		RunNumberPrefix:     "INC",
-		ChannelNameTemplate: "{Zone}",
-	}
-	pbStub := &allocPlaybookServiceStub{getResult: pb}
-	svc := &PlaybookRunServiceImpl{
-		playbookService: pbStub,
-		propertyService: &allocPropertyServiceStub{fields: []PropertyField{zoneField}},
-		licenseChecker:  &allocLicenseCheckerWithAttributes{},
-	}
+	svc, pbStub, pb := newAllocServiceWithZoneTemplate(0)
 
 	run := &PlaybookRun{PlaybookID: pb.ID, Name: "test"}
 	_, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
@@ -294,24 +302,7 @@ func TestResolveAndAllocate_DryRunFailureSkipsAllocation(t *testing.T) {
 // user-supplied value, the template's required property fields are NOT validated, and a sequential
 // ID is still allocated.
 func TestResolveAndAllocate_OverrideBypassesTemplate(t *testing.T) {
-	zoneField := PropertyField{
-		PropertyField: model.PropertyField{
-			ID:   "fld_zone",
-			Name: "Zone",
-			Type: model.PropertyFieldTypeText,
-		},
-	}
-	pb := Playbook{
-		ID:                  "pb_1",
-		RunNumberPrefix:     "INC",
-		ChannelNameTemplate: "{Zone}",
-	}
-	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 7}
-	svc := &PlaybookRunServiceImpl{
-		playbookService: pbStub,
-		propertyService: &allocPropertyServiceStub{fields: []PropertyField{zoneField}},
-		licenseChecker:  &allocLicenseCheckerWithAttributes{},
-	}
+	svc, pbStub, pb := newAllocServiceWithZoneTemplate(7)
 
 	run := &PlaybookRun{PlaybookID: pb.ID, Name: "My manual title", NameTemplateOverride: true}
 	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
@@ -328,24 +319,7 @@ func TestResolveAndAllocate_OverrideBypassesTemplate(t *testing.T) {
 // whitespace is trimmed before allocation, so the stored run name and derived channel name use the
 // trimmed value — matching HasNameOverride() which also trims when deciding to override.
 func TestResolveAndAllocate_OverrideTrimsPaddedName(t *testing.T) {
-	zoneField := PropertyField{
-		PropertyField: model.PropertyField{
-			ID:   "fld_zone",
-			Name: "Zone",
-			Type: model.PropertyFieldTypeText,
-		},
-	}
-	pb := Playbook{
-		ID:                  "pb_1",
-		RunNumberPrefix:     "INC",
-		ChannelNameTemplate: "{Zone}",
-	}
-	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 7}
-	svc := &PlaybookRunServiceImpl{
-		playbookService: pbStub,
-		propertyService: &allocPropertyServiceStub{fields: []PropertyField{zoneField}},
-		licenseChecker:  &allocLicenseCheckerWithAttributes{},
-	}
+	svc, pbStub, pb := newAllocServiceWithZoneTemplate(7)
 
 	run := &PlaybookRun{PlaybookID: pb.ID, Name: "   My manual title   ", NameTemplateOverride: true}
 	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)

--- a/server/app/resolve_and_allocate_test.go
+++ b/server/app/resolve_and_allocate_test.go
@@ -324,6 +324,40 @@ func TestResolveAndAllocate_OverrideBypassesTemplate(t *testing.T) {
 	assert.Equal(t, 1, pbStub.incrementCalled, "counter consumed exactly once")
 }
 
+// TestResolveAndAllocate_OverrideTrimsPaddedName pins that a manual override name with surrounding
+// whitespace is trimmed before allocation, so the stored run name and derived channel name use the
+// trimmed value — matching HasNameOverride() which also trims when deciding to override.
+func TestResolveAndAllocate_OverrideTrimsPaddedName(t *testing.T) {
+	zoneField := PropertyField{
+		PropertyField: model.PropertyField{
+			ID:   "fld_zone",
+			Name: "Zone",
+			Type: model.PropertyFieldTypeText,
+		},
+	}
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "{Zone}",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 7}
+	svc := &PlaybookRunServiceImpl{
+		playbookService: pbStub,
+		propertyService: &allocPropertyServiceStub{fields: []PropertyField{zoneField}},
+		licenseChecker:  &allocLicenseCheckerWithAttributes{},
+	}
+
+	run := &PlaybookRun{PlaybookID: pb.ID, Name: "   My manual title   ", NameTemplateOverride: true}
+	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
+
+	require.NoError(t, err, "override must skip template field validation entirely")
+	assert.Equal(t, "My manual title", run.Name, "run name must be the trimmed user-supplied value")
+	assert.Equal(t, "My manual title", channelName, "channel name must be derived from the trimmed name")
+	assert.Equal(t, int64(7), run.RunNumber, "sequential ID must still be allocated when overriding")
+	assert.Equal(t, "INC-00007", run.SequentialID)
+	assert.Equal(t, 1, pbStub.incrementCalled, "counter consumed exactly once")
+}
+
 // TestResolveAndAllocate_OverrideIgnoredWhenNameEmpty pins that the override flag has no effect
 // when no manual name is supplied — the template is still used to resolve the run name.
 func TestResolveAndAllocate_OverrideIgnoredWhenNameEmpty(t *testing.T) {

--- a/server/app/resolve_and_allocate_test.go
+++ b/server/app/resolve_and_allocate_test.go
@@ -288,3 +288,56 @@ func TestResolveAndAllocate_DryRunFailureSkipsAllocation(t *testing.T) {
 	assert.Equal(t, int64(0), run.RunNumber)
 	assert.Equal(t, "", run.SequentialID)
 }
+
+// TestResolveAndAllocate_OverrideBypassesTemplate pins that when the user opts to override the
+// template with a manually-supplied name, the playbook's template is ignored: the run name is the
+// user-supplied value, the template's required property fields are NOT validated, and a sequential
+// ID is still allocated.
+func TestResolveAndAllocate_OverrideBypassesTemplate(t *testing.T) {
+	zoneField := PropertyField{
+		PropertyField: model.PropertyField{
+			ID:   "fld_zone",
+			Name: "Zone",
+			Type: model.PropertyFieldTypeText,
+		},
+	}
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "{Zone}",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 7}
+	svc := &PlaybookRunServiceImpl{
+		playbookService: pbStub,
+		propertyService: &allocPropertyServiceStub{fields: []PropertyField{zoneField}},
+		licenseChecker:  &allocLicenseCheckerWithAttributes{},
+	}
+
+	run := &PlaybookRun{PlaybookID: pb.ID, Name: "My manual title", NameTemplateOverride: true}
+	channelName, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
+
+	require.NoError(t, err, "override must skip template field validation entirely")
+	assert.Equal(t, "My manual title", run.Name, "run name must be the user-supplied value")
+	assert.Equal(t, "My manual title", channelName, "channel name must be derived from the user-supplied name")
+	assert.Equal(t, int64(7), run.RunNumber, "sequential ID must still be allocated when overriding")
+	assert.Equal(t, "INC-00007", run.SequentialID)
+	assert.Equal(t, 1, pbStub.incrementCalled, "counter consumed exactly once")
+}
+
+// TestResolveAndAllocate_OverrideIgnoredWhenNameEmpty pins that the override flag has no effect
+// when no manual name is supplied — the template is still used to resolve the run name.
+func TestResolveAndAllocate_OverrideIgnoredWhenNameEmpty(t *testing.T) {
+	pb := Playbook{
+		ID:                  "pb_1",
+		RunNumberPrefix:     "INC",
+		ChannelNameTemplate: "Static Name",
+	}
+	pbStub := &allocPlaybookServiceStub{getResult: pb, incrementResult: 3}
+	svc := newAllocService(pbStub)
+
+	run := &PlaybookRun{PlaybookID: pb.ID, Name: "   ", NameTemplateOverride: true}
+	_, err := svc.resolveAndAllocate(run, &pb, nil, RunSourcePost)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Static Name", run.Name, "template must still drive the name when no manual name is supplied")
+}

--- a/server/app/resolve_run_creation_params_test.go
+++ b/server/app/resolve_run_creation_params_test.go
@@ -286,6 +286,43 @@ func TestResolveRunCreationParams_SetsPlaybookIDFromPlaybook(t *testing.T) {
 	assert.Equal(t, pbID, run.PlaybookID)
 }
 
+func TestResolveRunCreationParams_OverrideSkipsTemplateValidation(t *testing.T) {
+	pbID := mm_model.NewId()
+
+	// Template references a property field with no supplied value. Without override this would
+	// fail dry-run validation; with override + a manual name, validation is skipped entirely.
+	svc := &PlaybookRunServiceImpl{
+		licenseChecker:  &allocLicenseCheckerWithAttributes{},
+		propertyService: &allocPropertyServiceStub{fields: []PropertyField{{PropertyField: mm_model.PropertyField{ID: "fld_zone", Name: "Zone", Type: mm_model.PropertyFieldTypeText}}}},
+	}
+
+	run := &PlaybookRun{PlaybookID: pbID, Name: "Manual title", NameTemplateOverride: true}
+	pb := &Playbook{ID: pbID, ChannelNameTemplate: "{Zone}"}
+
+	err := svc.ResolveRunCreationParams(run, pb, nil, RunSourcePost)
+
+	require.NoError(t, err, "override with a manual name must skip template validation")
+}
+
+func TestResolveRunCreationParams_OverrideWithEmptyNameStillValidates(t *testing.T) {
+	pbID := mm_model.NewId()
+
+	svc := &PlaybookRunServiceImpl{
+		licenseChecker:  &allocLicenseCheckerWithAttributes{},
+		propertyService: &allocPropertyServiceStub{fields: []PropertyField{{PropertyField: mm_model.PropertyField{ID: "fld_zone", Name: "Zone", Type: mm_model.PropertyFieldTypeText}}}},
+	}
+
+	// Override requested but no manual name provided — validation should still run and fail.
+	// No ReporterUserID/OwnerUserID is set so the {Zone} dry-run does not resolve user tokens.
+	run := &PlaybookRun{PlaybookID: pbID, Name: "  ", NameTemplateOverride: true}
+	pb := &Playbook{ID: pbID, ChannelNameTemplate: "{Zone}"}
+
+	err := svc.ResolveRunCreationParams(run, pb, nil, RunSourcePost)
+
+	require.Error(t, err, "empty name must not bypass template validation even when override is set")
+	assert.True(t, errors.Is(err, ErrMalformedPlaybookRun))
+}
+
 func TestResolveRunCreationParams_DoesNotAllocateRunNumber(t *testing.T) {
 	pbID := mm_model.NewId()
 

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -88,6 +88,7 @@
   "5fGYe2": "No attributes yet",
   "5j6GD/": "{numParticipants, plural, =0 {no participants} =1 {# participant} other {# participants}}",
   "5kK+j9": "Restart",
+  "5kUiQw": "Override the name generated from the template",
   "5qBEKB": "What are playbook runs?",
   "69nlA3": "Please enter a duration in the format: dd:hh:mm (e.g., 12:00:00).",
   "6CGo3o": "Status / Last update",

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -95,7 +95,8 @@ export async function createPlaybookRun(
     summary: string,
     channel_id?: string,
     create_public_run?: boolean,
-    property_values?: Record<string, string | number | boolean | null | string[]>
+    property_values?: Record<string, string | number | boolean | null | string[]>,
+    name_template_override?: boolean,
 ) {
     const run = await doPost(`${apiUrl}/runs`, JSON.stringify({
         owner_user_id,
@@ -106,6 +107,7 @@ export async function createPlaybookRun(
         channel_id,
         create_public_run,
         property_values,
+        name_template_override,
     }));
     return run as PlaybookRun;
 }

--- a/webapp/src/components/modals/run_playbook_modal.test.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.test.tsx
@@ -719,6 +719,42 @@ describe('RunPlaybookModal — template mode', () => {
             expect(args[8]).toBe(true);
         });
 
+        it('does not send property values that were typed before enabling override', async () => {
+            mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
+            mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);
+            mockCreatePlaybookRun.mockResolvedValue({id: 'run-1', channel_id: 'ch-1'});
+
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            // Fill the template's property field first
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'property-field-field-sev').props.onChange({target: {value: 'Critical'}});
+            });
+
+            // Then enable override (hides the Attributes section) and type a manual name
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'override-run-name-checkbox').props.onChange({target: {checked: true}});
+            });
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'run-name-input').props.onChange({target: {value: 'Manual title'}});
+            });
+
+            await act(async () => {
+                findNodeByTestId(component!.toJSON(), 'confirm-button').props.onClick();
+            });
+
+            expect(mockCreatePlaybookRun).toHaveBeenCalledTimes(1);
+            const args = mockCreatePlaybookRun.mock.calls[0];
+
+            // args: playbookId, userId, teamId, name, summary, channelId, createPublicRun, propertyValues, nameTemplateOverride
+            // Property values must not be persisted when overriding.
+            expect(args[7]).toBeUndefined();
+            expect(args[8]).toBe(true);
+        });
+
         it('restores the template into the name field when override is toggled back off', () => {
             mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
             mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);

--- a/webapp/src/components/modals/run_playbook_modal.test.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.test.tsx
@@ -671,6 +671,27 @@ describe('RunPlaybookModal — template mode', () => {
             expect(findNodeByTestId(tree, 'confirm-button').props.disabled).toBe(false);
         });
 
+        it('keeps submit disabled when the override name is only whitespace', () => {
+            mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
+            mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);
+
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'override-run-name-checkbox').props.onChange({target: {checked: true}});
+            });
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'run-name-input').props.onChange({target: {value: '   '}});
+            });
+
+            // A whitespace-only name must not enable submit: the server trims it and would fall
+            // back to the template, which is not what the user intended when overriding.
+            expect(findNodeByTestId(component!.toJSON(), 'confirm-button').props.disabled).toBe(true);
+        });
+
         it('sends name_template_override=true and the manual name on submit', async () => {
             mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
             mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);

--- a/webapp/src/components/modals/run_playbook_modal.test.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.test.tsx
@@ -616,8 +616,107 @@ describe('RunPlaybookModal — template mode', () => {
             });
 
             expect(mockCreatePlaybookRun).toHaveBeenCalledWith(
-                'playbook-1', 'mock-user-id', 'team-1', 'My Run', '', undefined, false, undefined,
+                'playbook-1', 'mock-user-id', 'team-1', 'My Run', '', undefined, false, undefined, false,
             );
+        });
+    });
+
+    describe('override name', () => {
+        it('does not show the override checkbox when no template is set', () => {
+            mockUsePlaybook.mockReturnValue([basePlaybook, {isFetching: false, error: undefined}]);
+            const component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            expect(findNodeByTestId(component.toJSON(), 'override-run-name-checkbox')).toBeNull();
+        });
+
+        it('shows the override checkbox when a template is set', () => {
+            mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
+            mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);
+            const component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            expect(findNodeByTestId(component.toJSON(), 'override-run-name-checkbox')).not.toBeNull();
+        });
+
+        it('makes the name editable, hides the preview and fields, and requires a name when overriding', () => {
+            mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
+            mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);
+
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            // Toggle override on
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'override-run-name-checkbox').props.onChange({target: {checked: true}});
+            });
+
+            let tree = component!.toJSON();
+
+            // Preview and property fields are hidden while overriding
+            expect(findNodeByTestId(tree, 'run-name-preview')).toBeNull();
+            expect(findNodeByTestId(tree, 'property-field-field-sev')).toBeNull();
+
+            // Name input is now editable (not read-only) and cleared
+            const nameInput = findNodeByTestId(tree, 'run-name-input');
+            expect(nameInput.props.readOnly).toBeFalsy();
+            expect(nameInput.props.value).toBe('');
+
+            // With an empty name, submit is disabled
+            expect(findNodeByTestId(tree, 'confirm-button').props.disabled).toBe(true);
+
+            // Type a manual name, submit becomes enabled
+            act(() => {
+                nameInput.props.onChange({target: {value: 'Manual title'}});
+            });
+            tree = component!.toJSON();
+            expect(findNodeByTestId(tree, 'confirm-button').props.disabled).toBe(false);
+        });
+
+        it('sends name_template_override=true and the manual name on submit', async () => {
+            mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
+            mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);
+            mockCreatePlaybookRun.mockResolvedValue({id: 'run-1', channel_id: 'ch-1'});
+
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'override-run-name-checkbox').props.onChange({target: {checked: true}});
+            });
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'run-name-input').props.onChange({target: {value: 'Manual title'}});
+            });
+
+            await act(async () => {
+                findNodeByTestId(component!.toJSON(), 'confirm-button').props.onClick();
+            });
+
+            expect(mockCreatePlaybookRun).toHaveBeenCalledTimes(1);
+            const args = mockCreatePlaybookRun.mock.calls[0];
+            expect(args[3]).toBe('Manual title');
+            expect(args[8]).toBe(true);
+        });
+
+        it('restores the template into the name field when override is toggled back off', () => {
+            mockUsePlaybook.mockReturnValue([playbookWithTemplate, {isFetching: false, error: undefined}]);
+            mockUsePlaybookAttributes.mockReturnValue(playbookWithTemplate.propertyFields);
+
+            let component: renderer.ReactTestRenderer;
+            act(() => {
+                component = renderer.create(<RunPlaybookModal {...defaultProps}/>);
+            });
+
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'override-run-name-checkbox').props.onChange({target: {checked: true}});
+            });
+            act(() => {
+                findNodeByTestId(component!.toJSON(), 'override-run-name-checkbox').props.onChange({target: {checked: false}});
+            });
+
+            const nameInput = findNodeByTestId(component!.toJSON(), 'run-name-input');
+            expect(nameInput.props.value).toBe('{Severity} - Incident');
+            expect(nameInput.props.readOnly).toBe(true);
         });
     });
 

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -86,6 +86,7 @@ export const RunPlaybookModal = ({
     const playbookAttributes = usePlaybookAttributes(selectedPlaybookId || '');
     const [restPlaybook] = useRestPlaybook(selectedPlaybookId || '');
     const [runName, setRunName] = useState('');
+    const [overrideName, setOverrideName] = useState(false);
     const [runSummary, setRunSummary] = useState('');
     const [channelMode, setChannelMode] = useState('');
     const [channelId, setChannelId] = useState('');
@@ -174,6 +175,7 @@ export const RunPlaybookModal = ({
         // to avoid a split-brain where the button looks clickable but isSubmittingRef blocks clicks.
         setPropertyValues({});
         setSubmitError('');
+        setOverrideName(false);
         if (!isSubmittingRef.current) {
             setIsSubmitting(false);
         }
@@ -240,6 +242,18 @@ export const RunPlaybookModal = ({
 
     const hasTemplate = Boolean(playbook?.channel_name_template);
 
+    // When the playbook has a template, the user may opt to override it and type a name manually.
+    // In that mode we behave like a template-less playbook: free-text name, no preview, no fields.
+    const usingTemplate = hasTemplate && !overrideName;
+
+    const handleToggleOverrideName = useCallback((next: boolean) => {
+        setOverrideName(next);
+
+        // Clear the raw template string when switching to manual entry, and restore it when
+        // switching back so the preview reflects the playbook's template again.
+        setRunName(next ? '' : (playbook?.channel_name_template ?? ''));
+    }, [playbook?.channel_name_template]);
+
     // Preview the resolved name (client-side approximation)
     const namePreview = useMemo(() => {
         const tpl = playbook?.channel_name_template;
@@ -269,9 +283,9 @@ export const RunPlaybookModal = ({
     // accepts it; the raw template string itself is not validated against the limit.
     const templateNameValid = namePreview === '' || [...namePreview].length <= RUN_NAME_MAX_LENGTH;
     const freeNameValid = runName !== '' && [...runName].length <= RUN_NAME_MAX_LENGTH;
-    const nameValid = hasTemplate ? templateNameValid : freeNameValid;
+    const nameValid = usingTemplate ? templateNameValid : freeNameValid;
 
-    const namePreviewTooLong = hasTemplate && [...namePreview].length > RUN_NAME_MAX_LENGTH;
+    const namePreviewTooLong = usingTemplate && [...namePreview].length > RUN_NAME_MAX_LENGTH;
 
     const requiredFieldsFilled = useMemo(() => templateFields.every((field) => {
         const val = propertyValues[field.id];
@@ -284,7 +298,10 @@ export const RunPlaybookModal = ({
         return true;
     }), [templateFields, propertyValues]);
 
-    const isFormValid = !attributesLoading && nameValid && requiredFieldsFilled && unmatchedTemplateNames.length === 0 && (createNewChannel || channelId !== '');
+    // Template-only concerns (loading attributes, required fields, unmatched fields) are ignored
+    // when overriding the template with a manually-supplied name.
+    const templateConstraintsValid = !usingTemplate || (!attributesLoading && requiredFieldsFilled && unmatchedTemplateNames.length === 0);
+    const isFormValid = nameValid && templateConstraintsValid && (createNewChannel || channelId !== '');
 
     const handleSetChannelMode = useCallback((mode: 'link_existing_channel' | 'create_new_channel') => {
         if (isNewChannelOnly && mode === 'link_existing_channel') {
@@ -316,12 +333,12 @@ export const RunPlaybookModal = ({
         channelMode,
         public: isNewChannel ? createPublicRun : undefined,
         hasPlaybookChanged: playbookId !== selectedPlaybookId,
-        hasNameChanged: playbook!.channel_name_template ? false : runName !== '',
+        hasNameChanged: usingTemplate ? false : runName !== '',
         hasSummaryChanged: runSummary !== (playbook!.run_summary_template_enabled ? playbook!.run_summary_template : ''),
         hasChannelModeChanged: channelMode !== playbook!.channel_mode,
         hasChannelIdChanged: channelId !== playbook!.channel_id,
         hasPublicChanged: !isLinkedChannel && createPublicRun !== playbook!.create_public_playbook_run,
-    }), [selectedPlaybookId, channelMode, createPublicRun, playbookId, runName, runSummary, channelId, playbook]);
+    }), [selectedPlaybookId, channelMode, createPublicRun, playbookId, runName, runSummary, channelId, playbook, usingTemplate]);
 
     const resetSubmitting = useCallback(() => {
         isSubmittingRef.current = false;
@@ -366,6 +383,7 @@ export const RunPlaybookModal = ({
                 isLinkedChannel ? channelId : undefined,
                 isNewChannel ? createPublicRun : undefined,
                 pvToSend,
+                hasTemplate && overrideName,
             );
         } catch {
             resetSubmitting();
@@ -390,7 +408,7 @@ export const RunPlaybookModal = ({
                 resetSubmitting();
                 setSubmitError(formatMessage({defaultMessage: 'An error occurred while creating the run.'}));
             });
-    }, [playbook, selectedPlaybookId, isFormValid, propertyValues, userId, runName, runSummary, channelId, createPublicRun, channelMode, playbookId, onHide, onRunCreated, formatMessage, resetSubmitting, buildStatsData]);
+    }, [playbook, selectedPlaybookId, isFormValid, propertyValues, userId, runName, runSummary, channelId, createPublicRun, channelMode, playbookId, hasTemplate, overrideName, onHide, onRunCreated, formatMessage, resetSubmitting, buildStatsData]);
 
     // Start a run tab
     if (step === 'run-details') {
@@ -463,9 +481,20 @@ export const RunPlaybookModal = ({
                     <RunNameSection
                         runName={runName}
                         onSetRunName={setRunName}
-                        readOnly={hasTemplate}
+                        readOnly={usingTemplate}
                     />
-                    {hasTemplate && namePreview && (
+                    {hasTemplate && (
+                        <OverrideNameToggle>
+                            <StyledRadioInput
+                                type='checkbox'
+                                data-testid={'override-run-name-checkbox'}
+                                checked={overrideName}
+                                onChange={(e) => handleToggleOverrideName(e.target.checked)}
+                            />
+                            <FormattedMessage defaultMessage='Override the name generated from the template'/>
+                        </OverrideNameToggle>
+                    )}
+                    {usingTemplate && namePreview && (
                         <NamePreview data-testid='run-name-preview'>
                             {formatMessage({defaultMessage: 'Preview: {preview}'}, {preview: namePreview})}
                         </NamePreview>
@@ -475,7 +504,7 @@ export const RunPlaybookModal = ({
                             {formatMessage({defaultMessage: 'The resolved run name exceeds the {maxLength}-character limit. Edit the playbook template to use fewer or shorter fields.'}, {maxLength: RUN_NAME_MAX_LENGTH})}
                         </ErrorMessage>
                     )}
-                    {templateFields.length > 0 && (
+                    {usingTemplate && templateFields.length > 0 && (
                         <PropertyFieldsSection
                             fields={templateFields}
                             values={propertyValues}
@@ -884,6 +913,20 @@ const NamePreview = styled.div`
     color: rgba(var(--center-channel-color-rgb), 0.56);
     font-size: 12px;
     line-height: 16px;
+`;
+
+const OverrideNameToggle = styled.label`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    align-self: flex-start;
+    margin-top: -4px;
+    margin-bottom: 12px;
+    column-gap: 8px;
+    cursor: pointer;
+    font-weight: 400;
+    font-size: 12px;
+    color: rgba(var(--center-channel-color-rgb), 0.72);
 `;
 
 type PropertyFieldsSectionProps = {

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -282,7 +282,10 @@ export const RunPlaybookModal = ({
     // In template mode the resolved preview must also fit within the limit so the backend
     // accepts it; the raw template string itself is not validated against the limit.
     const templateNameValid = namePreview === '' || [...namePreview].length <= RUN_NAME_MAX_LENGTH;
-    const freeNameValid = runName !== '' && [...runName].length <= RUN_NAME_MAX_LENGTH;
+
+    // Trim before checking emptiness so a whitespace-only name does not enable submission: the
+    // server trims the name too, and would otherwise fall back to the template (or reject the run).
+    const freeNameValid = runName.trim() !== '' && [...runName].length <= RUN_NAME_MAX_LENGTH;
     const nameValid = usingTemplate ? templateNameValid : freeNameValid;
 
     const namePreviewTooLong = usingTemplate && [...namePreview].length > RUN_NAME_MAX_LENGTH;

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -374,7 +374,10 @@ export const RunPlaybookModal = ({
         isSubmittingRef.current = true;
         setSubmitError('');
         setIsSubmitting(true);
-        const pvToSend = Object.keys(propertyValues).length > 0 ? propertyValues : undefined;
+        // Property fields are only shown (and only relevant) while resolving the template. When
+        // overriding the name manually, the Attributes section is hidden, so any values typed
+        // before enabling override must not be silently persisted to the run.
+        const pvToSend = usingTemplate && Object.keys(propertyValues).length > 0 ? propertyValues : undefined;
         let runPromise: ReturnType<typeof createPlaybookRun>;
         try {
             runPromise = createPlaybookRun(
@@ -411,7 +414,7 @@ export const RunPlaybookModal = ({
                 resetSubmitting();
                 setSubmitError(formatMessage({defaultMessage: 'An error occurred while creating the run.'}));
             });
-    }, [playbook, selectedPlaybookId, isFormValid, propertyValues, userId, runName, runSummary, channelId, createPublicRun, channelMode, playbookId, hasTemplate, overrideName, onHide, onRunCreated, formatMessage, resetSubmitting, buildStatsData]);
+    }, [playbook, selectedPlaybookId, isFormValid, propertyValues, userId, runName, runSummary, channelId, createPublicRun, channelMode, playbookId, hasTemplate, overrideName, usingTemplate, onHide, onRunCreated, formatMessage, resetSubmitting, buildStatsData]);
 
     // Start a run tab
     if (step === 'run-details') {

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -366,6 +366,7 @@ export const RunPlaybookModal = ({
         isSubmittingRef.current = true;
         setSubmitError('');
         setIsSubmitting(true);
+
         // Don't persist attribute values typed before overriding: the Attributes section is hidden in override mode.
         const pvToSend = usingTemplate && Object.keys(propertyValues).length > 0 ? propertyValues : undefined;
         let runPromise: ReturnType<typeof createPlaybookRun>;

--- a/webapp/src/components/modals/run_playbook_modal.tsx
+++ b/webapp/src/components/modals/run_playbook_modal.tsx
@@ -242,15 +242,10 @@ export const RunPlaybookModal = ({
 
     const hasTemplate = Boolean(playbook?.channel_name_template);
 
-    // When the playbook has a template, the user may opt to override it and type a name manually.
-    // In that mode we behave like a template-less playbook: free-text name, no preview, no fields.
     const usingTemplate = hasTemplate && !overrideName;
 
     const handleToggleOverrideName = useCallback((next: boolean) => {
         setOverrideName(next);
-
-        // Clear the raw template string when switching to manual entry, and restore it when
-        // switching back so the preview reflects the playbook's template again.
         setRunName(next ? '' : (playbook?.channel_name_template ?? ''));
     }, [playbook?.channel_name_template]);
 
@@ -283,8 +278,7 @@ export const RunPlaybookModal = ({
     // accepts it; the raw template string itself is not validated against the limit.
     const templateNameValid = namePreview === '' || [...namePreview].length <= RUN_NAME_MAX_LENGTH;
 
-    // Trim before checking emptiness so a whitespace-only name does not enable submission: the
-    // server trims the name too, and would otherwise fall back to the template (or reject the run).
+    // Trim to reject whitespace-only names: the server trims too and would fall back to the template.
     const freeNameValid = runName.trim() !== '' && [...runName].length <= RUN_NAME_MAX_LENGTH;
     const nameValid = usingTemplate ? templateNameValid : freeNameValid;
 
@@ -301,8 +295,6 @@ export const RunPlaybookModal = ({
         return true;
     }), [templateFields, propertyValues]);
 
-    // Template-only concerns (loading attributes, required fields, unmatched fields) are ignored
-    // when overriding the template with a manually-supplied name.
     const templateConstraintsValid = !usingTemplate || (!attributesLoading && requiredFieldsFilled && unmatchedTemplateNames.length === 0);
     const isFormValid = nameValid && templateConstraintsValid && (createNewChannel || channelId !== '');
 
@@ -374,9 +366,7 @@ export const RunPlaybookModal = ({
         isSubmittingRef.current = true;
         setSubmitError('');
         setIsSubmitting(true);
-        // Property fields are only shown (and only relevant) while resolving the template. When
-        // overriding the name manually, the Attributes section is hidden, so any values typed
-        // before enabling override must not be silently persisted to the run.
+        // Don't persist attribute values typed before overriding: the Attributes section is hidden in override mode.
         const pvToSend = usingTemplate && Object.keys(propertyValues).length > 0 ? propertyValues : undefined;
         let runPromise: ReturnType<typeof createPlaybookRun>;
         try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #2255 made the run name field in the **Start a run** modal read-only when the playbook has a channel name template — the run title is always derived from the template.

This PR adds an **Override the name generated from the template** option to that modal. When checked, the run-name field becomes editable, the live preview and template property fields are hidden, and the manually-entered name is used verbatim for the run (and channel) — while the sequential ID is still allocated as usual.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-69446

## Walkthrough

<a href="https://cursor.com/agents/bc-4202f400-2522-4606-9027-ec8a7c603575/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverride_run_name_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-c61b2d9a-e7c5-4736-b7b7-436767302567" alt="override_run_name_walkthrough.mp4" /></a>

Read-only template name (`{OWNER}`) with the new override checkbox → checked, field becomes editable and cleared → typed a manual title → run created with that title.

![Read-only template name with override checkbox](https://cursor.com/artifacts/c/art-285b1871-5ae7-4e5f-b148-b026e744487a)
![Override checked: name field editable and cleared, preview hidden](https://cursor.com/artifacts/c/art-94cd1353-2c5f-41f6-b362-9f43b351a155)
![Run created with the overridden title](https://cursor.com/artifacts/c/art-d820617f-1fd7-478a-8485-0969edf2ab25)

## Changes

### Backend
- `client.PlaybookRunCreateOptions` gains a `name_template_override` flag.
- `app.PlaybookRun` gains a transient (non-persisted) `NameTemplateOverride` field, wired through the `POST /runs` handler.
- `ResolveRunCreationParams` and `resolveAndAllocate` skip template preparation/validation when the flag is set and a manual name is supplied, so required template property fields no longer block the run. The template still wins if the override name is blank.

### Frontend
- `run_playbook_modal.tsx`: added the override checkbox (only shown when the playbook has a template). Toggling it clears/restores the name field, switches the field between read-only template mode and free-text mode, hides the preview and attribute inputs, and requires a non-empty name. The flag is passed to `createPlaybookRun`.
- New i18n string in `en.json`.

## Testing
- Go unit tests for `resolveAndAllocate` / `ResolveRunCreationParams` override behavior.
- Webapp unit tests for the modal (checkbox visibility, field editability, submit payload, toggle-back restore).
- Cypress e2e tests in `start_run_template_spec.js` — 10/10 passing, including 4 new override tests (checkbox visibility, toggling, creating a run with an overridden name, and bypassing required template property fields).
- Manual end-to-end test in a running Mattermost instance (see walkthrough); verified the created run's `name` is the overridden value and a `sequential_id` was still assigned.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4202f400-2522-4606-9027-ec8a7c603575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4202f400-2522-4606-9027-ec8a7c603575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

