### PR TITLE
[MM-69518] Reject null conditions on playbook import

### DIFF
--- a/server/app/export.go
+++ b/server/app/export.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -79,6 +80,12 @@ type ExportCondition struct {
 // Since ConditionExpression is an interface, we need custom unmarshaling to properly
 // deserialize condition_expr based on the version field.
 func (ec *ExportCondition) UnmarshalJSON(data []byte) error {
+	// Reject JSON null: unmarshaling null into &aux would set aux to nil and panic
+	// on the ConditionExpr access below (MM-69518).
+	if string(data) == "null" {
+		return errors.New("condition cannot be null")
+	}
+
 	type Alias ExportCondition
 	aux := &struct {
 		ConditionExpr json.RawMessage `json:"condition_expr"`

--- a/server/app/export_test.go
+++ b/server/app/export_test.go
@@ -200,3 +200,22 @@ func TestExportConditionUnmarshalNullExpr(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, ec.ConditionExpr)
 }
+
+func TestExportConditionUnmarshalNull(t *testing.T) {
+	t.Run("null condition returns error", func(t *testing.T) {
+		var ec ExportCondition
+		err := json.Unmarshal([]byte(`null`), &ec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "condition cannot be null")
+	})
+
+	t.Run("null element in conditions array returns error", func(t *testing.T) {
+		var importBlock struct {
+			Version    int               `json:"version"`
+			Conditions []ExportCondition `json:"conditions,omitempty"`
+		}
+		err := json.Unmarshal([]byte(`{"version":1,"conditions":[null]}`), &importBlock)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "condition cannot be null")
+	})
+}


### PR DESCRIPTION
## Summary
- Reject JSON `null` elements in the import `conditions` array inside `ExportCondition.UnmarshalJSON`, so malformed imports return HTTP 400 instead of panicking the plugin process.
- Add regression coverage for a null condition and for `{"conditions":[null]}`.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69518

## Checklist
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated