### PR TITLE
Cherry pick #2344 to release-2.10

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_properties.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_properties.tsx
@@ -37,6 +37,7 @@ const RHSInfoProperties = (props: Props) => {
                 propertyFields={props.run.property_fields}
                 propertyValues={props.run.property_values}
                 runID={props.run.id}
+                readOnly={!props.editable}
             />
         </Section>
     );

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
@@ -25,7 +25,7 @@ import {useManageRunMembership} from 'src/graphql/hooks';
 
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
 
 import {SendMessageButton} from './send_message_button';
 import AddParticipantsModal from './add_participant_modal';
@@ -74,6 +74,8 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
         return true;
     };
 
+    const isFinished = playbookRun.current_status === PlaybookRunStatus.Finished;
+
     const manageParticipantsSection = () => {
         if (manageMode) {
             return (
@@ -118,7 +120,7 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
                     )}
                 </ParticipantsNumber>
 
-                {role === Role.Participant && manageParticipantsSection()}
+                {role === Role.Participant && !isFinished && manageParticipantsSection()}
 
             </HeaderSection>
 

--- a/webapp/src/components/rhs/properties/property_date.test.tsx
+++ b/webapp/src/components/rhs/properties/property_date.test.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import DateProperty from './property_date';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('src/components/datetime_selector', () => ({
+    DateTimeSelector: () => <div data-testid='edit-mode'/>,
+    optionFromMillis: () => ({}),
+}));
+
+jest.mock('src/components/datetime_parsing', () => ({
+    Mode: {DateTimeValue: 'datetime_value'},
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Due date',
+    type: 'date',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const value: PropertyValue = {field_id: 'field-1', value: '2026-01-01'} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+const triggerEnterKey = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onKeyDown?.({key: 'Enter', preventDefault: jest.fn()});
+    });
+};
+
+describe('DateProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <DateProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('does not enter edit mode on Enter key when readOnly', () => {
+        const component = create(
+            <DateProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerEnterKey(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <DateProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_date.tsx
+++ b/webapp/src/components/rhs/properties/property_date.tsx
@@ -87,12 +87,22 @@ const DateProperty = (props: Props) => {
         setDisplayMillis(newMillis);
     }, [props.value?.value]);
 
+    const handleClick = useCallback(() => {
+        if (props.readOnly) {
+            return;
+        }
+        setIsEditing(true);
+    }, [props.readOnly]);
+
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
+        if (props.readOnly) {
+            return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsEditing(true);
         }
-    }, []);
+    }, [props.readOnly]);
 
     const handleSelectedChange = useCallback((option: DateTimeOption | undefined | null) => {
         const seq = ++callSeqRef.current;
@@ -145,7 +155,8 @@ const DateProperty = (props: Props) => {
 
     return (
         <PropertyDisplayContainer
-            onClick={() => setIsEditing(true)}
+            $readOnly={props.readOnly}
+            onClick={handleClick}
             onKeyDown={handleActivateKey}
             data-testid='property-value'
         >

--- a/webapp/src/components/rhs/properties/property_multiselect.test.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import MultiselectProperty from './property_multiselect';
+
+jest.mock('./property_select_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Tags',
+    type: 'multiselect',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const emptyValue: PropertyValue = {field_id: 'field-1', value: []} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('MultiselectProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_multiselect.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.tsx
@@ -5,17 +5,15 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useUpdateEffect} from 'react-use';
 
-import {PropertyField, PropertyValue} from 'src/types/properties';
+import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
-interface Props {
-    field: PropertyField;
-    value?: PropertyValue;
-    runID: string;
+interface Props extends PropertyComponentProps {
     onValueChange: (value: string[] | null) => void;
 }
 
@@ -36,6 +34,9 @@ const MultiselectProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
         setTempValue(displayValue ?? null);
     };
@@ -72,6 +73,7 @@ const MultiselectProperty = (props: Props) => {
         return (
             <EmptyMultiselectDisplay
                 onClick={handleStartEdit}
+                $readOnly={props.readOnly}
                 data-testid='property-value'
             >
                 <EmptyState/>
@@ -89,7 +91,7 @@ const MultiselectProperty = (props: Props) => {
                 <PropertyChip
                     key={index}
                     label={label!}
-                    onClick={handleStartEdit}
+                    onClick={props.readOnly ? undefined : handleStartEdit}
                 />
             ))}
         </ChipsContainer>
@@ -102,18 +104,12 @@ const ChipsContainer = styled.div`
     gap: 4px;
 `;
 
-const EmptyMultiselectDisplay = styled.div`
+const EmptyMultiselectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 export default MultiselectProperty;

--- a/webapp/src/components/rhs/properties/property_select.test.tsx
+++ b/webapp/src/components/rhs/properties/property_select.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import SelectProperty from './property_select';
+
+jest.mock('./property_select_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Priority',
+    type: 'select',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const emptyValue: PropertyValue = {field_id: 'field-1', value: ''} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('SelectProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_select.tsx
+++ b/webapp/src/components/rhs/properties/property_select.tsx
@@ -5,17 +5,15 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useUpdateEffect} from 'react-use';
 
-import {PropertyField, PropertyValue} from 'src/types/properties';
+import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
-interface Props {
-    field: PropertyField;
-    value?: PropertyValue;
-    runID: string;
+interface Props extends PropertyComponentProps {
     onValueChange: (value: string | null) => void;
 }
 
@@ -36,6 +34,9 @@ const SelectProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
     };
 
@@ -73,6 +74,7 @@ const SelectProperty = (props: Props) => {
         return (
             <EmptySelectDisplay
                 onClick={handleStartEdit}
+                $readOnly={props.readOnly}
                 data-testid='property-value'
             >
                 <EmptyState/>
@@ -83,24 +85,18 @@ const SelectProperty = (props: Props) => {
     return (
         <PropertyChip
             label={displayLabel}
-            onClick={handleStartEdit}
+            onClick={props.readOnly ? undefined : handleStartEdit}
             data-testid='property-value'
         />
     );
 };
 
-const EmptySelectDisplay = styled.div`
+const EmptySelectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 export default SelectProperty;

--- a/webapp/src/components/rhs/properties/property_styles.ts
+++ b/webapp/src/components/rhs/properties/property_styles.ts
@@ -1,37 +1,41 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
-export const PropertyDisplayContainer = styled.div.attrs(() => ({
-    role: 'button',
-    tabIndex: 0,
-    onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            (e.currentTarget as HTMLElement).click();
-        }
-    },
-}))`
+// Shared cursor/hover affordance for editable property displays. When $readOnly
+// is set the pointer cursor and hover highlight are suppressed.
+export const readOnlyInteractiveStyles = css<{$readOnly?: boolean}>`
+    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
+
+    &:hover {
+        ${({$readOnly}) => !$readOnly && `
+            background-color: rgba(var(--center-channel-color-rgb), 0.04);
+            border-radius: 4px;
+            margin: 0 -4px;
+            padding: 4px;
+        `}
+    }
+`;
+
+export const PropertyDisplayContainer = styled.div.attrs<{$readOnly?: boolean}>(({$readOnly}) => ({
+    role: $readOnly ? undefined : 'button',
+    tabIndex: $readOnly ? undefined : 0,
+}))<{$readOnly?: boolean}>`
     flex: 1;
     color: var(--center-channel-color);
     font-size: 14px;
     line-height: 20px;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 
     &:focus-visible {
-        outline: 2px solid var(--button-bg);
-        outline-offset: 2px;
-        border-radius: 4px;
+        ${({$readOnly}) => !$readOnly && `
+            outline: 2px solid var(--button-bg);
+            outline-offset: 2px;
+            border-radius: 4px;
+        `}
     }
 `;

--- a/webapp/src/components/rhs/properties/property_text.test.tsx
+++ b/webapp/src/components/rhs/properties/property_text.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import TextProperty from './property_text';
+
+jest.mock('./property_text_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Summary',
+    type: 'text',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const value: PropertyValue = {field_id: 'field-1', value: 'hello'} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('TextProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <TextProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <TextProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_text.tsx
+++ b/webapp/src/components/rhs/properties/property_text.tsx
@@ -5,15 +5,13 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {useUpdateEffect} from 'react-use';
 
-import {PropertyField, PropertyValue} from 'src/types/properties';
+import {PropertyComponentProps} from 'src/types/properties';
 
 import PropertyTextInput from './property_text_input';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
-interface Props {
-    field: PropertyField;
-    value?: PropertyValue;
-    runID: string;
+interface Props extends PropertyComponentProps {
     onValueChange: (value: string | null) => void;
 }
 
@@ -34,6 +32,9 @@ const TextProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
     };
 
@@ -73,6 +74,7 @@ const TextProperty = (props: Props) => {
     return (
         <TextDisplay
             onClick={handleStartEdit}
+            $readOnly={props.readOnly}
             data-testid='property-value'
         >
             {content}
@@ -80,21 +82,15 @@ const TextProperty = (props: Props) => {
     );
 };
 
-const TextDisplay = styled.div`
+const TextDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
     color: var(--center-channel-color);
     font-size: 14px;
     line-height: 20px;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 const URLLink = styled.a`

--- a/webapp/src/components/rhs/properties/property_user.test.tsx
+++ b/webapp/src/components/rhs/properties/property_user.test.tsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import UserProperty, {MultiuserProperty} from './property_user';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('src/hooks', () => ({
+    useProfilesInTeam: () => [],
+}));
+
+jest.mock('src/components/profile/profile', () => ({
+    __esModule: true,
+    default: () => <div data-testid='profile'/>,
+}));
+
+jest.mock('src/components/profile/profile_selector', () => ({
+    __esModule: true,
+    default: () => <div data-testid='profile-selector'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Owner',
+    type: 'user',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const makeValue = (value: string | string[]): PropertyValue => ({
+    field_id: 'field-1',
+    value,
+} as unknown as PropertyValue);
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'profile-selector'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+const triggerEnterKey = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onKeyDown?.({key: 'Enter', preventDefault: jest.fn()});
+    });
+};
+
+describe('UserProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <UserProperty
+                field={field}
+                value={makeValue('user-1')}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('does not enter edit mode on Enter key when readOnly', () => {
+        const component = create(
+            <UserProperty
+                field={field}
+                value={makeValue('user-1')}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerEnterKey(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <UserProperty
+                field={field}
+                value={makeValue('user-1')}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});
+
+describe('MultiuserProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <MultiuserProperty
+                field={field}
+                value={makeValue(['user-1'])}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('does not enter edit mode on Enter key when readOnly', () => {
+        const component = create(
+            <MultiuserProperty
+                field={field}
+                value={makeValue(['user-1'])}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerEnterKey(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <MultiuserProperty
+                field={field}
+                value={makeValue(['user-1'])}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_user.tsx
+++ b/webapp/src/components/rhs/properties/property_user.tsx
@@ -48,12 +48,22 @@ const UserProperty = (props: Props) => {
 
     const fetchUsersInTeam = useCallback(async () => profilesInTeam, [profilesInTeam]);
 
+    const handleClick = useCallback(() => {
+        if (props.readOnly) {
+            return;
+        }
+        setIsEditing(true);
+    }, [props.readOnly]);
+
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
+        if (props.readOnly) {
+            return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsEditing(true);
         }
-    }, []);
+    }, [props.readOnly]);
 
     const handleSelectedChange = useCallback((user?: UserProfile) => {
         const newValue = user?.id ?? null;
@@ -96,7 +106,8 @@ const UserProperty = (props: Props) => {
 
     return (
         <PropertyDisplayContainer
-            onClick={() => setIsEditing(true)}
+            $readOnly={props.readOnly}
+            onClick={handleClick}
             onKeyDown={handleActivateKey}
             data-testid='property-value'
         >
@@ -131,12 +142,22 @@ export const MultiuserProperty = (props: Props) => {
 
     const fetchUsersInTeam = useCallback(async () => profilesInTeam, [profilesInTeam]);
 
+    const handleClick = useCallback(() => {
+        if (props.readOnly) {
+            return;
+        }
+        setIsEditing(true);
+    }, [props.readOnly]);
+
     const handleActivateKey = useCallback((e: KeyboardEvent) => {
+        if (props.readOnly) {
+            return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsEditing(true);
         }
-    }, []);
+    }, [props.readOnly]);
 
     const applyNewValues = useCallback((newValues: string[]) => {
         const seq = ++callSeqRef.current;
@@ -209,7 +230,8 @@ export const MultiuserProperty = (props: Props) => {
 
     return (
         <PropertyDisplayContainer
-            onClick={() => setIsEditing(true)}
+            $readOnly={props.readOnly}
+            onClick={handleClick}
             onKeyDown={handleActivateKey}
             data-testid='property-value'
         >

--- a/webapp/src/components/rhs/properties_list.tsx
+++ b/webapp/src/components/rhs/properties_list.tsx
@@ -13,6 +13,7 @@ interface Props {
     propertyValues?: PropertyValue[];
     runID: string;
     className?: string;
+    readOnly?: boolean;
 }
 
 const PropertiesList = (props: Props) => {
@@ -47,6 +48,7 @@ const PropertiesList = (props: Props) => {
                     field={field}
                     value={value}
                     runID={props.runID}
+                    readOnly={props.readOnly}
                 />
             ))}
         </div>

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -198,8 +198,9 @@ const RHSAbout = (props: Props) => {
                                 <MemberSectionTitle>{formatMessage({defaultMessage: 'Participants'})}</MemberSectionTitle>
                                 <RHSParticipants
                                     userIds={props.playbookRun.participant_ids.filter((id) => id !== props.playbookRun.owner_user_id)}
-                                    onParticipate={shouldShowParticipate ? showParticipateConfirm : undefined}
+                                    onParticipate={!isFinished && shouldShowParticipate ? showParticipateConfirm : undefined}
                                     setShowParticipants={props.setShowParticipants}
+                                    canAddParticipants={!isFinished}
                                 />
                             </ParticipantsSection>
                         </Row>
@@ -207,6 +208,7 @@ const RHSAbout = (props: Props) => {
                             propertyFields={props.playbookRun.property_fields}
                             propertyValues={props.playbookRun.property_values}
                             runID={props.playbookRun.id}
+                            readOnly={isFinished || props.readOnly}
                         />
                     </>
                 }

--- a/webapp/src/components/rhs/rhs_participants.test.tsx
+++ b/webapp/src/components/rhs/rhs_participants.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import RHSParticipants from './rhs_participants';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('src/hooks/redux', () => ({
+    useAppDispatch: () => jest.fn(),
+    useAppSelector: () => null,
+}));
+
+jest.mock('src/components/rhs/rhs_participant', () => ({
+    RHSParticipant: () => null,
+    Rest: () => null,
+}));
+
+describe('RHSParticipants', () => {
+    it('hides add participant controls when canAddParticipants is false', () => {
+        const component = renderer.create(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={false}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'})).toHaveLength(0);
+    });
+
+    it('shows add participant controls when canAddParticipants is true', () => {
+        const component = renderer.create(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={true}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'}).length).toBeGreaterThan(0);
+    });
+});

--- a/webapp/src/components/rhs/rhs_participants.tsx
+++ b/webapp/src/components/rhs/rhs_participants.tsx
@@ -18,11 +18,13 @@ interface Props {
     userIds: string[];
     onParticipate?: () => void;
     setShowParticipants: React.Dispatch<React.SetStateAction<boolean>>
+    canAddParticipants?: boolean;
 }
 
 const RHSParticipants = (props: Props) => {
     const {formatMessage} = useIntl();
     const openMembersModal = useOpenMembersModalIfPresent();
+    const canAddParticipants = props.canAddParticipants ?? true;
 
     const showParticipants = () => {
         props.setShowParticipants(true);
@@ -44,6 +46,29 @@ const RHSParticipants = (props: Props) => {
         </Tooltip>
     );
 
+    const addParticipantControl = (() => {
+        if (props.onParticipate) {
+            return becomeParticipant;
+        }
+        if (!canAddParticipants) {
+            return null;
+        }
+        return (
+            <Tooltip
+                id={'rhs-add-participant'}
+                content={formatMessage({defaultMessage: 'Add participant'})}
+            >
+                <AddParticipantIconButton
+                    onClick={showParticipants}
+                    data-testid={'rhs-add-participant-icon'}
+                    $format={'icon'}
+                >
+                    <AccountMultiplePlusOutlineIcon size={20}/>
+                </AddParticipantIconButton>
+            </Tooltip>
+        );
+    })();
+
     if (props.userIds.length === 0) {
         return (
             <Container>
@@ -51,7 +76,7 @@ const RHSParticipants = (props: Props) => {
                     <FormattedMessage defaultMessage='Nobody yet.'/>
                     {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
                     {' '}
-                    {props.onParticipate ? null : (
+                    {canAddParticipants && !props.onParticipate ? (
                         <LinkAddParticipants
                             to={'#'}
                             onClick={showParticipants}
@@ -59,7 +84,7 @@ const RHSParticipants = (props: Props) => {
                             {formatMessage({defaultMessage: 'Add participant'})}
                             <OpenInNewIcon size={11}/>
                         </LinkAddParticipants>
-                    )}
+                    ) : null}
                 </NoParticipants>
                 {props.onParticipate ? becomeParticipant : null}
             </Container>
@@ -86,20 +111,7 @@ const RHSParticipants = (props: Props) => {
                     sizeInPx={height}
                 />
             </UserRow>
-            {props.onParticipate ? becomeParticipant : (
-                <Tooltip
-                    id={'rhs-add-participant'}
-                    content={formatMessage({defaultMessage: 'Add participant'})}
-                >
-                    <AddParticipantIconButton
-                        onClick={showParticipants}
-                        data-testid={'rhs-add-participant-icon'}
-                        $format={'icon'}
-                    >
-                        <AccountMultiplePlusOutlineIcon size={20}/>
-                    </AddParticipantIconButton>
-                </Tooltip>
-            )}
+            {addParticipantControl}
         </Container>
     );
 };

--- a/webapp/src/components/rhs/rhs_property.test.tsx
+++ b/webapp/src/components/rhs/rhs_property.test.tsx
@@ -29,7 +29,12 @@ jest.mock('react-intl', () => {
 
 jest.mock('./properties/property_text', () => ({
     __esModule: true,
-    default: () => <div data-testid='mock-text-property'/>,
+    default: (props: {readOnly?: boolean}) => (
+        <div
+            data-testid='mock-text-property'
+            data-readonly={props.readOnly}
+        />
+    ),
 }));
 
 jest.mock('./properties/property_select', () => ({
@@ -145,5 +150,17 @@ describe('RHSProperty', () => {
                 'mock-user-property', 'mock-multiuser-property', 'mock-date-property'].includes(n.props['data-testid']),
         );
         expect(valueComponents.length).toBe(0);
+    });
+
+    it('passes readOnly to property components', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('text')}
+                runID='run-1'
+                readOnly={true}
+            />,
+        );
+        const instance = component.root;
+        expect(instance.findByProps({'data-testid': 'mock-text-property'}).props['data-readonly']).toBe(true);
     });
 });

--- a/webapp/src/components/rhs/rhs_property.tsx
+++ b/webapp/src/components/rhs/rhs_property.tsx
@@ -21,6 +21,7 @@ interface Props {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
 }
 
 const RHSProperty = (props: Props) => {
@@ -48,6 +49,7 @@ const RHSProperty = (props: Props) => {
             field: props.field,
             value: props.value,
             runID: props.runID,
+            readOnly: props.readOnly,
         };
 
         switch (props.field.type) {

--- a/webapp/src/types/properties.ts
+++ b/webapp/src/types/properties.ts
@@ -58,4 +58,5 @@ export interface PropertyComponentProps {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
 }


### PR DESCRIPTION
## Summary
Backport of #2344. On a finished playbook run, users could still edit attribute values and try to add participants, even though the server already blocks both actions — it looked like it worked, but nothing actually happened. This closes that gap by making attributes and the "add participant" option non-editable once a run is finished, so people aren't misled into thinking their change succeeded.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69462
(related: MM-68844, the server-side fix that already blocks this)

## Checklist
- [ ] Gated by experimental feature flag
- [x] Unit tests updated