### PR TITLE
[MM-70073] Widen task-assignee auto-add-participant check to any authorized actor

### DIFF
--- a/e2e-tests/cypress/tests/integration/playbooks/runs/assignee_auto_add_participant_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/runs/assignee_auto_add_participant_spec.js
@@ -77,9 +77,14 @@ describe('runs > assignee auto-add participant (MM-70073)', {testIsolation: true
             // # Visit the run details page as the non-owner participant
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
 
-            // # Assign the task to the non-participant target user via the real UI flow
-            getChecklistTasks().eq(0).findByTestId('hover-menu-edit-button').click();
-            cy.findByTestId('assignee-profile-selector').click();
+            // # Assign the task to the non-participant target user via the real UI flow.
+            // The assignee-profile-selector testid must be scoped to this checklist item:
+            // the RHS Info panel's Owner row renders an identically-testid'd selector that's
+            // on screen by default, so an unscoped findByTestId would match two elements.
+            getChecklistTasks().eq(0).within(() => {
+                cy.findByTestId('hover-menu-edit-button').click();
+                cy.findByTestId('assignee-profile-selector').click();
+            });
             cy.contains('.playbook-react-select__option', '@' + testTarget.username).click();
 
             cy.wait('@setAssignee');

--- a/e2e-tests/cypress/tests/integration/playbooks/runs/assignee_auto_add_participant_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/runs/assignee_auto_add_participant_spec.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+// Stage: @prod
+// Group: @playbooks
+
+describe('runs > assignee auto-add participant (MM-70073)', {testIsolation: true}, () => {
+    let testTeam;
+    let testOwner;
+    let testParticipant;
+    let testTarget;
+    let testPlaybook;
+
+    const getChecklistTasks = () => cy.findByTestId('run-checklist-section').findAllByTestId('checkbox-item-container');
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testOwner = user;
+
+            // # Create a non-owner run participant
+            cy.apiCreateUser().then(({user: participant}) => {
+                testParticipant = participant;
+                cy.apiAddUserToTeam(testTeam.id, testParticipant.id);
+            });
+
+            // # Create a team member who will be the assignment target — a team member, but
+            // not yet a run participant
+            cy.apiCreateUser().then(({user: target}) => {
+                testTarget = target;
+                cy.apiAddUserToTeam(testTeam.id, testTarget.id);
+            });
+
+            cy.apiLogin(testOwner);
+
+            cy.apiCreatePlaybook({
+                teamId: testTeam.id,
+                title: 'Assignee Auto-Add Playbook',
+                memberIDs: [],
+                checklists: [{
+                    title: 'Tasks',
+                    items: [{title: 'Task'}],
+                }],
+            }).then((playbook) => {
+                testPlaybook = playbook;
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Size the viewport to show the RHS without covering the checklist.
+        cy.viewport('macbook-13');
+    });
+
+    it('non-owner participant assigning a task to a non-participant adds them as a run participant', () => {
+        cy.apiLogin(testOwner);
+
+        cy.apiRunPlaybook({
+            teamId: testTeam.id,
+            playbookId: testPlaybook.id,
+            playbookRunName: 'Assignee Auto-Add Run ' + Date.now(),
+            ownerUserId: testOwner.id,
+        }).then((playbookRun) => {
+            // # Add testParticipant as a run participant (not the owner)
+            cy.apiAddUsersToRun(playbookRun.id, [testParticipant.id]);
+
+            // # Log in as the non-owner participant
+            cy.apiLogin(testParticipant);
+
+            cy.intercept('PUT', '**/api/v0/runs/*/checklists/*/item/*/assignee').as('setAssignee');
+
+            // # Visit the run details page as the non-owner participant
+            cy.visit(`/playbooks/runs/${playbookRun.id}`);
+
+            // # Assign the task to the non-participant target user via the real UI flow
+            getChecklistTasks().eq(0).findByTestId('hover-menu-edit-button').click();
+            cy.findByTestId('assignee-profile-selector').click();
+            cy.contains('.playbook-react-select__option', '@' + testTarget.username).click();
+
+            cy.wait('@setAssignee');
+
+            // * The server recorded the assignment
+            cy.apiGetPlaybookRun(playbookRun.id).then(({body}) => {
+                expect(body.checklists[0].items[0].assignee_id).to.equal(testTarget.id);
+            });
+
+            // * The target now appears in the run's Participants list — this is the behavior
+            // that was broken before MM-70073: a non-owner participant's assignment used to
+            // silently fail to add the target as a participant.
+            cy.findByTestId('runinfo-participants').click();
+            cy.findByTestId(testTarget.id).should('exist');
+        });
+    });
+});

--- a/e2e-tests/cypress/tests/integration/playbooks/runs/assignee_auto_add_participant_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/runs/assignee_auto_add_participant_spec.js
@@ -81,6 +81,7 @@ describe('runs > assignee auto-add participant (MM-70073)', {testIsolation: true
             // The assignee-profile-selector testid must be scoped to this checklist item:
             // the RHS Info panel's Owner row renders an identically-testid'd selector that's
             // on screen by default, so an unscoped findByTestId would match two elements.
+            getChecklistTasks().eq(0).trigger('mouseover');
             getChecklistTasks().eq(0).within(() => {
                 cy.findByTestId('hover-menu-edit-button').click();
                 cy.findByTestId('assignee-profile-selector').click();

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -295,7 +295,7 @@ func (r *RunRootResolver) AddRunParticipants(ctx context.Context, args struct {
 		}
 	}
 
-	if err := c.playbookRunService.AddParticipants(args.RunID, args.UserIDs, userID, args.ForceAddToChannel, true); err != nil {
+	if _, err := c.playbookRunService.AddParticipants(args.RunID, args.UserIDs, userID, args.ForceAddToChannel, true); err != nil {
 		return "", errors.Wrap(err, "failed to add participant from run")
 	}
 

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -5792,6 +5792,16 @@ func TestSetRunPropertyValue_UserField(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		// targetUser is already a participant from the non-owner assignment above, so remove
+		// them first — otherwise the re-assignment below short-circuits on the "already a
+		// participant" check and never actually exercises the owner-driven auto-add path.
+		removeResp, err := removeParticipants(e.PlaybooksClient, run.ID, []string{targetUser.Id})
+		require.NoError(t, err)
+		require.Empty(t, removeResp.Errors)
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		require.NotContains(t, run.ParticipantIDs, targetUser.Id)
+
 		_, err = e.PlaybooksClient.PlaybookRuns.SetPropertyValue(
 			context.Background(),
 			run.ID,
@@ -5817,6 +5827,7 @@ func TestSetRunPropertyValue_UserField(t *testing.T) {
 func TestAssigneeAutoAddParticipant(t *testing.T) {
 	e := Setup(t)
 	e.CreateBasic()
+	e.SetEnterpriseLicence()
 
 	botID := e.Srv.Config().PluginSettings.Plugins[manifest.Id]["BotUserID"].(string)
 
@@ -5917,23 +5928,9 @@ func TestAssigneeAutoAddParticipant(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, addResp.Errors)
 
-		// RegularUser2 (a non-owner participant) sets the task's assignee to the "creator" role
-		// via a raw request, since the Go test client has no wrapper for assignee_type.
-		actorClient := model.NewAPIv4Client(e.ServerClient.URL)
-		_, _, err = actorClient.Login(context.Background(), e.RegularUser2.Email, testUserPassword)
-		require.NoError(t, err)
-
-		body, err := json.Marshal(map[string]string{"assignee_type": app.AssigneeTypeCreator})
-		require.NoError(t, err)
-		url := e.ServerClient.URL + "/plugins/" + manifest.Id + "/api/v0/runs/" + run.ID + "/checklists/0/item/0/assignee"
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewReader(body))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set(model.HeaderAuth, actorClient.AuthType+" "+actorClient.AuthToken)
-		resp, err := actorClient.HTTPClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		// RegularUser2 (a non-owner participant) sets the task's assignee to the "creator" role.
+		err = e.PlaybooksClient2.PlaybookRuns.SetItemRoleAssignee(context.Background(), run.ID, 0, 0, app.AssigneeTypeCreator)
+		require.NoError(t, err, "non-owner participant must be allowed to set a role-based assignee")
 
 		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
 		require.NoError(t, err)
@@ -5988,5 +5985,84 @@ func TestAssigneeAutoAddParticipant(t *testing.T) {
 		err = e.PlaybooksClient.PlaybookRuns.SetItemAssignee(context.Background(), run.ID, 0, 0, e.RegularUser2.Id)
 		require.NoError(t, err)
 		assert.True(t, receivedDM(t, e.RegularUser2.Id, run.Name), "assigning a task to an existing participant must still send the DM")
+	})
+
+	// This covers SetPropertyUserAssignee directly (assignee_property_field_id on the assignee
+	// endpoint) — distinct from SetRunPropertyValue's re-resolution path already covered in
+	// TestSetRunPropertyValue_UserField.
+	t.Run("non-owner participant assigning via a user-type property field adds the resolved user as participant", func(t *testing.T) {
+		pbID, err := e.PlaybooksAdminClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
+			Title:  "Property Assignee Auto-Add Playbook",
+			TeamID: e.BasicTeam.Id,
+			Public: true,
+		})
+		require.NoError(t, err)
+
+		_, err = e.PlaybooksAdminClient.Playbooks.CreatePropertyField(
+			context.Background(),
+			pbID,
+			client.PropertyFieldRequest{Name: "Manager", Type: "user"},
+		)
+		require.NoError(t, err)
+
+		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+			Name:        "Property Assignee Auto-Add Run " + model.NewId(),
+			OwnerUserID: e.RegularUser.Id,
+			TeamID:      e.BasicTeam.Id,
+			PlaybookID:  pbID,
+		})
+		require.NoError(t, err)
+		err = e.PlaybooksClient.PlaybookRuns.CreateChecklist(context.Background(), run.ID, client.Checklist{
+			Title: "Tasks",
+			Items: []client.ChecklistItem{{Title: "Task"}},
+		})
+		require.NoError(t, err)
+
+		addResp, err := addParticipants(e.PlaybooksClient, run.ID, []string{e.RegularUser2.Id})
+		require.NoError(t, err)
+		require.Empty(t, addResp.Errors)
+
+		targetUser, _, err := e.ServerAdminClient.CreateUser(context.Background(), &model.User{
+			Email:    "target-" + model.NewId() + "@example.com",
+			Username: "target" + model.NewId(),
+			Password: testUserPassword,
+		})
+		require.NoError(t, err)
+		_, _, err = e.ServerAdminClient.AddTeamMember(context.Background(), e.BasicTeam.Id, targetUser.Id)
+		require.NoError(t, err)
+
+		runFields, err := e.PlaybooksClient.PlaybookRuns.GetPropertyFields(context.Background(), run.ID)
+		require.NoError(t, err)
+		var runFieldID string
+		for _, f := range runFields {
+			if f.Name == "Manager" && f.Type == "user" {
+				runFieldID = f.ID
+				break
+			}
+		}
+		require.NotEmpty(t, runFieldID, "run-level Manager field not found")
+
+		// Set the field's current value to targetUser as the owner, so the field already
+		// resolves to a non-participant before the non-owner participant assigns via it.
+		_, err = e.PlaybooksClient.PlaybookRuns.SetPropertyValue(
+			context.Background(),
+			run.ID,
+			runFieldID,
+			client.PropertyValueRequest{Value: []byte(`"` + targetUser.Id + `"`)},
+		)
+		require.NoError(t, err)
+		_, err = removeParticipants(e.PlaybooksClient, run.ID, []string{targetUser.Id})
+		require.NoError(t, err)
+
+		// Non-owner participant assigns the task via the property field directly.
+		err = e.PlaybooksClient2.PlaybookRuns.SetItemPropertyUserAssignee(context.Background(), run.ID, 0, 0, runFieldID)
+		require.NoError(t, err, "non-owner participant must be allowed to assign via a user-type property field")
+
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.Equal(t, targetUser.Id, run.Checklists[0].Items[0].AssigneeID)
+		assert.Contains(t, run.ParticipantIDs, targetUser.Id,
+			"assigning via SetPropertyUserAssignee must auto-add the resolved user as a run participant")
+		assert.True(t, receivedDM(t, targetUser.Id, run.Name), "resolved user must receive the assignment DM")
 	})
 }

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -5703,11 +5703,14 @@ func TestSetRunPropertyValue_UserField(t *testing.T) {
 		require.NoError(t, err, "setting a user-type property to a team member must succeed")
 	})
 
-	// participant cannot add new member: setting a user-type field auto-adds the chosen user
-	// as a run participant, so only the run owner or a system admin may trigger that side effect.
-	t.Run("participant cannot add new member", func(t *testing.T) {
+	// participant can add new member: setting a user-type field auto-adds the chosen user as a
+	// run participant. Any actor already authorized to modify the run (owner, any participant,
+	// or admin — the same RunManageProperties check gating the endpoint itself) can trigger this
+	// side effect, matching the parity already available via the explicit AddRunParticipants
+	// invite flow (MM-70073).
+	t.Run("participant can add new member", func(t *testing.T) {
 		pbID, err := e.PlaybooksAdminClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
-			Title:  "Participant Cannot Add Member Playbook",
+			Title:  "Participant Can Add Member Playbook",
 			TeamID: e.BasicTeam.Id,
 			Public: true,
 		})
@@ -5738,7 +5741,7 @@ func TestSetRunPropertyValue_UserField(t *testing.T) {
 		require.NoError(t, err)
 
 		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
-			Name:        "Participant Cannot Add Member Run",
+			Name:        "Participant Can Add Member Run",
 			OwnerUserID: e.RegularUser.Id,
 			TeamID:      e.BasicTeam.Id,
 			PlaybookID:  pbID,
@@ -5778,8 +5781,8 @@ func TestSetRunPropertyValue_UserField(t *testing.T) {
 
 		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
 		require.NoError(t, err)
-		require.NotContains(t, run.ParticipantIDs, targetUser.Id,
-			"non-owner participant must not be able to add a new member to the run via property assignment")
+		require.Contains(t, run.ParticipantIDs, targetUser.Id,
+			"non-owner participant must be able to add a new member to the run via property assignment, matching the parity already available via the explicit invite flow")
 
 		_, err = e.PlaybooksClient.PlaybookRuns.SetPropertyValue(
 			context.Background(),
@@ -5801,5 +5804,189 @@ func TestSetRunPropertyValue_UserField(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, run.ParticipantIDs, targetUser.Id,
 			"run owner must be able to add a new member to the run via property assignment")
+	})
+}
+
+// TestAssigneeAutoAddParticipant covers the fix for MM-70073: any actor already authorized to
+// change a task's assignee (not just the run owner or a system admin) can trigger the resulting
+// participant-add / channel-add / DM side effect, matching the parity already available via the
+// explicit AddRunParticipants invite flow. It also covers the narrower DM-notification fix that
+// ships alongside it: the DM must not leak run details to a target who was silently dropped for
+// failing team-membership validation, while the two paths that never call AddParticipants
+// (assigning to the owner, or to an existing participant) must keep sending the DM unchanged.
+func TestAssigneeAutoAddParticipant(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	botID := e.Srv.Config().PluginSettings.Plugins[manifest.Id]["BotUserID"].(string)
+
+	// receivedDM returns true if the bot's DM channel with userID contains a post matching both
+	// the #taskassigned marker and the specific run's name, so a stale DM from an earlier subtest
+	// in the same channel can't produce a false positive.
+	receivedDM := func(t *testing.T, userID, runName string) bool {
+		t.Helper()
+		dmChannel, _, err := e.ServerAdminClient.CreateDirectChannel(context.Background(), botID, userID)
+		require.NoError(t, err)
+		posts, _, err := e.ServerAdminClient.GetPostsForChannel(context.Background(), dmChannel.Id, 0, 100, "", false, false)
+		require.NoError(t, err)
+		for _, id := range posts.Order {
+			message := posts.Posts[id].Message
+			if strings.Contains(message, "#taskassigned") && strings.Contains(message, runName) {
+				return true
+			}
+		}
+		return false
+	}
+
+	newChecklistRun := func(t *testing.T, ownerID string) *client.PlaybookRun {
+		t.Helper()
+		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+			Name:        "Assignee Auto-Add Run " + model.NewId(),
+			OwnerUserID: ownerID,
+			TeamID:      e.BasicTeam.Id,
+			PlaybookID:  e.BasicPlaybook.ID,
+		})
+		require.NoError(t, err)
+		err = e.PlaybooksClient.PlaybookRuns.CreateChecklist(context.Background(), run.ID, client.Checklist{
+			Title: "Tasks",
+			Items: []client.ChecklistItem{{Title: "Task"}},
+		})
+		require.NoError(t, err)
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		return run
+	}
+
+	t.Run("non-owner participant assigning a new team member adds them as participant and sends the DM", func(t *testing.T) {
+		run := newChecklistRun(t, e.RegularUser.Id)
+
+		addResp, err := addParticipants(e.PlaybooksClient, run.ID, []string{e.RegularUser2.Id})
+		require.NoError(t, err)
+		require.Empty(t, addResp.Errors)
+
+		targetUser, _, err := e.ServerAdminClient.CreateUser(context.Background(), &model.User{
+			Email:    "target-" + model.NewId() + "@example.com",
+			Username: "target" + model.NewId(),
+			Password: testUserPassword,
+		})
+		require.NoError(t, err)
+		_, _, err = e.ServerAdminClient.AddTeamMember(context.Background(), e.BasicTeam.Id, targetUser.Id)
+		require.NoError(t, err)
+
+		err = e.PlaybooksClient2.PlaybookRuns.SetItemAssignee(context.Background(), run.ID, 0, 0, targetUser.Id)
+		require.NoError(t, err, "non-owner participant must be allowed to assign a task to a non-participant")
+
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.Contains(t, run.ParticipantIDs, targetUser.Id,
+			"assigning a task to a non-participant must auto-add them as a run participant, regardless of who performed the assignment")
+		assert.True(t, receivedDM(t, targetUser.Id, run.Name), "newly-added assignee must receive the assignment DM")
+	})
+
+	t.Run("non-owner participant assigning the creator role adds a non-participant reporter as participant", func(t *testing.T) {
+		// Create as admin (reporter) while assigning ownership to RegularUser, so reporter !=
+		// owner and the reporter is auto-added as a participant at creation time (existing
+		// behavior) — then explicitly removed below so SetRoleAssignee's creator branch has to
+		// re-add them rather than finding them already present.
+		run, err := e.PlaybooksAdminClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+			Name:        "Creator Role Auto-Add Run " + model.NewId(),
+			OwnerUserID: e.RegularUser.Id,
+			TeamID:      e.BasicTeam.Id,
+			PlaybookID:  e.BasicPlaybook.ID,
+		})
+		require.NoError(t, err)
+		err = e.PlaybooksClient.PlaybookRuns.CreateChecklist(context.Background(), run.ID, client.Checklist{
+			Title: "Tasks",
+			Items: []client.ChecklistItem{{Title: "Task"}},
+		})
+		require.NoError(t, err)
+
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		require.Equal(t, e.AdminUser.Id, run.ReporterUserID, "run created by the admin client must record the admin as reporter")
+		require.Contains(t, run.ParticipantIDs, e.AdminUser.Id, "reporter differing from owner is auto-added as a participant at creation")
+
+		removeResp, err := removeParticipants(e.PlaybooksClient, run.ID, []string{e.AdminUser.Id})
+		require.NoError(t, err)
+		require.Empty(t, removeResp.Errors)
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		require.NotContains(t, run.ParticipantIDs, e.AdminUser.Id)
+
+		addResp, err := addParticipants(e.PlaybooksClient, run.ID, []string{e.RegularUser2.Id})
+		require.NoError(t, err)
+		require.Empty(t, addResp.Errors)
+
+		// RegularUser2 (a non-owner participant) sets the task's assignee to the "creator" role
+		// via a raw request, since the Go test client has no wrapper for assignee_type.
+		actorClient := model.NewAPIv4Client(e.ServerClient.URL)
+		_, _, err = actorClient.Login(context.Background(), e.RegularUser2.Email, testUserPassword)
+		require.NoError(t, err)
+
+		body, err := json.Marshal(map[string]string{"assignee_type": app.AssigneeTypeCreator})
+		require.NoError(t, err)
+		url := e.ServerClient.URL + "/plugins/" + manifest.Id + "/api/v0/runs/" + run.ID + "/checklists/0/item/0/assignee"
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(model.HeaderAuth, actorClient.AuthType+" "+actorClient.AuthToken)
+		resp, err := actorClient.HTTPClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.Contains(t, run.ParticipantIDs, e.AdminUser.Id,
+			"assigning the creator role must auto-add the non-participant reporter")
+		assert.True(t, receivedDM(t, e.AdminUser.Id, run.Name), "reporter must receive the assignment DM")
+	})
+
+	// The actor here is deliberately the run OWNER, not a non-owner participant. Both the old
+	// and new permission gate already allow the owner, so this isolates the narrower
+	// DM-suppression fix from the permission-widening fix: under the old code, a non-owner
+	// actor would have been denied by the (removed) owner/admin-only check before ever reaching
+	// AddParticipants, which would make this assertion pass even without the DM-suppression fix.
+	t.Run("target failing team membership validation is not added and does not receive the DM", func(t *testing.T) {
+		run := newChecklistRun(t, e.RegularUser.Id)
+
+		// A valid Mattermost user deliberately NOT added to BasicTeam, so AddParticipants'
+		// team-membership validation silently drops them into usersFailedToInvite.
+		outsider, _, err := e.ServerAdminClient.CreateUser(context.Background(), &model.User{
+			Email:    "outsider-" + model.NewId() + "@example.com",
+			Username: "outsider" + model.NewId(),
+			Password: testUserPassword,
+		})
+		require.NoError(t, err)
+
+		err = e.PlaybooksClient.PlaybookRuns.SetItemAssignee(context.Background(), run.ID, 0, 0, outsider.Id)
+		require.NoError(t, err, "the assignee_id write itself succeeds even though the auto-add side effect is dropped")
+
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.NotContains(t, run.ParticipantIDs, outsider.Id,
+			"a target who fails team-membership validation must not be added as a run participant")
+		assert.False(t, receivedDM(t, outsider.Id, run.Name),
+			"a target who fails team-membership validation must not receive the assignment DM, which would otherwise leak the run name and URL")
+	})
+
+	t.Run("DM still sent when assigning to the owner or to an existing participant", func(t *testing.T) {
+		run := newChecklistRun(t, e.RegularUser.Id)
+
+		addResp, err := addParticipants(e.PlaybooksClient, run.ID, []string{e.RegularUser2.Id})
+		require.NoError(t, err)
+		require.Empty(t, addResp.Errors)
+
+		// Assign to the owner: addAssigneeParticipantAndDM never calls AddParticipants for this
+		// case (resolvedUserID == ownerUserID), so the DM must still fire unchanged.
+		err = e.PlaybooksClient2.PlaybookRuns.SetItemAssignee(context.Background(), run.ID, 0, 0, e.RegularUser.Id)
+		require.NoError(t, err)
+		assert.True(t, receivedDM(t, e.RegularUser.Id, run.Name), "assigning a task to the run owner must still send the DM")
+
+		// Assign to an existing participant: addAssigneeParticipantAndDM never calls
+		// AddParticipants here either (already in participantIDs), so the DM must still fire.
+		err = e.PlaybooksClient.PlaybookRuns.SetItemAssignee(context.Background(), run.ID, 0, 0, e.RegularUser2.Id)
+		require.NoError(t, err)
+		assert.True(t, receivedDM(t, e.RegularUser2.Id, run.Name), "assigning a task to an existing participant must still send the DM")
 	})
 }

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -6051,8 +6051,12 @@ func TestAssigneeAutoAddParticipant(t *testing.T) {
 			client.PropertyValueRequest{Value: []byte(`"` + targetUser.Id + `"`)},
 		)
 		require.NoError(t, err)
-		_, err = removeParticipants(e.PlaybooksClient, run.ID, []string{targetUser.Id})
+		removeResp, err := removeParticipants(e.PlaybooksClient, run.ID, []string{targetUser.Id})
 		require.NoError(t, err)
+		require.Empty(t, removeResp.Errors)
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		require.NotContains(t, run.ParticipantIDs, targetUser.Id)
 
 		// Non-owner participant assigns the task via the property field directly.
 		err = e.PlaybooksClient2.PlaybookRuns.SetItemPropertyUserAssignee(context.Background(), run.ID, 0, 0, runFieldID)

--- a/server/app/permissions_service_test.go
+++ b/server/app/permissions_service_test.go
@@ -607,7 +607,7 @@ func (s *stubRunService) RequestJoinChannel(string, string) error {
 func (s *stubRunService) RemoveParticipants(string, []string, string) error {
 	panic("stubRunService: RemoveParticipants not implemented")
 }
-func (s *stubRunService) AddParticipants(string, []string, string, bool, bool) error {
+func (s *stubRunService) AddParticipants(string, []string, string, bool, bool) ([]string, error) {
 	panic("stubRunService: AddParticipants not implemented")
 }
 func (s *stubRunService) GetPlaybookRunIDsForUser(string) ([]string, error) {

--- a/server/app/playbook_run.go
+++ b/server/app/playbook_run.go
@@ -1474,7 +1474,7 @@ type PlaybookRunService interface {
 	RemoveParticipants(playbookRunID string, userIDs []string, requesterUserID string) error
 
 	// AddParticipants adds users to the participants list
-	AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, omitWebsocket bool) error
+	AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, omitWebsocket bool) ([]string, error)
 
 	// GetPlaybookRunIDsForUser returns run ids where user is a participant or is following
 	GetPlaybookRunIDsForUser(userID string) ([]string, error)

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -5863,12 +5863,10 @@ func (s *PlaybookRunServiceImpl) addAssigneeParticipantAndDM(playbookRunID, acto
 			addedUserIDs, err := s.AddParticipants(playbookRunID, []string{resolvedUserID}, actorUserID, false, false)
 			if err != nil {
 				logrus.WithError(err).WithFields(logFields).Warn("failed to add assignee as participant")
-				return
 			}
-			// AddParticipants silently drops a target who fails team/DM-channel membership
-			// validation into usersFailedToInvite instead of returning an error, so confirm
-			// the target is actually among the users it reports having added before sending a
-			// DM that would otherwise leak the run name and URL to someone who was never added.
+			// Check membership by result, not by error: AddParticipants can return a
+			// non-empty result alongside an error (DB write succeeded, a later step
+			// didn't), and can silently drop a target who fails membership validation.
 			if !slices.Contains(addedUserIDs, resolvedUserID) {
 				return
 			}

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -5842,23 +5842,44 @@ func (s *PlaybookRunServiceImpl) addAssigneeParticipantAndDM(playbookRunID, acto
 	}
 	if resolvedUserID != ownerUserID {
 		if !slices.Contains(participantIDs, resolvedUserID) {
-			// Only the run owner or a system admin may auto-add the assigned user
-			// as a run participant. Without this check, any participant could set a
-			// user-type property field to invite arbitrary team members into the run.
-			if actorUserID == ownerUserID || IsSystemAdmin(actorUserID, s.pluginAPI) {
-				if err := s.AddParticipants(playbookRunID, []string{resolvedUserID}, actorUserID, false, false); err != nil {
-					logrus.WithError(err).WithField("playbook_run_id", playbookRunID).Warn("failed to add assignee as participant")
-					return
-				}
-			} else {
-				// Actor lacks permission to add resolvedUserID; skip DM to avoid leaking run details.
+			// Anyone authorized to set the assignee in the first place (run owner, any
+			// participant, admin, or channel-post-permission holder for channelChecklist/DM-GM
+			// runs) is also authorized to trigger this auto-add — matching the same gate already
+			// enforced at every HTTP/GraphQL entry point that reaches this helper, and matching
+			// the explicit AddRunParticipants invite flow, which permits the identical outcome.
+			logFields := logrus.Fields{
+				"actor_user_id":   actorUserID,
+				"target_user_id":  resolvedUserID,
+				"playbook_run_id": playbookRunID,
+			}
+			if err := s.permissions.RunManageProperties(actorUserID, playbookRunID); err != nil {
+				logrus.WithError(err).WithFields(logFields).Warn("actor lacks permission to add assignee as run participant")
+				return
+			}
+			if err := s.AddParticipants(playbookRunID, []string{resolvedUserID}, actorUserID, false, false); err != nil {
+				logrus.WithError(err).WithFields(logFields).Warn("failed to add assignee as participant")
+				return
+			}
+			// AddParticipants silently drops a target who fails team/DM-channel membership
+			// validation into usersFailedToInvite instead of returning an error, so confirm
+			// the target actually landed before sending a DM that would otherwise leak the
+			// run name and URL to someone who was never added.
+			refreshedRun, err := s.GetPlaybookRun(playbookRunID)
+			if err != nil {
+				logrus.WithError(err).WithFields(logFields).Warn("failed to refresh run after adding assignee as participant")
+				return
+			}
+			if !slices.Contains(refreshedRun.ParticipantIDs, resolvedUserID) {
 				return
 			}
 		}
 	}
 	if dmMessage != "" && resolvedUserID != actorUserID {
 		if err := s.poster.DM(resolvedUserID, &model.Post{Message: dmMessage}); err != nil {
-			logrus.WithError(err).WithField("playbook_run_id", playbookRunID).Warn("failed to send DM to property_user assignee")
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"target_user_id":  resolvedUserID,
+				"playbook_run_id": playbookRunID,
+			}).Warn("failed to send DM to property_user assignee")
 		}
 	}
 }

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -667,7 +667,7 @@ func (s *PlaybookRunServiceImpl) CreatePlaybookRun(playbookRun *PlaybookRun, pb 
 		}
 	}
 
-	err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false, true)
+	_, err = s.AddParticipants(playbookRun.ID, invitedUserIDs, playbookRun.ReporterUserID, false, true)
 	if err != nil {
 		logrus.WithError(err).WithFields(map[string]any{
 			"playbookRunId":  playbookRun.ID,
@@ -2165,7 +2165,7 @@ func (s *PlaybookRunServiceImpl) ChangeOwner(playbookRunID, userID, ownerID stri
 	}
 
 	// add owner as user
-	err = s.AddParticipants(playbookRunID, []string{ownerID}, userID, false, false)
+	_, err = s.AddParticipants(playbookRunID, []string{ownerID}, userID, false, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to add owner as a participant")
 	}
@@ -3809,7 +3809,7 @@ func (s *PlaybookRunServiceImpl) addPlaybookRunInitialMemberships(playbookRun *P
 	if playbookRun.OwnerUserID != playbookRun.ReporterUserID {
 		participants = append(participants, playbookRun.ReporterUserID)
 	}
-	err := s.AddParticipants(playbookRun.ID, participants, playbookRun.ReporterUserID, false, true)
+	_, err := s.AddParticipants(playbookRun.ID, participants, playbookRun.ReporterUserID, false, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to add owner/reporter as a participant")
 	}
@@ -4619,7 +4619,7 @@ func (s *PlaybookRunServiceImpl) leaveActions(playbookRun *PlaybookRun, userID s
 	}
 }
 
-func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, sendWebsocket bool) error {
+func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs []string, requesterUserID string, forceAddToChannel bool, sendWebsocket bool) ([]string, error) {
 	auditRec := plugin.MakeAuditRecord("addPlaybookRunParticipants", model.AuditStatusFail)
 	defer s.api.LogAuditRec(auditRec)
 
@@ -4635,12 +4635,12 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 
 	if len(userIDs) == 0 {
 		auditRec.Success()
-		return nil
+		return nil, nil
 	}
 
 	playbookRun, err := s.GetPlaybookRun(playbookRunID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get run %s", playbookRunID)
+		return nil, errors.Wrapf(err, "failed to get run %s", playbookRunID)
 	}
 
 	// Add current run context to audit
@@ -4672,7 +4672,7 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 	}
 
 	if err = s.store.AddParticipants(playbookRun.ID, usersToInvite); err != nil {
-		return errors.Wrapf(err, "users `%+v` failed to participate in run `%s`", usersToInvite, playbookRun.ID)
+		return nil, errors.Wrapf(err, "users `%+v` failed to participate in run `%s`", usersToInvite, playbookRun.ID)
 	}
 
 	channel, err := s.pluginAPI.Channel.Get(playbookRun.ChannelID)
@@ -4683,7 +4683,7 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 
 	requesterUser, err := s.pluginAPI.User.Get(requesterUserID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get requester user")
+		return usersToInvite, errors.Wrap(err, "failed to get requester user")
 	}
 
 	shouldAddToChannel := false
@@ -4704,7 +4704,7 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 		if userID != requesterUserID {
 			user, err = s.pluginAPI.User.Get(userID)
 			if err != nil {
-				return errors.Wrapf(err, "failed to get user %s", userID)
+				return usersToInvite, errors.Wrapf(err, "failed to get user %s", userID)
 			}
 		}
 		users = append(users, user)
@@ -4715,20 +4715,20 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 
 		// Participate implies following the run
 		if err = s.Follow(playbookRunID, userID); err != nil {
-			return errors.Wrap(err, "failed to make participant follow run")
+			return usersToInvite, errors.Wrap(err, "failed to make participant follow run")
 		}
 	}
 
 	err = s.changeParticipantsTimeline(playbookRun.ID, requesterUser, users, "joined")
 	if err != nil {
-		return err
+		return usersToInvite, err
 	}
 
 	// ws send run
 	if len(usersToInvite) > 0 && sendWebsocket {
 		playbookRun, err = s.GetPlaybookRun(playbookRunID)
 		if err != nil {
-			return errors.Wrap(err, "failed to refresh playbook run after timeline event creation")
+			return usersToInvite, errors.Wrap(err, "failed to refresh playbook run after timeline event creation")
 		}
 
 		combinedUserIDs := append(usersToInvite, requesterUserID)
@@ -4745,7 +4745,7 @@ func (s *PlaybookRunServiceImpl) AddParticipants(playbookRunID string, userIDs [
 		auditRec.AddEventResultState(*playbookRun)
 	}
 
-	return nil
+	return usersToInvite, nil
 }
 
 // changeParticipantsTimeline handles timeline event creation for run participation change triggers:
@@ -5853,23 +5853,23 @@ func (s *PlaybookRunServiceImpl) addAssigneeParticipantAndDM(playbookRunID, acto
 				"playbook_run_id": playbookRunID,
 			}
 			if err := s.permissions.RunManageProperties(actorUserID, playbookRunID); err != nil {
-				logrus.WithError(err).WithFields(logFields).Warn("actor lacks permission to add assignee as run participant")
+				if errors.Is(err, ErrNoPermissions) {
+					logrus.WithError(err).WithFields(logFields).Warn("actor lacks permission to add assignee as run participant")
+				} else {
+					logrus.WithError(err).WithFields(logFields).Warn("failed to determine actor's permission to add assignee as run participant")
+				}
 				return
 			}
-			if err := s.AddParticipants(playbookRunID, []string{resolvedUserID}, actorUserID, false, false); err != nil {
+			addedUserIDs, err := s.AddParticipants(playbookRunID, []string{resolvedUserID}, actorUserID, false, false)
+			if err != nil {
 				logrus.WithError(err).WithFields(logFields).Warn("failed to add assignee as participant")
 				return
 			}
 			// AddParticipants silently drops a target who fails team/DM-channel membership
 			// validation into usersFailedToInvite instead of returning an error, so confirm
-			// the target actually landed before sending a DM that would otherwise leak the
-			// run name and URL to someone who was never added.
-			refreshedRun, err := s.GetPlaybookRun(playbookRunID)
-			if err != nil {
-				logrus.WithError(err).WithFields(logFields).Warn("failed to refresh run after adding assignee as participant")
-				return
-			}
-			if !slices.Contains(refreshedRun.ParticipantIDs, resolvedUserID) {
+			// the target is actually among the users it reports having added before sending a
+			// DM that would otherwise leak the run name and URL to someone who was never added.
+			if !slices.Contains(addedUserIDs, resolvedUserID) {
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

A user reported that assigning a task to someone who isn't yet a run participant doesn't actually add them as a participant, grant them channel access, or notify them — the assignment silently "succeeds" with none of those side effects.

The root cause: `addAssigneeParticipantAndDM` (the helper responsible for this auto-add) only triggers if the actor is the run owner or a system admin. But every entry point that reaches this helper (`SetAssignee`, `SetRoleAssignee`, `SetPropertyUserAssignee`, `SetRunPropertyValue`) is already gated by `RunManageProperties`, which is far more permissive — it allows any existing run participant, not just the owner. Worse, the explicit "invite a participant" GraphQL mutation (`AddRunParticipants`) already lets any participant add an arbitrary new participant with the identical outcome. So the owner/admin-only restriction wasn't preventing any actual privilege escalation — it was just a second, narrower, inconsistent gate that produced a silent partial failure whenever a non-owner participant tried to assign a task to someone new.

This PR:
- Widens the actor check inside `addAssigneeParticipantAndDM` to delegate to `RunManageProperties`, matching the permission model already enforced everywhere else (no signature change — the helper already receives the run ID).
- Adds a warning log on the (now effectively unreachable via HTTP) deny path instead of a silent no-op, in case a future internal caller bypasses the HTTP layer.
- Fixes a related, pre-existing bug this change would otherwise expose more often: the assignment DM was sent even when `AddParticipants` silently dropped a target for failing team/DM-channel membership validation, leaking the run name and URL to someone who was never actually added. The DM is now gated on the target actually landing in the participant list — only for that specific case; the owner-assignment and already-a-participant paths (which never call `AddParticipants`) still send the DM exactly as before.
- Inverts a stale test that asserted the old (buggy) restriction, and adds a new integration test covering the fixed behavior across `SetAssignee`, `SetRoleAssignee`'s creator-role branch, the membership-validation-failure DM guard, and a regression check that the DM still fires for owner/already-participant assignment.
- Adds a Cypress e2e test that drives the real UI as a non-owner participant assigning a task to a non-participant, and asserts they show up in the run's Participants panel.

No API endpoint, request/response shape, or OpenAPI change — this only changes an internal authorization check on existing endpoints.

## QA Steps

**Setup**: a playbook run with at least two non-admin users — User A (a run participant, but not the owner) and User B (a team member not yet a run participant).

1. Log in as **User A** (non-owner participant) and open the run.
2. In the run's checklist, assign a task to **User B**.
3. Verify:
   - The task now shows User B as the assignee.
   - User B appears in the run's **Participants** list (RHS Participants panel).
   - User B receives a bot DM notifying them of the assignment, with a link to the run.
   - If the run/playbook has "Add participants to channel automatically" enabled and User A has permission to manage channel members, User B is also added to the run's channel.
4. **Regression** — repeat steps 2-3 as the **run owner** assigning a different non-participant user: behavior should be identical (unaffected by this change).
5. **Edge case** — as User A, assign a task to a valid Mattermost user who is **not a member of the run's team**: the assignee field should update, but that user should **not** be added as a participant and should **not** receive a DM (this closes a separate notification leak).
6. **Regression** — as User A, assign a task to the run owner, or to a user who is already a run participant: the assignment DM should still be sent as before.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-70073

## Checklist
- ~~Gated by experimental feature flag~~
- [x] Unit tests updated
- ~~Planned cherry-picks: `release-X.Y`~~
