### PR TITLE
Cherry pick FIPS autobuild to release-2.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,40 +128,42 @@ jobs:
         run: make dist
 
   dist-fips:
-    # Skip FIPS testing for forks, which won't have docker login credentials.
+    # Skip FIPS testing for forks, which won't have the chainguard identity.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs:
       - go
       - lint
-    container:
-      image: mattermostdevelopment/mattermost-build-server-fips:${{ needs.go.outputs.version }}
-      credentials:
-        username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
-    env:
-      FIPS_ENABLED: true
+    permissions:
+      contents: read
+      id-token: write # required for chainctl OIDC inside build-fips
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
-      - name: ci/configure-git-safe-directory
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: ci/setup-go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: ${{ needs.go.outputs.version }}
+      - name: ci/setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
       - name: ci/get-short-sha
         id: short-sha
         run: echo "sha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-      - name: ci/build-for-upload
-        run: make dist
+      - name: ci/build-fips
+        uses: mattermost/actions/plugin-ci/build-fips@c7a06bc642f72fc227deb2cae3af03cff72c0f0d
+        with:
+          chainguard-identity: ${{ secrets.CHAINGUARD_IDENTITY }}
       - name: ci/upload-build-artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playbooks-bundle-fips-${{ steps.short-sha.outputs.sha }}
           path: |
-            dist/playbooks-*.tar.gz
+            dist-fips/playbooks-*.tar.gz
           retention-days: 7 ## No need to keep build artifacts for more than 7 days
-      - name: ci/ensure-build-on-all-platforms ## Verify builds on all platforms *after* ci/build-for-upload to keep artifact small
-        run: make dist
 
   upload:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,17 @@ default: all
 include build/setup.mk
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
+BUNDLE_DIR ?= dist
+SERVER_DIST_SRC ?= server/dist
 
 # Include custom makefile, if present
 ifneq ($(wildcard build/custom.mk),)
 	include build/custom.mk
+endif
+
+# Presence of build/fips.mk is the per-plugin FIPS opt-in marker.
+ifneq ($(wildcard build/fips.mk),)
+	include build/fips.mk
 endif
 
 ifneq ($(MM_DEBUG),)
@@ -149,11 +156,7 @@ ifneq ($(MM_DEBUG),)
 endif
 else
 	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-linux-amd64;
-ifeq ($(FIPS_ENABLED),true)
-	@echo Only building linux-amd64 for FIPS
-else
 	cd server && env GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-linux-arm64;
-endif
 endif
 endif
 
@@ -186,36 +189,36 @@ endif
 ## Generates a tar bundle of the plugin for install.
 .PHONY: bundle
 bundle:
-	rm -rf dist/
-	mkdir -p dist/$(PLUGIN_ID)
-	./build/bin/manifest dist
+	rm -rf $(BUNDLE_DIR)/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_ID)
+	./build/bin/manifest dist $(BUNDLE_DIR)
 ifneq ($(wildcard LICENSE.txt),)
-	cp -r LICENSE.txt dist/$(PLUGIN_ID)/
+	cp -r LICENSE.txt $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(wildcard NOTICE.txt),)
-	cp -r NOTICE.txt dist/$(PLUGIN_ID)/
+	cp -r NOTICE.txt $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(wildcard $(ASSETS_DIR)/.),)
-	cp -r $(ASSETS_DIR) dist/$(PLUGIN_ID)/
+	cp -r $(ASSETS_DIR) $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(HAS_PUBLIC),)
-	cp -r public dist/$(PLUGIN_ID)/public/
+	cp -r public $(BUNDLE_DIR)/$(PLUGIN_ID)/public/
 endif
 ifneq ($(HAS_SERVER),)
-	mkdir -p dist/$(PLUGIN_ID)/server
-	cp -r server/dist dist/$(PLUGIN_ID)/server/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_ID)/server/dist
+	cp -r $(SERVER_DIST_SRC)/. $(BUNDLE_DIR)/$(PLUGIN_ID)/server/dist/
 endif
 ifneq ($(HAS_WEBAPP),)
-	mkdir -p dist/$(PLUGIN_ID)/webapp
-	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_ID)/webapp
+	cp -r webapp/dist $(BUNDLE_DIR)/$(PLUGIN_ID)/webapp/
 endif
 ifeq ($(shell uname),Darwin)
-	cd dist && tar --disable-copyfile -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd $(BUNDLE_DIR) && tar --disable-copyfile -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 else
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd $(BUNDLE_DIR) && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 endif
 
-	@echo plugin built at: dist/$(BUNDLE_NAME)
+	@echo plugin built at: $(BUNDLE_DIR)/$(BUNDLE_NAME)
 
 ## Builds and bundles the plugin.
 .PHONY: dist
@@ -380,9 +383,12 @@ kill: detach
 .PHONY: clean
 clean:
 	rm -fr dist/
+	rm -fr dist-fips/
 ifneq ($(HAS_SERVER),)
 	rm -fr server/coverage.txt
 	rm -fr server/dist
+	rm -fr server/dist-fips
+	rm -fr server/dist-fips-staged
 endif
 ifneq ($(HAS_WEBAPP),)
 	rm -fr webapp/junit.xml

