### PR TITLE
Add channel-aware checklist item resolution to Playbooks MCP

### DIFF
--- a/internal/playbooksmcp/tools/checklist.go
+++ b/internal/playbooksmcp/tools/checklist.go
@@ -93,7 +93,7 @@ type MoveSectionArgs struct {
 
 func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Server) {
 	addMCPHelperTool(server, p.clientFactory, "check_item",
-		"Change the state of a checklist item in a playbook run. Use new_state='closed' to check it off or 'open' to uncheck it. Checklist and item numbers are zero-based indexes. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2, \"new_state\": \"closed\"}",
+		"Change the state of a checklist item in a playbook run. Use new_state='closed' to check it off or 'open' to uncheck it. Checklist and item numbers are zero-based indexes. If you do not already know the run_id and the exact indexes, do NOT guess them: first call resolve_channel_context (passing the channel the agent is operating in) or find_checklist_item to look them up. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2, \"new_state\": \"closed\"}",
 		toolCheckItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_checklist_item",
@@ -168,6 +168,24 @@ func toolCheckItem(ctx context.Context, client APIClient, args CheckItemArgs) (s
 		return "", fmt.Errorf("new_state must be one of open, closed, or skipped")
 	}
 
+	// Fetch the run first so we can give an actionable error (listing the real
+	// items) instead of an opaque API failure when the caller guessed indexes.
+	var run playbookRunDetail
+	if err := client.Get(ctx, fmt.Sprintf("runs/%s", args.RunID), nil, &run); err != nil {
+		return "", fmt.Errorf("failed to get run: %w", err)
+	}
+	if args.ChecklistNumber >= len(run.Checklists) {
+		return "", outOfRangeError("checklist_number", args.ChecklistNumber, run)
+	}
+	if args.ItemNumber >= len(run.Checklists[args.ChecklistNumber].Items) {
+		return "", outOfRangeError("item_number", args.ItemNumber, run)
+	}
+
+	current := run.Checklists[args.ChecklistNumber].Items[args.ItemNumber]
+	if current.State == apiState {
+		return fmt.Sprintf("Checklist item [%d][%d] (%q) in run %s is already '%s'; no change made.", args.ChecklistNumber, args.ItemNumber, current.Title, args.RunID, state), nil
+	}
+
 	body := map[string]string{
 		"new_state": apiState,
 	}
@@ -177,7 +195,16 @@ func toolCheckItem(ctx context.Context, client APIClient, args CheckItemArgs) (s
 		return "", fmt.Errorf("failed to update item state: %w", err)
 	}
 
-	return fmt.Sprintf("Checklist item [%d][%d] in run %s set to '%s'.", args.ChecklistNumber, args.ItemNumber, args.RunID, state), nil
+	return fmt.Sprintf("Checklist item [%d][%d] (%q) in run %s set to '%s'.", args.ChecklistNumber, args.ItemNumber, current.Title, args.RunID, state), nil
+}
+
+// outOfRangeError builds an error that lists the run's actual checklist items so
+// the caller can correct the indexes rather than guessing again.
+func outOfRangeError(field string, value int, run playbookRunDetail) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s %d is out of range for run %s. Available items:\n", field, value, run.ID)
+	writeRunChecklists(&sb, run)
+	return fmt.Errorf("%s", sb.String())
 }
 
 func toolAddChecklistItem(ctx context.Context, client APIClient, args AddChecklistItemArgs) (string, error) {

--- a/internal/playbooksmcp/tools/checklist.go
+++ b/internal/playbooksmcp/tools/checklist.go
@@ -117,7 +117,7 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolRemoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "move_checklist_item",
-		"Move a checklist item within or between sections in a playbook run. Source and destination indexes are zero-based; the destination item index is an insertion position (0 = prepend, item count = append). If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 0, \"source_item_idx\": 2, \"dest_checklist_idx\": 1, \"dest_item_idx\": 0}",
+		"Move a checklist item within or between sections in a playbook run. Source and destination indexes are zero-based. The destination item index is an insertion position: within the same section it must be an existing item index (0..item count-1); when moving to a different section you may also use the item count itself to append. If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 0, \"source_item_idx\": 2, \"dest_checklist_idx\": 1, \"dest_item_idx\": 0}",
 		toolMoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_section",
@@ -133,7 +133,7 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolRemoveSection)
 
 	addMCPHelperTool(server, p.clientFactory, "move_section",
-		"Move a section within a playbook run. Source and destination indexes are zero-based; the destination is an insertion position (0 = first, section count = last). If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}",
+		"Move a section within a playbook run. Source and destination indexes are zero-based existing section indexes (0 = first, section count-1 = last). If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}",
 		toolMoveSection)
 }
 
@@ -233,14 +233,23 @@ func checkItemIndex(run playbookRunDetail, checklistIdx, itemIdx int, field stri
 	return nil
 }
 
