### PR TITLE
FIPS build for v2.8.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -533,6 +533,6 @@ jobs:
       - name: ci/download-test-results
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       - name: ci/publish-results
-        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
+        uses: mikepenz/action-junit-report@49b2ca06f62aa7ef83ae6769a2179271e160d8e4 # v6.3.1
         with:
           report_paths: "**/*.xml"


### PR DESCRIPTION
Empty PR to trigger CI for the FIPS bundle.