### PR TITLE
Rename status operationId to updatePlaybookRunStatus

### DIFF
--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -708,7 +708,7 @@ paths:
   /plugins/playbooks/api/v0/runs/{id}/status:
     post:
       summary: Update a playbook run's status
-      operationId: status
+      operationId: updatePlaybookRunStatus
       security:
         - BearerAuth: []
       tags:


### PR DESCRIPTION
## Summary
- The `POST /plugins/playbooks/api/v0/runs/{id}/status` endpoint used the generic `operationId: status`, which collides with the `status` tag from the main Mattermost server API once both OpenAPI specs are merged for the docs site build, breaking `docusaurus-plugin-openapi-docs` generation with a duplicate doc id error.
- Renamed to `updatePlaybookRunStatus` to match the camelCase, descriptive naming convention used by every other operationId in this file (e.g. `updatePlaybookRun`, `endPlaybookRun`, `changeOwner`).
- This is a spec-only metadata change: the route, request/response schemas, and runtime behavior are unaffected.

## Checklist
- ~~Gated by experimental feature flag~~
- ~~Unit tests updated~~

Made with [Cursor](https://cursor.com)