### PR TITLE
Fix run number prefix and run name template being disabled by channel mode

### DIFF
--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/edit/run_naming_channel_mode_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/edit/run_naming_channel_mode_spec.js
@@ -10,6 +10,7 @@
 // Group: @playbooks
 
 import {getRandomId} from '../../../../utils';
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 describe('playbooks > edit > run naming channel mode', {testIsolation: true}, () => {
     let testTeam;
@@ -55,40 +56,53 @@ describe('playbooks > edit > run naming channel mode', {testIsolation: true}, ()
         cy.visitPlaybookEditor(testPlaybook.id, 'outline');
 
         // * Assert the run number prefix input is not disabled
-        cy.findByTestId('channel-access-run-number-prefix').should('not.be.disabled');
+        cy.findByTestId('channel-access-run-number-prefix').scrollIntoView().should('not.be.disabled');
 
         // * Assert the run name template input is not disabled
-        cy.findByTestId('channel-access-run-name-template-input').should('not.be.disabled');
+        cy.findByTestId('channel-access-run-name-template-input').scrollIntoView().should('not.be.disabled');
 
         // * Assert the Insert variable button is visible
-        cy.findByTestId('channel-access-run-name-template-insert-variable').should('be.visible');
+        cy.findByTestId('channel-access-run-name-template-insert-variable').scrollIntoView().should('be.visible');
 
         // * Assert the Lock run name checkbox is not disabled
-        cy.findByTestId('channel-access-run-name-template-locked').find('input').should('not.be.disabled');
+        cy.findByTestId('channel-access-run-name-template-locked').scrollIntoView().find('input').should('not.be.disabled');
     });
 
     it('persists an edited run number prefix and run name template while linked to an existing channel', () => {
         // # Visit the playbook outline editor
         cy.visitPlaybookEditor(testPlaybook.id, 'outline');
 
-        // # Intercept the REST PATCH so we can wait for each debounced field save
+        // # Intercept the REST PATCH so we can wait for a debounced field save to round-trip
         cy.playbooksInterceptPatchPlaybook();
 
         // # Type a run number prefix
-        cy.findByTestId('channel-access-run-number-prefix').clear();
-        cy.findByTestId('channel-access-run-number-prefix').type('INC-');
-        cy.wait('@PatchPlaybook').its('request.body').should('have.property', 'run_number_prefix', 'INC-');
+        cy.findByTestId('channel-access-run-number-prefix').scrollIntoView().clear();
+        cy.findByTestId('channel-access-run-number-prefix').type('INC');
+
+        // * The input reflects the fully typed value (client-side truth, independent of debounce timing)
+        cy.findByTestId('channel-access-run-number-prefix').should('have.value', 'INC');
+
+        // # Wait for a debounced PATCH to round-trip; the field may save more than once while
+        // # typing, so only the response status is checked here — the final persisted value is
+        // # verified below via polling, which tolerates any earlier intermediate saves.
+        cy.wait('@PatchPlaybook').its('response.statusCode').should('be.oneOf', [200, 204]);
 
         // # Type a run name template
-        cy.findByTestId('channel-access-run-name-template-input').click();
+        cy.findByTestId('channel-access-run-name-template-input').scrollIntoView().click();
         cy.findByTestId('channel-access-run-name-template-input').type('Incident');
-        cy.wait('@PatchPlaybook').its('request.body').should('have.property', 'channel_name_template', 'Incident');
 
-        // * Assert the values persisted via the API
-        cy.apiGetPlaybook(testPlaybook.id).then((pb) => {
-            expect(pb.run_number_prefix).to.equal('INC-');
-            expect(pb.channel_name_template).to.equal('Incident');
-        });
+        // * The input reflects the fully typed value
+        cy.findByTestId('channel-access-run-name-template-input').should('have.value', 'Incident');
+
+        cy.wait('@PatchPlaybook').its('response.statusCode').should('be.oneOf', [200, 204]);
+
+        // * Assert the values persisted via the API, polling in case a later debounced save
+        // * (e.g. one carrying an intermediate keystroke) is still in flight
+        cy.waitUntil(
+            () => cy.apiGetPlaybook(testPlaybook.id).then((pb) =>
+                pb.run_number_prefix === 'INC' && pb.channel_name_template === 'Incident'),
+            {timeout: TIMEOUTS.TEN_SEC, interval: TIMEOUTS.HALF_SEC, errorMsg: 'Run number prefix and run name template were not persisted'},
+        );
     });
 
     it('keeps the Public/Private visibility and Configure channel controls disabled while linked to an existing channel', () => {

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/edit/run_naming_channel_mode_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/edit/run_naming_channel_mode_spec.js
@@ -1,0 +1,107 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+// Stage: @prod
+// Group: @playbooks
+
+import {getRandomId} from '../../../../utils';
+
+describe('playbooks > edit > run naming channel mode', {testIsolation: true}, () => {
+    let testTeam;
+    let testUser;
+    let testPlaybook;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+
+        // # Size the viewport
+        cy.viewport('macbook-13');
+
+        // # Create a fresh playbook linked to an existing channel for each test
+        cy.apiCreatePlaybook({
+            teamId: testTeam.id,
+            title: 'Run Naming Channel Mode Playbook ' + getRandomId(),
+            memberIDs: [testUser.id],
+            createPublicPlaybookRun: true,
+            channelMode: 'link_existing_channel',
+        }).then((playbook) => {
+            testPlaybook = playbook;
+        });
+    });
+
+    afterEach(() => {
+        // # Login as testUser and archive the playbook created in beforeEach
+        cy.apiLogin(testUser);
+        if (testPlaybook) {
+            cy.apiArchivePlaybook(testPlaybook.id);
+        }
+    });
+
+    it('keeps the run number prefix and run name template editable when linking to an existing channel', () => {
+        // # Visit the playbook outline editor
+        cy.visitPlaybookEditor(testPlaybook.id, 'outline');
+
+        // * Assert the run number prefix input is not disabled
+        cy.findByTestId('channel-access-run-number-prefix').should('not.be.disabled');
+
+        // * Assert the run name template input is not disabled
+        cy.findByTestId('channel-access-run-name-template-input').should('not.be.disabled');
+
+        // * Assert the Insert variable button is visible
+        cy.findByTestId('channel-access-run-name-template-insert-variable').should('be.visible');
+
+        // * Assert the Lock run name checkbox is not disabled
+        cy.findByTestId('channel-access-run-name-template-locked').find('input').should('not.be.disabled');
+    });
+
+    it('persists an edited run number prefix and run name template while linked to an existing channel', () => {
+        // # Visit the playbook outline editor
+        cy.visitPlaybookEditor(testPlaybook.id, 'outline');
+
+        // # Intercept the REST PATCH so we can wait for each debounced field save
+        cy.playbooksInterceptPatchPlaybook();
+
+        // # Type a run number prefix
+        cy.findByTestId('channel-access-run-number-prefix').clear();
+        cy.findByTestId('channel-access-run-number-prefix').type('INC-');
+        cy.wait('@PatchPlaybook').its('request.body').should('have.property', 'run_number_prefix', 'INC-');
+
+        // # Type a run name template
+        cy.findByTestId('channel-access-run-name-template-input').click();
+        cy.findByTestId('channel-access-run-name-template-input').type('Incident');
+        cy.wait('@PatchPlaybook').its('request.body').should('have.property', 'channel_name_template', 'Incident');
+
+        // * Assert the values persisted via the API
+        cy.apiGetPlaybook(testPlaybook.id).then((pb) => {
+            expect(pb.run_number_prefix).to.equal('INC-');
+            expect(pb.channel_name_template).to.equal('Incident');
+        });
+    });
+
+    it('keeps the Public/Private visibility and Configure channel controls disabled while linked to an existing channel', () => {
+        // # Visit the playbook outline editor
+        cy.visitPlaybookEditor(testPlaybook.id, 'outline');
+
+        // * Assert the Public/Private radios remain disabled (channel-creation-only controls)
+        cy.get('#create-new-channel').within(() => {
+            cy.contains('label', 'Public').find('input[type="radio"]').should('be.disabled');
+            cy.contains('label', 'Private').find('input[type="radio"]').should('be.disabled');
+        });
+
+        // * Assert the Configure channel button remains disabled
+        cy.findByTestId('playbook-channel-actions-button').should('be.disabled');
+    });
+});

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -719,6 +719,7 @@
   "wCDmf3": "Enable updates",
   "wDorPP": "Playbook Examples",
   "wEQDC6": "Edit",
+  "wG0lnn": "Run naming",
   "wJt/1b": "Section name",
   "wL7VAE": "Actions",
   "wRM2AO": "The update request was unsuccessful.",

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.test.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.test.tsx
@@ -76,12 +76,37 @@ describe('CreateAChannel — run number prefix input', () => {
         expect(prefixInput?.props.value).toBe('INC');
     });
 
-    it('disables the prefix input when channel_mode is link_existing_channel', () => {
+    it('keeps the prefix input enabled when channel_mode is link_existing_channel', () => {
         const playbook = {
             create_public_playbook_run: true,
             channel_name_template: '',
             channel_name_template_locked: false,
             delete_at: 0,
+            channel_mode: 'link_existing_channel' as const,
+            channel_id: '',
+            run_number_prefix: '',
+            next_run_number: 1,
+        };
+
+        const component = renderWithIntl(
+            <CreateAChannel
+                playbook={playbook}
+                setPlaybook={jest.fn()}
+            />,
+        );
+
+        const [prefixInput] = component.root.findAll(
+            (node) => node.props['data-testid'] === 'channel-access-run-number-prefix',
+        );
+        expect(prefixInput?.props.disabled).toBe(false);
+    });
+
+    it('disables the prefix input when the playbook is archived, regardless of channel_mode', () => {
+        const playbook = {
+            create_public_playbook_run: true,
+            channel_name_template: '',
+            channel_name_template_locked: false,
+            delete_at: 1234,
             channel_mode: 'link_existing_channel' as const,
             channel_id: '',
             run_number_prefix: '',
@@ -213,12 +238,37 @@ describe('CreateAChannel — lock run name checkbox', () => {
         expect(onChannelNameTemplateLockedChange).toHaveBeenCalledWith(true);
     });
 
-    it('disables the checkbox when channel_mode is link_existing_channel', () => {
+    it('keeps the checkbox enabled when channel_mode is link_existing_channel', () => {
         const playbook = {
             create_public_playbook_run: true,
             channel_name_template: 'Incident {SEQ}',
             channel_name_template_locked: false,
             delete_at: 0,
+            channel_mode: 'link_existing_channel' as const,
+            channel_id: '',
+            run_number_prefix: '',
+            next_run_number: 1,
+        };
+
+        const component = renderWithIntl(
+            <CreateAChannel
+                playbook={playbook}
+                setPlaybook={jest.fn()}
+            />,
+        );
+
+        const [checkbox] = component.root.findAll(
+            (node) => node.props.testId === checkboxTestId,
+        );
+        expect(checkbox?.props.disabled).toBe(false);
+    });
+
+    it('disables the checkbox when the playbook is archived, regardless of channel_mode', () => {
+        const playbook = {
+            create_public_playbook_run: true,
+            channel_name_template: 'Incident {SEQ}',
+            channel_name_template_locked: false,
+            delete_at: 1234,
             channel_mode: 'link_existing_channel' as const,
             channel_id: '',
             run_number_prefix: '',
@@ -350,6 +400,60 @@ describe('CreateAChannel — lock run name checkbox', () => {
         );
         expect(checkbox?.props.disabled).toBe(false);
         expect(checkbox?.props.checked).toBe(true);
+    });
+});
+
+describe('CreateAChannel — insert variable button', () => {
+    const insertButtonTestId = 'channel-access-run-name-template-insert-variable';
+
+    it('renders the Insert variable button when channel_mode is link_existing_channel', () => {
+        const playbook = {
+            create_public_playbook_run: true,
+            channel_name_template: '',
+            channel_name_template_locked: false,
+            delete_at: 0,
+            channel_mode: 'link_existing_channel' as const,
+            channel_id: '',
+            run_number_prefix: '',
+            next_run_number: 1,
+        };
+
+        const component = renderWithIntl(
+            <CreateAChannel
+                playbook={playbook}
+                setPlaybook={jest.fn()}
+            />,
+        );
+
+        const insertButtons = component.root.findAll(
+            (node) => node.props['data-testid'] === insertButtonTestId,
+        );
+        expect(insertButtons.length).toBeGreaterThan(0);
+    });
+
+    it('does not render the Insert variable button when the playbook is archived', () => {
+        const playbook = {
+            create_public_playbook_run: true,
+            channel_name_template: '',
+            channel_name_template_locked: false,
+            delete_at: 1234,
+            channel_mode: 'create_new_channel' as const,
+            channel_id: '',
+            run_number_prefix: '',
+            next_run_number: 1,
+        };
+
+        const component = renderWithIntl(
+            <CreateAChannel
+                playbook={playbook}
+                setPlaybook={jest.fn()}
+            />,
+        );
+
+        const insertButtons = component.root.findAll(
+            (node) => node.props['data-testid'] === insertButtonTestId,
+        );
+        expect(insertButtons.length).toBe(0);
     });
 });
 

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -17,6 +17,7 @@ import {
     SelectorWrapper,
 } from 'src/components/backstage/playbook_edit/automation/styles';
 import {HorizontalSpacer, RadioInput} from 'src/components/backstage/styles';
+import {SectionTitle} from 'src/components/backstage/playbook_edit/styles';
 import {showPlaybookActionsModal} from 'src/actions';
 import {SecondaryButtonLarger} from 'src/components/backstage/playbook_editor/controls';
 import ChannelSelector from 'src/components/backstage/channel_selector';
@@ -46,7 +47,7 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade, fieldName
     const teamId = useAppSelector(getCurrentTeamId);
     const disabled = disabledProp || playbook.delete_at !== 0;
     const [insertCounter, setInsertCounter] = useState(0);
-    const templateEnabled = !disabled && playbook.channel_mode === 'create_new_channel';
+    const templateEnabled = !disabled;
     const templateLockedChecked = playbook.channel_name_template_locked ?? false;
 
     const handlePublicChange = (isPublic: boolean) => {
@@ -176,53 +177,6 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade, fieldName
                             <BigText>{formatMessage({defaultMessage: 'Private'})}</BigText>
                         </ButtonLabel>
                     </VerticalSplit>
-                    <RunNamingBlock>
-                        <InputLabel htmlFor='channel-access-run-number-prefix'>{formatMessage({defaultMessage: 'Run number prefix'})}</InputLabel>
-                        <BaseInput
-                            id='channel-access-run-number-prefix'
-                            data-testid='channel-access-run-number-prefix'
-                            type='text'
-                            disabled={disabled || playbook.channel_mode === 'link_existing_channel'}
-                            value={playbook.run_number_prefix ?? ''}
-                            onChange={(e) => handleRunNumberPrefixChange(e.target.value)}
-                            placeholder={formatMessage({defaultMessage: 'e.g. INC-'})}
-                        />
-                        <LabelRow>
-                            <InputLabel as='div'>{formatMessage({defaultMessage: 'Run name template'})}</InputLabel>
-                            {templateEnabled && (
-                                <InsertVariableButton
-                                    type='button'
-                                    onClick={() => setInsertCounter((n) => n + 1)}
-                                    aria-label={formatMessage({defaultMessage: 'Insert variable'})}
-                                    title={formatMessage({defaultMessage: 'Insert variable'})}
-                                    data-testid='channel-access-run-name-template-insert-variable'
-                                >
-                                    <CodeBracketsIcon
-                                        size={14}
-                                        aria-hidden={true}
-                                    />
-                                </InsertVariableButton>
-                            )}
-                        </LabelRow>
-                        <TemplateInput
-                            enabled={templateEnabled}
-                            placeholderText={formatMessage({defaultMessage: 'Run name template (optional)'})}
-                            input={playbook.channel_name_template ?? ''}
-                            onChange={handleChannelNameTemplateChange}
-                            fieldNames={fieldNames ?? []}
-                            prefix={playbook.run_number_prefix ?? ''}
-                            maxLength={1024}
-                            testId='channel-access-run-name-template'
-                            openInsertToggle={insertCounter}
-                        />
-                        <TemplateLockedCheckbox
-                            testId='channel-access-run-name-template-locked'
-                            text={formatMessage({defaultMessage: 'Lock run name'})}
-                            checked={templateLockedChecked}
-                            disabled={!templateEnabled}
-                            onChange={handleChannelNameTemplateLockedChange}
-                        />
-                    </RunNamingBlock>
                     <ChannelActionButton
                         disabled={disabled || playbook.channel_mode === 'link_existing_channel'}
                         data-testid='playbook-channel-actions-button'
@@ -233,6 +187,61 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade, fieldName
                     </ChannelActionButton>
                 </HorizontalSplit>
             </AutomationHeader>
+            <RunNamingSection>
+                <RunNamingSectionTitle id='run-naming-title'>
+                    {formatMessage({defaultMessage: 'Run naming'})}
+                </RunNamingSectionTitle>
+                <RunNamingBlock
+                    role='group'
+                    aria-labelledby='run-naming-title'
+                >
+                    <InputLabel htmlFor='channel-access-run-number-prefix'>{formatMessage({defaultMessage: 'Run number prefix'})}</InputLabel>
+                    <BaseInput
+                        id='channel-access-run-number-prefix'
+                        data-testid='channel-access-run-number-prefix'
+                        type='text'
+                        disabled={disabled}
+                        value={playbook.run_number_prefix ?? ''}
+                        onChange={(e) => handleRunNumberPrefixChange(e.target.value)}
+                        placeholder={formatMessage({defaultMessage: 'e.g. INC-'})}
+                    />
+                    <LabelRow>
+                        <InputLabel as='div'>{formatMessage({defaultMessage: 'Run name template'})}</InputLabel>
+                        {templateEnabled && (
+                            <InsertVariableButton
+                                type='button'
+                                onClick={() => setInsertCounter((n) => n + 1)}
+                                aria-label={formatMessage({defaultMessage: 'Insert variable'})}
+                                title={formatMessage({defaultMessage: 'Insert variable'})}
+                                data-testid='channel-access-run-name-template-insert-variable'
+                            >
+                                <CodeBracketsIcon
+                                    size={14}
+                                    aria-hidden={true}
+                                />
+                            </InsertVariableButton>
+                        )}
+                    </LabelRow>
+                    <TemplateInput
+                        enabled={templateEnabled}
+                        placeholderText={formatMessage({defaultMessage: 'Run name template (optional)'})}
+                        input={playbook.channel_name_template ?? ''}
+                        onChange={handleChannelNameTemplateChange}
+                        fieldNames={fieldNames ?? []}
+                        prefix={playbook.run_number_prefix ?? ''}
+                        maxLength={1024}
+                        testId='channel-access-run-name-template'
+                        openInsertToggle={insertCounter}
+                    />
+                    <TemplateLockedCheckbox
+                        testId='channel-access-run-name-template-locked'
+                        text={formatMessage({defaultMessage: 'Lock run name'})}
+                        checked={templateLockedChecked}
+                        disabled={!templateEnabled}
+                        onChange={handleChannelNameTemplateLockedChange}
+                    />
+                </RunNamingBlock>
+            </RunNamingSection>
         </Container>
     );
 };
@@ -308,11 +317,20 @@ export const ChannelModeRadio = styled(RadioInput)`
     }
 `;
 
+const RunNamingSection = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const RunNamingSectionTitle = styled(SectionTitle)`
+    margin: 0 0 8px;
+`;
+
 const RunNamingBlock = styled.div`
     display: flex;
     flex-direction: column;
     gap: 4px;
-    margin-top: 8px;
+    max-width: 460px;
 `;
 
 const InputLabel = styled.label`

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -195,51 +195,63 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade, fieldName
                     role='group'
                     aria-labelledby='run-naming-title'
                 >
-                    <InputLabel htmlFor='channel-access-run-number-prefix'>{formatMessage({defaultMessage: 'Run number prefix'})}</InputLabel>
-                    <BaseInput
-                        id='channel-access-run-number-prefix'
-                        data-testid='channel-access-run-number-prefix'
-                        type='text'
-                        disabled={disabled}
-                        value={playbook.run_number_prefix ?? ''}
-                        onChange={(e) => handleRunNumberPrefixChange(e.target.value)}
-                        placeholder={formatMessage({defaultMessage: 'e.g. INC-'})}
-                    />
-                    <LabelRow>
-                        <InputLabel as='div'>{formatMessage({defaultMessage: 'Run name template'})}</InputLabel>
-                        {templateEnabled && (
-                            <InsertVariableButton
-                                type='button'
-                                onClick={() => setInsertCounter((n) => n + 1)}
-                                aria-label={formatMessage({defaultMessage: 'Insert variable'})}
-                                title={formatMessage({defaultMessage: 'Insert variable'})}
-                                data-testid='channel-access-run-name-template-insert-variable'
-                            >
-                                <CodeBracketsIcon
-                                    size={14}
-                                    aria-hidden={true}
-                                />
-                            </InsertVariableButton>
-                        )}
-                    </LabelRow>
-                    <TemplateInput
-                        enabled={templateEnabled}
-                        placeholderText={formatMessage({defaultMessage: 'Run name template (optional)'})}
-                        input={playbook.channel_name_template ?? ''}
-                        onChange={handleChannelNameTemplateChange}
-                        fieldNames={fieldNames ?? []}
-                        prefix={playbook.run_number_prefix ?? ''}
-                        maxLength={1024}
-                        testId='channel-access-run-name-template'
-                        openInsertToggle={insertCounter}
-                    />
-                    <TemplateLockedCheckbox
-                        testId='channel-access-run-name-template-locked'
-                        text={formatMessage({defaultMessage: 'Lock run name'})}
-                        checked={templateLockedChecked}
-                        disabled={!templateEnabled}
-                        onChange={handleChannelNameTemplateLockedChange}
-                    />
+                    <AutomationHeader id={'run-number-prefix'}>
+                        <AutomationTitle>
+                            <InputLabel htmlFor='channel-access-run-number-prefix'>{formatMessage({defaultMessage: 'Run number prefix'})}</InputLabel>
+                        </AutomationTitle>
+                        <PrefixInputWrapper>
+                            <BaseInput
+                                id='channel-access-run-number-prefix'
+                                data-testid='channel-access-run-number-prefix'
+                                type='text'
+                                disabled={disabled}
+                                value={playbook.run_number_prefix ?? ''}
+                                onChange={(e) => handleRunNumberPrefixChange(e.target.value)}
+                                placeholder={formatMessage({defaultMessage: 'e.g. INC-'})}
+                            />
+                        </PrefixInputWrapper>
+                    </AutomationHeader>
+                    <AutomationHeader id={'run-name-template'}>
+                        <AutomationTitle style={{alignSelf: 'flex-start'}}>
+                            <InputLabel as='div'>{formatMessage({defaultMessage: 'Run name template'})}</InputLabel>
+                        </AutomationTitle>
+                        <TemplateInputWrapper>
+                            {templateEnabled && (
+                                <InsertVariableRow>
+                                    <InsertVariableButton
+                                        type='button'
+                                        onClick={() => setInsertCounter((n) => n + 1)}
+                                        aria-label={formatMessage({defaultMessage: 'Insert variable'})}
+                                        title={formatMessage({defaultMessage: 'Insert variable'})}
+                                        data-testid='channel-access-run-name-template-insert-variable'
+                                    >
+                                        <CodeBracketsIcon
+                                            size={14}
+                                            aria-hidden={true}
+                                        />
+                                    </InsertVariableButton>
+                                </InsertVariableRow>
+                            )}
+                            <TemplateInput
+                                enabled={templateEnabled}
+                                placeholderText={formatMessage({defaultMessage: 'Run name template (optional)'})}
+                                input={playbook.channel_name_template ?? ''}
+                                onChange={handleChannelNameTemplateChange}
+                                fieldNames={fieldNames ?? []}
+                                prefix={playbook.run_number_prefix ?? ''}
+                                maxLength={1024}
+                                testId='channel-access-run-name-template'
+                                openInsertToggle={insertCounter}
+                            />
+                            <TemplateLockedCheckbox
+                                testId='channel-access-run-name-template-locked'
+                                text={formatMessage({defaultMessage: 'Lock run name'})}
+                                checked={templateLockedChecked}
+                                disabled={!templateEnabled}
+                                onChange={handleChannelNameTemplateLockedChange}
+                            />
+                        </TemplateInputWrapper>
+                    </AutomationHeader>
                 </RunNamingBlock>
             </RunNamingSection>
         </Container>
@@ -329,21 +341,33 @@ const RunNamingSectionTitle = styled(SectionTitle)`
 const RunNamingBlock = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 16px;
+`;
+
+const PrefixInputWrapper = styled.div`
+    flex: 1;
     max-width: 460px;
+
+    input {
+        width: 100%;
+    }
+`;
+
+const TemplateInputWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 `;
 
 const InputLabel = styled.label`
     font-size: 12px;
     font-weight: 600;
     color: rgba(var(--center-channel-color-rgb), 0.72);
-    margin-top: 8px;
 `;
 
-const LabelRow = styled.div`
+const InsertVariableRow = styled.div`
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
 `;
 
 const InsertVariableButton = styled.button`

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -199,8 +199,8 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade, fieldName
                         <AutomationTitle>
                             <InputLabel htmlFor='channel-access-run-number-prefix'>{formatMessage({defaultMessage: 'Run number prefix'})}</InputLabel>
                         </AutomationTitle>
-                        <PrefixInputWrapper>
-                            <BaseInput
+                        <SelectorWrapper>
+                            <PrefixInput
                                 id='channel-access-run-number-prefix'
                                 data-testid='channel-access-run-number-prefix'
                                 type='text'
@@ -209,7 +209,7 @@ export const CreateAChannel = ({playbook, setPlaybook, setChangesMade, fieldName
                                 onChange={(e) => handleRunNumberPrefixChange(e.target.value)}
                                 placeholder={formatMessage({defaultMessage: 'e.g. INC-'})}
                             />
-                        </PrefixInputWrapper>
+                        </SelectorWrapper>
                     </AutomationHeader>
                     <AutomationHeader id={'run-name-template'}>
                         <AutomationTitle style={{alignSelf: 'flex-start'}}>
@@ -344,13 +344,8 @@ const RunNamingBlock = styled.div`
     gap: 16px;
 `;
 
-const PrefixInputWrapper = styled.div`
-    flex: 1;
-    max-width: 460px;
-
-    input {
-        width: 100%;
-    }
+const PrefixInput = styled(BaseInput)`
+    width: 100%;
 `;
 
 const TemplateInputWrapper = styled.div`

--- a/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/channel_access.tsx
@@ -391,6 +391,7 @@ const InsertVariableButton = styled.button`
 `;
 
 const TemplateLockedCheckbox = styled(CheckboxInput)`
+    align-self: flex-end;
     padding: 6px 0;
     margin-top: 4px;
 

--- a/webapp/src/components/backstage/playbook_edit/automation/template_input.tsx
+++ b/webapp/src/components/backstage/playbook_edit/automation/template_input.tsx
@@ -432,6 +432,7 @@ const TextBox = styled(BaseInput)`
 const Preview = styled.div`
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     margin-top: 4px;
     font-size: 12px;
     line-height: 16px;


### PR DESCRIPTION
## Summary

When a playbook is configured to link to an existing channel (rather than create a new channel per run), the "Run number prefix" and "Run name template" fields in the playbook editor were greyed out and uneditable. These settings govern the **name of a run** — they have nothing to do with whether a channel is created — so the disabling was a UI-only bug with no underlying data or server justification.

Confirmed with a teammate familiar with the run-naming feature: the server has no equivalent restriction on `RunNumberPrefix` / `ChannelNameTemplate` tied to `ChannelMode`, and the run-creation modal already prefills the run name from these fields unconditionally. Toggling channel mode to "create new channel," editing the fields, then toggling back to "link existing channel" was already a working (if awkward) manual workaround, confirming the stored values are respected regardless of channel mode.

This PR:
- Removes the `channel_mode` coupling from the run number prefix and run name template enablement in `channel_access.tsx`
- Relocates the run-naming controls out of the "Create a run channel" conditional section into their own labeled, accessible section (`role="group" aria-labelledby`), so their independence from channel mode is visually clear — the original nesting is what caused the bug in the first place
- Leaves the Public/Private visibility radios and "Configure channel" button correctly gated on `channel_mode`, since those genuinely depend on a channel being created

A related but distinct gap was found in the `/playbook run` interactive dialog, which still only prefills the run name when `channel_mode` is `create_new_channel`. That's a different code path with its own UX constraints, tracked separately in [MM-70096](https://mattermost.atlassian.net/browse/MM-70096) rather than folded into this fix.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-70093

## Checklist
- ~~Gated by experimental feature flag~~
- [x] Unit tests updated
- ~~Planned cherry-picks: `release-X.Y`~~

[MM-70096]: https://mattermost.atlassian.net/browse/MM-70096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