### PR TITLE
Cherry pick #2344 to release-2.4

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
@@ -23,7 +23,7 @@ import {useManageRunMembership} from 'src/graphql/hooks';
 
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
 
 import {SendMessageButton} from './send_message_button';
 import AddParticipantsModal from './add_participant_modal';
@@ -72,6 +72,8 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
         return true;
     };
 
+    const isFinished = playbookRun.current_status === PlaybookRunStatus.Finished;
+
     const manageParticipantsSection = () => {
         if (manageMode) {
             return (
@@ -116,7 +118,7 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
                     )}
                 </ParticipantsNumber>
 
-                {role === Role.Participant && manageParticipantsSection()}
+                {role === Role.Participant && !isFinished && manageParticipantsSection()}
 
             </HeaderSection>
 

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -142,8 +142,9 @@ const RHSAbout = (props: Props) => {
                                 <MemberSectionTitle>{formatMessage({defaultMessage: 'Participants'})}</MemberSectionTitle>
                                 <RHSParticipants
                                     userIds={props.playbookRun.participant_ids.filter((id) => id !== props.playbookRun.owner_user_id)}
-                                    onParticipate={shouldShowParticipate ? showParticipateConfirm : undefined}
+                                    onParticipate={!isFinished && shouldShowParticipate ? showParticipateConfirm : undefined}
                                     setShowParticipants={props.setShowParticipants}
+                                    canAddParticipants={!isFinished}
                                 />
                             </ParticipantsSection>
                         </Row>

--- a/webapp/src/components/rhs/rhs_participants.test.tsx
+++ b/webapp/src/components/rhs/rhs_participants.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {MemoryRouter} from 'react-router-dom';
+
+import RHSParticipants from './rhs_participants';
+
+// The formatjs babel plugin precompiles `defaultMessage` into an AST
+// (array of {type, value} nodes) rather than a plain string. Flatten it
+// back into a string so these mocks can be used directly as React children.
+function mockFlattenDefaultMessage(descriptor: {defaultMessage: unknown}): string {
+    const raw = descriptor.defaultMessage;
+    if (typeof raw === 'string') {
+        return raw;
+    }
+    if (Array.isArray(raw)) {
+        return raw.map((part: unknown) => (typeof part === 'string' ? part : (part as {value?: string}).value ?? '')).join('');
+    }
+    return String(raw);
+}
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    return {
+        ...reactIntl,
+        useIntl: () => ({formatMessage: mockFlattenDefaultMessage}),
+        FormattedMessage: (props: {defaultMessage: unknown}) => mockFlattenDefaultMessage(props as {defaultMessage: unknown}),
+    };
+});
+
+jest.mock('react-redux', () => ({
+    useDispatch: () => jest.fn(),
+    useSelector: () => null,
+}));
+
+jest.mock('src/components/rhs/rhs_participant', () => ({
+    RHSParticipant: () => null,
+    Rest: () => null,
+}));
+
+const renderWithRouter = (element: React.ReactElement) => renderer.create(
+    <MemoryRouter>
+        {element}
+    </MemoryRouter>,
+);
+
+describe('RHSParticipants', () => {
+    it('hides add participant icon control when canAddParticipants is false', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={false}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'})).toHaveLength(0);
+    });
+
+    it('shows add participant icon control when canAddParticipants is true', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={true}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'}).length).toBeGreaterThan(0);
+    });
+
+    it('defaults to showing add participant icon control when canAddParticipants is not provided', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'}).length).toBeGreaterThan(0);
+    });
+
+    it('hides add participant link (empty state) when canAddParticipants is false', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={[]}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={false}
+            />,
+        );
+        expect(component.root.findAllByType('a')).toHaveLength(0);
+    });
+
+    it('shows add participant link (empty state) when canAddParticipants is true', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={[]}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={true}
+            />,
+        );
+        expect(component.root.findAllByType('a').length).toBeGreaterThan(0);
+    });
+
+    it('hides the become-a-participant control when onParticipate is not provided, even if canAddParticipants is true', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={true}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-participate-icon'})).toHaveLength(0);
+    });
+
+    it('shows the become-a-participant control when onParticipate is provided, regardless of canAddParticipants', () => {
+        const component = renderWithRouter(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                onParticipate={jest.fn()}
+                canAddParticipants={false}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-participate-icon'}).length).toBeGreaterThan(0);
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'})).toHaveLength(0);
+    });
+});

