### PR TITLE
Add version support matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Mattermost Playbooks allows your team to create and run playbooks from within Ma
 
 ![Mattermost Playbooks](assets/incident_response.png)
 
+## Version Support
+
+| Mattermost version | Playbooks version | Supported Until |
+|---|---|---|
+| master | v2.11.1 | always |
+| v11.10 | v2.11.1 | TDB |
+| v11.9 | v2.10.0 | 2026-10-15 |
+| v11.8 | v2.9.1 | 2026-09-15 |
+| v11.7 ESR | v2.9.2 | 2027-05-15 |
+| v10.11 ESR | v2.4.7 | 2026-08-15 |
+
 ## Development Builds
 In your `mattermost-server` configuration (`config/config.json`), set the following values:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mattermost Playbooks allows your team to create and run playbooks from within Ma
 | Mattermost version | Playbooks version | Supported Until |
 |---|---|---|
 | master | v2.11.1 | always |
-| v11.10 | v2.11.1 | TDB |
+| v11.10 | v2.11.1 | TBD |
 | v11.9 | v2.10.0 | 2026-10-15 |
 | v11.8 | v2.9.1 | 2026-09-15 |
 | v11.7 ESR | v2.9.2 | 2027-05-15 |


### PR DESCRIPTION
## Summary
There was no single place documenting which Playbooks version is compatible with which Mattermost version, or how long each pairing is supported. This adds a version support matrix to the README, placed right before the "Development Builds" section, so users and contributors can quickly check compatibility and support windows.

## Ticket Link
N/A — documentation-only change, no associated ticket.

## Checklist
- ~~Gated by experimental feature flag~~
- ~~Unit tests updated~~
- ~~Planned cherry-picks: `release-X.Y`~~