### PR TITLE
Cherry pick #2344 to release-2.9

### DIFF
--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_properties.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_info_properties.tsx
@@ -37,6 +37,7 @@ const RHSInfoProperties = (props: Props) => {
                 propertyFields={props.run.property_fields}
                 propertyValues={props.run.property_values}
                 runID={props.run.id}
+                readOnly={!props.editable}
             />
         </Section>
     );

--- a/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
+++ b/webapp/src/components/backstage/playbook_runs/playbook_run/rhs_participants.tsx
@@ -25,7 +25,7 @@ import {useManageRunMembership} from 'src/graphql/hooks';
 
 import {Role} from 'src/components/backstage/playbook_runs/shared';
 
-import {PlaybookRun} from 'src/types/playbook_run';
+import {PlaybookRun, PlaybookRunStatus} from 'src/types/playbook_run';
 
 import {SendMessageButton} from './send_message_button';
 import AddParticipantsModal from './add_participant_modal';
@@ -74,6 +74,8 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
         return true;
     };
 
+    const isFinished = playbookRun.current_status === PlaybookRunStatus.Finished;
+
     const manageParticipantsSection = () => {
         if (manageMode) {
             return (
@@ -118,7 +120,7 @@ export const Participants = ({playbookRun, role, teamName}: Props) => {
                     )}
                 </ParticipantsNumber>
 
-                {role === Role.Participant && manageParticipantsSection()}
+                {role === Role.Participant && !isFinished && manageParticipantsSection()}
 
             </HeaderSection>
 

--- a/webapp/src/components/rhs/properties/property_multiselect.test.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import MultiselectProperty from './property_multiselect';
+
+jest.mock('./property_select_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Tags',
+    type: 'multiselect',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const emptyValue: PropertyValue = {field_id: 'field-1', value: []} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('MultiselectProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_multiselect.test.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.test.tsx
@@ -26,7 +26,11 @@ const field: PropertyField = {
     target_id: '',
     target_type: 'run',
     object_type: 'run',
-    attrs: {visibility: 'always', sort_order: 0, options: null},
+    attrs: {
+        visibility: 'always',
+        sort_order: 0,
+        options: [{id: 'opt-1', name: 'Option 1'}],
+    },
     create_at: 0,
     update_at: 0,
     delete_at: 0,
@@ -35,6 +39,7 @@ const field: PropertyField = {
 } as unknown as PropertyField;
 
 const emptyValue: PropertyValue = {field_id: 'field-1', value: []} as unknown as PropertyValue;
+const populatedValue: PropertyValue = {field_id: 'field-1', value: ['opt-1']} as unknown as PropertyValue;
 
 const isEditing = (root: ReturnType<typeof create>['root']) =>
     root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
@@ -72,5 +77,34 @@ describe('MultiselectProperty readOnly guards', () => {
         );
         triggerClick(component.root);
         expect(isEditing(component.root)).toBe(true);
+    });
+
+    it('renders chips with an undefined onClick when readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={populatedValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        const chips = component.root.findAllByProps({label: 'Option 1'});
+        expect(chips.length).toBeGreaterThan(0);
+        chips.forEach((chip) => expect(chip.props.onClick).toBeUndefined());
+    });
+
+    it('renders chips with a defined onClick when not readOnly', () => {
+        const component = create(
+            <MultiselectProperty
+                field={field}
+                value={populatedValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        const chips = component.root.findAllByProps({label: 'Option 1'});
+        expect(chips.length).toBeGreaterThan(0);
+        chips.forEach((chip) => expect(chip.props.onClick).toBeDefined());
     });
 });

--- a/webapp/src/components/rhs/properties/property_multiselect.tsx
+++ b/webapp/src/components/rhs/properties/property_multiselect.tsx
@@ -11,11 +11,13 @@ import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
 interface Props {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
     onValueChange: (value: string[] | null) => void;
 }
 
@@ -36,6 +38,9 @@ const MultiselectProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
         setTempValue(displayValue ?? null);
     };
@@ -72,6 +77,7 @@ const MultiselectProperty = (props: Props) => {
         return (
             <EmptyMultiselectDisplay
                 onClick={handleStartEdit}
+                $readOnly={props.readOnly}
                 data-testid='property-value'
             >
                 <EmptyState/>
@@ -89,7 +95,7 @@ const MultiselectProperty = (props: Props) => {
                 <PropertyChip
                     key={index}
                     label={label!}
-                    onClick={handleStartEdit}
+                    onClick={props.readOnly ? undefined : handleStartEdit}
                 />
             ))}
         </ChipsContainer>
@@ -102,18 +108,12 @@ const ChipsContainer = styled.div`
     gap: 4px;
 `;
 
-const EmptyMultiselectDisplay = styled.div`
+const EmptyMultiselectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 export default MultiselectProperty;

--- a/webapp/src/components/rhs/properties/property_select.test.tsx
+++ b/webapp/src/components/rhs/properties/property_select.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import SelectProperty from './property_select';
+
+jest.mock('./property_select_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Priority',
+    type: 'select',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const emptyValue: PropertyValue = {field_id: 'field-1', value: ''} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('SelectProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={emptyValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_select.test.tsx
+++ b/webapp/src/components/rhs/properties/property_select.test.tsx
@@ -26,7 +26,11 @@ const field: PropertyField = {
     target_id: '',
     target_type: 'run',
     object_type: 'run',
-    attrs: {visibility: 'always', sort_order: 0, options: null},
+    attrs: {
+        visibility: 'always',
+        sort_order: 0,
+        options: [{id: 'opt-1', name: 'High'}],
+    },
     create_at: 0,
     update_at: 0,
     delete_at: 0,
@@ -35,6 +39,7 @@ const field: PropertyField = {
 } as unknown as PropertyField;
 
 const emptyValue: PropertyValue = {field_id: 'field-1', value: ''} as unknown as PropertyValue;
+const populatedValue: PropertyValue = {field_id: 'field-1', value: 'opt-1'} as unknown as PropertyValue;
 
 const isEditing = (root: ReturnType<typeof create>['root']) =>
     root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
@@ -72,5 +77,32 @@ describe('SelectProperty readOnly guards', () => {
         );
         triggerClick(component.root);
         expect(isEditing(component.root)).toBe(true);
+    });
+
+    it('renders the selected chip with an undefined onClick when readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={populatedValue}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        const chip = component.root.findByProps({label: 'High'});
+        expect(chip.props.onClick).toBeUndefined();
+    });
+
+    it('renders the selected chip with a defined onClick when not readOnly', () => {
+        const component = create(
+            <SelectProperty
+                field={field}
+                value={populatedValue}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        const chip = component.root.findByProps({label: 'High'});
+        expect(chip.props.onClick).toBeDefined();
     });
 });

--- a/webapp/src/components/rhs/properties/property_select.tsx
+++ b/webapp/src/components/rhs/properties/property_select.tsx
@@ -11,11 +11,13 @@ import PropertySelectInput from './property_select_input';
 
 import PropertyChip from './property_chip';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
 interface Props {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
     onValueChange: (value: string | null) => void;
 }
 
@@ -36,6 +38,9 @@ const SelectProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
     };
 
@@ -73,6 +78,7 @@ const SelectProperty = (props: Props) => {
         return (
             <EmptySelectDisplay
                 onClick={handleStartEdit}
+                $readOnly={props.readOnly}
                 data-testid='property-value'
             >
                 <EmptyState/>
@@ -83,24 +89,18 @@ const SelectProperty = (props: Props) => {
     return (
         <PropertyChip
             label={displayLabel}
-            onClick={handleStartEdit}
+            onClick={props.readOnly ? undefined : handleStartEdit}
             data-testid='property-value'
         />
     );
 };
 
-const EmptySelectDisplay = styled.div`
+const EmptySelectDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 export default SelectProperty;

--- a/webapp/src/components/rhs/properties/property_styles.ts
+++ b/webapp/src/components/rhs/properties/property_styles.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {css} from 'styled-components';
+
+// Shared cursor/hover affordance for editable property displays. When $readOnly
+// is set the pointer cursor and hover highlight are suppressed.
+export const readOnlyInteractiveStyles = css<{$readOnly?: boolean}>`
+    cursor: ${({$readOnly}) => ($readOnly ? 'default' : 'pointer')};
+
+    &:hover {
+        ${({$readOnly}) => !$readOnly && `
+            background-color: rgba(var(--center-channel-color-rgb), 0.04);
+            border-radius: 4px;
+            margin: 0 -4px;
+            padding: 4px;
+        `}
+    }
+`;

--- a/webapp/src/components/rhs/properties/property_text.test.tsx
+++ b/webapp/src/components/rhs/properties/property_text.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+
+import {PropertyField, PropertyValue} from 'src/types/properties';
+
+import TextProperty from './property_text';
+
+jest.mock('./property_text_input', () => ({
+    __esModule: true,
+    default: () => <div data-testid='edit-mode'/>,
+}));
+
+jest.mock('./empty_state', () => ({
+    __esModule: true,
+    default: () => <div data-testid='empty'/>,
+}));
+
+const field: PropertyField = {
+    id: 'field-1',
+    group_id: '',
+    name: 'Summary',
+    type: 'text',
+    target_id: '',
+    target_type: 'run',
+    object_type: 'run',
+    attrs: {visibility: 'always', sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+} as unknown as PropertyField;
+
+const value: PropertyValue = {field_id: 'field-1', value: 'hello'} as unknown as PropertyValue;
+
+const isEditing = (root: ReturnType<typeof create>['root']) =>
+    root.findAllByProps({'data-testid': 'edit-mode'}).length > 0;
+
+const triggerClick = (root: ReturnType<typeof create>['root']) => {
+    const display = root.findByProps({'data-testid': 'property-value'});
+    act(() => {
+        display.props.onClick?.();
+    });
+};
+
+describe('TextProperty readOnly guards', () => {
+    it('does not enter edit mode on click when readOnly', () => {
+        const component = create(
+            <TextProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                readOnly={true}
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(false);
+    });
+
+    it('enters edit mode on click when not readOnly', () => {
+        const component = create(
+            <TextProperty
+                field={field}
+                value={value}
+                runID='run-1'
+                onValueChange={jest.fn()}
+            />,
+        );
+        triggerClick(component.root);
+        expect(isEditing(component.root)).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/properties/property_text.tsx
+++ b/webapp/src/components/rhs/properties/property_text.tsx
@@ -9,11 +9,13 @@ import {PropertyField, PropertyValue} from 'src/types/properties';
 
 import PropertyTextInput from './property_text_input';
 import EmptyState from './empty_state';
+import {readOnlyInteractiveStyles} from './property_styles';
 
 interface Props {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
     onValueChange: (value: string | null) => void;
 }
 
@@ -34,6 +36,9 @@ const TextProperty = (props: Props) => {
     };
 
     const handleStartEdit = () => {
+        if (props.readOnly) {
+            return;
+        }
         setIsEditing(true);
     };
 
@@ -73,6 +78,7 @@ const TextProperty = (props: Props) => {
     return (
         <TextDisplay
             onClick={handleStartEdit}
+            $readOnly={props.readOnly}
             data-testid='property-value'
         >
             {content}
@@ -80,21 +86,15 @@ const TextProperty = (props: Props) => {
     );
 };
 
-const TextDisplay = styled.div`
+const TextDisplay = styled.div<{$readOnly?: boolean}>`
     flex: 1;
     color: var(--center-channel-color);
     font-size: 14px;
     line-height: 20px;
-    cursor: pointer;
     padding: 4px 0;
     min-height: 20px;
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.04);
-        border-radius: 4px;
-        margin: 0 -4px;
-        padding: 4px;
-    }
+    ${readOnlyInteractiveStyles}
 `;
 
 const URLLink = styled.a`

--- a/webapp/src/components/rhs/properties_list.tsx
+++ b/webapp/src/components/rhs/properties_list.tsx
@@ -13,6 +13,7 @@ interface Props {
     propertyValues?: PropertyValue[];
     runID: string;
     className?: string;
+    readOnly?: boolean;
 }
 
 const PropertiesList = (props: Props) => {
@@ -47,6 +48,7 @@ const PropertiesList = (props: Props) => {
                     field={field}
                     value={value}
                     runID={props.runID}
+                    readOnly={props.readOnly}
                 />
             ))}
         </div>

--- a/webapp/src/components/rhs/rhs_about.tsx
+++ b/webapp/src/components/rhs/rhs_about.tsx
@@ -151,8 +151,9 @@ const RHSAbout = (props: Props) => {
                                 <MemberSectionTitle>{formatMessage({defaultMessage: 'Participants'})}</MemberSectionTitle>
                                 <RHSParticipants
                                     userIds={props.playbookRun.participant_ids.filter((id) => id !== props.playbookRun.owner_user_id)}
-                                    onParticipate={shouldShowParticipate ? showParticipateConfirm : undefined}
+                                    onParticipate={!isFinished && shouldShowParticipate ? showParticipateConfirm : undefined}
                                     setShowParticipants={props.setShowParticipants}
+                                    canAddParticipants={!isFinished}
                                 />
                             </ParticipantsSection>
                         </Row>
@@ -160,6 +161,7 @@ const RHSAbout = (props: Props) => {
                             propertyFields={props.playbookRun.property_fields}
                             propertyValues={props.playbookRun.property_values}
                             runID={props.playbookRun.id}
+                            readOnly={isFinished || props.readOnly}
                         />
                     </>
                 }

--- a/webapp/src/components/rhs/rhs_participants.test.tsx
+++ b/webapp/src/components/rhs/rhs_participants.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import RHSParticipants from './rhs_participants';
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('src/hooks/redux', () => ({
+    useAppDispatch: () => jest.fn(),
+    useAppSelector: () => null,
+}));
+
+jest.mock('src/components/rhs/rhs_participant', () => ({
+    RHSParticipant: () => null,
+    Rest: () => null,
+}));
+
+describe('RHSParticipants', () => {
+    it('hides add participant controls when canAddParticipants is false', () => {
+        const component = renderer.create(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={false}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'})).toHaveLength(0);
+    });
+
+    it('shows add participant controls when canAddParticipants is true', () => {
+        const component = renderer.create(
+            <RHSParticipants
+                userIds={['user-1']}
+                setShowParticipants={jest.fn()}
+                canAddParticipants={true}
+            />,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'}).length).toBeGreaterThan(0);
+    });
+});

--- a/webapp/src/components/rhs/rhs_participants.test.tsx
+++ b/webapp/src/components/rhs/rhs_participants.test.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import {MemoryRouter} from 'react-router-dom';
 
 import RHSParticipants from './rhs_participants';
 
@@ -14,7 +15,10 @@ jest.mock('react-intl', () => {
     return {
         ...reactIntl,
         useIntl: () => intl,
-        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+
+        // The formatjs babel plugin pre-compiles defaultMessage into an ICU AST, so
+        // defer to the real formatMessage implementation to resolve it to text.
+        FormattedMessage: (descriptor: {defaultMessage: string}) => <span>{intl.formatMessage(descriptor)}</span>,
     };
 });
 
@@ -49,5 +53,36 @@ describe('RHSParticipants', () => {
             />,
         );
         expect(component.root.findAllByProps({'data-testid': 'rhs-add-participant-icon'}).length).toBeGreaterThan(0);
+    });
+
+    it('hides the "Add participant" link and "Become a participant" icon on a finished run with no participants', () => {
+        // Mirrors how rhs_about.tsx wires RHSParticipants for a finished run:
+        // onParticipate is undefined and canAddParticipants is false.
+        const component = renderer.create(
+            <MemoryRouter>
+                <RHSParticipants
+                    userIds={[]}
+                    setShowParticipants={jest.fn()}
+                    canAddParticipants={false}
+                />
+            </MemoryRouter>,
+        );
+        expect(component.root.findAllByProps({'data-testid': 'rhs-participate-icon'})).toHaveLength(0);
+        const links = component.root.findAll((node) => node.type === 'a' && node.props.children?.[0] === 'Add participant');
+        expect(links).toHaveLength(0);
+    });
+
+    it('shows the "Add participant" link when canAddParticipants is true and there are no participants', () => {
+        const component = renderer.create(
+            <MemoryRouter>
+                <RHSParticipants
+                    userIds={[]}
+                    setShowParticipants={jest.fn()}
+                    canAddParticipants={true}
+                />
+            </MemoryRouter>,
+        );
+        const links = component.root.findAll((node) => node.type === 'a' && node.props.children?.[0] === 'Add participant');
+        expect(links.length).toBeGreaterThan(0);
     });
 });

--- a/webapp/src/components/rhs/rhs_participants.tsx
+++ b/webapp/src/components/rhs/rhs_participants.tsx
@@ -18,11 +18,13 @@ interface Props {
     userIds: string[];
     onParticipate?: () => void;
     setShowParticipants: React.Dispatch<React.SetStateAction<boolean>>
+    canAddParticipants?: boolean;
 }
 
 const RHSParticipants = (props: Props) => {
     const {formatMessage} = useIntl();
     const openMembersModal = useOpenMembersModalIfPresent();
+    const canAddParticipants = props.canAddParticipants ?? true;
 
     const showParticipants = () => {
         props.setShowParticipants(true);
@@ -44,6 +46,29 @@ const RHSParticipants = (props: Props) => {
         </Tooltip>
     );
 
+    const addParticipantControl = (() => {
+        if (props.onParticipate) {
+            return becomeParticipant;
+        }
+        if (!canAddParticipants) {
+            return null;
+        }
+        return (
+            <Tooltip
+                id={'rhs-add-participant'}
+                content={formatMessage({defaultMessage: 'Add participant'})}
+            >
+                <AddParticipantIconButton
+                    onClick={showParticipants}
+                    data-testid={'rhs-add-participant-icon'}
+                    $format={'icon'}
+                >
+                    <AccountMultiplePlusOutlineIcon size={20}/>
+                </AddParticipantIconButton>
+            </Tooltip>
+        );
+    })();
+
     if (props.userIds.length === 0) {
         return (
             <Container>
@@ -51,7 +76,7 @@ const RHSParticipants = (props: Props) => {
                     <FormattedMessage defaultMessage='Nobody yet.'/>
                     {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
                     {' '}
-                    {props.onParticipate ? null : (
+                    {canAddParticipants && !props.onParticipate ? (
                         <LinkAddParticipants
                             to={'#'}
                             onClick={showParticipants}
@@ -59,7 +84,7 @@ const RHSParticipants = (props: Props) => {
                             {formatMessage({defaultMessage: 'Add participant'})}
                             <OpenInNewIcon size={11}/>
                         </LinkAddParticipants>
-                    )}
+                    ) : null}
                 </NoParticipants>
                 {props.onParticipate ? becomeParticipant : null}
             </Container>
@@ -86,20 +111,7 @@ const RHSParticipants = (props: Props) => {
                     sizeInPx={height}
                 />
             </UserRow>
-            {props.onParticipate ? becomeParticipant : (
-                <Tooltip
-                    id={'rhs-add-participant'}
-                    content={formatMessage({defaultMessage: 'Add participant'})}
-                >
-                    <AddParticipantIconButton
-                        onClick={showParticipants}
-                        data-testid={'rhs-add-participant-icon'}
-                        $format={'icon'}
-                    >
-                        <AccountMultiplePlusOutlineIcon size={20}/>
-                    </AddParticipantIconButton>
-                </Tooltip>
-            )}
+            {addParticipantControl}
         </Container>
     );
 };

--- a/webapp/src/components/rhs/rhs_property.test.tsx
+++ b/webapp/src/components/rhs/rhs_property.test.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import {PropertyField} from 'src/types/properties';
+
+import RHSProperty from './rhs_property';
+
+jest.mock('src/graphql/hooks', () => ({
+    useSetRunPropertyValue: jest.fn(() => [jest.fn().mockResolvedValue({errors: []})]),
+}));
+
+jest.mock('src/components/backstage/toast_banner', () => ({
+    useToaster: jest.fn(() => ({add: jest.fn()})),
+}));
+
+jest.mock('react-intl', () => {
+    const reactIntl = jest.requireActual('react-intl');
+    const intl = reactIntl.createIntl({locale: 'en'});
+    return {
+        ...reactIntl,
+        useIntl: () => intl,
+    };
+});
+
+jest.mock('./properties/property_text', () => ({
+    __esModule: true,
+    default: (props: {readOnly?: boolean}) => (
+        <div
+            data-testid='mock-text-property'
+            data-readonly={props.readOnly}
+        />
+    ),
+}));
+
+jest.mock('./properties/property_select', () => ({
+    __esModule: true,
+    default: () => <div data-testid='mock-select-property'/>,
+}));
+
+jest.mock('./properties/property_multiselect', () => ({
+    __esModule: true,
+    default: () => <div data-testid='mock-multiselect-property'/>,
+}));
+
+const makeField = (type: string) => ({
+    id: 'field-1',
+    group_id: '',
+    name: 'TestField',
+    type: type as PropertyField['type'],
+    target_id: '',
+    target_type: 'run' as const,
+    object_type: 'run',
+    attrs: {visibility: 'always' as const, sort_order: 0, options: null},
+    create_at: 0,
+    update_at: 0,
+    delete_at: 0,
+    created_by: '',
+    updated_by: '',
+});
+
+describe('RHSProperty', () => {
+    it('renders TextProperty for type=text', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('text')}
+                runID='run-1'
+            />,
+        );
+        const instance = component.root;
+        expect(instance.findByProps({'data-testid': 'mock-text-property'})).toBeTruthy();
+    });
+
+    it('renders SelectProperty for type=select', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('select')}
+                runID='run-1'
+            />,
+        );
+        const instance = component.root;
+        expect(instance.findByProps({'data-testid': 'mock-select-property'})).toBeTruthy();
+    });
+
+    it('renders MultiselectProperty for type=multiselect', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('multiselect')}
+                runID='run-1'
+            />,
+        );
+        const instance = component.root;
+        expect(instance.findByProps({'data-testid': 'mock-multiselect-property'})).toBeTruthy();
+    });
+
+    it('renders only the label row for an unknown type', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('unknown')}
+                runID='run-1'
+            />,
+        );
+        const instance = component.root;
+        const valueComponents = instance.findAll((n) =>
+            ['mock-text-property', 'mock-select-property', 'mock-multiselect-property'].includes(n.props['data-testid']),
+        );
+        expect(valueComponents.length).toBe(0);
+    });
+
+    it('passes readOnly to property components', () => {
+        const component = renderer.create(
+            <RHSProperty
+                field={makeField('text')}
+                runID='run-1'
+                readOnly={true}
+            />,
+        );
+        const instance = component.root;
+        expect(instance.findByProps({'data-testid': 'mock-text-property'}).props['data-readonly']).toBe(true);
+    });
+});

--- a/webapp/src/components/rhs/rhs_property.tsx
+++ b/webapp/src/components/rhs/rhs_property.tsx
@@ -16,6 +16,7 @@ interface Props {
     field: PropertyField;
     value?: PropertyValue;
     runID: string;
+    readOnly?: boolean;
 }
 
 const RHSProperty = (props: Props) => {
@@ -30,6 +31,7 @@ const RHSProperty = (props: Props) => {
             field: props.field,
             value: props.value,
             runID: props.runID,
+            readOnly: props.readOnly,
         };
 
         switch (props.field.type) {


### PR DESCRIPTION
## Summary
Backport of #2344. On a finished playbook run, users could still edit attribute values and try to add participants, even though the server already blocks both actions — it looked like it worked, but nothing actually happened. This closes that gap by making attributes and the "add participant" option non-editable once a run is finished, so people aren't misled into thinking their change succeeded.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-69462
(related: MM-68844, the server-side fix that already blocks this)

## Checklist
- [ ] Gated by experimental feature flag
- [x] Unit tests updated