--- a/build/fips.mk
+++ b/build/fips.mk
@@ -1,0 +1,60 @@
+# FIPS-compliant Linux/amd64 build. Linux/amd64 is the only platform
+# mattermost-server's FIPS release path supports.
+
+FIPS_IMAGE ?= cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev@sha256:48ab99fede7fb33e132a0636072971e1ec4a69520865bfa1e4b517ee9cfdef34
+# Same filename as the non-FIPS bundle on purpose: `make upload-to-server`
+# (called from .github/actions/e2e-test) expects `dist/$(BUNDLE_NAME)`. The
+# FIPS variant lives in dist-fips/, so there's no collision. delivery-platform's
+# release pipeline renames to `<plugin>-<version>+<sha>-fips.tar.gz` itself.
+BUNDLE_NAME_FIPS ?= $(BUNDLE_NAME)
+FIPS_BIN := server/dist-fips/plugin-linux-amd64-fips
+
+# Empty by default. Inheriting the plugin's release LDFLAGS (`-ldflags="-s -w"`)
+# would strip the symbol table, and verify-fips below needs symbols intact
+# for `go tool nm` to find the OpenSSL integration.
+FIPS_GO_BUILD_LDFLAGS ?=
+
+# GO_BUILD_* are Make-substituted into the single-quoted inner script.
+# Env-var passing (`-e VAR=...`) doesn't survive a second pass of word
+# splitting on values with embedded quotes like `-gcflags "all=-N -l"`.
+.PHONY: server-fips
+server-fips:
+	mkdir -p server/dist-fips
+	docker run --rm \
+	  --entrypoint="" \
+	  -v $(PWD):/plugin \
+	  -w /plugin/server \
+	  $(FIPS_IMAGE) \
+	  /bin/sh -c 'CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+	    go build -trimpath -buildvcs=false \
+	    $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(FIPS_GO_BUILD_LDFLAGS) \
+	    -tags requirefips \
+	    -o dist-fips/plugin-linux-amd64-fips'
+
+# Mirrors mattermost-server/build/release.mk. Each check is its own recipe
+# line so a failure exits with the right status; joined with `; \`, only
+# the last command's exit propagates and a failed check would be masked.
+.PHONY: verify-fips
+verify-fips:
+	@test -f $(FIPS_BIN) || (echo "verify-fips: $(FIPS_BIN) not built" && exit 1)
+	$(GO) version -m $(FIPS_BIN) | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: missing GOEXPERIMENT=systemcrypto" && exit 1)
+	$(GO) version -m $(FIPS_BIN) | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: missing -tags=requirefips" && exit 1)
+	$(GO) tool nm $(FIPS_BIN) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: missing OpenSSL integration" && exit 1)
+	@echo "verify-fips: OK"
+
+# Depends on verify-fips so a direct `make bundle-fips` can't package an
+# unverified binary. Phony-target dedup means dist-fips / dist-all still
+# run verify-fips exactly once.
+.PHONY: bundle-fips
+bundle-fips: verify-fips
+	rm -rf server/dist-fips-staged
+	mkdir -p server/dist-fips-staged
+	cp $(FIPS_BIN) server/dist-fips-staged/plugin-linux-amd64
+	$(MAKE) bundle BUNDLE_DIR=dist-fips BUNDLE_NAME=$(BUNDLE_NAME_FIPS) SERVER_DIST_SRC=server/dist-fips-staged
+
+.PHONY: dist-fips
+dist-fips: apply server-fips verify-fips webapp bundle-fips
+
+# Flat prerequisite list so `apply` and `webapp` run once, not twice.
+.PHONY: dist-all
+dist-all: apply webapp server server-fips verify-fips bundle bundle-fips

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -86,7 +86,11 @@ func main() {
 		}
 
 	case "dist":
-		if err := distManifest(manifest); err != nil {
+		outDir := "dist"
+		if len(os.Args) > 2 {
+			outDir = os.Args[2]
+		}
+		if err := distManifest(manifest, outDir); err != nil {
 			panic("failed to write manifest to dist directory: " + err.Error())
 		}
 
@@ -206,13 +210,13 @@ func applyManifest(manifest *model.Manifest) error {
 }
 
 // distManifest writes the manifest file to the dist directory
-func distManifest(manifest *model.Manifest) error {
+func distManifest(manifest *model.Manifest, outDir string) error {
 	manifestBytes, err := json.MarshalIndent(manifest, "", "    ")
 	if err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("dist/%s/plugin.json", manifest.Id), manifestBytes, 0600); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s/plugin.json", outDir, manifest.Id), manifestBytes, 0600); err != nil {
 		return errors.Wrap(err, "failed to write plugin.json")
 	}
 


### PR DESCRIPTION
## Summary

`release-2.9` still builds its FIPS bundle the old way: a `mattermostdevelopment/mattermost-build-server-fips` Docker image gated behind dev Dockerhub credentials, with no verification that the resulting binary is actually FIPS-compliant. `master`/`release-2.10` moved to a Chainguard-based build (#2281) that's properly verified (checks for `GOEXPERIMENT=systemcrypto`, the `requirefips` tag, and OpenSSL symbols) and, crucially, is what `delivery-platform`'s tagged-release pipeline looks for (via `build/fips.mk`) to auto-produce a signed FIPS artifact for a release tag.

This cherry-picks that change to `release-2.9`, so tagged releases on this branch get the same automated, verified FIPS build as newer branches.

## Ticket Link

N/A

## Checklist
- [x] ~~Gated by experimental feature flag~~
- [x] ~~Unit tests updated~~