### PR TITLE
Add planned cherry-picks item to PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,3 +28,5 @@ Otherwise, link the Jira ticket.
 <!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
 - [ ] Gated by experimental feature flag
 - [ ] Unit tests updated
+<!-- For bugfixes, security fixes, or other changes that need backporting, list target release branches. Strike through if no cherry picks are needed. -->
+- [ ] Planned cherry-picks: `release-X.Y`


### PR DESCRIPTION
## Summary
PRs that contain bugfixes or security fixes often need to be cherry-picked onto release branches. Without a dedicated field, this step is easy to forget. This adds a checklist item to the PR template so authors explicitly flag which release branches need backporting.

## Ticket Link
N/A

## Checklist
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
- [ ] ~~Planned cherry-picks: `release-X.Y`~~