-// checkInsertPosition verifies a destination position for a move; unlike an item
-// index, a position may equal the item count (append).
-func checkInsertPosition(run playbookRunDetail, checklistIdx, pos int, field string) error {
-	if err := checkChecklistIndex(run, checklistIdx, "dest_checklist_idx"); err != nil {
+// checkMoveItemDest validates a move destination item index against the same
+// bounds the backend enforces (MoveChecklistItem): within the same section the
+// position must be an existing item index (0..count-1), while moving to a
+// different section also allows the item count itself (append).
+func checkMoveItemDest(run playbookRunDetail, sourceChecklistIdx, destChecklistIdx, destItemIdx int) error {
+	if err := checkChecklistIndex(run, destChecklistIdx, "dest_checklist_idx"); err != nil {
 		return err
 	}
-	if pos > len(run.Checklists[checklistIdx].Items) {
-		return outOfRangeError(field, pos, run)
+	lenDest := len(run.Checklists[destChecklistIdx].Items)
+	if sourceChecklistIdx == destChecklistIdx {
+		if destItemIdx >= lenDest {
+			return outOfRangeError("dest_item_idx", destItemIdx, run)
+		}
+		return nil
+	}
+	if destItemIdx > lenDest {
+		return outOfRangeError("dest_item_idx", destItemIdx, run)
 	}
 	return nil
 }
@@ -482,7 +491,7 @@ func toolMoveChecklistItem(ctx context.Context, client APIClient, args MoveCheck
 	if err := checkItemIndex(run, args.SourceChecklistIdx, args.SourceItemIdx, "source_item_idx"); err != nil {
 		return "", err
 	}
-	if err := checkInsertPosition(run, args.DestChecklistIdx, args.DestItemIdx, "dest_item_idx"); err != nil {
+	if err := checkMoveItemDest(run, args.SourceChecklistIdx, args.DestChecklistIdx, args.DestItemIdx); err != nil {
 		return "", err
 	}
 
@@ -597,9 +606,10 @@ func toolMoveSection(ctx context.Context, client APIClient, args MoveSectionArgs
 	if err := checkChecklistIndex(run, args.SourceChecklistIdx, "source_checklist_idx"); err != nil {
 		return "", err
 	}
-	// The destination is an insertion position, so it may equal the section count.
-	if args.DestChecklistIdx > len(run.Checklists) {
-		return "", outOfRangeError("dest_checklist_idx", args.DestChecklistIdx, run)
+	// MoveChecklist rejects a destination >= section count; the last valid slot
+	// is count-1, not an append at count.
+	if err := checkChecklistIndex(run, args.DestChecklistIdx, "dest_checklist_idx"); err != nil {
+		return "", err
 	}
 
 	body := map[string]int{

--- a/internal/playbooksmcp/tools/checklist.go
+++ b/internal/playbooksmcp/tools/checklist.go
@@ -174,7 +174,7 @@ func toolCheckItem(ctx context.Context, client APIClient, args CheckItemArgs) (s
 	if err != nil {
 		return "", err
 	}
-	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "checklist_number", "item_number"); err != nil {
 		return "", err
 	}
 
@@ -223,12 +223,15 @@ func checkChecklistIndex(run playbookRunDetail, idx int, field string) error {
 }
 
 // checkItemIndex verifies an item index exists within an existing checklist.
-func checkItemIndex(run playbookRunDetail, checklistIdx, itemIdx int, field string) error {
-	if err := checkChecklistIndex(run, checklistIdx, "checklist_number"); err != nil {
+// checklistField/itemField name the respective arguments so the actionable
+// error refers to the field the caller actually passed (e.g. move_checklist_item
+// uses source_checklist_idx/source_item_idx, not checklist_number/item_number).
+func checkItemIndex(run playbookRunDetail, checklistIdx, itemIdx int, checklistField, itemField string) error {
+	if err := checkChecklistIndex(run, checklistIdx, checklistField); err != nil {
 		return err
 	}
 	if itemIdx >= len(run.Checklists[checklistIdx].Items) {
-		return outOfRangeError(field, itemIdx, run)
+		return outOfRangeError(itemField, itemIdx, run)
 	}
 	return nil
 }
@@ -315,7 +318,7 @@ func toolSetChecklistItemDueDate(ctx context.Context, client APIClient, args Set
 	if err != nil {
 		return "", err
 	}
-	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "checklist_number", "item_number"); err != nil {
 		return "", err
 	}
 
@@ -364,7 +367,7 @@ func toolEditChecklistItem(ctx context.Context, client APIClient, args EditCheck
 	if err != nil {
 		return "", err
 	}
-	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "checklist_number", "item_number"); err != nil {
 		return "", err
 	}
 
@@ -420,7 +423,7 @@ func toolSetChecklistItemAssignee(ctx context.Context, client APIClient, args Se
 	if err != nil {
 		return "", err
 	}
-	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "checklist_number", "item_number"); err != nil {
 		return "", err
 	}
 
@@ -454,7 +457,7 @@ func toolRemoveChecklistItem(ctx context.Context, client APIClient, args RemoveC
 	if err != nil {
 		return "", err
 	}
-	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "checklist_number", "item_number"); err != nil {
 		return "", err
 	}
 	removed := run.Checklists[args.ChecklistNumber].Items[args.ItemNumber].Title
@@ -488,7 +491,7 @@ func toolMoveChecklistItem(ctx context.Context, client APIClient, args MoveCheck
 	if err != nil {
 		return "", err
 	}
-	if err := checkItemIndex(run, args.SourceChecklistIdx, args.SourceItemIdx, "source_item_idx"); err != nil {
+	if err := checkItemIndex(run, args.SourceChecklistIdx, args.SourceItemIdx, "source_checklist_idx", "source_item_idx"); err != nil {
 		return "", err
 	}
 	if err := checkMoveItemDest(run, args.SourceChecklistIdx, args.DestChecklistIdx, args.DestItemIdx); err != nil {

--- a/internal/playbooksmcp/tools/checklist.go
+++ b/internal/playbooksmcp/tools/checklist.go
@@ -97,27 +97,27 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolCheckItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_checklist_item",
-		"Add a new item to an existing checklist in a playbook run. The checklist_number is a zero-based index. due_date is an optional Unix timestamp in milliseconds. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix in staging\", \"due_date\": 1717200000000}",
+		"Add a new item to an existing checklist in a playbook run. The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context first. due_date is an optional Unix timestamp in milliseconds. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix in staging\", \"due_date\": 1717200000000}",
 		toolAddChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "set_checklist_item_due_date",
-		"Set or clear the due date for an existing checklist item in a playbook run. due_date is a Unix timestamp in milliseconds; use 0 to clear. Checklist and item numbers are zero-based indexes. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"due_date\": 1717200000000}",
+		"Set or clear the due date for an existing checklist item in a playbook run. due_date is a Unix timestamp in milliseconds; use 0 to clear. Checklist and item numbers are zero-based indexes; if you don't know them, call resolve_channel_context or find_checklist_item first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"due_date\": 1717200000000}",
 		toolSetChecklistItemDueDate)
 
 	addMCPHelperTool(server, p.clientFactory, "edit_checklist_item",
-		"Edit the title, description, slash command, or due date of an existing checklist item. Only provided fields are updated. due_date is a Unix timestamp in milliseconds; use 0 to clear. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task title\", \"due_date\": 1717200000000}",
+		"Edit the title, description, slash command, or due date of an existing checklist item. Only provided fields are updated. due_date is a Unix timestamp in milliseconds; use 0 to clear. If you don't know the indexes, call resolve_channel_context or find_checklist_item first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task title\", \"due_date\": 1717200000000}",
 		toolEditChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "set_checklist_item_assignee",
-		"Assign or clear the assignee for an existing checklist item. Omit assignee_id or set it to an empty string to clear the assignee. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"assignee_id\": \"user123...\"}",
+		"Assign or clear the assignee for an existing checklist item. Omit assignee_id or set it to an empty string to clear the assignee. If you don't know the indexes, call resolve_channel_context or find_checklist_item first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"assignee_id\": \"user123...\"}",
 		toolSetChecklistItemAssignee)
 
 	addMCPHelperTool(server, p.clientFactory, "remove_checklist_item",
-		"Remove a checklist item from a playbook run. This permanently deletes the item. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}",
+		"Remove a checklist item from a playbook run. This permanently deletes the item, so confirm the indexes first — if unsure, call resolve_channel_context or find_checklist_item. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}",
 		toolRemoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "move_checklist_item",
-		"Move a checklist item within or between sections in a playbook run. Source and destination indexes are zero-based. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 0, \"source_item_idx\": 2, \"dest_checklist_idx\": 1, \"dest_item_idx\": 0}",
+		"Move a checklist item within or between sections in a playbook run. Source and destination indexes are zero-based; the destination item index is an insertion position (0 = prepend, item count = append). If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 0, \"source_item_idx\": 2, \"dest_checklist_idx\": 1, \"dest_item_idx\": 0}",
 		toolMoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_section",
@@ -125,15 +125,15 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolAddSection)
 
 	addMCPHelperTool(server, p.clientFactory, "rename_section",
-		"Rename an existing section in a playbook run. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}",
+		"Rename an existing section in a playbook run. The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}",
 		toolRenameSection)
 
 	addMCPHelperTool(server, p.clientFactory, "remove_section",
-		"Remove an entire section and all its items from a playbook run. This is permanent. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 1}",
+		"Remove an entire section and all its items from a playbook run. This is permanent, so confirm the index first — if unsure, call resolve_channel_context. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 1}",
 		toolRemoveSection)
 
 	addMCPHelperTool(server, p.clientFactory, "move_section",
-		"Move a section within a playbook run. Source and destination indexes are zero-based. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}",
+		"Move a section within a playbook run. Source and destination indexes are zero-based; the destination is an insertion position (0 = first, section count = last). If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}",
 		toolMoveSection)
 }
 
@@ -170,15 +170,12 @@ func toolCheckItem(ctx context.Context, client APIClient, args CheckItemArgs) (s
 
 	// Fetch the run first so we can give an actionable error (listing the real
 	// items) instead of an opaque API failure when the caller guessed indexes.
-	var run playbookRunDetail
-	if err := client.Get(ctx, fmt.Sprintf("runs/%s", args.RunID), nil, &run); err != nil {
-		return "", fmt.Errorf("failed to get run: %w", err)
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
 	}
-	if args.ChecklistNumber >= len(run.Checklists) {
-		return "", outOfRangeError("checklist_number", args.ChecklistNumber, run)
-	}
-	if args.ItemNumber >= len(run.Checklists[args.ChecklistNumber].Items) {
-		return "", outOfRangeError("item_number", args.ItemNumber, run)
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+		return "", err
 	}
 
 	current := run.Checklists[args.ChecklistNumber].Items[args.ItemNumber]
@@ -207,6 +204,47 @@ func outOfRangeError(field string, value int, run playbookRunDetail) error {
 	return fmt.Errorf("%s", sb.String())
 }
 
+// fetchRunForBounds retrieves the run so callers can validate indexes against
+// its real checklists before mutating, giving actionable errors on a miss.
+func fetchRunForBounds(ctx context.Context, client APIClient, runID string) (playbookRunDetail, error) {
+	var run playbookRunDetail
+	if err := client.Get(ctx, fmt.Sprintf("runs/%s", runID), nil, &run); err != nil {
+		return playbookRunDetail{}, fmt.Errorf("failed to get run: %w", err)
+	}
+	return run, nil
+}
+
+// checkChecklistIndex verifies a checklist (section) index exists in the run.
+func checkChecklistIndex(run playbookRunDetail, idx int, field string) error {
+	if idx >= len(run.Checklists) {
+		return outOfRangeError(field, idx, run)
+	}
+	return nil
+}
+
+// checkItemIndex verifies an item index exists within an existing checklist.
+func checkItemIndex(run playbookRunDetail, checklistIdx, itemIdx int, field string) error {
+	if err := checkChecklistIndex(run, checklistIdx, "checklist_number"); err != nil {
+		return err
+	}
+	if itemIdx >= len(run.Checklists[checklistIdx].Items) {
+		return outOfRangeError(field, itemIdx, run)
+	}
+	return nil
+}
+
+// checkInsertPosition verifies a destination position for a move; unlike an item
+// index, a position may equal the item count (append).
+func checkInsertPosition(run playbookRunDetail, checklistIdx, pos int, field string) error {
+	if err := checkChecklistIndex(run, checklistIdx, "dest_checklist_idx"); err != nil {
+		return err
+	}
+	if pos > len(run.Checklists[checklistIdx].Items) {
+		return outOfRangeError(field, pos, run)
+	}
+	return nil
+}
+
 func toolAddChecklistItem(ctx context.Context, client APIClient, args AddChecklistItemArgs) (string, error) {
 	if err := validateID(args.RunID, "run_id"); err != nil {
 		return "", err
@@ -218,6 +256,19 @@ func toolAddChecklistItem(ctx context.Context, client APIClient, args AddCheckli
 	if title == "" {
 		return "", fmt.Errorf("title is required")
 	}
+	if args.AssigneeID != "" {
+		if err := validateID(args.AssigneeID, "assignee_id"); err != nil {
+			return "", err
+		}
+	}
+
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkChecklistIndex(run, args.ChecklistNumber, "checklist_number"); err != nil {
+		return "", err
+	}
 
 	body := map[string]any{
 		"title": title,
@@ -226,9 +277,6 @@ func toolAddChecklistItem(ctx context.Context, client APIClient, args AddCheckli
 		body["description"] = args.Description
 	}
 	if args.AssigneeID != "" {
-		if err := validateID(args.AssigneeID, "assignee_id"); err != nil {
-			return "", err
-		}
 		body["assignee_id"] = args.AssigneeID
 	}
 	if args.DueDate != 0 {
@@ -251,6 +299,14 @@ func toolSetChecklistItemDueDate(ctx context.Context, client APIClient, args Set
 		return "", err
 	}
 	if err := validateIndex(args.ItemNumber, "item_number"); err != nil {
+		return "", err
+	}
+
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
 		return "", err
 	}
 
@@ -295,18 +351,15 @@ func toolEditChecklistItem(ctx context.Context, client APIClient, args EditCheck
 		}
 	}
 
-	if args.Title != nil || args.Description != nil || args.Command != nil {
-		var run playbookRunDetail
-		if err := client.Get(ctx, fmt.Sprintf("runs/%s", args.RunID), nil, &run); err != nil {
-			return "", fmt.Errorf("failed to get current checklist item: %w", err)
-		}
-		if args.ChecklistNumber >= len(run.Checklists) {
-			return "", fmt.Errorf("checklist_number %d is out of range", args.ChecklistNumber)
-		}
-		if args.ItemNumber >= len(run.Checklists[args.ChecklistNumber].Items) {
-			return "", fmt.Errorf("item_number %d is out of range", args.ItemNumber)
-		}
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+		return "", err
+	}
 
+	if args.Title != nil || args.Description != nil || args.Command != nil {
 		currentItem := run.Checklists[args.ChecklistNumber].Items[args.ItemNumber]
 		body := map[string]string{
 			"title":       currentItem.Title,
@@ -354,6 +407,14 @@ func toolSetChecklistItemAssignee(ctx context.Context, client APIClient, args Se
 		}
 	}
 
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+		return "", err
+	}
+
 	body := map[string]string{
 		"assignee_id": args.AssigneeID,
 	}
@@ -380,12 +441,21 @@ func toolRemoveChecklistItem(ctx context.Context, client APIClient, args RemoveC
 		return "", err
 	}
 
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkItemIndex(run, args.ChecklistNumber, args.ItemNumber, "item_number"); err != nil {
+		return "", err
+	}
+	removed := run.Checklists[args.ChecklistNumber].Items[args.ItemNumber].Title
+
 	endpoint := fmt.Sprintf("runs/%s/checklists/%d/item/%d", args.RunID, args.ChecklistNumber, args.ItemNumber)
 	if err := client.Delete(ctx, endpoint); err != nil {
 		return "", fmt.Errorf("failed to remove checklist item: %w", err)
 	}
 
-	return fmt.Sprintf("Removed checklist item [%d][%d] from run %s.", args.ChecklistNumber, args.ItemNumber, args.RunID), nil
+	return fmt.Sprintf("Removed checklist item [%d][%d] (%q) from run %s.", args.ChecklistNumber, args.ItemNumber, removed, args.RunID), nil
 }
 
 func toolMoveChecklistItem(ctx context.Context, client APIClient, args MoveChecklistItemArgs) (string, error) {
@@ -402,6 +472,17 @@ func toolMoveChecklistItem(ctx context.Context, client APIClient, args MoveCheck
 		return "", err
 	}
 	if err := validateIndex(args.DestItemIdx, "dest_item_idx"); err != nil {
+		return "", err
+	}
+
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkItemIndex(run, args.SourceChecklistIdx, args.SourceItemIdx, "source_item_idx"); err != nil {
+		return "", err
+	}
+	if err := checkInsertPosition(run, args.DestChecklistIdx, args.DestItemIdx, "dest_item_idx"); err != nil {
 		return "", err
 	}
 
@@ -453,6 +534,14 @@ func toolRenameSection(ctx context.Context, client APIClient, args RenameSection
 		return "", fmt.Errorf("title is required")
 	}
 
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkChecklistIndex(run, args.ChecklistNumber, "checklist_number"); err != nil {
+		return "", err
+	}
+
 	body := map[string]string{
 		"title": title,
 	}
@@ -473,12 +562,21 @@ func toolRemoveSection(ctx context.Context, client APIClient, args RemoveSection
 		return "", err
 	}
 
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkChecklistIndex(run, args.ChecklistNumber, "checklist_number"); err != nil {
+		return "", err
+	}
+	removed := run.Checklists[args.ChecklistNumber].Title
+
 	endpoint := fmt.Sprintf("runs/%s/checklists/%d", args.RunID, args.ChecklistNumber)
 	if err := client.Delete(ctx, endpoint); err != nil {
 		return "", fmt.Errorf("failed to remove section: %w", err)
 	}
 
-	return fmt.Sprintf("Removed section %d from run %s.", args.ChecklistNumber, args.RunID), nil
+	return fmt.Sprintf("Removed section %d (%q) from run %s.", args.ChecklistNumber, removed, args.RunID), nil
 }
 
 func toolMoveSection(ctx context.Context, client APIClient, args MoveSectionArgs) (string, error) {
@@ -490,6 +588,18 @@ func toolMoveSection(ctx context.Context, client APIClient, args MoveSectionArgs
 	}
 	if err := validateIndex(args.DestChecklistIdx, "dest_checklist_idx"); err != nil {
 		return "", err
+	}
+
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkChecklistIndex(run, args.SourceChecklistIdx, "source_checklist_idx"); err != nil {
+		return "", err
+	}
+	// The destination is an insertion position, so it may equal the section count.
+	if args.DestChecklistIdx > len(run.Checklists) {
+		return "", outOfRangeError("dest_checklist_idx", args.DestChecklistIdx, run)
 	}
 
 	body := map[string]int{

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -131,20 +131,13 @@ func TestToolCheckItemOpenTranslatesToEmptyAPIState(t *testing.T) {
 		NewState:        "open",
 	}
 
-	if _, err := toolCheckItem(context.Background(), client, args); err != nil {
-		t.Fatalf("toolCheckItem returned error: %v", err)
-	}
+	_, err := toolCheckItem(context.Background(), client, args)
+	require.NoError(t, err)
 
-	if client.putEndpoint != "runs/abcdefghijklmnopqrstuvwxyz/checklists/1/item/2/state" {
-		t.Fatalf("unexpected endpoint: %s", client.putEndpoint)
-	}
+	require.Equal(t, "runs/abcdefghijklmnopqrstuvwxyz/checklists/1/item/2/state", client.putEndpoint)
 	body, ok := client.putBody.(map[string]string)
-	if !ok {
-		t.Fatalf("unexpected body type %T", client.putBody)
-	}
-	if got := body["new_state"]; got != "" {
-		t.Fatalf("expected open state to be sent as empty string, got %q", got)
-	}
+	require.Truef(t, ok, "unexpected body type %T", client.putBody)
+	assert.Empty(t, body["new_state"], "expected open state to be sent as empty string")
 }
 
 func TestToolEditChecklistItemPreservesOmittedFields(t *testing.T) {

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,8 +19,14 @@ type fakeAPIClient struct {
 	run      playbookRunDetail
 	listRuns listRunsResponse
 
-	getEndpoint string
-	getParams   url.Values
+	// runsByID, when set, lets Get resolve a specific run by the ID in the
+	// "runs/{id}" endpoint. Falls back to run when the ID is not present.
+	runsByID map[string]playbookRunDetail
+
+	getEndpoint  string
+	getParams    url.Values
+	getEndpoints []string
+	listParams   url.Values
 
 	postEndpoint string
 	postBody     any
@@ -36,11 +43,19 @@ type fakeAPIClient struct {
 func (f *fakeAPIClient) Get(_ context.Context, endpoint string, params url.Values, result any) error {
 	f.getEndpoint = endpoint
 	f.getParams = params
+	f.getEndpoints = append(f.getEndpoints, endpoint)
 	switch v := result.(type) {
 	case *playbookRunDetail:
 		*v = f.run
+		if f.runsByID != nil {
+			id := strings.TrimPrefix(endpoint, "runs/")
+			if run, ok := f.runsByID[id]; ok {
+				*v = run
+			}
+		}
 	case *listRunsResponse:
 		*v = f.listRuns
+		f.listParams = params
 	case *map[string]any:
 		*v = map[string]any{"id": "abcdefghijklmnopqrstuvwxyz", "title": "Created playbook"}
 	default:
@@ -86,7 +101,15 @@ func (f *fakeAPIClient) GetPlaybookURL(playbookID string) string {
 }
 
 func TestToolCheckItemOpenTranslatesToEmptyAPIState(t *testing.T) {
-	client := &fakeAPIClient{}
+	client := &fakeAPIClient{
+		run: playbookRunDetail{
+			ID: "abcdefghijklmnopqrstuvwxyz",
+			Checklists: []checklist{
+				{Items: []checklistItem{{}}},
+				{Items: []checklistItem{{}, {}, {Title: "Deploy", State: "closed"}}},
+			},
+		},
+	}
 	args := CheckItemArgs{
 		RunID:           "abcdefghijklmnopqrstuvwxyz",
 		ChecklistNumber: 1,

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,15 +19,23 @@ import (
 type fakeAPIClient struct {
 	run      playbookRunDetail
 	listRuns listRunsResponse
+	// listPages, when set, returns a distinct listRunsResponse per page index
+	// so pagination can be exercised.
+	listPages []listRunsResponse
 
 	// runsByID, when set, lets Get resolve a specific run by the ID in the
 	// "runs/{id}" endpoint. Falls back to run when the ID is not present.
 	runsByID map[string]playbookRunDetail
 
+	// currentUserID / currentUserErr override GetCurrentUserID when set.
+	currentUserID  string
+	currentUserErr error
+
 	getEndpoint  string
 	getParams    url.Values
 	getEndpoints []string
 	listParams   url.Values
+	listCalls    []url.Values
 
 	postEndpoint string
 	postBody     any
@@ -55,7 +64,16 @@ func (f *fakeAPIClient) Get(_ context.Context, endpoint string, params url.Value
 		}
 	case *listRunsResponse:
 		*v = f.listRuns
+		if f.listPages != nil {
+			page, _ := strconv.Atoi(params.Get("page"))
+			if page >= 0 && page < len(f.listPages) {
+				*v = f.listPages[page]
+			} else {
+				*v = listRunsResponse{}
+			}
+		}
 		f.listParams = params
+		f.listCalls = append(f.listCalls, cloneValues(params))
 	case *map[string]any:
 		*v = map[string]any{"id": "abcdefghijklmnopqrstuvwxyz", "title": "Created playbook"}
 	default:
@@ -93,11 +111,27 @@ func (f *fakeAPIClient) Delete(_ context.Context, endpoint string) error {
 }
 
 func (f *fakeAPIClient) GetCurrentUserID(context.Context) (string, error) {
+	if f.currentUserErr != nil {
+		return "", f.currentUserErr
+	}
+	if f.currentUserID != "" {
+		return f.currentUserID, nil
+	}
 	return "abcdefghijklmnopqrstuvwxy0", nil
 }
 
 func (f *fakeAPIClient) GetPlaybookURL(playbookID string) string {
 	return "https://mattermost.example.com/playbooks/playbooks/" + playbookID
+}
+
+// cloneValues snapshots query params, since fetchRunDetails mutates the same
+// url.Values across pagination iterations.
+func cloneValues(v url.Values) url.Values {
+	out := url.Values{}
+	for k, vals := range v {
+		out[k] = append([]string(nil), vals...)
+	}
+	return out
 }
 
 // fixtureRun builds a run with the given number of sections and items per

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -100,6 +100,20 @@ func (f *fakeAPIClient) GetPlaybookURL(playbookID string) string {
 	return "https://mattermost.example.com/playbooks/playbooks/" + playbookID
 }
 
+// fixtureRun builds a run with the given number of sections and items per
+// section, so tests can exercise index-based tools that bounds-check.
+func fixtureRun(runID string, checklists, items int) playbookRunDetail {
+	run := playbookRunDetail{ID: runID}
+	for c := 0; c < checklists; c++ {
+		cl := checklist{Title: fmt.Sprintf("Section %d", c)}
+		for i := 0; i < items; i++ {
+			cl.Items = append(cl.Items, checklistItem{Title: fmt.Sprintf("Item %d-%d", c, i)})
+		}
+		run.Checklists = append(run.Checklists, cl)
+	}
+	return run
+}
+
 func TestToolCheckItemOpenTranslatesToEmptyAPIState(t *testing.T) {
 	client := &fakeAPIClient{
 		run: playbookRunDetail{
@@ -246,7 +260,7 @@ func TestToolEditChecklistItemSetsDueDate(t *testing.T) {
 	_, err := toolEditChecklistItem(context.Background(), client, args)
 	require.NoError(t, err)
 
-	assert.Empty(t, client.getEndpoint)
+	assert.Equal(t, "runs/abcdefghijklmnopqrstuvwxyz", client.getEndpoint)
 	require.Equal(t, "runs/abcdefghijklmnopqrstuvwxyz/checklists/0/item/0/duedate", client.putEndpoint)
 	require.IsType(t, map[string]int64{}, client.putBody)
 	body := client.putBody.(map[string]int64)
@@ -281,7 +295,7 @@ func TestToolEditChecklistItemClearsDueDate(t *testing.T) {
 	_, err := toolEditChecklistItem(context.Background(), client, args)
 	require.NoError(t, err)
 
-	assert.Empty(t, client.getEndpoint)
+	assert.Equal(t, "runs/abcdefghijklmnopqrstuvwxyz", client.getEndpoint)
 	require.Equal(t, "runs/abcdefghijklmnopqrstuvwxyz/checklists/0/item/0/duedate", client.putEndpoint)
 	require.IsType(t, map[string]int64{}, client.putBody)
 	body := client.putBody.(map[string]int64)
@@ -469,8 +483,13 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	const runID = "abcdefghijklmnopqrstuvwxyz"
 	const assigneeID = "bcdefghijklmnopqrstuvwxyza"
 
+	// The mutating tools now bounds-check indexes against the run, so provide a
+	// run large enough for every index used below (checklists 0-3, items 0-4).
+	fixture := fixtureRun(runID, 4, 5)
+	newClient := func() *fakeAPIClient { return &fakeAPIClient{run: fixture} }
+
 	t.Run("add checklist item", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := AddChecklistItemArgs{RunID: runID, ChecklistNumber: 1, Title: " New item ", Description: "details", AssigneeID: assigneeID, DueDate: 1717200000000}
 		_, err := toolAddChecklistItem(context.Background(), client, args)
 		require.NoError(t, err)
@@ -484,7 +503,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("add checklist item without due date omits due date", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := AddChecklistItemArgs{RunID: runID, ChecklistNumber: 1, Title: " New item "}
 		_, err := toolAddChecklistItem(context.Background(), client, args)
 		require.NoError(t, err)
@@ -495,7 +514,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("set checklist item due date", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := SetChecklistItemDueDateArgs{RunID: runID, ChecklistNumber: 1, ItemNumber: 2, DueDate: 1717200000000}
 		_, err := toolSetChecklistItemDueDate(context.Background(), client, args)
 		require.NoError(t, err)
@@ -506,7 +525,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("clear checklist item due date", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := SetChecklistItemDueDateArgs{RunID: runID, ChecklistNumber: 1, ItemNumber: 2, DueDate: 0}
 		_, err := toolSetChecklistItemDueDate(context.Background(), client, args)
 		require.NoError(t, err)
@@ -517,7 +536,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("set checklist item assignee", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := SetChecklistItemAssigneeArgs{RunID: runID, ChecklistNumber: 1, ItemNumber: 2, AssigneeID: assigneeID}
 		_, err := toolSetChecklistItemAssignee(context.Background(), client, args)
 		require.NoError(t, err)
@@ -529,7 +548,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("clear checklist item assignee", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := SetChecklistItemAssigneeArgs{RunID: runID, ChecklistNumber: 1, ItemNumber: 2}
 		_, err := toolSetChecklistItemAssignee(context.Background(), client, args)
 		require.NoError(t, err)
@@ -541,7 +560,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("remove checklist item", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		if _, err := toolRemoveChecklistItem(context.Background(), client, RemoveChecklistItemArgs{RunID: runID, ChecklistNumber: 1, ItemNumber: 2}); err != nil {
 			t.Fatalf("toolRemoveChecklistItem returned error: %v", err)
 		}
@@ -551,7 +570,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("move checklist item", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := MoveChecklistItemArgs{
 			RunID:              runID,
 			SourceChecklistIdx: 1,
@@ -581,7 +600,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("add section", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		if _, err := toolAddSection(context.Background(), client, AddSectionArgs{RunID: runID, Title: " Section "}); err != nil {
 			t.Fatalf("toolAddSection returned error: %v", err)
 		}
@@ -598,7 +617,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("rename section", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		if _, err := toolRenameSection(context.Background(), client, RenameSectionArgs{RunID: runID, ChecklistNumber: 1, Title: " Renamed "}); err != nil {
 			t.Fatalf("toolRenameSection returned error: %v", err)
 		}
@@ -615,7 +634,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("remove section", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		if _, err := toolRemoveSection(context.Background(), client, RemoveSectionArgs{RunID: runID, ChecklistNumber: 1}); err != nil {
 			t.Fatalf("toolRemoveSection returned error: %v", err)
 		}
@@ -625,7 +644,7 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 	})
 
 	t.Run("move section", func(t *testing.T) {
-		client := &fakeAPIClient{}
+		client := newClient()
 		args := MoveSectionArgs{RunID: runID, SourceChecklistIdx: 2, DestChecklistIdx: 0}
 		if _, err := toolMoveSection(context.Background(), client, args); err != nil {
 			t.Fatalf("toolMoveSection returned error: %v", err)

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -791,6 +791,87 @@ func TestMoveChecklistToolsValidation(t *testing.T) {
 	}
 }
 
+func TestChecklistToolsOutOfRangeIndexes(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+	const assigneeID = "bcdefghijklmnopqrstuvwxyza"
+
+	// A run with two sections of two items each: valid indexes are 0-1, so
+	// index 5 is always out of range while still passing the negative-index
+	// validation that runs before the run is fetched.
+	fixture := fixtureRun(runID, 2, 2)
+
+	tests := []struct {
+		name    string
+		runTool func(context.Context, APIClient) (string, error)
+		wantErr string
+	}{
+		{
+			name: "add checklist item rejects out-of-range checklist",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				return toolAddChecklistItem(ctx, client, AddChecklistItemArgs{RunID: runID, ChecklistNumber: 5, Title: "New item"})
+			},
+			wantErr: "checklist_number 5 is out of range",
+		},
+		{
+			name: "set checklist item due date rejects out-of-range item",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				return toolSetChecklistItemDueDate(ctx, client, SetChecklistItemDueDateArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 5, DueDate: 1717200000000})
+			},
+			wantErr: "item_number 5 is out of range",
+		},
+		{
+			name: "edit checklist item rejects out-of-range item",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				title := "Updated"
+				return toolEditChecklistItem(ctx, client, EditChecklistItemArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 5, Title: &title})
+			},
+			wantErr: "item_number 5 is out of range",
+		},
+		{
+			name: "set checklist item assignee rejects out-of-range item",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				return toolSetChecklistItemAssignee(ctx, client, SetChecklistItemAssigneeArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 5, AssigneeID: assigneeID})
+			},
+			wantErr: "item_number 5 is out of range",
+		},
+		{
+			name: "remove checklist item rejects out-of-range item",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				return toolRemoveChecklistItem(ctx, client, RemoveChecklistItemArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 5})
+			},
+			wantErr: "item_number 5 is out of range",
+		},
+		{
+			name: "rename section rejects out-of-range checklist",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				return toolRenameSection(ctx, client, RenameSectionArgs{RunID: runID, ChecklistNumber: 5, Title: "Renamed"})
+			},
+			wantErr: "checklist_number 5 is out of range",
+		},
+		{
+			// The move tool's argument is source_checklist_idx, not
+			// checklist_number, so the error must name the field the caller passed.
+			name: "move checklist item names source_checklist_idx when out of range",
+			runTool: func(ctx context.Context, client APIClient) (string, error) {
+				return toolMoveChecklistItem(ctx, client, MoveChecklistItemArgs{RunID: runID, SourceChecklistIdx: 5, SourceItemIdx: 0, DestChecklistIdx: 0, DestItemIdx: 0})
+			},
+			wantErr: "source_checklist_idx 5 is out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{run: fixture}
+			_, err := tt.runTool(context.Background(), client)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Empty(t, client.postEndpoint, "expected no create/move on out-of-range")
+			assert.Empty(t, client.putEndpoint, "expected no update on out-of-range")
+			assert.Empty(t, client.deleteEndpoint, "expected no delete on out-of-range")
+		})
+	}
+}
+
 func TestToolSetChecklistItemAssigneeValidation(t *testing.T) {
 	const runID = "abcdefghijklmnopqrstuvwxyz"
 	const assigneeID = "bcdefghijklmnopqrstuvwxyza"

--- a/internal/playbooksmcp/tools/provider.go
+++ b/internal/playbooksmcp/tools/provider.go
@@ -42,6 +42,7 @@ func NewPlaybooksToolProvider(clientFactory ClientFactory) (*PlaybooksToolProvid
 func (p *PlaybooksToolProvider) ProvideMCPHelperTools(mcpServer *mcphelper.Server) {
 	p.addMCPHelperRunTools(mcpServer)
 	p.addMCPHelperChecklistTools(mcpServer)
+	p.addMCPHelperResolveTools(mcpServer)
 	p.addMCPHelperPlaybookTools(mcpServer)
 }
 

--- a/internal/playbooksmcp/tools/provider_test.go
+++ b/internal/playbooksmcp/tools/provider_test.go
@@ -26,7 +26,7 @@ func TestNewPlaybooksToolProviderRejectsNilClientFactory(t *testing.T) {
 
 func TestProvideMCPHelperToolsRegistersChecklistAssigneeTool(t *testing.T) {
 	ctx := context.Background()
-	fakeClient := &fakeAPIClient{}
+	fakeClient := &fakeAPIClient{run: fixtureRun("abcdefghijklmnopqrstuvwxyz", 3, 3)}
 
 	provider, err := NewPlaybooksToolProvider(func(context.Context) (APIClient, error) {
 		return fakeClient, nil

--- a/internal/playbooksmcp/tools/provider_test.go
+++ b/internal/playbooksmcp/tools/provider_test.go
@@ -64,15 +64,18 @@ func TestProvideMCPHelperToolsRegistersChecklistAssigneeTool(t *testing.T) {
 		t.Fatalf("ListTools returned error: %v", err)
 	}
 
-	found := false
+	registered := make(map[string]bool)
 	for _, tool := range tools.Tools {
-		if tool.Name == "playbooks__set_checklist_item_assignee" {
-			found = true
-			break
-		}
+		registered[tool.Name] = true
 	}
-	if !found {
-		t.Fatalf("expected set_checklist_item_assignee to be registered, got tools %#v", tools.Tools)
+	for _, want := range []string{
+		"playbooks__set_checklist_item_assignee",
+		"playbooks__resolve_channel_context",
+		"playbooks__find_checklist_item",
+	} {
+		if !registered[want] {
+			t.Fatalf("expected %s to be registered, got tools %#v", want, tools.Tools)
+		}
 	}
 
 	_, err = session.CallTool(ctx, &mcp.CallToolParams{

--- a/internal/playbooksmcp/tools/resolve.go
+++ b/internal/playbooksmcp/tools/resolve.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/public/mcphelper"
+)
+
+// --- Argument structs ---
+
+type ResolveChannelContextArgs struct {
+	ChannelID       string `json:"channel_id" jsonschema:"The Mattermost channel ID the agent is operating in (26-char ID). Returns the runs in this channel with their checklist items and the zero-based indexes needed by check_item and the other item tools."`
+	IncludeFinished bool   `json:"include_finished,omitempty" jsonschema:"If true, also include finished runs. Defaults to false (only in-progress runs)."`
+}
+
+type FindChecklistItemArgs struct {
+	Query         string `json:"query" jsonschema:"Text to match against checklist item titles (case-insensitive)."`
+	ChannelID     string `json:"channel_id,omitempty" jsonschema:"If set, search runs in this channel first. Pass the channel the agent is operating in so the matching item is found without guessing a run."`
+	RunID         string `json:"run_id,omitempty" jsonschema:"If set, restrict the search to this single run."`
+	IncludeClosed bool   `json:"include_closed,omitempty" jsonschema:"If true, also match items that are already closed or skipped. Defaults to false (only open/in-progress items)."`
+}
+
+// --- Tool registration ---
+
+func (p *PlaybooksToolProvider) addMCPHelperResolveTools(server *mcphelper.Server) {
+	addMCPHelperTool(server, p.clientFactory, "resolve_channel_context",
+		"Resolve the runs and checklist items that live in a Mattermost channel. Use this first, passing the channel the agent is operating in, to discover the run_id and the zero-based checklist/item indexes before calling check_item (or any other item tool). Returns each run with its checklist items formatted as [checklist_number][item_number] title (state). Example: {\"channel_id\": \"abc123...\"}",
+		toolResolveChannelContext)
+
+	addMCPHelperTool(server, p.clientFactory, "find_checklist_item",
+		"Find a checklist item by matching text against item titles, so you can mark it done without knowing its indexes. Pass channel_id (the channel the agent is operating in) to search that channel's runs first. Returns the matching item(s) with run_id and the zero-based checklist_number/item_number to feed into check_item. Example: {\"query\": \"deploy to staging\", \"channel_id\": \"abc123...\"}",
+		toolFindChecklistItem)
+}
+
+// --- Tool implementations ---
+
+func toolResolveChannelContext(ctx context.Context, client APIClient, args ResolveChannelContextArgs) (string, error) {
+	if err := validateID(args.ChannelID, "channel_id"); err != nil {
+		return "", err
+	}
+
+	runs, err := fetchChannelRuns(ctx, client, args.ChannelID, args.IncludeFinished)
+	if err != nil {
+		return "", err
+	}
+
+	if len(runs) == 0 {
+		scope := "in-progress runs"
+		if args.IncludeFinished {
+			scope = "runs"
+		}
+		return fmt.Sprintf("No %s found in channel %s.", scope, args.ChannelID), nil
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Channel %s has %d run(s):\n", args.ChannelID, len(runs))
+	for _, run := range runs {
+		sb.WriteString("\n")
+		writeRunChecklists(&sb, run)
+	}
+	sb.WriteString("\nTo change an item, call check_item with the run_id and the [checklist_number][item_number] shown above.")
+	return sb.String(), nil
+}
+
+func toolFindChecklistItem(ctx context.Context, client APIClient, args FindChecklistItemArgs) (string, error) {
+	query := strings.TrimSpace(args.Query)
+	if query == "" {
+		return "", fmt.Errorf("query is required")
+	}
+	if args.ChannelID != "" {
+		if err := validateID(args.ChannelID, "channel_id"); err != nil {
+			return "", err
+		}
+	}
+	if args.RunID != "" {
+		if err := validateID(args.RunID, "run_id"); err != nil {
+			return "", err
+		}
+	}
+
+	runs, err := candidateRuns(ctx, client, args.RunID, args.ChannelID)
+	if err != nil {
+		return "", err
+	}
+
+	matches := matchChecklistItems(runs, query, args.IncludeClosed)
+	if len(matches) == 0 {
+		return formatNoMatches(runs, query, args.IncludeClosed), nil
+	}
+	return formatMatches(matches), nil
+}
+
+// --- Candidate run resolution ---
+
+// candidateRuns returns the runs to search, in priority order: an explicit run,
+// then a channel's in-progress runs, then the current user's in-progress runs.
+func candidateRuns(ctx context.Context, client APIClient, runID, channelID string) ([]playbookRunDetail, error) {
+	if runID != "" {
+		var run playbookRunDetail
+		if err := client.Get(ctx, fmt.Sprintf("runs/%s", runID), nil, &run); err != nil {
+			return nil, fmt.Errorf("failed to get run: %w", err)
+		}
+		return []playbookRunDetail{run}, nil
+	}
+	if channelID != "" {
+		return fetchChannelRuns(ctx, client, channelID, false)
+	}
+
+	userID, err := client.GetCurrentUserID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user ID: %w", err)
+	}
+	return fetchRunDetails(ctx, client, listRunsParams(map[string]string{
+		"statuses":      "InProgress",
+		"owner_user_id": userID,
+	}))
+}
+
+// fetchChannelRuns lists a channel's runs (in-progress unless includeFinished)
+// and fetches full details for each so checklist items are available.
+func fetchChannelRuns(ctx context.Context, client APIClient, channelID string, includeFinished bool) ([]playbookRunDetail, error) {
+	params := map[string]string{"channel_id": channelID}
+	if !includeFinished {
+		params["statuses"] = "InProgress"
+	}
+	return fetchRunDetails(ctx, client, listRunsParams(params))
+}
+
+func fetchRunDetails(ctx context.Context, client APIClient, params url.Values) ([]playbookRunDetail, error) {
+	var resp listRunsResponse
+	if err := client.Get(ctx, "runs", params, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list runs: %w", err)
+	}
+
+	runs := make([]playbookRunDetail, 0, len(resp.Items))
+	for _, summary := range resp.Items {
+		var run playbookRunDetail
+		if err := client.Get(ctx, fmt.Sprintf("runs/%s", summary.ID), nil, &run); err != nil {
+			return nil, fmt.Errorf("failed to get run %s: %w", summary.ID, err)
+		}
+		runs = append(runs, run)
+	}
+	return runs, nil
+}
+
+func listRunsParams(pairs map[string]string) url.Values {
+	params := url.Values{}
+	for k, v := range pairs {
+		params.Set(k, v)
+	}
+	params.Set("page", "0")
+	params.Set("per_page", "50")
+	return params
+}
+
+// --- Matching ---
+
+type itemMatch struct {
+	runID           string
+	runName         string
+	checklistNumber int
+	itemNumber      int
+	title           string
+	state           string
+	score           int
+}
+
+func matchChecklistItems(runs []playbookRunDetail, query string, includeClosed bool) []itemMatch {
+	q := strings.ToLower(query)
+	qTokens := strings.Fields(q)
+
+	var matches []itemMatch
+	for _, run := range runs {
+		for ci, cl := range run.Checklists {
+			for ii, item := range cl.Items {
+				if !includeClosed && !itemIsOpen(item.State) {
+					continue
+				}
+				score := matchScore(strings.ToLower(item.Title), q, qTokens)
+				if score == 0 {
+					continue
+				}
+				matches = append(matches, itemMatch{
+					runID:           run.ID,
+					runName:         run.Name,
+					checklistNumber: ci,
+					itemNumber:      ii,
+					title:           item.Title,
+					state:           displayState(item.State),
+					score:           score,
+				})
+			}
+		}
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		return matches[i].score > matches[j].score
+	})
+	return matches
+}
+
+// matchScore ranks a title against the query: 3 exact, 2 substring, 1 all
+// query tokens present, 0 no match.
+func matchScore(title, query string, queryTokens []string) int {
+	if title == query {
+		return 3
+	}
+	if strings.Contains(title, query) {
+		return 2
+	}
+	for _, tok := range queryTokens {
+		if !strings.Contains(title, tok) {
+			return 0
+		}
+	}
+	if len(queryTokens) > 0 {
+		return 1
+	}
+	return 0
+}
+
+func itemIsOpen(state string) bool {
+	return state != "closed" && state != "skipped"
+}
+
+func displayState(state string) string {
+	if state == "" {
+		return "open"
+	}
+	return state
+}
+
+// --- Formatting ---
+
+func writeRunChecklists(sb *strings.Builder, run playbookRunDetail) {
+	fmt.Fprintf(sb, "**%s** (run_id: %s) — Status: %s\n", run.Name, run.ID, run.CurrentStatus)
+	if len(run.Checklists) == 0 {
+		sb.WriteString("  (no checklists)\n")
+		return
+	}
+	for ci, cl := range run.Checklists {
+		fmt.Fprintf(sb, "  Checklist %d: %q\n", ci, cl.Title)
+		if len(cl.Items) == 0 {
+			sb.WriteString("    (no items)\n")
+			continue
+		}
+		for ii, item := range cl.Items {
+			fmt.Fprintf(sb, "    [%d][%d] %s (%s)\n", ci, ii, item.Title, displayState(item.State))
+		}
+	}
+}
+
+func formatMatches(matches []itemMatch) string {
+	if len(matches) == 1 {
+		m := matches[0]
+		return fmt.Sprintf(
+			"Found 1 matching item:\n\n"+
+				"- %q (%s) in run %q\n"+
+				"  run_id: %s, checklist_number: %d, item_number: %d\n\n"+
+				"Call check_item with run_id=%s, checklist_number=%d, item_number=%d.",
+			m.title, m.state, m.runName, m.runID, m.checklistNumber, m.itemNumber,
+			m.runID, m.checklistNumber, m.itemNumber)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Found %d matching items — pick the intended one:\n\n", len(matches))
+	for _, m := range matches {
+		fmt.Fprintf(&sb, "- %q (%s) in run %q\n  run_id: %s, checklist_number: %d, item_number: %d\n",
+			m.title, m.state, m.runName, m.runID, m.checklistNumber, m.itemNumber)
+	}
+	return sb.String()
+}
+
+func formatNoMatches(runs []playbookRunDetail, query string, includeClosed bool) string {
+	scope := "open "
+	if includeClosed {
+		scope = ""
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "No %schecklist item matching %q found.", scope, query)
+
+	var available []itemMatch
+	for _, run := range runs {
+		for ci, cl := range run.Checklists {
+			for ii, item := range cl.Items {
+				if !includeClosed && !itemIsOpen(item.State) {
+					continue
+				}
+				available = append(available, itemMatch{
+					runID:           run.ID,
+					runName:         run.Name,
+					checklistNumber: ci,
+					itemNumber:      ii,
+					title:           item.Title,
+					state:           displayState(item.State),
+				})
+			}
+		}
+	}
+
+	if len(available) == 0 {
+		sb.WriteString(" No candidate items were found in the searched runs.")
+		return sb.String()
+	}
+
+	sb.WriteString("\n\nAvailable items:\n")
+	for _, m := range available {
+		fmt.Fprintf(&sb, "- %q (%s) in run %q — run_id: %s, checklist_number: %d, item_number: %d\n",
+			m.title, m.state, m.runName, m.runID, m.checklistNumber, m.itemNumber)
+	}
+	return sb.String()
+}

--- a/internal/playbooksmcp/tools/resolve.go
+++ b/internal/playbooksmcp/tools/resolve.go
@@ -117,10 +117,45 @@ func candidateRuns(ctx context.Context, client APIClient, runID, channelID strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current user ID: %w", err)
 	}
-	return fetchRunDetails(ctx, client, listRunsParams(map[string]string{
+	return fetchUserRuns(ctx, client, userID)
+}
+
+// fetchUserRuns returns the user's in-progress runs covering both runs they own
+// and runs they only participate in. The list API ANDs owner_user_id and
+// participant_id, so the two must be queried separately and merged rather than
+// combined into one filter.
+func fetchUserRuns(ctx context.Context, client APIClient, userID string) ([]playbookRunDetail, error) {
+	owned, err := fetchRunDetails(ctx, client, listRunsParams(map[string]string{
 		"statuses":      "InProgress",
 		"owner_user_id": userID,
 	}))
+	if err != nil {
+		return nil, err
+	}
+	participating, err := fetchRunDetails(ctx, client, listRunsParams(map[string]string{
+		"statuses":       "InProgress",
+		"participant_id": userID,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return mergeRunsByID(owned, participating), nil
+}
+
+// mergeRunsByID concatenates run lists, keeping first occurrence of each run ID.
+func mergeRunsByID(lists ...[]playbookRunDetail) []playbookRunDetail {
+	seen := make(map[string]bool)
+	var merged []playbookRunDetail
+	for _, list := range lists {
+		for _, run := range list {
+			if seen[run.ID] {
+				continue
+			}
+			seen[run.ID] = true
+			merged = append(merged, run)
+		}
+	}
+	return merged
 }
 
 // fetchChannelRuns lists a channel's runs (in-progress unless includeFinished)
@@ -134,20 +169,26 @@ func fetchChannelRuns(ctx context.Context, client APIClient, channelID string, i
 }
 
 func fetchRunDetails(ctx context.Context, client APIClient, params url.Values) ([]playbookRunDetail, error) {
-	var resp listRunsResponse
-	if err := client.Get(ctx, "runs", params, &resp); err != nil {
-		return nil, fmt.Errorf("failed to list runs: %w", err)
-	}
-
-	runs := make([]playbookRunDetail, 0, len(resp.Items))
-	for _, summary := range resp.Items {
-		var run playbookRunDetail
-		if err := client.Get(ctx, fmt.Sprintf("runs/%s", summary.ID), nil, &run); err != nil {
-			return nil, fmt.Errorf("failed to get run %s: %w", summary.ID, err)
+	var runs []playbookRunDetail
+	for page := 0; ; page++ {
+		params.Set("page", fmt.Sprintf("%d", page))
+		var resp listRunsResponse
+		if err := client.Get(ctx, "runs", params, &resp); err != nil {
+			return nil, fmt.Errorf("failed to list runs: %w", err)
 		}
-		runs = append(runs, run)
+		for _, summary := range resp.Items {
+			var run playbookRunDetail
+			if err := client.Get(ctx, fmt.Sprintf("runs/%s", summary.ID), nil, &run); err != nil {
+				return nil, fmt.Errorf("failed to get run %s: %w", summary.ID, err)
+			}
+			runs = append(runs, run)
+		}
+		// Stop once we've collected everything or a page came back empty (guards
+		// against a mismatched TotalCount causing an endless loop).
+		if len(resp.Items) == 0 || len(runs) >= resp.TotalCount {
+			return runs, nil
+		}
 	}
-	return runs, nil
 }
 
 func listRunsParams(pairs map[string]string) url.Values {
@@ -155,7 +196,6 @@ func listRunsParams(pairs map[string]string) url.Values {
 	for k, v := range pairs {
 		params.Set(k, v)
 	}
-	params.Set("page", "0")
 	params.Set("per_page", "50")
 	return params
 }
@@ -172,32 +212,43 @@ type itemMatch struct {
 	score           int
 }
 
-func matchChecklistItems(runs []playbookRunDetail, query string, includeClosed bool) []itemMatch {
-	q := strings.ToLower(query)
-	qTokens := strings.Fields(q)
-
-	var matches []itemMatch
+// collectCandidateItems flattens the runs into unscored item candidates,
+// applying the open/closed filter. Both the matcher and the no-match listing
+// build on this so the two stay in sync.
+func collectCandidateItems(runs []playbookRunDetail, includeClosed bool) []itemMatch {
+	var items []itemMatch
 	for _, run := range runs {
 		for ci, cl := range run.Checklists {
 			for ii, item := range cl.Items {
 				if !includeClosed && !itemIsOpen(item.State) {
 					continue
 				}
-				score := matchScore(strings.ToLower(item.Title), q, qTokens)
-				if score == 0 {
-					continue
-				}
-				matches = append(matches, itemMatch{
+				items = append(items, itemMatch{
 					runID:           run.ID,
 					runName:         run.Name,
 					checklistNumber: ci,
 					itemNumber:      ii,
 					title:           item.Title,
 					state:           displayState(item.State),
-					score:           score,
 				})
 			}
 		}
+	}
+	return items
+}
+
+func matchChecklistItems(runs []playbookRunDetail, query string, includeClosed bool) []itemMatch {
+	q := strings.ToLower(query)
+	qTokens := strings.Fields(q)
+
+	var matches []itemMatch
+	for _, cand := range collectCandidateItems(runs, includeClosed) {
+		score := matchScore(strings.ToLower(cand.title), q, qTokens)
+		if score == 0 {
+			continue
+		}
+		cand.score = score
+		matches = append(matches, cand)
 	}
 
 	sort.SliceStable(matches, func(i, j int) bool {
@@ -287,25 +338,7 @@ func formatNoMatches(runs []playbookRunDetail, query string, includeClosed bool)
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "No %schecklist item matching %q found.", scope, query)
 
-	var available []itemMatch
-	for _, run := range runs {
-		for ci, cl := range run.Checklists {
-			for ii, item := range cl.Items {
-				if !includeClosed && !itemIsOpen(item.State) {
-					continue
-				}
-				available = append(available, itemMatch{
-					runID:           run.ID,
-					runName:         run.Name,
-					checklistNumber: ci,
-					itemNumber:      ii,
-					title:           item.Title,
-					state:           displayState(item.State),
-				})
-			}
-		}
-	}
-
+	available := collectCandidateItems(runs, includeClosed)
 	if len(available) == 0 {
 		sb.WriteString(" No candidate items were found in the searched runs.")
 		return sb.String()

--- a/internal/playbooksmcp/tools/resolve_test.go
+++ b/internal/playbooksmcp/tools/resolve_test.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,6 +165,75 @@ func TestToolFindChecklistItemByRunID(t *testing.T) {
 	assert.Contains(t, out, "Found 1 matching item")
 	// Should fetch only the single run, never list.
 	assert.NotContains(t, client.getEndpoints, "runs", "expected no list_runs call when run_id given")
+}
+
+func TestToolResolveChannelContextPaginatesAllRuns(t *testing.T) {
+	// Two pages of run summaries; resolve must fetch both, not just the first.
+	client := &fakeAPIClient{
+		listPages: []listRunsResponse{
+			{TotalCount: 2, Items: []playbookRunSummary{{ID: testRunID1}}},
+			{TotalCount: 2, Items: []playbookRunSummary{{ID: testRunID2}}},
+		},
+		runsByID: map[string]playbookRunDetail{
+			testRunID1: {ID: testRunID1, Name: "Run one", CurrentStatus: "InProgress"},
+			testRunID2: {ID: testRunID2, Name: "Run two", CurrentStatus: "InProgress"},
+		},
+	}
+
+	out, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: testChannelID})
+	require.NoError(t, err)
+	assert.Contains(t, out, "Run one")
+	assert.Contains(t, out, "Run two")
+	assert.Contains(t, out, "has 2 run(s)")
+
+	// page 0 and page 1 both requested.
+	var pages []string
+	for _, call := range client.listCalls {
+		pages = append(pages, call.Get("page"))
+	}
+	assert.Equal(t, []string{"0", "1"}, pages)
+}
+
+func TestToolFindChecklistItemFallsBackToCurrentUserRuns(t *testing.T) {
+	const currentUser = "usr00000000000000000000000"
+	client := &fakeAPIClient{
+		currentUserID: currentUser,
+		listRuns:      listRunsResponse{Items: []playbookRunSummary{{ID: testRunID1}}},
+		runsByID: map[string]playbookRunDetail{
+			testRunID1: {ID: testRunID1, Name: "My run", Checklists: []checklist{
+				{Items: []checklistItem{{Title: "Rotate credentials", State: ""}}},
+			}},
+		},
+	}
+
+	// No run_id and no channel_id -> fall back to the current user's runs.
+	out, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
+		Query: "rotate",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "Found 1 matching item")
+
+	// The fallback must cover both owned and participant runs (the backend ANDs
+	// the two filters, so they are queried separately).
+	var owner, participant bool
+	for _, call := range client.listCalls {
+		if call.Get("owner_user_id") == currentUser {
+			owner = true
+		}
+		if call.Get("participant_id") == currentUser {
+			participant = true
+		}
+	}
+	assert.True(t, owner, "expected an owner_user_id=me query")
+	assert.True(t, participant, "expected a participant_id=me query")
+}
+
+func TestToolFindChecklistItemFallbackSurfacesUserIDError(t *testing.T) {
+	client := &fakeAPIClient{currentUserErr: errors.New("no user")}
+
+	_, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{Query: "rotate"})
+	require.Error(t, err)
+	assert.Empty(t, client.listCalls, "expected no run listing when the user ID is unavailable")
 }
 
 func TestToolFindChecklistItemRequiresQuery(t *testing.T) {

--- a/internal/playbooksmcp/tools/resolve_test.go
+++ b/internal/playbooksmcp/tools/resolve_test.go
@@ -287,10 +287,65 @@ func TestToolMoveChecklistItemRejectsPositionBeyondAppend(t *testing.T) {
 		SourceChecklistIdx: 0,
 		SourceItemIdx:      0,
 		DestChecklistIdx:   1,
-		DestItemIdx:        4, // > item count, invalid
+		DestItemIdx:        4, // > item count, invalid even cross-checklist
 	})
 	if err == nil {
 		t.Fatal("expected out-of-range error for dest_item_idx")
+	}
+	if client.postEndpoint != "" {
+		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)
+	}
+}
+
+func TestToolMoveChecklistItemSameChecklistRejectsItemCount(t *testing.T) {
+	// Within the same section the backend caps the destination at count-1, so
+	// dest_item_idx == item count must be rejected (not treated as append).
+	client := &fakeAPIClient{run: fixtureRun(testRunID1, 1, 3)}
+
+	_, err := toolMoveChecklistItem(context.Background(), client, MoveChecklistItemArgs{
+		RunID:              testRunID1,
+		SourceChecklistIdx: 0,
+		SourceItemIdx:      0,
+		DestChecklistIdx:   0,
+		DestItemIdx:        3, // == item count, invalid for same-checklist move
+	})
+	if err == nil {
+		t.Fatal("expected out-of-range error for same-checklist dest_item_idx == count")
+	}
+	if client.postEndpoint != "" {
+		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)
+	}
+}
+
+func TestToolMoveChecklistItemSameChecklistAllowsLastIndex(t *testing.T) {
+	client := &fakeAPIClient{run: fixtureRun(testRunID1, 1, 3)}
+
+	_, err := toolMoveChecklistItem(context.Background(), client, MoveChecklistItemArgs{
+		RunID:              testRunID1,
+		SourceChecklistIdx: 0,
+		SourceItemIdx:      0,
+		DestChecklistIdx:   0,
+		DestItemIdx:        2, // == count-1, the last valid slot for same-checklist
+	})
+	if err != nil {
+		t.Fatalf("expected count-1 to be accepted for same-checklist move, got: %v", err)
+	}
+	if client.postEndpoint != "runs/"+testRunID1+"/checklists/move-item" {
+		t.Fatalf("unexpected endpoint: %s", client.postEndpoint)
+	}
+}
+
+func TestToolMoveSectionRejectsSectionCount(t *testing.T) {
+	// MoveChecklist rejects a destination >= section count; count itself is invalid.
+	client := &fakeAPIClient{run: fixtureRun(testRunID1, 2, 1)}
+
+	_, err := toolMoveSection(context.Background(), client, MoveSectionArgs{
+		RunID:              testRunID1,
+		SourceChecklistIdx: 0,
+		DestChecklistIdx:   2, // == section count, invalid
+	})
+	if err == nil {
+		t.Fatal("expected out-of-range error for dest_checklist_idx == section count")
 	}
 	if client.postEndpoint != "" {
 		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)

--- a/internal/playbooksmcp/tools/resolve_test.go
+++ b/internal/playbooksmcp/tools/resolve_test.go
@@ -5,8 +5,10 @@ package tools
 
 import (
 	"context"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -37,55 +39,37 @@ func TestToolResolveChannelContextListsItemsWithIndexes(t *testing.T) {
 	}
 
 	out, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: testChannelID})
-	if err != nil {
-		t.Fatalf("toolResolveChannelContext returned error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if client.listParams.Get("channel_id") != testChannelID {
-		t.Fatalf("expected channel_id filter %q, got %q", testChannelID, client.listParams.Get("channel_id"))
-	}
-	if client.listParams.Get("statuses") != "InProgress" {
-		t.Fatalf("expected InProgress status filter, got %q", client.listParams.Get("statuses"))
-	}
+	assert.Equal(t, testChannelID, client.listParams.Get("channel_id"))
+	assert.Equal(t, "InProgress", client.listParams.Get("statuses"))
 	for _, want := range []string{"Incident 42", testRunID1, "[0][0] Acknowledge (closed)", "[0][1] Deploy fix (open)"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
-		}
+		assert.Contains(t, out, want)
 	}
 }
 
 func TestToolResolveChannelContextIncludeFinished(t *testing.T) {
 	client := &fakeAPIClient{}
-	if _, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{
+	_, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{
 		ChannelID:       testChannelID,
 		IncludeFinished: true,
-	}); err != nil {
-		t.Fatalf("toolResolveChannelContext returned error: %v", err)
-	}
-	if client.listParams.Get("statuses") != "" {
-		t.Fatalf("expected no status filter when include_finished, got %q", client.listParams.Get("statuses"))
-	}
+	})
+	require.NoError(t, err)
+	assert.Empty(t, client.listParams.Get("statuses"))
 }
 
 func TestToolResolveChannelContextNoRuns(t *testing.T) {
 	client := &fakeAPIClient{}
 	out, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: testChannelID})
-	if err != nil {
-		t.Fatalf("toolResolveChannelContext returned error: %v", err)
-	}
-	if !strings.Contains(out, "No in-progress runs found") {
-		t.Fatalf("unexpected output: %s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "No in-progress runs found")
 }
 
 func TestToolResolveChannelContextRejectsBadChannel(t *testing.T) {
 	client := &fakeAPIClient{}
-	if _, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: "bad"}); err == nil {
-		t.Fatal("expected channel_id validation error")
-	}
-	if len(client.getEndpoints) != 0 {
-		t.Fatalf("expected no API calls on validation failure, got %v", client.getEndpoints)
-	}
+	_, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: "bad"})
+	require.Error(t, err)
+	assert.Empty(t, client.getEndpoints, "expected no API calls on validation failure")
 }
 
 func TestToolFindChecklistItemSingleMatch(t *testing.T) {
@@ -109,15 +93,9 @@ func TestToolFindChecklistItemSingleMatch(t *testing.T) {
 		Query:     "deploy to staging",
 		ChannelID: testChannelID,
 	})
-	if err != nil {
-		t.Fatalf("toolFindChecklistItem returned error: %v", err)
-	}
-	if !strings.Contains(out, "Found 1 matching item") {
-		t.Fatalf("expected single match, got:\n%s", out)
-	}
-	if !strings.Contains(out, "checklist_number: 0, item_number: 1") {
-		t.Fatalf("expected indexes for matched item, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "Found 1 matching item")
+	assert.Contains(t, out, "checklist_number: 0, item_number: 1")
 }
 
 func TestToolFindChecklistItemMultipleMatches(t *testing.T) {
@@ -137,12 +115,8 @@ func TestToolFindChecklistItemMultipleMatches(t *testing.T) {
 		Query:     "deploy",
 		ChannelID: testChannelID,
 	})
-	if err != nil {
-		t.Fatalf("toolFindChecklistItem returned error: %v", err)
-	}
-	if !strings.Contains(out, "Found 2 matching items") {
-		t.Fatalf("expected multiple matches, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "Found 2 matching items")
 }
 
 func TestToolFindChecklistItemSkipsClosedByDefault(t *testing.T) {
@@ -159,24 +133,16 @@ func TestToolFindChecklistItemSkipsClosedByDefault(t *testing.T) {
 		Query:     "deploy",
 		ChannelID: testChannelID,
 	})
-	if err != nil {
-		t.Fatalf("toolFindChecklistItem returned error: %v", err)
-	}
-	if !strings.Contains(out, "No open checklist item matching") {
-		t.Fatalf("expected no open match, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "No open checklist item matching")
 
 	out, err = toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
 		Query:         "deploy",
 		ChannelID:     testChannelID,
 		IncludeClosed: true,
 	})
-	if err != nil {
-		t.Fatalf("toolFindChecklistItem returned error: %v", err)
-	}
-	if !strings.Contains(out, "Found 1 matching item") {
-		t.Fatalf("expected match when include_closed, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "Found 1 matching item")
 }
 
 func TestToolFindChecklistItemByRunID(t *testing.T) {
@@ -194,25 +160,16 @@ func TestToolFindChecklistItemByRunID(t *testing.T) {
 		Query: "rotate",
 		RunID: testRunID1,
 	})
-	if err != nil {
-		t.Fatalf("toolFindChecklistItem returned error: %v", err)
-	}
-	if !strings.Contains(out, "Found 1 matching item") {
-		t.Fatalf("expected single match, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "Found 1 matching item")
 	// Should fetch only the single run, never list.
-	for _, ep := range client.getEndpoints {
-		if ep == "runs" {
-			t.Fatalf("expected no list_runs call when run_id given, got endpoints %v", client.getEndpoints)
-		}
-	}
+	assert.NotContains(t, client.getEndpoints, "runs", "expected no list_runs call when run_id given")
 }
 
 func TestToolFindChecklistItemRequiresQuery(t *testing.T) {
 	client := &fakeAPIClient{}
-	if _, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{Query: "  "}); err == nil {
-		t.Fatal("expected query validation error")
-	}
+	_, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{Query: "  "})
+	require.Error(t, err)
 }
 
 func TestToolCheckItemOutOfRangeListsItems(t *testing.T) {
@@ -231,15 +188,10 @@ func TestToolCheckItemOutOfRangeListsItems(t *testing.T) {
 		ItemNumber:      5,
 		NewState:        "closed",
 	})
-	if err == nil {
-		t.Fatal("expected out-of-range error")
-	}
-	if !strings.Contains(err.Error(), "item_number 5 is out of range") || !strings.Contains(err.Error(), "[0][0] First") {
-		t.Fatalf("expected actionable out-of-range error, got: %v", err)
-	}
-	if client.putEndpoint != "" {
-		t.Fatalf("expected no state update on out-of-range, got %q", client.putEndpoint)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "item_number 5 is out of range")
+	assert.Contains(t, err.Error(), "[0][0] First")
+	assert.Empty(t, client.putEndpoint, "expected no state update on out-of-range")
 }
 
 func TestToolRemoveSectionOutOfRangeDoesNotDelete(t *testing.T) {
@@ -249,15 +201,9 @@ func TestToolRemoveSectionOutOfRangeDoesNotDelete(t *testing.T) {
 		RunID:           testRunID1,
 		ChecklistNumber: 5,
 	})
-	if err == nil {
-		t.Fatal("expected out-of-range error")
-	}
-	if !strings.Contains(err.Error(), "checklist_number 5 is out of range") {
-		t.Fatalf("expected actionable error, got: %v", err)
-	}
-	if client.deleteEndpoint != "" {
-		t.Fatalf("expected no delete on out-of-range, got %q", client.deleteEndpoint)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checklist_number 5 is out of range")
+	assert.Empty(t, client.deleteEndpoint, "expected no delete on out-of-range")
 }
 
 func TestToolMoveChecklistItemAllowsAppendPosition(t *testing.T) {
@@ -271,12 +217,8 @@ func TestToolMoveChecklistItemAllowsAppendPosition(t *testing.T) {
 		DestChecklistIdx:   1,
 		DestItemIdx:        3, // == item count of dest checklist
 	})
-	if err != nil {
-		t.Fatalf("expected append position to be accepted, got: %v", err)
-	}
-	if client.postEndpoint != "runs/"+testRunID1+"/checklists/move-item" {
-		t.Fatalf("unexpected endpoint: %s", client.postEndpoint)
-	}
+	require.NoError(t, err, "expected append position to be accepted")
+	assert.Equal(t, "runs/"+testRunID1+"/checklists/move-item", client.postEndpoint)
 }
 
 func TestToolMoveChecklistItemRejectsPositionBeyondAppend(t *testing.T) {
@@ -289,12 +231,8 @@ func TestToolMoveChecklistItemRejectsPositionBeyondAppend(t *testing.T) {
 		DestChecklistIdx:   1,
 		DestItemIdx:        4, // > item count, invalid even cross-checklist
 	})
-	if err == nil {
-		t.Fatal("expected out-of-range error for dest_item_idx")
-	}
-	if client.postEndpoint != "" {
-		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)
-	}
+	require.Error(t, err)
+	assert.Empty(t, client.postEndpoint, "expected no move on invalid position")
 }
 
 func TestToolMoveChecklistItemSameChecklistRejectsItemCount(t *testing.T) {
@@ -309,12 +247,8 @@ func TestToolMoveChecklistItemSameChecklistRejectsItemCount(t *testing.T) {
 		DestChecklistIdx:   0,
 		DestItemIdx:        3, // == item count, invalid for same-checklist move
 	})
-	if err == nil {
-		t.Fatal("expected out-of-range error for same-checklist dest_item_idx == count")
-	}
-	if client.postEndpoint != "" {
-		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)
-	}
+	require.Error(t, err, "expected out-of-range error for same-checklist dest_item_idx == count")
+	assert.Empty(t, client.postEndpoint, "expected no move on invalid position")
 }
 
 func TestToolMoveChecklistItemSameChecklistAllowsLastIndex(t *testing.T) {
@@ -327,12 +261,8 @@ func TestToolMoveChecklistItemSameChecklistAllowsLastIndex(t *testing.T) {
 		DestChecklistIdx:   0,
 		DestItemIdx:        2, // == count-1, the last valid slot for same-checklist
 	})
-	if err != nil {
-		t.Fatalf("expected count-1 to be accepted for same-checklist move, got: %v", err)
-	}
-	if client.postEndpoint != "runs/"+testRunID1+"/checklists/move-item" {
-		t.Fatalf("unexpected endpoint: %s", client.postEndpoint)
-	}
+	require.NoError(t, err, "expected count-1 to be accepted for same-checklist move")
+	assert.Equal(t, "runs/"+testRunID1+"/checklists/move-item", client.postEndpoint)
 }
 
 func TestToolMoveSectionRejectsSectionCount(t *testing.T) {
@@ -344,12 +274,8 @@ func TestToolMoveSectionRejectsSectionCount(t *testing.T) {
 		SourceChecklistIdx: 0,
 		DestChecklistIdx:   2, // == section count, invalid
 	})
-	if err == nil {
-		t.Fatal("expected out-of-range error for dest_checklist_idx == section count")
-	}
-	if client.postEndpoint != "" {
-		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)
-	}
+	require.Error(t, err, "expected out-of-range error for dest_checklist_idx == section count")
+	assert.Empty(t, client.postEndpoint, "expected no move on invalid position")
 }
 
 func TestToolCheckItemAlreadyInStateIsNoOp(t *testing.T) {
@@ -368,13 +294,7 @@ func TestToolCheckItemAlreadyInStateIsNoOp(t *testing.T) {
 		ItemNumber:      0,
 		NewState:        "closed",
 	})
-	if err != nil {
-		t.Fatalf("toolCheckItem returned error: %v", err)
-	}
-	if !strings.Contains(out, "already 'closed'") {
-		t.Fatalf("expected no-op message, got: %s", out)
-	}
-	if client.putEndpoint != "" {
-		t.Fatalf("expected no PUT on no-op, got %q", client.putEndpoint)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "already 'closed'")
+	assert.Empty(t, client.putEndpoint, "expected no PUT on no-op")
 }

--- a/internal/playbooksmcp/tools/resolve_test.go
+++ b/internal/playbooksmcp/tools/resolve_test.go
@@ -242,6 +242,61 @@ func TestToolCheckItemOutOfRangeListsItems(t *testing.T) {
 	}
 }
 
+func TestToolRemoveSectionOutOfRangeDoesNotDelete(t *testing.T) {
+	client := &fakeAPIClient{run: fixtureRun(testRunID1, 2, 1)}
+
+	_, err := toolRemoveSection(context.Background(), client, RemoveSectionArgs{
+		RunID:           testRunID1,
+		ChecklistNumber: 5,
+	})
+	if err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+	if !strings.Contains(err.Error(), "checklist_number 5 is out of range") {
+		t.Fatalf("expected actionable error, got: %v", err)
+	}
+	if client.deleteEndpoint != "" {
+		t.Fatalf("expected no delete on out-of-range, got %q", client.deleteEndpoint)
+	}
+}
+
+func TestToolMoveChecklistItemAllowsAppendPosition(t *testing.T) {
+	// A destination item index equal to the item count is a valid append.
+	client := &fakeAPIClient{run: fixtureRun(testRunID1, 2, 3)}
+
+	_, err := toolMoveChecklistItem(context.Background(), client, MoveChecklistItemArgs{
+		RunID:              testRunID1,
+		SourceChecklistIdx: 0,
+		SourceItemIdx:      0,
+		DestChecklistIdx:   1,
+		DestItemIdx:        3, // == item count of dest checklist
+	})
+	if err != nil {
+		t.Fatalf("expected append position to be accepted, got: %v", err)
+	}
+	if client.postEndpoint != "runs/"+testRunID1+"/checklists/move-item" {
+		t.Fatalf("unexpected endpoint: %s", client.postEndpoint)
+	}
+}
+
+func TestToolMoveChecklistItemRejectsPositionBeyondAppend(t *testing.T) {
+	client := &fakeAPIClient{run: fixtureRun(testRunID1, 2, 3)}
+
+	_, err := toolMoveChecklistItem(context.Background(), client, MoveChecklistItemArgs{
+		RunID:              testRunID1,
+		SourceChecklistIdx: 0,
+		SourceItemIdx:      0,
+		DestChecklistIdx:   1,
+		DestItemIdx:        4, // > item count, invalid
+	})
+	if err == nil {
+		t.Fatal("expected out-of-range error for dest_item_idx")
+	}
+	if client.postEndpoint != "" {
+		t.Fatalf("expected no move on invalid position, got %q", client.postEndpoint)
+	}
+}
+
 func TestToolCheckItemAlreadyInStateIsNoOp(t *testing.T) {
 	client := &fakeAPIClient{
 		run: playbookRunDetail{

--- a/internal/playbooksmcp/tools/resolve_test.go
+++ b/internal/playbooksmcp/tools/resolve_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+const (
+	testChannelID = "chan0000000000000000000000"
+	testRunID1    = "run10000000000000000000000"
+	testRunID2    = "run20000000000000000000000"
+)
+
+func TestToolResolveChannelContextListsItemsWithIndexes(t *testing.T) {
+	client := &fakeAPIClient{
+		listRuns: listRunsResponse{
+			TotalCount: 1,
+			Items:      []playbookRunSummary{{ID: testRunID1}},
+		},
+		runsByID: map[string]playbookRunDetail{
+			testRunID1: {
+				ID:            testRunID1,
+				Name:          "Incident 42",
+				CurrentStatus: "InProgress",
+				Checklists: []checklist{
+					{Title: "Triage", Items: []checklistItem{
+						{Title: "Acknowledge", State: "closed"},
+						{Title: "Deploy fix", State: ""},
+					}},
+				},
+			},
+		},
+	}
+
+	out, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: testChannelID})
+	if err != nil {
+		t.Fatalf("toolResolveChannelContext returned error: %v", err)
+	}
+
+	if client.listParams.Get("channel_id") != testChannelID {
+		t.Fatalf("expected channel_id filter %q, got %q", testChannelID, client.listParams.Get("channel_id"))
+	}
+	if client.listParams.Get("statuses") != "InProgress" {
+		t.Fatalf("expected InProgress status filter, got %q", client.listParams.Get("statuses"))
+	}
+	for _, want := range []string{"Incident 42", testRunID1, "[0][0] Acknowledge (closed)", "[0][1] Deploy fix (open)"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestToolResolveChannelContextIncludeFinished(t *testing.T) {
+	client := &fakeAPIClient{}
+	if _, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{
+		ChannelID:       testChannelID,
+		IncludeFinished: true,
+	}); err != nil {
+		t.Fatalf("toolResolveChannelContext returned error: %v", err)
+	}
+	if client.listParams.Get("statuses") != "" {
+		t.Fatalf("expected no status filter when include_finished, got %q", client.listParams.Get("statuses"))
+	}
+}
+
+func TestToolResolveChannelContextNoRuns(t *testing.T) {
+	client := &fakeAPIClient{}
+	out, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: testChannelID})
+	if err != nil {
+		t.Fatalf("toolResolveChannelContext returned error: %v", err)
+	}
+	if !strings.Contains(out, "No in-progress runs found") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestToolResolveChannelContextRejectsBadChannel(t *testing.T) {
+	client := &fakeAPIClient{}
+	if _, err := toolResolveChannelContext(context.Background(), client, ResolveChannelContextArgs{ChannelID: "bad"}); err == nil {
+		t.Fatal("expected channel_id validation error")
+	}
+	if len(client.getEndpoints) != 0 {
+		t.Fatalf("expected no API calls on validation failure, got %v", client.getEndpoints)
+	}
+}
+
+func TestToolFindChecklistItemSingleMatch(t *testing.T) {
+	client := &fakeAPIClient{
+		listRuns: listRunsResponse{Items: []playbookRunSummary{{ID: testRunID1}}},
+		runsByID: map[string]playbookRunDetail{
+			testRunID1: {
+				ID:   testRunID1,
+				Name: "Release",
+				Checklists: []checklist{
+					{Items: []checklistItem{
+						{Title: "Write release notes", State: ""},
+						{Title: "Deploy to staging", State: ""},
+					}},
+				},
+			},
+		},
+	}
+
+	out, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
+		Query:     "deploy to staging",
+		ChannelID: testChannelID,
+	})
+	if err != nil {
+		t.Fatalf("toolFindChecklistItem returned error: %v", err)
+	}
+	if !strings.Contains(out, "Found 1 matching item") {
+		t.Fatalf("expected single match, got:\n%s", out)
+	}
+	if !strings.Contains(out, "checklist_number: 0, item_number: 1") {
+		t.Fatalf("expected indexes for matched item, got:\n%s", out)
+	}
+}
+
+func TestToolFindChecklistItemMultipleMatches(t *testing.T) {
+	client := &fakeAPIClient{
+		listRuns: listRunsResponse{Items: []playbookRunSummary{{ID: testRunID1}, {ID: testRunID2}}},
+		runsByID: map[string]playbookRunDetail{
+			testRunID1: {ID: testRunID1, Name: "Run A", Checklists: []checklist{
+				{Items: []checklistItem{{Title: "Deploy service", State: ""}}},
+			}},
+			testRunID2: {ID: testRunID2, Name: "Run B", Checklists: []checklist{
+				{Items: []checklistItem{{Title: "Deploy database", State: ""}}},
+			}},
+		},
+	}
+
+	out, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
+		Query:     "deploy",
+		ChannelID: testChannelID,
+	})
+	if err != nil {
+		t.Fatalf("toolFindChecklistItem returned error: %v", err)
+	}
+	if !strings.Contains(out, "Found 2 matching items") {
+		t.Fatalf("expected multiple matches, got:\n%s", out)
+	}
+}
+
+func TestToolFindChecklistItemSkipsClosedByDefault(t *testing.T) {
+	client := &fakeAPIClient{
+		listRuns: listRunsResponse{Items: []playbookRunSummary{{ID: testRunID1}}},
+		runsByID: map[string]playbookRunDetail{
+			testRunID1: {ID: testRunID1, Name: "Run", Checklists: []checklist{
+				{Items: []checklistItem{{Title: "Deploy", State: "closed"}}},
+			}},
+		},
+	}
+
+	out, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
+		Query:     "deploy",
+		ChannelID: testChannelID,
+	})
+	if err != nil {
+		t.Fatalf("toolFindChecklistItem returned error: %v", err)
+	}
+	if !strings.Contains(out, "No open checklist item matching") {
+		t.Fatalf("expected no open match, got:\n%s", out)
+	}
+
+	out, err = toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
+		Query:         "deploy",
+		ChannelID:     testChannelID,
+		IncludeClosed: true,
+	})
+	if err != nil {
+		t.Fatalf("toolFindChecklistItem returned error: %v", err)
+	}
+	if !strings.Contains(out, "Found 1 matching item") {
+		t.Fatalf("expected match when include_closed, got:\n%s", out)
+	}
+}
+
+func TestToolFindChecklistItemByRunID(t *testing.T) {
+	client := &fakeAPIClient{
+		run: playbookRunDetail{
+			ID:   testRunID1,
+			Name: "Run",
+			Checklists: []checklist{
+				{Items: []checklistItem{{Title: "Rotate credentials", State: ""}}},
+			},
+		},
+	}
+
+	out, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{
+		Query: "rotate",
+		RunID: testRunID1,
+	})
+	if err != nil {
+		t.Fatalf("toolFindChecklistItem returned error: %v", err)
+	}
+	if !strings.Contains(out, "Found 1 matching item") {
+		t.Fatalf("expected single match, got:\n%s", out)
+	}
+	// Should fetch only the single run, never list.
+	for _, ep := range client.getEndpoints {
+		if ep == "runs" {
+			t.Fatalf("expected no list_runs call when run_id given, got endpoints %v", client.getEndpoints)
+		}
+	}
+}
+
+func TestToolFindChecklistItemRequiresQuery(t *testing.T) {
+	client := &fakeAPIClient{}
+	if _, err := toolFindChecklistItem(context.Background(), client, FindChecklistItemArgs{Query: "  "}); err == nil {
+		t.Fatal("expected query validation error")
+	}
+}
+
+func TestToolCheckItemOutOfRangeListsItems(t *testing.T) {
+	client := &fakeAPIClient{
+		run: playbookRunDetail{
+			ID: testRunID1,
+			Checklists: []checklist{
+				{Title: "Only", Items: []checklistItem{{Title: "First", State: ""}}},
+			},
+		},
+	}
+
+	_, err := toolCheckItem(context.Background(), client, CheckItemArgs{
+		RunID:           testRunID1,
+		ChecklistNumber: 0,
+		ItemNumber:      5,
+		NewState:        "closed",
+	})
+	if err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+	if !strings.Contains(err.Error(), "item_number 5 is out of range") || !strings.Contains(err.Error(), "[0][0] First") {
+		t.Fatalf("expected actionable out-of-range error, got: %v", err)
+	}
+	if client.putEndpoint != "" {
+		t.Fatalf("expected no state update on out-of-range, got %q", client.putEndpoint)
+	}
+}
+
+func TestToolCheckItemAlreadyInStateIsNoOp(t *testing.T) {
+	client := &fakeAPIClient{
+		run: playbookRunDetail{
+			ID: testRunID1,
+			Checklists: []checklist{
+				{Items: []checklistItem{{Title: "Done", State: "closed"}}},
+			},
+		},
+	}
+
+	out, err := toolCheckItem(context.Background(), client, CheckItemArgs{
+		RunID:           testRunID1,
+		ChecklistNumber: 0,
+		ItemNumber:      0,
+		NewState:        "closed",
+	})
+	if err != nil {
+		t.Fatalf("toolCheckItem returned error: %v", err)
+	}
+	if !strings.Contains(out, "already 'closed'") {
+		t.Fatalf("expected no-op message, got: %s", out)
+	}
+	if client.putEndpoint != "" {
+		t.Fatalf("expected no PUT on no-op, got %q", client.putEndpoint)
+	}
+}

--- a/internal/playbooksmcp/tools/runs.go
+++ b/internal/playbooksmcp/tools/runs.go
@@ -17,6 +17,7 @@ import (
 
 type ListRunsArgs struct {
 	TeamID      string   `json:"team_id,omitempty" jsonschema:"Filter by team ID (26-char Mattermost ID)"`
+	ChannelID   string   `json:"channel_id,omitempty" jsonschema:"Filter by channel ID (26-char Mattermost ID). If the agent is operating within a channel, set this to that channel's ID to see only its runs."`
 	Status      string   `json:"status,omitempty" jsonschema:"Filter by status: InProgress or Finished"`
 	OwnerUserID string   `json:"owner_user_id,omitempty" jsonschema:"Filter by owner user ID. Use 'me' for the current user."`
 	Type        string   `json:"type,omitempty" jsonschema:"Filter by run type: playbook or channelChecklist"`
@@ -125,7 +126,7 @@ type playbookRunDetail struct {
 
 func (p *PlaybooksToolProvider) addMCPHelperRunTools(server *mcphelper.Server) {
 	addMCPHelperTool(server, p.clientFactory, "list_runs",
-		"List playbook runs and channel checklists with optional filters. Returns a paginated list showing ID, name, type, status, owner, and timestamps. Use status='InProgress' to see active runs and type='channelChecklist' to list checklists. Example: {\"status\": \"InProgress\", \"type\": \"channelChecklist\", \"per_page\": 5}",
+		"List playbook runs and channel checklists with optional filters. Returns a paginated list showing ID, name, type, status, owner, and timestamps. Use status='InProgress' to see active runs, type='channelChecklist' to list checklists, and channel_id to restrict to a single channel. Example: {\"status\": \"InProgress\", \"channel_id\": \"abc123...\", \"per_page\": 5}",
 		toolListRuns)
 
 	addMCPHelperTool(server, p.clientFactory, "create_checklist",
@@ -158,6 +159,12 @@ func toolListRuns(ctx context.Context, client APIClient, args ListRunsArgs) (str
 	}
 	if args.TeamID != "" {
 		params.Set("team_id", args.TeamID)
+	}
+	if args.ChannelID != "" {
+		if err := validateID(args.ChannelID, "channel_id"); err != nil {
+			return "", err
+		}
+		params.Set("channel_id", args.ChannelID)
 	}
 	if args.Status != "" {
 		params.Add("statuses", args.Status)


### PR DESCRIPTION
## Summary

When a user asks the agent to "mark task X done" via the Playbooks MCP, `check_item` required the caller to already know the exact `run_id` and zero-based `checklist_number`/`item_number`. Nothing steered the model to discover those, and there was no by-name matching — so it guessed indexes or failed.

This adds discovery, makes `check_item` self-correcting, and extends the same bounds-check pattern across all index-based checklist/section tools.

### Discovery (commit 1)
- **New tool `resolve_channel_context`** — given a `channel_id`, lists that channel's runs with each checklist item formatted as `[checklist_number][item_number] title (state)`, so the model can go straight to `check_item`. This is the "current context resolver."
- **New tool `find_checklist_item`** — matches a `query` against item titles, searching **channel-first** (explicit `run_id` → the given `channel_id`'s in-progress runs → the user's in-progress runs), and returns the `run_id` + indexes. Skips closed/skipped items unless `include_closed` is set. Handles 1 / many / no matches.
- **`list_runs`** — accepts an optional `channel_id` filter (the primitive the resolvers build on; the `GET runs` API already supports it with a channel-view permission check).

### Bounds-checking across all index-based tools (commit 2)
Every index-based item/section tool now fetches the run and validates the indexes against its real checklists, returning the actual items on a miss instead of an opaque API error — and, for destructive tools, never deleting the wrong thing.
- Shared helpers: `fetchRunForBounds`, `checkChecklistIndex`, `checkItemIndex`, `checkInsertPosition` (the last allows `position == count` for move appends).
- Applied to `check_item`, `add_checklist_item`, `set_checklist_item_due_date`, `set_checklist_item_assignee`, `remove_checklist_item`, `move_checklist_item`, `edit_checklist_item`, `rename_section`, `remove_section`, `move_section`.
- `check_item` also no-ops when the item is already in the requested state; `remove_*` name the removed item/section in the result.
- Resolve-first pointers added to the mutating tool descriptions.

### Design note / known limitation
The Playbooks MCP server only receives the **user ID** today (`mcphelper` extracts `X-Mattermost-UserID` and nothing else). No channel context reaches the tool handlers, so `channel_id` must be passed explicitly by the calling model from its conversation context. Making channel-first behavior fully automatic would require an upstream Agents + `mcphelper` change (forward an `X-Mattermost-ChannelID` header + a `GetChannelID` accessor) — scoped as a follow-up, not included here.

Per review, `check_item` stays index-based (resolver-first) rather than also accepting a title to self-resolve; that convenience is a possible later follow-up.

## Testing
- Unit tests for both new tools and for the bounds-check/no-op paths (out-of-range listing, destructive no-delete, move append-position edge cases, closed-item filtering, run-id scoping, query validation).
- Existing table tests updated with run fixtures for the new fetch-first behavior; provider registration test asserts both new tools register end-to-end via the MCP server.
- `go test ./internal/playbooksmcp/...` and `go test ./server/ -run MCP` pass; `golangci-lint` clean on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)