### PR TITLE
MM-70119: fix blank admin DM for checklist due-date trial nudge

### DIFF
--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -236,6 +236,10 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		message = fmt.Sprintf("@%s requested access to ask for status updates in playbook runs", author.Username)
 		title = "Try request update with a free trial"
 		text = "Request updates for playbook runs in a single click and get notified directly when an update is posted. Start a free, 30-day trial to try it out.\n" + footer
+	case "start_trial_to_set_checklist_item_due_date":
+		message = fmt.Sprintf("@%s requested access to set due dates on checklist items.", author.Username)
+		title = "Work more effectively"
+		text = "Assign due dates to tasks so assignees can prioritize and get things done.\n" + footer
 	}
 
 	actions := []*model.PostAction{

--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -240,6 +240,11 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		message = fmt.Sprintf("@%s requested access to set due dates on checklist items.", author.Username)
 		title = "Work more effectively"
 		text = "Assign due dates to tasks so assignees can prioritize and get things done.\n" + footer
+	default:
+		logrus.WithField("message_type", messageType).Warn("NotifyAdmins received an unrecognized message type; sending a generic upgrade notice")
+		message = fmt.Sprintf("@%s requested access to a Professional feature.", author.Username)
+		title = "Upgrade to unlock this feature"
+		text = "This feature requires a Professional plan or higher.\n" + footer
 	}
 
 	actions := []*model.PostAction{

--- a/server/bot/poster_test.go
+++ b/server/bot/poster_test.go
@@ -50,6 +50,10 @@ var allAdminNotificationMessageTypes = []string{
 	"start_trial_to_access_metrics",
 	"start_trial_to_set_checklist_item_due_date",
 	"start_trial_to_request_update",
+	// Not a real AdminNotificationType: exercises the default case for any
+	// message type the frontend enum and this switch fall out of sync on
+	// (or any caller hitting the endpoint directly with an arbitrary string).
+	"some_future_message_type_nobody_added_a_case_for",
 }
 
 func TestNotifyAdmins(t *testing.T) {

--- a/server/bot/poster_test.go
+++ b/server/bot/poster_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package bot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-playbooks/server/config"
+)
+
+// fakeConfigService is a minimal config.Service stub for tests that don't
+// care about most config behavior.
+type fakeConfigService struct {
+	isCloud bool
+}
+
+func (f *fakeConfigService) GetConfiguration() *config.Configuration               { return &config.Configuration{} }
+func (f *fakeConfigService) UpdateConfiguration(func(*config.Configuration)) error { return nil }
+func (f *fakeConfigService) RegisterConfigChangeListener(func()) string            { return "" }
+func (f *fakeConfigService) UnregisterConfigChangeListener(string)                 {}
+func (f *fakeConfigService) GetManifest() *model.Manifest {
+	return &model.Manifest{Id: "playbooks"}
+}
+func (f *fakeConfigService) IsConfiguredForDevelopmentAndTesting() bool { return false }
+func (f *fakeConfigService) IsCloud() bool                              { return f.isCloud }
+func (f *fakeConfigService) SupportsGivingFeedback() error              { return nil }
+func (f *fakeConfigService) IsIncrementalUpdatesEnabled() bool          { return false }
+func (f *fakeConfigService) IsExperimentalFeaturesEnabled() bool        { return false }
+
+// allAdminNotificationMessageTypes mirrors webapp/src/constants.ts's AdminNotificationType
+// enum. Every value there must produce a non-blank DM: this test would have caught the
+// bug where "start_trial_to_set_checklist_item_due_date" fell through the switch in
+// NotifyAdmins with no title or text.
+var allAdminNotificationMessageTypes = []string{
+	"start_trial_to_view_timeline",
+	"start_trial_to_add_message_to_timeline",
+	"start_trial_to_access_retrospective",
+	"start_trial_to_restrict_playbook_access",
+	"start_trial_to_restrict_playbook_creation",
+	"start_trial_to_export_channel",
+	"start_trial_to_access_playbook_dashboard",
+	"start_trial_to_access_metrics",
+	"start_trial_to_set_checklist_item_due_date",
+	"start_trial_to_request_update",
+}
+
+func TestNotifyAdmins(t *testing.T) {
+	for _, messageType := range allAdminNotificationMessageTypes {
+		t.Run(messageType, func(t *testing.T) {
+			api := &plugintest.API{}
+			defer api.AssertExpectations(t)
+
+			authorID := model.NewId()
+			adminID := model.NewId()
+			botID := model.NewId()
+
+			api.On("GetUser", authorID).Return(&model.User{Id: authorID, Username: "author"}, (*model.AppError)(nil))
+			api.On("GetUsers", mock.AnythingOfType("*model.UserGetOptions")).
+				Return([]*model.User{{Id: adminID, Username: "admin"}}, (*model.AppError)(nil))
+			api.On("GetDirectChannel", adminID, botID).
+				Return(&model.Channel{Id: model.NewId()}, (*model.AppError)(nil))
+
+			// PostService.CreatePost shallow-copies the mock's returned post back onto the
+			// original pointer, which would wipe out the attachment props if we returned a
+			// blank post. Read the attachments off the post while handling the mock call,
+			// before that copy-back happens.
+			attachmentsCh := make(chan []*model.MessageAttachment, 1)
+			api.On("CreatePost", mock.AnythingOfType("*model.Post")).
+				Run(func(args mock.Arguments) {
+					post := args.Get(0).(*model.Post)
+					attachmentsCh <- post.Attachments()
+				}).
+				Return(&model.Post{Id: model.NewId()}, (*model.AppError)(nil))
+
+			b := &Bot{
+				pluginAPI:     pluginapi.NewClient(api, &plugintest.Driver{}),
+				botUserID:     botID,
+				configService: &fakeConfigService{},
+			}
+
+			err := b.NotifyAdmins(messageType, authorID, false)
+			require.NoError(t, err)
+
+			select {
+			case attachments := <-attachmentsCh:
+				require.Len(t, attachments, 1)
+				require.NotEmpty(t, attachments[0].Title, "title must not be blank")
+				require.NotEmpty(t, attachments[0].Text, "text must not be blank")
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for the admin DM to be created")
+			}
+		})
+	}
+}

--- a/server/bot/poster_test.go
+++ b/server/bot/poster_test.go
@@ -95,7 +95,7 @@ func TestNotifyAdmins(t *testing.T) {
 				require.NotEmpty(t, attachments[0].Title, "title must not be blank")
 				require.NotEmpty(t, attachments[0].Text, "text must not be blank")
 			case <-time.After(5 * time.Second):
-				t.Fatal("timed out waiting for the admin DM to be created")
+				require.FailNow(t, "timed out waiting for the admin DM to be created")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

When a non-admin user without the required license tries to set a due date on a checklist item, Playbooks sends a DM to all System Admins nudging them to start a trial. That DM rendered completely blank — no title, no body text, just a divider line and a "Start 30-day trial" button — because `NotifyAdmins` never had a `case` for the `start_trial_to_set_checklist_item_due_date` message type (defined in `webapp/src/constants.ts` and used in `webapp/src/components/checklist_item/duedate.tsx`). `title` and `text` stayed as empty strings when the switch fell through.

This was the only one of the 9 `AdminNotificationType` values missing its corresponding backend case, and it's been broken since the checklist due-date feature was introduced in 2022 (PR #1115).

This PR adds the missing case, using the same copy already present in the frontend modal (`upgrade_modal_data.tsx`) for consistency, plus a table-driven regression test asserting every `AdminNotificationType` produces a non-blank DM — so a future addition to the frontend enum that forgets the matching backend case fails a unit test instead of shipping silently.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-70119

## QA Test Steps

Precondition: server has no active Professional/Enterprise trial or license (Team Edition, or a licensed edition with the trial not started/expired), and cloud licensing is off.

1. Log in as a non-admin user who is a member of a playbook run's channel.
2. Open the run's checklist (RHS) and try to set a due date on any checklist item (click the due-date icon/button on a task).
3. Confirm the upgrade nudge modal that appears (title "Work more effectively" / text about assigning due dates) by clicking its confirm button as a non-admin.
4. Log in as a System Admin (or open a second session).
5. Open the DM from the "Playbooks" bot to the admin account.

**Expected:** the DM shows a title ("Work more effectively"), body text ("Assign due dates to tasks so assignees can prioritize and get things done."), a learn-more/upgrade footer, and the "Start 30-day trial" button.

**Before the fix:** the DM showed only a blank divider line and the "Start 30-day trial" button, with no title or text.

**Regression check:** repeat steps 1-5 for a couple of the other upgrade-nudge entry points (e.g. RHS timeline "add to timeline", playbook run channel export, key metrics) to confirm those DMs still render their title/text correctly.

## Checklist
- ~~Gated by experimental feature flag~~
- [x] Unit tests updated
- [ ] Planned cherry-picks: `release-2.11`, `release-2.10`, `release-2.9`, `release-2.4`