### PR TITLE
Resolve run number prefix collisions on playbook import

### DIFF
--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/export_import_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/export_import_spec.js
@@ -287,6 +287,24 @@ describe('playbooks > export and import with attributes and conditions', {testIs
             });
         });
 
+        it('round-trip: reimporting into the same team resolves a colliding run number prefix', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'Prefix Collision Source',
+                userId: testUser.id,
+            }).then((playbook) => {
+                cy.apiPatchPlaybook(playbook.id, {run_number_prefix: 'NUM'}).then(() => {
+                    cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                        cy.apiImportPlaybook(exportData, testTeam.id).then((importResult) => {
+                            cy.apiGetPlaybook(importResult.id).then((imported) => {
+                                expect(imported.run_number_prefix).to.equal('NUM-2');
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
         it('rejects import with unsupported version', () => {
             const badExport = {
                 title: 'Bad Version Playbook',
@@ -481,6 +499,40 @@ describe('playbooks > export and import with attributes and conditions', {testIs
                                 cy.findByText('Urgency').should('exist');
                             });
                         });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('UI import with run number prefix', () => {
+        it('resolves a colliding run number prefix on reimport into the same team', () => {
+            cy.apiCreateTestPlaybook({
+                teamId: testTeam.id,
+                title: 'UI Prefix Collision Source',
+                userId: testUser.id,
+            }).then((playbook) => {
+                cy.apiPatchPlaybook(playbook.id, {run_number_prefix: 'NUM'}).then(() => {
+                    cy.apiExportPlaybook(playbook.id).then((exportData) => {
+                        const exportBuffer = Cypress.Buffer.from(JSON.stringify(exportData));
+
+                        // # Open the Playbooks list
+                        cy.visit('/playbooks');
+                        cy.findByTestId('playbooksLHSButton').click();
+
+                        // # Use the file input to import into the same team
+                        cy.findByTestId('titlePlaybook').within(() => {
+                            cy.findByTestId('playbook-import-input').selectFile(
+                                {contents: exportBuffer, fileName: 'export.json', mimeType: 'application/json'},
+                                {force: true},
+                            );
+                        });
+
+                        // * Verify the playbook editor opens with the correct title (no import error toast)
+                        cy.findByTestId('playbook-editor-title').should('contain', 'UI Prefix Collision Source');
+
+                        // * Verify the colliding prefix was resolved to a suffixed variant
+                        cy.findByTestId('channel-access-run-number-prefix').should('have.value', 'NUM-2');
                     });
                 });
             });

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/export_import_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/export_import_spec.js
@@ -293,11 +293,11 @@ describe('playbooks > export and import with attributes and conditions', {testIs
                 title: 'Prefix Collision Source',
                 userId: testUser.id,
             }).then((playbook) => {
-                cy.apiPatchPlaybook(playbook.id, {run_number_prefix: 'NUM'}).then(() => {
+                cy.apiPatchPlaybook(playbook.id, {run_number_prefix: 'API-NUM'}).then(() => {
                     cy.apiExportPlaybook(playbook.id).then((exportData) => {
                         cy.apiImportPlaybook(exportData, testTeam.id).then((importResult) => {
                             cy.apiGetPlaybook(importResult.id).then((imported) => {
-                                expect(imported.run_number_prefix).to.equal('NUM-2');
+                                expect(imported.run_number_prefix).to.equal('API-NUM-2');
                             });
                         });
                     });
@@ -512,7 +512,7 @@ describe('playbooks > export and import with attributes and conditions', {testIs
                 title: 'UI Prefix Collision Source',
                 userId: testUser.id,
             }).then((playbook) => {
-                cy.apiPatchPlaybook(playbook.id, {run_number_prefix: 'NUM'}).then(() => {
+                cy.apiPatchPlaybook(playbook.id, {run_number_prefix: 'UI-NUM'}).then(() => {
                     cy.apiExportPlaybook(playbook.id).then((exportData) => {
                         const exportBuffer = Cypress.Buffer.from(JSON.stringify(exportData));
 
@@ -532,7 +532,7 @@ describe('playbooks > export and import with attributes and conditions', {testIs
                         cy.findByTestId('playbook-editor-title').should('contain', 'UI Prefix Collision Source');
 
                         // * Verify the colliding prefix was resolved to a suffixed variant
-                        cy.findByTestId('channel-access-run-number-prefix').should('have.value', 'NUM-2');
+                        cy.findByTestId('channel-access-run-number-prefix').should('have.value', 'UI-NUM-2');
                     });
                 });
             });

--- a/server/api_playbooks_test.go
+++ b/server/api_playbooks_test.go
@@ -1618,9 +1618,6 @@ func TestPlaybooksImportExport(t *testing.T) {
 	})
 
 	t.Run("Export and reimport into the same team resolves a colliding run number prefix", func(t *testing.T) {
-		// Simulates exporting a playbook and immediately reimporting it into the same team
-		// (e.g. to sanity-check the export), which collides with the still-existing source
-		// playbook's run number prefix since it's unique per team.
 		sourceID, err := e.PlaybooksClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
 			Title:           "Prefix Source Playbook",
 			TeamID:          e.BasicTeam.Id,
@@ -1633,13 +1630,12 @@ func TestPlaybooksImportExport(t *testing.T) {
 		require.NoError(t, err)
 
 		newPlaybookID, err := e.PlaybooksClient.Playbooks.Import(context.Background(), result, e.BasicTeam.Id)
-		require.NoError(t, err, "import should not fail because of a run number prefix collision")
+		require.NoError(t, err)
 
 		newPlaybook, err := e.PlaybooksClient.Playbooks.Get(context.Background(), newPlaybookID)
 		require.NoError(t, err)
 
-		assert.Equal(t, "NUM-2", newPlaybook.RunNumberPrefix,
-			"colliding prefix should be resolved to a suffixed variant instead of being dropped")
+		assert.Equal(t, "NUM-2", newPlaybook.RunNumberPrefix)
 	})
 
 	t.Run("Export and import into a different team preserves the run number prefix", func(t *testing.T) {
@@ -1660,8 +1656,7 @@ func TestPlaybooksImportExport(t *testing.T) {
 		newPlaybook, err := e.PlaybooksClient.Playbooks.Get(context.Background(), newPlaybookID)
 		require.NoError(t, err)
 
-		assert.Equal(t, "CROSS", newPlaybook.RunNumberPrefix,
-			"prefix should be preserved unchanged when importing into a team with no collision")
+		assert.Equal(t, "CROSS", newPlaybook.RunNumberPrefix)
 	})
 }
 

--- a/server/api_playbooks_test.go
+++ b/server/api_playbooks_test.go
@@ -1616,6 +1616,53 @@ func TestPlaybooksImportExport(t *testing.T) {
 		assert.Equal(t, newFields[0].ID, importedConditions.Items[0].ConditionExpr.Is.FieldID,
 			"imported condition should reference the new property field ID")
 	})
+
+	t.Run("Export and reimport into the same team resolves a colliding run number prefix", func(t *testing.T) {
+		// Simulates exporting a playbook and immediately reimporting it into the same team
+		// (e.g. to sanity-check the export), which collides with the still-existing source
+		// playbook's run number prefix since it's unique per team.
+		sourceID, err := e.PlaybooksClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
+			Title:           "Prefix Source Playbook",
+			TeamID:          e.BasicTeam.Id,
+			Public:          true,
+			RunNumberPrefix: "NUM",
+		})
+		require.NoError(t, err)
+
+		result, err := e.PlaybooksClient.Playbooks.Export(context.Background(), sourceID)
+		require.NoError(t, err)
+
+		newPlaybookID, err := e.PlaybooksClient.Playbooks.Import(context.Background(), result, e.BasicTeam.Id)
+		require.NoError(t, err, "import should not fail because of a run number prefix collision")
+
+		newPlaybook, err := e.PlaybooksClient.Playbooks.Get(context.Background(), newPlaybookID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "NUM-2", newPlaybook.RunNumberPrefix,
+			"colliding prefix should be resolved to a suffixed variant instead of being dropped")
+	})
+
+	t.Run("Export and import into a different team preserves the run number prefix", func(t *testing.T) {
+		sourceID, err := e.PlaybooksClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
+			Title:           "Prefix Cross-Team Source Playbook",
+			TeamID:          e.BasicTeam.Id,
+			Public:          true,
+			RunNumberPrefix: "CROSS",
+		})
+		require.NoError(t, err)
+
+		result, err := e.PlaybooksClient.Playbooks.Export(context.Background(), sourceID)
+		require.NoError(t, err)
+
+		newPlaybookID, err := e.PlaybooksClient.Playbooks.Import(context.Background(), result, e.BasicTeam2.Id)
+		require.NoError(t, err)
+
+		newPlaybook, err := e.PlaybooksClient.Playbooks.Get(context.Background(), newPlaybookID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "CROSS", newPlaybook.RunNumberPrefix,
+			"prefix should be preserved unchanged when importing into a team with no collision")
+	})
 }
 
 func TestPlaybooksDuplicate(t *testing.T) {

--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -111,9 +111,6 @@ func (s *playbookService) Import(data PlaybookImportData, userID string) (string
 
 	condRefs := saveAndClearConditionRefs(&playbook)
 
-	// A run number prefix is unique per team; re-importing a playbook into the team it was
-	// exported from (or any team that already has a playbook using the same prefix) would
-	// otherwise fail the whole import. Resolve the collision instead of failing.
 	playbook.RunNumberPrefix = s.resolveImportRunNumberPrefix(playbook.TeamID, playbook.RunNumberPrefix, playbook.Title)
 
 	newPlaybookID, err := s.Create(playbook, userID)
@@ -678,18 +675,11 @@ func (s *playbookService) checkRunNumberPrefixUnique(teamID, prefix, excludeID s
 	return nil
 }
 
-// maxImportPrefixSuffixAttempts caps the "-N" suffixes tried when resolving a run number
-// prefix collision on import (i.e. we try "-2" through "-maxImportPrefixSuffixAttempts").
+// maxImportPrefixSuffixAttempts caps the "-N" suffixes tried below.
 const maxImportPrefixSuffixAttempts = 50
 
-// resolveImportRunNumberPrefix returns a run number prefix that's unique within teamID.
-// A playbook exported with a prefix set is commonly re-imported into the same team it came
-// from (e.g. a sanity-check re-import right after exporting), which would otherwise collide
-// with the still-existing source playbook's prefix. If prefix doesn't collide (including the
-// common case of importing into a different team), it's returned unchanged, preserving
-// cross-team import fidelity. If it does collide, a suffixed variant ("-2", "-3", ...) is
-// returned instead, preserving the admin's intent to have some prefix rather than silently
-// dropping it.
+// resolveImportRunNumberPrefix suffixes prefix (e.g. "-2") if it collides with an existing
+// playbook in teamID, instead of failing the import or silently dropping the prefix.
 func (s *playbookService) resolveImportRunNumberPrefix(teamID, prefix, playbookTitle string) string {
 	if prefix == "" {
 		return prefix

--- a/server/app/playbook_service.go
+++ b/server/app/playbook_service.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -109,6 +110,11 @@ func (s *playbookService) Import(data PlaybookImportData, userID string) (string
 	}
 
 	condRefs := saveAndClearConditionRefs(&playbook)
+
+	// A run number prefix is unique per team; re-importing a playbook into the team it was
+	// exported from (or any team that already has a playbook using the same prefix) would
+	// otherwise fail the whole import. Resolve the collision instead of failing.
+	playbook.RunNumberPrefix = s.resolveImportRunNumberPrefix(playbook.TeamID, playbook.RunNumberPrefix, playbook.Title)
 
 	newPlaybookID, err := s.Create(playbook, userID)
 	if err != nil {
@@ -670,6 +676,58 @@ func (s *playbookService) checkRunNumberPrefixUnique(teamID, prefix, excludeID s
 		return ErrDuplicateEntry
 	}
 	return nil
+}
+
+// maxImportPrefixSuffixAttempts caps the "-N" suffixes tried when resolving a run number
+// prefix collision on import (i.e. we try "-2" through "-maxImportPrefixSuffixAttempts").
+const maxImportPrefixSuffixAttempts = 50
+
+// resolveImportRunNumberPrefix returns a run number prefix that's unique within teamID.
+// A playbook exported with a prefix set is commonly re-imported into the same team it came
+// from (e.g. a sanity-check re-import right after exporting), which would otherwise collide
+// with the still-existing source playbook's prefix. If prefix doesn't collide (including the
+// common case of importing into a different team), it's returned unchanged, preserving
+// cross-team import fidelity. If it does collide, a suffixed variant ("-2", "-3", ...) is
+// returned instead, preserving the admin's intent to have some prefix rather than silently
+// dropping it.
+func (s *playbookService) resolveImportRunNumberPrefix(teamID, prefix, playbookTitle string) string {
+	if prefix == "" {
+		return prefix
+	}
+
+	if err := s.checkRunNumberPrefixUnique(teamID, prefix, ""); err == nil {
+		return prefix
+	} else if !errors.Is(err, ErrDuplicateEntry) {
+		// Couldn't determine uniqueness (e.g. store error); leave the prefix as-is and let
+		// Create's own check surface the error.
+		return prefix
+	}
+
+	for n := 2; n <= maxImportPrefixSuffixAttempts; n++ {
+		suffix := fmt.Sprintf("-%d", n)
+		base := prefix
+		if len(base)+len(suffix) > MaxRunNumberPrefixLength {
+			base = base[:MaxRunNumberPrefixLength-len(suffix)]
+		}
+		candidate := base + suffix
+
+		if err := s.checkRunNumberPrefixUnique(teamID, candidate, ""); err == nil {
+			logrus.WithFields(logrus.Fields{
+				"team_id":         teamID,
+				"playbook_title":  playbookTitle,
+				"original_prefix": prefix,
+				"resolved_prefix": candidate,
+			}).Warn("run number prefix collided with an existing playbook on import, using a suffixed variant instead")
+			return candidate
+		}
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"team_id":         teamID,
+		"playbook_title":  playbookTitle,
+		"original_prefix": prefix,
+	}).Warn("could not find a unique run number prefix variant on import after exhausting attempts, clearing prefix")
+	return ""
 }
 
 func (s *playbookService) IncrementRunNumber(playbookID string) (int64, error) {


### PR DESCRIPTION
## Summary

Exporting a playbook and immediately reimporting it into the same team — a natural way to sanity-check an export — always failed with the generic "playbook import has failed" toast whenever the playbook had a `run_number_prefix` set. Lindy hit this while testing PR #2350: https://github.com/mattermost/mattermost-plugin-playbooks/pull/2350#issuecomment-4969663109

`run_number_prefix` is unique per team, so reimporting into the same team always collides with the still-existing source playbook's prefix, and that collision surfaced as an unhandled HTTP 409 with no useful signal to the user. Unrelated to the channel name template lock feature in #2350 — that's just what QA happened to be testing when they hit this pre-existing gap.

Import now resolves a colliding prefix with a suffix (e.g. `NUM` -> `NUM-2`) instead of failing the import or silently dropping the prefix.

## Ticket Link

[MM-69844](https://mattermost.atlassian.net/browse/MM-69844)

## Checklist
- ~~Gated by experimental feature flag~~
- [x] Unit tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-69844]: https://mattermost.atlassian.net/browse/MM-69844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