--- a/webapp/src/components/rhs/rhs_participants.tsx
+++ b/webapp/src/components/rhs/rhs_participants.tsx
@@ -16,11 +16,13 @@ interface Props {
     userIds: string[];
     onParticipate?: () => void;
     setShowParticipants: React.Dispatch<React.SetStateAction<boolean>>
+    canAddParticipants?: boolean;
 }
 
 const RHSParticipants = (props: Props) => {
     const {formatMessage} = useIntl();
     const openMembersModal = useOpenMembersModalIfPresent();
+    const canAddParticipants = props.canAddParticipants ?? true;
 
     const showParticipants = () => {
         props.setShowParticipants(true);
@@ -42,6 +44,29 @@ const RHSParticipants = (props: Props) => {
         </Tooltip>
     );
 
+    const addParticipantControl = (() => {
+        if (props.onParticipate) {
+            return becomeParticipant;
+        }
+        if (!canAddParticipants) {
+            return null;
+        }
+        return (
+            <Tooltip
+                id={'rhs-add-participant'}
+                content={formatMessage({defaultMessage: 'Add participant'})}
+            >
+                <AddParticipantIconButton
+                    onClick={showParticipants}
+                    data-testid={'rhs-add-participant-icon'}
+                    $format={'icon'}
+                >
+                    <AccountMultiplePlusOutlineIcon size={20}/>
+                </AddParticipantIconButton>
+            </Tooltip>
+        );
+    })();
+
     if (props.userIds.length === 0) {
         return (
             <Container>
@@ -49,7 +74,7 @@ const RHSParticipants = (props: Props) => {
                     <FormattedMessage defaultMessage='Nobody yet.'/>
                     {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
                     {' '}
-                    {props.onParticipate ? null : (
+                    {canAddParticipants && !props.onParticipate ? (
                         <LinkAddParticipants
                             to={'#'}
                             onClick={showParticipants}
@@ -57,7 +82,7 @@ const RHSParticipants = (props: Props) => {
                             {formatMessage({defaultMessage: 'Add participant'})}
                             <OpenInNewIcon size={11}/>
                         </LinkAddParticipants>
-                    )}
+                    ) : null}
                 </NoParticipants>
                 {props.onParticipate ? becomeParticipant : null}
             </Container>
@@ -84,20 +109,7 @@ const RHSParticipants = (props: Props) => {
                     sizeInPx={height}
                 />
             </UserRow>
-            {props.onParticipate ? becomeParticipant : (
-                <Tooltip
-                    id={'rhs-add-participant'}
-                    content={formatMessage({defaultMessage: 'Add participant'})}
-                >
-                    <AddParticipantIconButton
-                        onClick={showParticipants}
-                        data-testid={'rhs-add-participant-icon'}
-                        $format={'icon'}
-                    >
-                        <AccountMultiplePlusOutlineIcon size={20}/>
-                    </AddParticipantIconButton>
-                </Tooltip>
-            )}
+            {addParticipantControl}
         </Container>
     );
 };


### PR DESCRIPTION
## Summary
Backport of #2344. On a finished playbook run, users could still try to add participants even though the server already blocks that action — it looked like it worked, but nothing actually happened. This closes that gap by hiding the "add participant" option once a run is finished, so people aren't misled into thinking it succeeded.

Only part of the original fix applies here, since this branch doesn't have the run-attributes feature that the other part of #2344 covered.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69462
(related: MM-68844, the server-side fix that already blocks this)

## Checklist
- [ ] Gated by experimental feature flag
- [x] Unit tests updated