### PR TITLE
Expand Playbooks MCP server: start runs from playbooks, run/playbook lifecycle, username resolution, LLM eval harness

### DIFF
--- a/client/playbook_runs.go
+++ b/client/playbook_runs.go
@@ -223,6 +223,36 @@ func (s *PlaybookRunService) Restore(ctx context.Context, playbookRunID string) 
 	return nil
 }
 
+// AddParticipants adds the given users to the playbook run. Passing only the requesting
+// user's own ID joins the run, which needs no more than view access to it; adding anybody
+// else requires permission to manage the run's properties.
+func (s *PlaybookRunService) AddParticipants(ctx context.Context, playbookRunID string, userIDs []string, forceAddToChannel bool) error {
+	participantsURL := fmt.Sprintf("runs/%s/participants", playbookRunID)
+	req, err := s.client.newAPIRequest(http.MethodPost, participantsURL, struct {
+		UserIDs           []string `json:"user_ids"`
+		ForceAddToChannel bool     `json:"force_add_to_channel"`
+	}{UserIDs: userIDs, ForceAddToChannel: forceAddToChannel})
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	return err
+}
+
+// RemoveParticipant removes a user from the playbook run and stops them following it.
+// Passing the requesting user's own ID leaves the run, which needs no more than view
+// access to it; removing anybody else requires permission to manage the run's properties.
+func (s *PlaybookRunService) RemoveParticipant(ctx context.Context, playbookRunID, userID string) error {
+	participantURL := fmt.Sprintf("runs/%s/participants/%s", playbookRunID, userID)
+	req, err := s.client.newAPIRequest(http.MethodDelete, participantURL, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	return err
+}
 
 func (s *PlaybookRunService) CreateChecklist(ctx context.Context, playbookRunID string, checklist Checklist) error {
 	createURL := fmt.Sprintf("runs/%s/checklists", playbookRunID)

--- a/internal/playbooksmcp/AGENTS.md
+++ b/internal/playbooksmcp/AGENTS.md
@@ -64,6 +64,13 @@ task state, etc.). The server re-preserves its own managed fields (`NextRunNumbe
 `AdminOnlyEdit`, `ChannelNameTemplateLocked`) and assigns item IDs itself, so you do
 not need to generate item IDs.
 
+Mutate **only the keys the caller asked to change** — `update_playbook` writes `title`
+and/or `description` and nothing else. The API offers no optimistic concurrency here,
+so an edit landing between the GET and the PUT is lost; the same applies to the
+run-side read-modify-write in `edit_checklist_item`, which must re-send
+`title`/`description`/`command` together because the server's `itemEdit` replaces all
+three unconditionally. Every such tool needs a preservation test.
+
 ## Assigning a task requires enabling invites
 
 The server rejects a playbook whose assignees aren't invited
@@ -72,11 +79,82 @@ must also add that user to `invited_user_ids` and set `invite_users_enabled = tr
 (see `ensurePlaybookInvitesUser`). This flips a playbook-wide setting as a side
 effect — mention it in the tool's success message so it isn't silent.
 
+## A playbook is a template; a run is an instance of it
+
+Users conflate the two constantly — "start the incident playbook" means "create a run
+from the incident playbook template". Every tool name, description, and error message
+must make the distinction unambiguous:
+
+- Say "playbook template" and "playbook run" rather than a bare "playbook".
+- Template tools point at their run counterpart and vice versa (`add_playbook_task` ↔
+  `add_checklist_item`, `add_playbook_section` ↔ `add_section`, `update_playbook` ↔
+  `update_run`).
+- `run_playbook` is the one tool that crosses the boundary. Anything that could be read
+  as "start a playbook" must route the model there — `create_playbook` explicitly says
+  it creates a template and does *not* start anything.
+
 ## Tool description conventions
 
+- **The description is retrieval text, not just usage text.** Agents defaults
+  `MCPDynamicToolLoading` to true, so the model does not see the tool list: it calls
+  `search_tools`, which BM25-ranks over `name + bare name + description` and returns the
+  description as the result summary (`mcp/dynamic_registry.go`, `mcp/meta_tools.go` in
+  mattermost-plugin-agents). A tool whose description omits the words a user would say
+  is unfindable no matter how good its schema is. So:
+  - Include the user's vocabulary verbatim, including the quoted phrasings — "start the
+    X playbook", "mark that task done", "close the incident", "who's on this run".
+  - Front-load them in the first sentence, and keep each description a single paragraph
+    with no newlines. Nothing truncates today, but the opening words carry the most
+    retrieval weight and are what a reader skims.
+  - Say what the tool acts on (a run or a template) in that first sentence. Don't open
+    with "This tool …" or defer the keywords to a later sentence.
 - State that indexes are zero-based.
 - Include a concrete JSON example of the arguments.
 - For destructive tools, tell the model to confirm indexes first.
+- Name the discovery tool to call when an ID or index is unknown.
+
+## Render results, don't dump JSON
+
+Tool output is model input, so it competes for context. Do not `json.MarshalIndent` an
+API response into the result (`get_run` used to, and buried the checklist indexes in
+several KB of internal fields). Render a compact, structured summary instead:
+
+- Lead with identity (name, ID, and the human-facing run number when present), then
+  status, then the fields that enable the next action.
+- Render run checklists through the shared `[checklist_number][item_number]` notation
+  so indexes match `writeRunChecklists` in `resolve.go` and stay consistent across
+  tools; `writeRunChecklistsVerbose` in `runs.go` is the detailed variant.
+- Summarize collections that are large and rarely needed — report the count and name
+  the tool that reads them (status posts → `get_status_updates`, timeline events → not
+  exposed) rather than inlining them.
+- Surface fields whose absence would mislead: an item assigned by role or property has
+  an empty `assignee_id` and looks unassigned unless `assignee_type` /
+  `assignee_property_field_id` are rendered too.
+
+## Client interface additions
+
+`tools.APIClient` (`tools/provider.go`) is implemented three times: `pluginMCPClient`
+in `server/mcp.go`, the eval harness client under `server/`, and `fakeAPIClient` in
+`tools/checklist_test.go`. Adding a method means updating all three, so keep signatures
+stable once added. Current URL helpers mirror the webapp routes:
+`GetPlaybookURL` → `/playbooks/playbooks/{id}`, `GetRunURL` → `/playbooks/runs/{id}`
+(matching `app.GetRunDetailsRelativeURL`).
+
+## "me" resolution
+
+The list endpoint resolves the literal `me` for `owner_user_id` and `participant_id`
+server-side (`parsePlaybookRunsFilterOptions`), so those are forwarded verbatim. Every
+other endpoint requires a real ID: resolve `me` client-side with `resolveUserID`, which
+calls `GetCurrentUserID` and validates anything else as a Mattermost ID.
+
+## Run participants
+
+`POST runs/{id}/participants` takes `{"user_ids": [...], "force_add_to_channel": bool}`
+and `DELETE runs/{id}/participants/{user_id}` removes one user, who also stops
+following the run. A user acting on themselves only needs `RunView` (joining and
+leaving), while acting on anyone else needs `RunManageProperties` on an active run. The
+run's owner cannot be removed — `remove_run_participant` fetches the run and says to
+call `change_run_owner` first rather than letting that surface as a bare 400.
 
 ## Testing
 
@@ -86,3 +164,13 @@ effect — mention it in the tool's success message so it isn't silent.
   `*_test.go` preservation tests in `tools/`).
 - Cover the out-of-range / no-op / validation-error paths, and assert that no
   mutating call (PUT/POST/DELETE) happens when validation fails.
+- Assert the HTTP verb, not just the path: several tools differ only by method
+  (`PUT`/`DELETE` on `runs/{id}/followers`, `PATCH` on `runs/{id}`), so a test that only
+  checks the endpoint would pass against the wrong call. The fake records each verb in
+  its own field, so check `putEndpoint` / `patchEndpoint` / `deleteEndpoint` specifically.
+- **Add every new tool to `TestEveryToolIsRegistered`** in `provider_test.go`. The other
+  tests call handlers directly, so a tool that is implemented but never wired into
+  `addMCPHelper*Tools` is invisible to the model and otherwise passes CI. That test also
+  asserts the registered count, so it fails until the new tool is listed.
+  `TestToolDescriptionsFollowRetrievalConventions` then enforces the description rules
+  above across every tool.

--- a/internal/playbooksmcp/AGENTS.md
+++ b/internal/playbooksmcp/AGENTS.md
@@ -113,6 +113,43 @@ must make the distinction unambiguous:
 - For destructive tools, tell the model to confirm indexes first.
 - Name the discovery tool to call when an ID or index is unknown.
 
+## Every run/playbook API error goes through the wrapping helpers
+
+The Playbooks API answers **403 "Not authorized" for an object that does not
+exist** as well as one the caller may not see. Passed through raw, a model that
+mistypes one character of a run_id reads a permission wall and abandons the task
+— this was observed in an eval run. So never return a bare API error from a call
+that takes a caller-supplied `run_id` or `playbook_id`:
+
+- Wrap with `wrapRunError(err, runID, action, hints...)` or
+  `wrapPlaybookError(...)` in `tools/apierror.go`. On 403/404 they name both
+  possibilities and the discovery tool to call (`resolve_channel_context` /
+  `list_runs`, or `list_playbooks` with `with_archived=true`); on anything else
+  they stay terse. `action` is a verb phrase ("finish", "post a status update
+  to"), and `hints` carry tool-specific causes worth adding.
+- This applies to **mutations that never fetch first** (`finish_run`,
+  `follow_run`, `update_run_status`, …) just as much as to the fetch helpers —
+  those are exactly where the ambiguity reaches the model unmediated.
+- `isUnknownOrForbidden` recovers the status by parsing the error text, because
+  `APIClient` passes plain errors. Both implementations format failures as
+  `API error (status %d)`; if that ever changes, `apierror_test.go` fails.
+
+## Report the index a mutation just created
+
+A tool that creates an indexed object must say where it landed, or the model
+guesses the index for its next call and fails (observed with `add_section` →
+`add_checklist_item`). Both run-side add endpoints **append**:
+`AddChecklist` and `AddChecklistItem` in `server/app/playbook_run_service.go`.
+
+- `add_checklist_item` reads the pre-add item count from the bounds fetch it
+  already does. Capture it *before* the POST, not after.
+- `add_section` has no prior fetch and the endpoint returns 201 with no body, so
+  it reads the run back afterwards and reports `len(checklists)-1` plus every
+  section's index via `writeRunSectionIndexes`. A failed read-back must still
+  report success — the section exists by then.
+- Tools that create a whole run (`run_playbook`, `create_checklist`) render the
+  resulting checklist indexes too, so no follow-up `get_run` is needed.
+
 ## Render results, don't dump JSON
 
 Tool output is model input, so it competes for context. Do not `json.MarshalIndent` an
@@ -140,12 +177,43 @@ stable once added. Current URL helpers mirror the webapp routes:
 `GetPlaybookURL` → `/playbooks/playbooks/{id}`, `GetRunURL` → `/playbooks/runs/{id}`
 (matching `app.GetRunDetailsRelativeURL`).
 
-## "me" resolution
+`ResolveUserID` is the one method whose semantics live in the implementations rather
+than in the tools layer, and all three must agree: `me` → the acting user, a valid
+26-character ID → returned unchanged, anything else → a case-folded username lookup with
+one optional leading `@` stripped. `pluginMCPClient` takes the lookup itself as a
+`usernameResolver` func injected by `newPlaybooksMCPServer` (backed by
+`pluginAPI.User.GetByUsername`), which keeps the server constructible in tests; a nil
+resolver reports "user lookup unavailable" instead of panicking.
 
-The list endpoint resolves the literal `me` for `owner_user_id` and `participant_id`
-server-side (`parsePlaybookRunsFilterOptions`), so those are forwarded verbatim. Every
-other endpoint requires a real ID: resolve `me` client-side with `resolveUserID`, which
-calls `GetCurrentUserID` and validates anything else as a Mattermost ID.
+## User references: always `resolveUserRef`, never `validateID`
+
+People are the one kind of object a model usually knows by name rather than by ID:
+"add @bob to this run" is the canonical phrasing, and a tool that only takes a
+26-character ID leaves the model stuck (Anthropic models invent a user-lookup tool that
+does not exist). So **every argument that names a user goes through
+`resolveUserRef(ctx, client, ref, field)`** — `tools/users.go` — and none of them is
+validated with `validateID`. Lists use `resolveUserRefs`, which also reports the failing
+index and deduplicates references that landed on the same user.
+
+`resolveUserRef` delegates to `APIClient.ResolveUserID`, which accepts `me`, a raw ID
+(returned as-is, no lookup), or a username with or without a leading `@`. The empty
+string stays empty so callers can distinguish "not provided" from a bad reference; where
+an empty value means "clear the assignee", pass it through unchanged rather than
+special-casing it earlier. Resolve **before** any mutation so an unknown username fails
+without half-applying a change, and before `fetchPlaybookForMutation` in the playbook
+tools.
+
+Non-user IDs — team, channel, run, playbook — keep strict `validateID`. There is no
+name-based lookup for those, so a loose value there is a genuine argument error.
+
+Each user-reference `jsonschema` tag and the tool's description must both say that a
+user ID, `me`, or a username (with or without `@`) is accepted; `userRefSchemaHint` in
+`tools/users.go` is the canonical wording (struct tags cannot reference it, so it is
+spelled out at each site).
+
+`list_runs`' `owner_user_id` and `participant_id` are resolved client-side even though
+the list endpoint understands `me` itself (`parsePlaybookRunsFilterOptions`), so
+usernames work there too and the convention has no exceptions.
 
 ## Run participants
 

--- a/internal/playbooksmcp/tools/apierror.go
+++ b/internal/playbooksmcp/tools/apierror.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// apiErrorStatusPattern matches the status code in the errors every APIClient
+// implementation produces. Both the plugin client (server/mcp.go) and the eval
+// harness client format failures as "API error (status %d): body", and the
+// APIClient interface passes plain errors, so the text is the only place the
+// status survives. Parsing it here keeps that coupling in one tested spot
+// instead of spreading string matching through the tools.
+var apiErrorStatusPattern = regexp.MustCompile(`API error \(status (\d+)\)`)
+
+func apiErrorStatus(err error) (int, bool) {
+	if err == nil {
+		return 0, false
+	}
+	match := apiErrorStatusPattern.FindStringSubmatch(err.Error())
+	if match == nil {
+		return 0, false
+	}
+	status, convErr := strconv.Atoi(match[1])
+	if convErr != nil {
+		return 0, false
+	}
+	return status, true
+}
+
+// isUnknownOrForbidden reports whether an error is the response the Playbooks
+// API gives for an object that either does not exist or is not visible to the
+// caller. It deliberately answers 403 for both, so these two cases cannot be
+// told apart from the outside.
+func isUnknownOrForbidden(err error) bool {
+	status, ok := apiErrorStatus(err)
+	return ok && (status == 403 || status == 404)
+}
+
+// wrapRunError explains an ambiguous run failure instead of passing the API's
+// bare "Not authorized" through. A model that mistypes one character of a
+// run_id otherwise reads that as a permission wall and abandons the task, when
+// re-running discovery would have fixed it. action is a verb phrase such as
+// "finish" or "post a status update to"; hints add tool-specific causes worth
+// mentioning, such as an operation only being valid on an in-progress run.
+func wrapRunError(err error, runID, action string, hints ...string) error {
+	if !isUnknownOrForbidden(err) {
+		return fmt.Errorf("failed to %s run %s: %w%s", action, runID, err, joinHints(hints))
+	}
+	return fmt.Errorf("failed to %s run %s: no playbook run with that ID is visible to you. "+
+		"The run_id may be mistyped or the run may not exist, or you may lack access to it — the API cannot tell these apart. "+
+		"Do not retry the same ID: call resolve_channel_context with the channel you are working in, or list_runs, to find the correct run_id.%s "+
+		"Underlying error: %w", action, runID, joinHints(hints), err)
+}
+
+// wrapPlaybookError is the playbook-template counterpart of wrapRunError.
+// Archived templates are hidden from list_playbooks by default, which is a
+// common reason a valid-looking playbook_id appears to be forbidden.
+func wrapPlaybookError(err error, playbookID, action string, hints ...string) error {
+	if !isUnknownOrForbidden(err) {
+		return fmt.Errorf("failed to %s playbook template %s: %w%s", action, playbookID, err, joinHints(hints))
+	}
+	return fmt.Errorf("failed to %s playbook template %s: no playbook template with that ID is visible to you. "+
+		"The playbook_id may be mistyped or the template may not exist, or you may lack access to it — the API cannot tell these apart. "+
+		"Do not retry the same ID: call list_playbooks to find the correct playbook_id, passing with_archived=true if the template may have been archived.%s "+
+		"Underlying error: %w", action, playbookID, joinHints(hints), err)
+}
+
+func joinHints(hints []string) string {
+	if len(hints) == 0 {
+		return ""
+	}
+	return " " + strings.Join(hints, " ")
+}

--- a/internal/playbooksmcp/tools/apierror_test.go
+++ b/internal/playbooksmcp/tools/apierror_test.go
@@ -1,0 +1,357 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apiError builds the error string both APIClient implementations produce, so
+// these tests break if either client changes its format out from under the
+// parser.
+func apiError(status int, body string) error {
+	return fmt.Errorf("API error (status %d): %s", status, body)
+}
+
+func TestAPIErrorStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantOK     bool
+	}{
+		{name: "nil error", err: nil},
+		{name: "unrelated error", err: errors.New("connection refused")},
+		{
+			name:       "forbidden",
+			err:        apiError(403, `{"error":"Not authorized"}`),
+			wantStatus: 403,
+			wantOK:     true,
+		},
+		{
+			name:       "not found",
+			err:        apiError(404, "not found"),
+			wantStatus: 404,
+			wantOK:     true,
+		},
+		{
+			name:       "server error",
+			err:        apiError(500, "boom"),
+			wantStatus: 500,
+			wantOK:     true,
+		},
+		{
+			// The client uses a semicolon in this variant, so the parser must
+			// not depend on the colon that follows the status in the common case.
+			name:       "unreadable body variant",
+			err:        fmt.Errorf("API error (status 403); failed to read response body: %w", errors.New("eof")),
+			wantStatus: 403,
+			wantOK:     true,
+		},
+		{
+			name:       "wrapped by a tool",
+			err:        fmt.Errorf("failed to get run: %w", apiError(403, "Not authorized")),
+			wantStatus: 403,
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, ok := apiErrorStatus(tt.err)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantStatus, status)
+		})
+	}
+}
+
+func TestIsUnknownOrForbidden(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil is not ambiguous", err: nil, want: false},
+		{name: "403 is ambiguous", err: apiError(403, "Not authorized"), want: true},
+		{name: "404 is ambiguous", err: apiError(404, "not found"), want: true},
+		{name: "400 is not", err: apiError(400, "bad request"), want: false},
+		{name: "500 is not", err: apiError(500, "boom"), want: false},
+		{name: "transport failure is not", err: errors.New("connection refused"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isUnknownOrForbidden(tt.err))
+		})
+	}
+}
+
+func TestWrapRunError(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name        string
+		err         error
+		hints       []string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			// The case that made a model give up: a mistyped ID reads as a
+			// permission wall unless the ambiguity is spelled out.
+			name: "403 explains the ambiguity and names the discovery tools",
+			err:  apiError(403, `{"error":"Not authorized"}`),
+			wantContain: []string{
+				"failed to finish run " + runID,
+				"no playbook run with that ID is visible to you",
+				"may be mistyped",
+				"lack access",
+				"resolve_channel_context",
+				"list_runs",
+				"Not authorized",
+			},
+		},
+		{
+			name: "404 gets the same guidance",
+			err:  apiError(404, "not found"),
+			wantContain: []string{
+				"no playbook run with that ID is visible to you",
+				"list_runs",
+			},
+		},
+		{
+			name:        "other statuses stay terse",
+			err:         apiError(500, "boom"),
+			wantContain: []string{"failed to finish run " + runID, "boom"},
+			wantAbsent:  []string{"resolve_channel_context", "is visible to you"},
+		},
+		{
+			name:        "hints are appended for unambiguous failures",
+			err:         apiError(400, "cannot modify a finished run"),
+			hints:       []string{"Finished runs cannot be edited — call restore_run first."},
+			wantContain: []string{"cannot modify a finished run", "call restore_run first"},
+			wantAbsent:  []string{"resolve_channel_context"},
+		},
+		{
+			name:        "hints survive alongside the ambiguity guidance",
+			err:         apiError(403, "Not authorized"),
+			hints:       []string{"Finished runs cannot be edited — call restore_run first."},
+			wantContain: []string{"is visible to you", "list_runs", "call restore_run first"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := wrapRunError(tt.err, runID, "finish", tt.hints...)
+			require.Error(t, err)
+			for _, want := range tt.wantContain {
+				assert.Contains(t, err.Error(), want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, err.Error(), absent)
+			}
+			assert.ErrorIs(t, err, tt.err, "the underlying error must stay unwrappable")
+		})
+	}
+}
+
+func TestWrapPlaybookError(t *testing.T) {
+	const playbookID = "bcdefghijklmnopqrstuvwxyza"
+
+	tests := []struct {
+		name        string
+		err         error
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "403 points at list_playbooks and the archived case",
+			err:  apiError(403, "Not authorized"),
+			wantContain: []string{
+				"failed to archive playbook template " + playbookID,
+				"no playbook template with that ID is visible to you",
+				"list_playbooks",
+				"with_archived=true",
+			},
+		},
+		{
+			name:        "other statuses stay terse",
+			err:         apiError(500, "boom"),
+			wantContain: []string{"boom"},
+			wantAbsent:  []string{"with_archived=true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := wrapPlaybookError(tt.err, playbookID, "archive")
+			require.Error(t, err)
+			for _, want := range tt.wantContain {
+				assert.Contains(t, err.Error(), want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, err.Error(), absent)
+			}
+		})
+	}
+}
+
+// The wrapping only helps if it is actually reached, so drive it through the
+// tools: the ones that fetch a run first, the ones that mutate without
+// fetching, and the playbook side.
+func TestToolsExplainAmbiguous403(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+	const playbookID = "bcdefghijklmnopqrstuvwxyza"
+	forbidden := apiError(403, `{"error":"Not authorized"}`)
+
+	runTests := []struct {
+		name   string
+		invoke func(context.Context, APIClient) (string, error)
+	}{
+		{
+			name: "get_run",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolGetRun(ctx, c, GetRunArgs{RunID: runID})
+			},
+		},
+		{
+			name: "check_item (fetches for bounds first)",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolCheckItem(ctx, c, CheckItemArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 0})
+			},
+		},
+		{
+			name: "finish_run (mutates without fetching)",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolFinishRun(ctx, c, FinishRunArgs{RunID: runID})
+			},
+		},
+		{
+			name: "follow_run",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolFollowRun(ctx, c, RunIDArgs{RunID: runID})
+			},
+		},
+		{
+			name: "unfollow_run",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolUnfollowRun(ctx, c, RunIDArgs{RunID: runID})
+			},
+		},
+		{
+			name: "update_run_status",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolUpdateRunStatus(ctx, c, UpdateRunStatusArgs{RunID: runID, Message: "Update", ReminderSeconds: 3600})
+			},
+		},
+		{
+			name: "update_run",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				name := "Renamed"
+				return toolUpdateRun(ctx, c, UpdateRunArgs{RunID: runID, Name: &name})
+			},
+		},
+		{
+			name: "get_status_updates",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolGetStatusUpdates(ctx, c, GetStatusUpdatesArgs{RunID: runID})
+			},
+		},
+		{
+			name: "get_run_metadata",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolGetRunMetadata(ctx, c, RunIDArgs{RunID: runID})
+			},
+		},
+		{
+			name: "add_run_participants",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolAddRunParticipants(ctx, c, AddRunParticipantsArgs{RunID: runID, UserIDs: []string{"me"}})
+			},
+		},
+		{
+			name: "add_section",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolAddSection(ctx, c, AddSectionArgs{RunID: runID, Title: "New section"})
+			},
+		},
+		{
+			name: "resolve run via find_checklist_item",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolFindChecklistItem(ctx, c, FindChecklistItemArgs{Query: "deploy", RunID: runID})
+			},
+		},
+	}
+
+	for _, tt := range runTests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{getErr: forbidden, postErr: forbidden, putErr: forbidden, patchErr: forbidden, deleteErr: forbidden}
+
+			_, err := tt.invoke(context.Background(), client)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no playbook run with that ID is visible to you")
+			assert.Contains(t, err.Error(), "list_runs")
+			assert.NotContains(t, err.Error(), "you lack permission to")
+		})
+	}
+
+	playbookTests := []struct {
+		name   string
+		invoke func(context.Context, APIClient) (string, error)
+	}{
+		{
+			name: "run_playbook's template fetch",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolRunPlaybook(ctx, c, RunPlaybookArgs{PlaybookID: playbookID, Name: "Attempt"})
+			},
+		},
+		{
+			name: "get_playbook",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolGetPlaybook(ctx, c, GetPlaybookArgs{PlaybookID: playbookID})
+			},
+		},
+		{
+			name: "archive_playbook",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolArchivePlaybook(ctx, c, PlaybookIDArgs{PlaybookID: playbookID})
+			},
+		},
+		{
+			name: "restore_playbook",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolRestorePlaybook(ctx, c, PlaybookIDArgs{PlaybookID: playbookID})
+			},
+		},
+		{
+			name: "duplicate_playbook",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolDuplicatePlaybook(ctx, c, PlaybookIDArgs{PlaybookID: playbookID})
+			},
+		},
+		{
+			name: "add_playbook_task",
+			invoke: func(ctx context.Context, c APIClient) (string, error) {
+				return toolAddPlaybookTask(ctx, c, AddPlaybookTaskArgs{PlaybookID: playbookID, ChecklistNumber: 0, Title: "Task"})
+			},
+		},
+	}
+
+	for _, tt := range playbookTests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{getErr: forbidden, postErr: forbidden, putErr: forbidden, patchErr: forbidden, deleteErr: forbidden}
+
+			_, err := tt.invoke(context.Background(), client)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no playbook template with that ID is visible to you")
+			assert.Contains(t, err.Error(), "list_playbooks")
+		})
+	}
+}

--- a/internal/playbooksmcp/tools/checklist.go
+++ b/internal/playbooksmcp/tools/checklist.go
@@ -17,7 +17,7 @@ type CheckItemArgs struct {
 	RunID           string `json:"run_id" jsonschema:"The ID of the playbook run"`
 	ChecklistNumber int    `json:"checklist_number" jsonschema:"The zero-based index of the checklist"`
 	ItemNumber      int    `json:"item_number" jsonschema:"The zero-based index of the item within the checklist"`
-	NewState        string `json:"new_state,omitempty" jsonschema:"The new state for the item: open, closed, or skipped (default: closed)"`
+	NewState        string `json:"new_state,omitempty" jsonschema:"The new state for the item: open, in_progress, closed, or skipped (default: closed)"`
 }
 
 type AddChecklistItemArgs struct {
@@ -68,8 +68,19 @@ type MoveChecklistItemArgs struct {
 }
 
 type AddSectionArgs struct {
-	RunID string `json:"run_id" jsonschema:"The ID of the playbook run"`
-	Title string `json:"title" jsonschema:"Title of the new section"`
+	RunID string                `json:"run_id" jsonschema:"The ID of the playbook run"`
+	Title string                `json:"title" jsonschema:"Title of the new section"`
+	Items []CreateChecklistItem `json:"items,omitempty" jsonschema:"Optional initial tasks for the section, same shape as create_checklist section items. Item due_date is an absolute Unix timestamp in milliseconds because this is a run, not a template."`
+}
+
+type SkipSectionArgs struct {
+	RunID           string `json:"run_id" jsonschema:"The ID of the playbook run"`
+	ChecklistNumber int    `json:"checklist_number" jsonschema:"The zero-based index of the section to skip"`
+}
+
+type RestoreSectionArgs struct {
+	RunID           string `json:"run_id" jsonschema:"The ID of the playbook run"`
+	ChecklistNumber int    `json:"checklist_number" jsonschema:"The zero-based index of the section to un-skip"`
 }
 
 type RenameSectionArgs struct {
@@ -93,47 +104,55 @@ type MoveSectionArgs struct {
 
 func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Server) {
 	addMCPHelperTool(server, p.clientFactory, "check_item",
-		"Change the state of a checklist item in a playbook run. Use new_state='closed' to check it off or 'open' to uncheck it. Checklist and item numbers are zero-based indexes. If you do not already know the run_id and the exact indexes, do NOT guess them: first call resolve_channel_context (passing the channel the agent is operating in) or find_checklist_item to look them up. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2, \"new_state\": \"closed\"}",
+		"Check off, uncheck, skip, or start a task in a playbook run — \"mark that task done\", \"tick it off\", \"mark it in progress\", \"skip that step\". new_state is one of closed (done, the default), open (not started), in_progress (being worked on), or skipped (does not apply). This edits a task inside a live run, not a playbook template. Checklist and item numbers are zero-based indexes; if you do not already know the run_id and the exact indexes, do NOT guess them: call resolve_channel_context (passing the channel the agent is operating in), find_checklist_item, or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2, \"new_state\": \"closed\"}",
 		toolCheckItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_checklist_item",
-		"Add a new item to an existing checklist in a playbook run. The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context first. due_date is an optional Unix timestamp in milliseconds. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix in staging\", \"due_date\": 1717200000000}",
+		"Add a task to an existing checklist section in a playbook run (a live run, not a playbook template — use add_playbook_task for templates). The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context or get_run first. due_date is an absolute Unix timestamp in milliseconds because this is a run. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix in staging\", \"due_date\": 1717200000000}",
 		toolAddChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "set_checklist_item_due_date",
-		"Set or clear the due date for an existing checklist item in a playbook run. due_date is a Unix timestamp in milliseconds; use 0 to clear. Checklist and item numbers are zero-based indexes; if you don't know them, call resolve_channel_context or find_checklist_item first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"due_date\": 1717200000000}",
+		"Set or clear the due date/deadline of a task in a playbook run. due_date is an absolute Unix timestamp in milliseconds (runs use absolute dates; playbook templates use relative offsets); use 0 to clear. Checklist and item numbers are zero-based indexes; if you don't know them, call resolve_channel_context, find_checklist_item, or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"due_date\": 1717200000000}",
 		toolSetChecklistItemDueDate)
 
 	addMCPHelperTool(server, p.clientFactory, "edit_checklist_item",
-		"Edit the title, description, slash command, or due date of an existing checklist item. Only provided fields are updated. due_date is a Unix timestamp in milliseconds; use 0 to clear. If you don't know the indexes, call resolve_channel_context or find_checklist_item first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task title\", \"due_date\": 1717200000000}",
+		"Edit the title, description, slash command, or due date of a task in a playbook run. Only provided fields change; the rest are preserved. due_date is an absolute Unix timestamp in milliseconds; use 0 to clear. To change whether the task is done use check_item instead. If you don't know the indexes, call resolve_channel_context, find_checklist_item, or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task title\", \"due_date\": 1717200000000}",
 		toolEditChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "set_checklist_item_assignee",
-		"Assign or clear the assignee for an existing checklist item. Omit assignee_id or set it to an empty string to clear the assignee. If you don't know the indexes, call resolve_channel_context or find_checklist_item first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"assignee_id\": \"user123...\"}",
+		"Assign a task in a playbook run to someone, or clear its assignee — \"give that task to Alice\", \"unassign it\". Omit assignee_id or set it to an empty string to clear. If you don't know the indexes, call resolve_channel_context, find_checklist_item, or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"assignee_id\": \"user123...\"}",
 		toolSetChecklistItemAssignee)
 
 	addMCPHelperTool(server, p.clientFactory, "remove_checklist_item",
-		"Remove a checklist item from a playbook run. This permanently deletes the item, so confirm the indexes first — if unsure, call resolve_channel_context or find_checklist_item. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}",
+		"Delete a task from a playbook run permanently. Prefer check_item with new_state='skipped' when the task simply does not apply. This is destructive, so confirm the indexes first — call resolve_channel_context, find_checklist_item, or get_run if unsure. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}",
 		toolRemoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "move_checklist_item",
-		"Move a checklist item within or between sections in a playbook run. Source and destination indexes are zero-based. The destination item index is an insertion position: within the same section it must be an existing item index (0..item count-1); when moving to a different section you may also use the item count itself to append. If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 0, \"source_item_idx\": 2, \"dest_checklist_idx\": 1, \"dest_item_idx\": 0}",
+		"Reorder a task within a playbook run, or move it to a different checklist section. Source and destination indexes are zero-based. The destination item index is an insertion position: within the same section it must be an existing item index (0..item count-1); when moving to a different section you may also use the item count itself to append. If you don't know the indexes, call resolve_channel_context or get_run first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 0, \"source_item_idx\": 2, \"dest_checklist_idx\": 1, \"dest_item_idx\": 0}",
 		toolMoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_section",
-		"Add a new section (checklist group) to a playbook run. Sections organize tasks into logical groups. Example: {\"run_id\": \"abc123...\", \"title\": \"Post-incident review\"}",
+		"Add a checklist section (task group, stage) to a playbook run, optionally with its initial tasks in the same call. Sections group tasks in a live run; to add a section to a reusable playbook template use add_playbook_section. Example: {\"run_id\": \"abc123...\", \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}",
 		toolAddSection)
 
 	addMCPHelperTool(server, p.clientFactory, "rename_section",
-		"Rename an existing section in a playbook run. The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}",
+		"Rename a checklist section in a playbook run. The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}",
 		toolRenameSection)
 
 	addMCPHelperTool(server, p.clientFactory, "remove_section",
-		"Remove an entire section and all its items from a playbook run. This is permanent, so confirm the index first — if unsure, call resolve_channel_context. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 1}",
+		"Delete a whole checklist section and all its tasks from a playbook run permanently. Prefer skip_section when the section simply does not apply this time. This is destructive, so confirm the index first — call resolve_channel_context or get_run if unsure. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 1}",
 		toolRemoveSection)
 
+	addMCPHelperTool(server, p.clientFactory, "skip_section",
+		"Skip an entire checklist section in a playbook run — \"this whole stage doesn't apply this time\" — without deleting it. To skip one individual task instead, call check_item with new_state='skipped'. Un-skip with restore_section. The checklist_number is a zero-based index; call resolve_channel_context or get_run if you don't know it. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 1}",
+		toolSkipSection)
+
+	addMCPHelperTool(server, p.clientFactory, "restore_section",
+		"Un-skip a previously skipped checklist section in a playbook run, bringing its tasks back into play. This is the inverse of skip_section. The checklist_number is a zero-based index; call resolve_channel_context or get_run if you don't know it. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 1}",
+		toolRestoreSection)
+
 	addMCPHelperTool(server, p.clientFactory, "move_section",
-		"Move a section within a playbook run. Source and destination indexes are zero-based existing section indexes (0 = first, section count-1 = last). If you don't know the indexes, call resolve_channel_context first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}",
+		"Reorder a checklist section within a playbook run. Source and destination indexes are zero-based existing section indexes (0 = first, section count-1 = last). If you don't know the indexes, call resolve_channel_context or get_run first. Example: {\"run_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}",
 		toolMoveSection)
 }
 
@@ -161,11 +180,9 @@ func toolCheckItem(ctx context.Context, client APIClient, args CheckItemArgs) (s
 		// The Playbooks API uses an empty new_state to reopen an item. This is distinct
 		// from the omitted MCP argument above, which defaults the tool action to closed.
 		apiState = ""
-	case "closed", "skipped":
-	case "in_progress":
-		return "", fmt.Errorf("new_state %q is not supported by this tool; use open, closed, or skipped", state)
+	case "in_progress", "closed", "skipped":
 	default:
-		return "", fmt.Errorf("new_state must be one of open, closed, or skipped")
+		return "", fmt.Errorf("new_state must be one of open, in_progress, closed, or skipped")
 	}
 
 	// Fetch the run first so we can give an actionable error (listing the real
@@ -215,8 +232,10 @@ func fetchRunForBounds(ctx context.Context, client APIClient, runID string) (pla
 }
 
 // checkChecklistIndex verifies a checklist (section) index exists in the run.
+// It rejects negatives itself rather than trusting every caller to have run
+// validateIndex first, since indexing a slice with one would panic.
 func checkChecklistIndex(run playbookRunDetail, idx int, field string) error {
-	if idx >= len(run.Checklists) {
+	if idx < 0 || idx >= len(run.Checklists) {
 		return outOfRangeError(field, idx, run)
 	}
 	return nil
@@ -230,7 +249,7 @@ func checkItemIndex(run playbookRunDetail, checklistIdx, itemIdx int, checklistF
 	if err := checkChecklistIndex(run, checklistIdx, checklistField); err != nil {
 		return err
 	}
-	if itemIdx >= len(run.Checklists[checklistIdx].Items) {
+	if itemIdx < 0 || itemIdx >= len(run.Checklists[checklistIdx].Items) {
 		return outOfRangeError(itemField, itemIdx, run)
 	}
 	return nil
@@ -245,6 +264,9 @@ func checkMoveItemDest(run playbookRunDetail, sourceChecklistIdx, destChecklistI
 		return err
 	}
 	lenDest := len(run.Checklists[destChecklistIdx].Items)
+	if destItemIdx < 0 {
+		return outOfRangeError("dest_item_idx", destItemIdx, run)
+	}
 	if sourceChecklistIdx == destChecklistIdx {
 		if destItemIdx >= lenDest {
 			return outOfRangeError("dest_item_idx", destItemIdx, run)
@@ -521,9 +543,20 @@ func toolAddSection(ctx context.Context, client APIClient, args AddSectionArgs) 
 	if title == "" {
 		return "", fmt.Errorf("title is required")
 	}
+	if err := validateChecklistItems(args.Items, "items"); err != nil {
+		return "", err
+	}
 
-	body := map[string]string{
+	// The endpoint decodes a full app.Checklist, so the section and its tasks
+	// can be created in one round trip.
+	items := make([]CreateChecklistItem, 0, len(args.Items))
+	for _, item := range args.Items {
+		item.Title = strings.TrimSpace(item.Title)
+		items = append(items, item)
+	}
+	body := map[string]any{
 		"title": title,
+		"items": items,
 	}
 
 	endpoint := fmt.Sprintf("runs/%s/checklists", args.RunID)
@@ -531,7 +564,48 @@ func toolAddSection(ctx context.Context, client APIClient, args AddSectionArgs) 
 		return "", fmt.Errorf("failed to add section: %w", err)
 	}
 
+	if len(items) > 0 {
+		return fmt.Sprintf("Added section '%s' with %d task(s) to run %s.", title, len(items), args.RunID), nil
+	}
 	return fmt.Sprintf("Added section '%s' to run %s.", title, args.RunID), nil
+}
+
+func toolSkipSection(ctx context.Context, client APIClient, args SkipSectionArgs) (string, error) {
+	return setSectionSkipped(ctx, client, args.RunID, args.ChecklistNumber, true)
+}
+
+func toolRestoreSection(ctx context.Context, client APIClient, args RestoreSectionArgs) (string, error) {
+	return setSectionSkipped(ctx, client, args.RunID, args.ChecklistNumber, false)
+}
+
+func setSectionSkipped(ctx context.Context, client APIClient, runID string, checklistNumber int, skip bool) (string, error) {
+	if err := validateID(runID, "run_id"); err != nil {
+		return "", err
+	}
+	if err := validateIndex(checklistNumber, "checklist_number"); err != nil {
+		return "", err
+	}
+
+	run, err := fetchRunForBounds(ctx, client, runID)
+	if err != nil {
+		return "", err
+	}
+	if err := checkChecklistIndex(run, checklistNumber, "checklist_number"); err != nil {
+		return "", err
+	}
+	title := run.Checklists[checklistNumber].Title
+
+	action, verb := "restore", "restored"
+	if skip {
+		action, verb = "skip", "skipped"
+	}
+
+	endpoint := fmt.Sprintf("runs/%s/checklists/%d/%s", runID, checklistNumber, action)
+	if err := client.Put(ctx, endpoint, nil, nil); err != nil {
+		return "", fmt.Errorf("failed to %s section %d in run %s: %w", action, checklistNumber, runID, err)
+	}
+
+	return fmt.Sprintf("Section %d (%q) in run %s %s.", checklistNumber, title, runID, verb), nil
 }
 
 func toolRenameSection(ctx context.Context, client APIClient, args RenameSectionArgs) (string, error) {

--- a/internal/playbooksmcp/tools/checklist.go
+++ b/internal/playbooksmcp/tools/checklist.go
@@ -25,7 +25,7 @@ type AddChecklistItemArgs struct {
 	ChecklistNumber int    `json:"checklist_number" jsonschema:"The zero-based index of the checklist to add the item to"`
 	Title           string `json:"title" jsonschema:"Title of the new checklist item"`
 	Description     string `json:"description,omitempty" jsonschema:"Optional description for the item (supports Markdown)"`
-	AssigneeID      string `json:"assignee_id,omitempty" jsonschema:"Optional user ID to assign the item to"`
+	AssigneeID      string `json:"assignee_id,omitempty" jsonschema:"Optional user to assign the item to. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
 	DueDate         int64  `json:"due_date,omitempty" jsonschema:"Optional due date as Unix timestamp in milliseconds"`
 }
 
@@ -50,7 +50,7 @@ type SetChecklistItemAssigneeArgs struct {
 	RunID           string `json:"run_id" jsonschema:"The ID of the playbook run"`
 	ChecklistNumber int    `json:"checklist_number" jsonschema:"The zero-based index of the checklist"`
 	ItemNumber      int    `json:"item_number" jsonschema:"The zero-based index of the item within the checklist"`
-	AssigneeID      string `json:"assignee_id,omitempty" jsonschema:"Optional user ID to assign the item to; omit or send an empty string to clear the assignee"`
+	AssigneeID      string `json:"assignee_id,omitempty" jsonschema:"User to assign the item to. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob'). Omit or send an empty string to clear the assignee."`
 }
 
 type RemoveChecklistItemArgs struct {
@@ -108,7 +108,7 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolCheckItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_checklist_item",
-		"Add a task to an existing checklist section in a playbook run (a live run, not a playbook template — use add_playbook_task for templates). The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context or get_run first. due_date is an absolute Unix timestamp in milliseconds because this is a run. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix in staging\", \"due_date\": 1717200000000}",
+		"Add a task to an existing checklist section in a playbook run (a live run, not a playbook template — use add_playbook_task for templates). The checklist_number is a zero-based index; if you don't know it, call resolve_channel_context or get_run first. assignee_id accepts a username with or without @, 'me', or a user ID. due_date is an absolute Unix timestamp in milliseconds because this is a run. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix in staging\", \"assignee_id\": \"@alice\", \"due_date\": 1717200000000}",
 		toolAddChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "set_checklist_item_due_date",
@@ -120,7 +120,7 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolEditChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "set_checklist_item_assignee",
-		"Assign a task in a playbook run to someone, or clear its assignee — \"give that task to Alice\", \"unassign it\". Omit assignee_id or set it to an empty string to clear. If you don't know the indexes, call resolve_channel_context, find_checklist_item, or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"assignee_id\": \"user123...\"}",
+		"Assign a task in a playbook run to someone, or clear its assignee — \"give that task to @alice\", \"unassign it\". assignee_id accepts a username with or without @, 'me', or a 26-character user ID; omit it or set it to an empty string to clear. If you don't know the indexes, call resolve_channel_context, find_checklist_item, or get_run first. Example: {\"run_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"assignee_id\": \"@alice\"}",
 		toolSetChecklistItemAssignee)
 
 	addMCPHelperTool(server, p.clientFactory, "remove_checklist_item",
@@ -132,7 +132,7 @@ func (p *PlaybooksToolProvider) addMCPHelperChecklistTools(server *mcphelper.Ser
 		toolMoveChecklistItem)
 
 	addMCPHelperTool(server, p.clientFactory, "add_section",
-		"Add a checklist section (task group, stage) to a playbook run, optionally with its initial tasks in the same call. Sections group tasks in a live run; to add a section to a reusable playbook template use add_playbook_section. Example: {\"run_id\": \"abc123...\", \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}",
+		"Add a checklist section (task group, stage) to a playbook run, optionally with its initial tasks in the same call. Sections group tasks in a live run; to add a section to a reusable playbook template use add_playbook_section. The new section is appended last, and the result reports its zero-based checklist_number along with every section's index — use that number for add_checklist_item rather than guessing it. Example: {\"run_id\": \"abc123...\", \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}",
 		toolAddSection)
 
 	addMCPHelperTool(server, p.clientFactory, "rename_section",
@@ -226,7 +226,7 @@ func outOfRangeError(field string, value int, run playbookRunDetail) error {
 func fetchRunForBounds(ctx context.Context, client APIClient, runID string) (playbookRunDetail, error) {
 	var run playbookRunDetail
 	if err := client.Get(ctx, fmt.Sprintf("runs/%s", runID), nil, &run); err != nil {
-		return playbookRunDetail{}, fmt.Errorf("failed to get run: %w", err)
+		return playbookRunDetail{}, wrapRunError(err, runID, "get")
 	}
 	return run, nil
 }
@@ -290,10 +290,9 @@ func toolAddChecklistItem(ctx context.Context, client APIClient, args AddCheckli
 	if title == "" {
 		return "", fmt.Errorf("title is required")
 	}
-	if args.AssigneeID != "" {
-		if err := validateID(args.AssigneeID, "assignee_id"); err != nil {
-			return "", err
-		}
+	assigneeID, err := resolveUserRef(ctx, client, args.AssigneeID, "assignee_id")
+	if err != nil {
+		return "", err
 	}
 
 	run, err := fetchRunForBounds(ctx, client, args.RunID)
@@ -303,6 +302,11 @@ func toolAddChecklistItem(ctx context.Context, client APIClient, args AddCheckli
 	if err := checkChecklistIndex(run, args.ChecklistNumber, "checklist_number"); err != nil {
 		return "", err
 	}
+	// AddChecklistItem appends, so the new task lands at the pre-add count.
+	// Read it before the POST, while it is unambiguously the prior state.
+	// Reporting it saves a get_run round trip before assigning the task or
+	// setting its due date.
+	itemNumber := len(run.Checklists[args.ChecklistNumber].Items)
 
 	body := map[string]any{
 		"title": title,
@@ -310,8 +314,8 @@ func toolAddChecklistItem(ctx context.Context, client APIClient, args AddCheckli
 	if args.Description != "" {
 		body["description"] = args.Description
 	}
-	if args.AssigneeID != "" {
-		body["assignee_id"] = args.AssigneeID
+	if assigneeID != "" {
+		body["assignee_id"] = assigneeID
 	}
 	if args.DueDate != 0 {
 		body["due_date"] = args.DueDate
@@ -319,10 +323,11 @@ func toolAddChecklistItem(ctx context.Context, client APIClient, args AddCheckli
 
 	endpoint := fmt.Sprintf("runs/%s/checklists/%d/add", args.RunID, args.ChecklistNumber)
 	if err := client.Post(ctx, endpoint, body, nil); err != nil {
-		return "", fmt.Errorf("failed to add checklist item: %w", err)
+		return "", wrapRunError(err, args.RunID, fmt.Sprintf("add a task to checklist %d of", args.ChecklistNumber))
 	}
 
-	return fmt.Sprintf("Added item '%s' to checklist %d in run %s.", title, args.ChecklistNumber, args.RunID), nil
+	return fmt.Sprintf("Added task %q to run %s as [%d][%d] (checklist_number %d, item_number %d).",
+		title, args.RunID, args.ChecklistNumber, itemNumber, args.ChecklistNumber, itemNumber), nil
 }
 
 func toolSetChecklistItemDueDate(ctx context.Context, client APIClient, args SetChecklistItemDueDateArgs) (string, error) {
@@ -435,10 +440,11 @@ func toolSetChecklistItemAssignee(ctx context.Context, client APIClient, args Se
 	if err := validateIndex(args.ItemNumber, "item_number"); err != nil {
 		return "", err
 	}
-	if args.AssigneeID != "" {
-		if err := validateID(args.AssigneeID, "assignee_id"); err != nil {
-			return "", err
-		}
+	// An empty assignee_id clears the assignee, so it stays empty rather than
+	// being treated as a reference to resolve.
+	assigneeID, err := resolveUserRef(ctx, client, args.AssigneeID, "assignee_id")
+	if err != nil {
+		return "", err
 	}
 
 	run, err := fetchRunForBounds(ctx, client, args.RunID)
@@ -450,7 +456,7 @@ func toolSetChecklistItemAssignee(ctx context.Context, client APIClient, args Se
 	}
 
 	body := map[string]string{
-		"assignee_id": args.AssigneeID,
+		"assignee_id": assigneeID,
 	}
 
 	endpoint := fmt.Sprintf("runs/%s/checklists/%d/item/%d/assignee", args.RunID, args.ChecklistNumber, args.ItemNumber)
@@ -458,10 +464,10 @@ func toolSetChecklistItemAssignee(ctx context.Context, client APIClient, args Se
 		return "", fmt.Errorf("failed to set checklist item assignee: %w", err)
 	}
 
-	if args.AssigneeID == "" {
+	if assigneeID == "" {
 		return fmt.Sprintf("Cleared assignee for checklist item [%d][%d] in run %s.", args.ChecklistNumber, args.ItemNumber, args.RunID), nil
 	}
-	return fmt.Sprintf("Set assignee for checklist item [%d][%d] in run %s to user %s.", args.ChecklistNumber, args.ItemNumber, args.RunID, args.AssigneeID), nil
+	return fmt.Sprintf("Set assignee for checklist item [%d][%d] in run %s to user %s.", args.ChecklistNumber, args.ItemNumber, args.RunID, assigneeID), nil
 }
 
 func toolRemoveChecklistItem(ctx context.Context, client APIClient, args RemoveChecklistItemArgs) (string, error) {
@@ -543,16 +549,11 @@ func toolAddSection(ctx context.Context, client APIClient, args AddSectionArgs) 
 	if title == "" {
 		return "", fmt.Errorf("title is required")
 	}
-	if err := validateChecklistItems(args.Items, "items"); err != nil {
-		return "", err
-	}
-
 	// The endpoint decodes a full app.Checklist, so the section and its tasks
 	// can be created in one round trip.
-	items := make([]CreateChecklistItem, 0, len(args.Items))
-	for _, item := range args.Items {
-		item.Title = strings.TrimSpace(item.Title)
-		items = append(items, item)
+	items, err := resolveChecklistItems(ctx, client, args.Items, "items")
+	if err != nil {
+		return "", err
 	}
 	body := map[string]any{
 		"title": title,
@@ -561,13 +562,50 @@ func toolAddSection(ctx context.Context, client APIClient, args AddSectionArgs) 
 
 	endpoint := fmt.Sprintf("runs/%s/checklists", args.RunID)
 	if err := client.Post(ctx, endpoint, body, nil); err != nil {
-		return "", fmt.Errorf("failed to add section: %w", err)
+		return "", wrapRunError(err, args.RunID, "add a section to")
 	}
 
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Added section %q to run %s", title, args.RunID)
 	if len(items) > 0 {
-		return fmt.Sprintf("Added section '%s' with %d task(s) to run %s.", title, len(items), args.RunID), nil
+		fmt.Fprintf(&sb, " with %d task(s)", len(items))
 	}
-	return fmt.Sprintf("Added section '%s' to run %s.", title, args.RunID), nil
+	sb.WriteString(".\n")
+
+	// The endpoint returns 201 with no body, so the only way to report the
+	// index the caller needs next is to read the run back. Without it the
+	// model has to guess checklist_number for add_checklist_item.
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		fmt.Fprintf(&sb, "Could not read the run back to report the new section's checklist_number (%v). Call get_run to get it before adding tasks.", err)
+		return sb.String(), nil
+	}
+
+	// AddChecklist appends (server/app/playbook_run_service.go), so the new
+	// section is always last.
+	newIndex := len(run.Checklists) - 1
+	fmt.Fprintf(&sb, "Its checklist_number is %d — pass that to add_checklist_item to add tasks to it.\n\n", newIndex)
+	sb.WriteString("Sections in this run now:\n")
+	writeRunSectionIndexes(&sb, run, newIndex)
+
+	return strings.TrimRight(sb.String(), "\n"), nil
+}
+
+// writeRunSectionIndexes lists a run's sections against the zero-based
+// checklist_number the item tools take, using the same index-first framing as
+// writeRunChecklists. highlight marks a section as just added; pass -1 for none.
+func writeRunSectionIndexes(sb *strings.Builder, run playbookRunDetail, highlight int) {
+	if len(run.Checklists) == 0 {
+		sb.WriteString("  (no sections)\n")
+		return
+	}
+	for ci, cl := range run.Checklists {
+		fmt.Fprintf(sb, "  checklist_number %d: %q (%d task(s))", ci, cl.Title, len(cl.Items))
+		if ci == highlight {
+			sb.WriteString("  <- the section just added")
+		}
+		sb.WriteString("\n")
+	}
 }
 
 func toolSkipSection(ctx context.Context, client APIClient, args SkipSectionArgs) (string, error) {

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,11 +39,17 @@ type fakeAPIClient struct {
 	currentUserID  string
 	currentUserErr error
 
+	// usersByUsername backs ResolveUserID's username lookup; every reference
+	// the tools resolve is recorded in resolvedRefs.
+	usersByUsername map[string]string
+	resolvedRefs    []string
+
 	getEndpoint  string
 	getParams    url.Values
 	getEndpoints []string
 	listParams   url.Values
 	listCalls    []url.Values
+	getErr       error
 
 	postEndpoint string
 	postBody     any
@@ -55,18 +63,24 @@ type fakeAPIClient struct {
 	putBody      any
 	putEndpoints []string
 	putBodies    []any
+	putErr       error
 
 	patchEndpoint string
 	patchBody     any
+	patchErr      error
 
 	deleteEndpoint  string
 	deleteEndpoints []string
+	deleteErr       error
 }
 
 func (f *fakeAPIClient) Get(_ context.Context, endpoint string, params url.Values, result any) error {
 	f.getEndpoint = endpoint
 	f.getParams = params
 	f.getEndpoints = append(f.getEndpoints, endpoint)
+	if f.getErr != nil {
+		return f.getErr
+	}
 	switch v := result.(type) {
 	case *playbookRunDetail:
 		*v = f.run
@@ -136,7 +150,42 @@ func (f *fakeAPIClient) Post(_ context.Context, endpoint string, body any, resul
 		*created = cloneMapAny(bodyMap)
 		(*created)["id"] = "bcdefghijklmnopqrstuvwxyza"
 	}
+	f.applyChecklistWrite(endpoint, body)
 	return nil
+}
+
+// applyChecklistWrite mirrors the server's insert position for the two "add"
+// endpoints so tools that read a run back after mutating it see what the real
+// API would return. Both append: AddChecklist and AddChecklistItem end with
+// `append(...)` in server/app/playbook_run_service.go.
+func (f *fakeAPIClient) applyChecklistWrite(endpoint string, body any) {
+	bodyMap, ok := body.(map[string]any)
+	if !ok {
+		return
+	}
+	parts := strings.Split(endpoint, "/")
+	title, _ := bodyMap["title"].(string)
+
+	// runs/{id}/checklists
+	if len(parts) == 3 && parts[0] == "runs" && parts[2] == "checklists" {
+		added := checklist{Title: title}
+		if items, ok := bodyMap["items"].([]CreateChecklistItem); ok {
+			for _, item := range items {
+				added.Items = append(added.Items, checklistItem{Title: item.Title, AssigneeID: item.AssigneeID, DueDate: item.DueDate})
+			}
+		}
+		f.run.Checklists = append(f.run.Checklists, added)
+		return
+	}
+
+	// runs/{id}/checklists/{n}/add
+	if len(parts) == 5 && parts[0] == "runs" && parts[2] == "checklists" && parts[4] == "add" {
+		idx, err := strconv.Atoi(parts[3])
+		if err != nil || idx < 0 || idx >= len(f.run.Checklists) {
+			return
+		}
+		f.run.Checklists[idx].Items = append(f.run.Checklists[idx].Items, checklistItem{Title: title})
+	}
 }
 
 func (f *fakeAPIClient) Put(_ context.Context, endpoint string, body any, _ any) error {
@@ -144,19 +193,19 @@ func (f *fakeAPIClient) Put(_ context.Context, endpoint string, body any, _ any)
 	f.putBody = body
 	f.putEndpoints = append(f.putEndpoints, endpoint)
 	f.putBodies = append(f.putBodies, body)
-	return nil
+	return f.putErr
 }
 
 func (f *fakeAPIClient) Patch(_ context.Context, endpoint string, body any, _ any) error {
 	f.patchEndpoint = endpoint
 	f.patchBody = body
-	return nil
+	return f.patchErr
 }
 
 func (f *fakeAPIClient) Delete(_ context.Context, endpoint string) error {
 	f.deleteEndpoint = endpoint
 	f.deleteEndpoints = append(f.deleteEndpoints, endpoint)
-	return nil
+	return f.deleteErr
 }
 
 func (f *fakeAPIClient) GetCurrentUserID(context.Context) (string, error) {
@@ -167,6 +216,27 @@ func (f *fakeAPIClient) GetCurrentUserID(context.Context) (string, error) {
 		return f.currentUserID, nil
 	}
 	return "abcdefghijklmnopqrstuvwxy0", nil
+}
+
+// ResolveUserID mirrors pluginMCPClient.ResolveUserID in server/mcp.go: "me"
+// and well-formed IDs short-circuit, everything else is a username lookup.
+func (f *fakeAPIClient) ResolveUserID(ctx context.Context, userRef string) (string, error) {
+	ref := strings.TrimSpace(userRef)
+	f.resolvedRefs = append(f.resolvedRefs, ref)
+	if ref == "" {
+		return "", fmt.Errorf("a user reference is required")
+	}
+	if ref == meUserID {
+		return f.GetCurrentUserID(ctx)
+	}
+	if model.IsValidId(ref) {
+		return ref, nil
+	}
+	username := strings.ToLower(strings.TrimPrefix(ref, "@"))
+	if userID, ok := f.usersByUsername[username]; ok {
+		return userID, nil
+	}
+	return "", fmt.Errorf("no user found with username %q — check the spelling (usernames are case-insensitive, without the @)", username)
 }
 
 func (f *fakeAPIClient) GetPlaybookURL(playbookID string) string {
@@ -335,6 +405,120 @@ func TestToolAddSectionSendsItems(t *testing.T) {
 	assert.Equal(t, "Write summary", items[1].Title)
 }
 
+// A model that adds a section immediately needs its checklist_number for
+// add_checklist_item; eval runs showed it guessing and failing. AddChecklist
+// appends (server/app/playbook_run_service.go), so the new index is always the
+// old section count, and the fake reproduces that append.
+func TestToolAddSectionReportsNewChecklistNumber(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name          string
+		existing      playbookRunDetail
+		items         []CreateChecklistItem
+		wantIndex     int
+		wantInMessage []string
+	}{
+		{
+			name:      "first section in an empty run",
+			existing:  playbookRunDetail{ID: runID},
+			wantIndex: 0,
+		},
+		{
+			name:      "appends after existing sections",
+			existing:  fixtureRun(runID, 3, 2),
+			wantIndex: 3,
+			wantInMessage: []string{
+				`checklist_number 0: "Section 0"`,
+				`checklist_number 2: "Section 2"`,
+			},
+		},
+		{
+			name:      "reports the index when created with tasks",
+			existing:  fixtureRun(runID, 1, 1),
+			items:     []CreateChecklistItem{{Title: "Schedule retrospective"}},
+			wantIndex: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{run: tt.existing}
+
+			out, err := toolAddSection(context.Background(), client, AddSectionArgs{
+				RunID: runID,
+				Title: "Post-incident review",
+				Items: tt.items,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, "runs/"+runID+"/checklists", client.postEndpoint)
+			assert.Equal(t, "runs/"+runID, client.getEndpoint, "expected the run to be read back for the index")
+
+			assert.Contains(t, out, fmt.Sprintf("Its checklist_number is %d", tt.wantIndex))
+			assert.Contains(t, out, fmt.Sprintf(`checklist_number %d: "Post-incident review"`, tt.wantIndex))
+			assert.Contains(t, out, "the section just added")
+			assert.Contains(t, out, "add_checklist_item")
+			for _, want := range tt.wantInMessage {
+				assert.Contains(t, out, want)
+			}
+		})
+	}
+}
+
+// The section exists at this point, so a read-back failure must not read as
+// the add having failed.
+func TestToolAddSectionStillReportsSuccessWhenReadBackFails(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+	client := &fakeAPIClient{getErr: errors.New("connection refused")}
+
+	out, err := toolAddSection(context.Background(), client, AddSectionArgs{RunID: runID, Title: "Post-incident review"})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Added section")
+	assert.Contains(t, out, "get_run")
+}
+
+func TestToolAddChecklistItemReportsNewItemNumber(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name            string
+		run             playbookRunDetail
+		checklistNumber int
+		wantItemNumber  int
+	}{
+		{
+			name:            "first task in an empty section",
+			run:             fixtureRun(runID, 2, 0),
+			checklistNumber: 1,
+			wantItemNumber:  0,
+		},
+		{
+			name:            "appends after existing tasks",
+			run:             fixtureRun(runID, 2, 3),
+			checklistNumber: 0,
+			wantItemNumber:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{run: tt.run}
+
+			out, err := toolAddChecklistItem(context.Background(), client, AddChecklistItemArgs{
+				RunID:           runID,
+				ChecklistNumber: tt.checklistNumber,
+				Title:           "Verify fix",
+			})
+			require.NoError(t, err)
+
+			assert.Contains(t, out, fmt.Sprintf("[%d][%d]", tt.checklistNumber, tt.wantItemNumber))
+			assert.Contains(t, out, fmt.Sprintf("item_number %d", tt.wantItemNumber))
+		})
+	}
+}
+
 func TestToolAddSectionValidatesItems(t *testing.T) {
 	const runID = "abcdefghijklmnopqrstuvwxyz"
 
@@ -349,9 +533,9 @@ func TestToolAddSectionValidatesItems(t *testing.T) {
 			wantErr: "items[0].title is required",
 		},
 		{
-			name:    "rejects an invalid item assignee",
-			args:    AddSectionArgs{RunID: runID, Title: "Section", Items: []CreateChecklistItem{{Title: "Task", AssigneeID: "invalid"}}},
-			wantErr: "items[0].assignee_id must be a valid Mattermost ID",
+			name:    "rejects an unresolvable item assignee",
+			args:    AddSectionArgs{RunID: runID, Title: "Section", Items: []CreateChecklistItem{{Title: "Task", AssigneeID: "nobody"}}},
+			wantErr: `items[0].assignee_id: no user found with username "nobody" — check the spelling (usernames are case-insensitive, without the @)`,
 		},
 	}
 
@@ -625,22 +809,18 @@ func TestToolEditChecklistItemUpdatesFieldsAndDueDate(t *testing.T) {
 	assert.Equal(t, int64(1717200000000), dueDateBody["due_date"])
 }
 
-func TestToolAddChecklistItemRejectsInvalidAssignee(t *testing.T) {
+func TestToolAddChecklistItemRejectsUnresolvableAssignee(t *testing.T) {
 	client := &fakeAPIClient{}
 	args := AddChecklistItemArgs{
 		RunID:           "abcdefghijklmnopqrstuvwxyz",
 		ChecklistNumber: 0,
 		Title:           "New item",
-		AssigneeID:      "invalid",
+		AssigneeID:      "@nobody",
 	}
 
-	if _, err := toolAddChecklistItem(context.Background(), client, args); err == nil || err.Error() != "assignee_id must be a valid Mattermost ID" {
-		t.Fatalf("expected assignee validation error, got %v", err)
-	}
-
-	if client.postEndpoint != "" {
-		t.Fatalf("expected validation to fail before API call, got endpoint %q", client.postEndpoint)
-	}
+	_, err := toolAddChecklistItem(context.Background(), client, args)
+	require.EqualError(t, err, `assignee_id: no user found with username "nobody" — check the spelling (usernames are case-insensitive, without the @)`)
+	assert.Empty(t, client.postEndpoint, "expected resolution to fail before the API call")
 }
 
 func TestToolListRunsAddsTypeFilter(t *testing.T) {
@@ -1169,9 +1349,9 @@ func TestToolSetChecklistItemAssigneeValidation(t *testing.T) {
 			wantErr: "item_number must be a non-negative integer, got -1",
 		},
 		{
-			name:    "rejects invalid assignee id",
-			args:    SetChecklistItemAssigneeArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 1, AssigneeID: "invalid"},
-			wantErr: "assignee_id must be a valid Mattermost ID",
+			name:    "rejects an unresolvable assignee",
+			args:    SetChecklistItemAssigneeArgs{RunID: runID, ChecklistNumber: 0, ItemNumber: 1, AssigneeID: "@nobody"},
+			wantErr: `assignee_id: no user found with username "nobody" — check the spelling (usernames are case-insensitive, without the @)`,
 		},
 	}
 

--- a/internal/playbooksmcp/tools/checklist_test.go
+++ b/internal/playbooksmcp/tools/checklist_test.go
@@ -21,6 +21,10 @@ type fakeAPIClient struct {
 	listRuns      listRunsResponse
 	playbook      map[string]any
 	listPlaybooks listPlaybooksResponse
+	// runPlaybook backs the typed playbook fetch that run_playbook performs.
+	runPlaybook   playbookForRun
+	statusUpdates []runStatusUpdate
+	metadata      runMetadata
 	// listPages, when set, returns a distinct listRunsResponse per page index
 	// so pagination can be exercised.
 	listPages []listRunsResponse
@@ -52,7 +56,11 @@ type fakeAPIClient struct {
 	putEndpoints []string
 	putBodies    []any
 
-	deleteEndpoint string
+	patchEndpoint string
+	patchBody     any
+
+	deleteEndpoint  string
+	deleteEndpoints []string
 }
 
 func (f *fakeAPIClient) Get(_ context.Context, endpoint string, params url.Values, result any) error {
@@ -82,6 +90,12 @@ func (f *fakeAPIClient) Get(_ context.Context, endpoint string, params url.Value
 		f.listCalls = append(f.listCalls, cloneValues(params))
 	case *listPlaybooksResponse:
 		*v = f.listPlaybooks
+	case *playbookForRun:
+		*v = f.runPlaybook
+	case *[]runStatusUpdate:
+		*v = f.statusUpdates
+	case *runMetadata:
+		*v = f.metadata
 	case *map[string]any:
 		if f.playbook != nil {
 			*v = cloneMapAny(f.playbook)
@@ -133,8 +147,15 @@ func (f *fakeAPIClient) Put(_ context.Context, endpoint string, body any, _ any)
 	return nil
 }
 
+func (f *fakeAPIClient) Patch(_ context.Context, endpoint string, body any, _ any) error {
+	f.patchEndpoint = endpoint
+	f.patchBody = body
+	return nil
+}
+
 func (f *fakeAPIClient) Delete(_ context.Context, endpoint string) error {
 	f.deleteEndpoint = endpoint
+	f.deleteEndpoints = append(f.deleteEndpoints, endpoint)
 	return nil
 }
 
@@ -150,6 +171,10 @@ func (f *fakeAPIClient) GetCurrentUserID(context.Context) (string, error) {
 
 func (f *fakeAPIClient) GetPlaybookURL(playbookID string) string {
 	return "https://mattermost.example.com/playbooks/playbooks/" + playbookID
+}
+
+func (f *fakeAPIClient) GetRunURL(runID string) string {
+	return "https://mattermost.example.com/playbooks/runs/" + runID
 }
 
 // cloneValues snapshots query params, since fetchRunDetails mutates the same
@@ -223,6 +248,182 @@ func TestToolCheckItemOpenTranslatesToEmptyAPIState(t *testing.T) {
 	body, ok := client.putBody.(map[string]string)
 	require.Truef(t, ok, "unexpected body type %T", client.putBody)
 	assert.Empty(t, body["new_state"], "expected open state to be sent as empty string")
+}
+
+func TestToolCheckItemStates(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name         string
+		newState     string
+		currentState string
+		wantAPIState string
+		wantErr      string
+		wantNoOp     bool
+	}{
+		{name: "defaults to closed", newState: "", wantAPIState: "closed"},
+		{name: "closed", newState: "closed", wantAPIState: "closed"},
+		{name: "open sends an empty state", newState: "open", currentState: "closed", wantAPIState: ""},
+		{name: "in_progress is accepted", newState: "in_progress", wantAPIState: "in_progress"},
+		{name: "skipped", newState: "skipped", wantAPIState: "skipped"},
+		{name: "already in state is a no-op", newState: "in_progress", currentState: "in_progress", wantNoOp: true},
+		{
+			name:     "rejects an unknown state",
+			newState: "done",
+			wantErr:  "new_state must be one of open, in_progress, closed, or skipped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{
+				run: playbookRunDetail{
+					ID:         runID,
+					Checklists: []checklist{{Items: []checklistItem{{Title: "Deploy", State: tt.currentState}}}},
+				},
+			}
+
+			_, err := toolCheckItem(context.Background(), client, CheckItemArgs{
+				RunID:           runID,
+				ChecklistNumber: 0,
+				ItemNumber:      0,
+				NewState:        tt.newState,
+			})
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, client.putEndpoint)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNoOp {
+				assert.Empty(t, client.putEndpoint, "expected no state change")
+				return
+			}
+			require.Equal(t, "runs/"+runID+"/checklists/0/item/0/state", client.putEndpoint)
+			require.IsType(t, map[string]string{}, client.putBody)
+			assert.Equal(t, tt.wantAPIState, client.putBody.(map[string]string)["new_state"])
+		})
+	}
+}
+
+func TestToolAddSectionSendsItems(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+	const assigneeID = "bcdefghijklmnopqrstuvwxyza"
+	client := &fakeAPIClient{}
+
+	_, err := toolAddSection(context.Background(), client, AddSectionArgs{
+		RunID: runID,
+		Title: " Post-incident review ",
+		Items: []CreateChecklistItem{
+			{Title: " Schedule retrospective ", AssigneeID: assigneeID, DueDate: 1717200000000},
+			{Title: "Write summary", Description: "Two paragraphs"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "runs/"+runID+"/checklists", client.postEndpoint)
+	require.IsType(t, map[string]any{}, client.postBody)
+	body := client.postBody.(map[string]any)
+	assert.Equal(t, "Post-incident review", body["title"])
+	items, ok := body["items"].([]CreateChecklistItem)
+	require.True(t, ok, "unexpected items type %T", body["items"])
+	require.Len(t, items, 2)
+	assert.Equal(t, "Schedule retrospective", items[0].Title)
+	assert.Equal(t, assigneeID, items[0].AssigneeID)
+	assert.Equal(t, int64(1717200000000), items[0].DueDate)
+	assert.Equal(t, "Write summary", items[1].Title)
+}
+
+func TestToolAddSectionValidatesItems(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name    string
+		args    AddSectionArgs
+		wantErr string
+	}{
+		{
+			name:    "rejects a blank item title",
+			args:    AddSectionArgs{RunID: runID, Title: "Section", Items: []CreateChecklistItem{{Title: "  "}}},
+			wantErr: "items[0].title is required",
+		},
+		{
+			name:    "rejects an invalid item assignee",
+			args:    AddSectionArgs{RunID: runID, Title: "Section", Items: []CreateChecklistItem{{Title: "Task", AssigneeID: "invalid"}}},
+			wantErr: "items[0].assignee_id must be a valid Mattermost ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+			_, err := toolAddSection(context.Background(), client, tt.args)
+			require.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, client.postEndpoint, "expected no section to be created")
+		})
+	}
+}
+
+func TestToolSkipAndRestoreSection(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+	fixture := fixtureRun(runID, 2, 2)
+
+	t.Run("skip section", func(t *testing.T) {
+		client := &fakeAPIClient{run: fixture}
+		out, err := toolSkipSection(context.Background(), client, SkipSectionArgs{RunID: runID, ChecklistNumber: 1})
+		require.NoError(t, err)
+		assert.Equal(t, "runs/"+runID, client.getEndpoint)
+		assert.Equal(t, "runs/"+runID+"/checklists/1/skip", client.putEndpoint)
+		assert.Nil(t, client.putBody)
+		assert.Contains(t, out, `"Section 1"`)
+	})
+
+	t.Run("restore section", func(t *testing.T) {
+		client := &fakeAPIClient{run: fixture}
+		_, err := toolRestoreSection(context.Background(), client, RestoreSectionArgs{RunID: runID, ChecklistNumber: 0})
+		require.NoError(t, err)
+		assert.Equal(t, "runs/"+runID+"/checklists/0/restore", client.putEndpoint)
+	})
+}
+
+func TestToolSkipSectionValidation(t *testing.T) {
+	const runID = "abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name    string
+		client  *fakeAPIClient
+		args    SkipSectionArgs
+		wantErr string
+	}{
+		{
+			name:    "rejects an invalid run id",
+			client:  &fakeAPIClient{},
+			args:    SkipSectionArgs{RunID: "invalid", ChecklistNumber: 0},
+			wantErr: "run_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "rejects a negative index",
+			client:  &fakeAPIClient{},
+			args:    SkipSectionArgs{RunID: runID, ChecklistNumber: -1},
+			wantErr: "checklist_number must be a non-negative integer, got -1",
+		},
+		{
+			name:    "rejects an out-of-range index",
+			client:  &fakeAPIClient{run: fixtureRun(runID, 2, 2)},
+			args:    SkipSectionArgs{RunID: runID, ChecklistNumber: 5},
+			wantErr: "checklist_number 5 is out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := toolSkipSection(context.Background(), tt.client, tt.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Empty(t, tt.client.putEndpoint, "expected no skip call")
+		})
+	}
 }
 
 func TestToolEditChecklistItemPreservesOmittedFields(t *testing.T) {
@@ -444,19 +645,13 @@ func TestToolAddChecklistItemRejectsInvalidAssignee(t *testing.T) {
 
 func TestToolListRunsAddsTypeFilter(t *testing.T) {
 	client := &fakeAPIClient{}
-	args := ListRunsArgs{Type: "channelChecklist", Types: []string{"playbook"}}
+	args := ListRunsArgs{Types: []string{"channelChecklist", "playbook"}}
 
-	if _, err := toolListRuns(context.Background(), client, args); err != nil {
-		t.Fatalf("toolListRuns returned error: %v", err)
-	}
+	_, err := toolListRuns(context.Background(), client, args)
+	require.NoError(t, err)
 
-	if client.getEndpoint != "runs" {
-		t.Fatalf("unexpected get endpoint: %s", client.getEndpoint)
-	}
-	gotTypes := client.getParams["types"]
-	if len(gotTypes) != 2 || gotTypes[0] != "channelChecklist" || gotTypes[1] != "playbook" {
-		t.Fatalf("unexpected type filters: %#v", gotTypes)
-	}
+	require.Equal(t, "runs", client.getEndpoint)
+	assert.Equal(t, []string{"channelChecklist", "playbook"}, client.getParams["types"])
 }
 
 func TestToolCreateChecklistUsesCurrentUserAsOwner(t *testing.T) {
@@ -679,19 +874,13 @@ func TestChecklistStructureToolEndpointsAndBodies(t *testing.T) {
 
 	t.Run("add section", func(t *testing.T) {
 		client := newClient()
-		if _, err := toolAddSection(context.Background(), client, AddSectionArgs{RunID: runID, Title: " Section "}); err != nil {
-			t.Fatalf("toolAddSection returned error: %v", err)
-		}
-		if client.postEndpoint != "runs/abcdefghijklmnopqrstuvwxyz/checklists" {
-			t.Fatalf("unexpected endpoint: %s", client.postEndpoint)
-		}
-		body, ok := client.postBody.(map[string]string)
-		if !ok {
-			t.Fatalf("unexpected body type %T", client.postBody)
-		}
-		if body["title"] != "Section" {
-			t.Fatalf("unexpected body: %#v", body)
-		}
+		_, err := toolAddSection(context.Background(), client, AddSectionArgs{RunID: runID, Title: " Section "})
+		require.NoError(t, err)
+		require.Equal(t, "runs/abcdefghijklmnopqrstuvwxyz/checklists", client.postEndpoint)
+		require.IsType(t, map[string]any{}, client.postBody)
+		body := client.postBody.(map[string]any)
+		assert.Equal(t, "Section", body["title"])
+		assert.Empty(t, body["items"])
 	})
 
 	t.Run("rename section", func(t *testing.T) {
@@ -919,6 +1108,38 @@ func TestChecklistToolsOutOfRangeIndexes(t *testing.T) {
 			assert.Empty(t, client.postEndpoint, "expected no create/move on out-of-range")
 			assert.Empty(t, client.putEndpoint, "expected no update on out-of-range")
 			assert.Empty(t, client.deleteEndpoint, "expected no delete on out-of-range")
+		})
+	}
+}
+
+// The bounds helpers are shared by every index-based run tool, and each one
+// currently rejects negatives via validateIndex before reaching them. Assert
+// the helpers refuse negatives on their own so a future tool that forgets that
+// call returns an error instead of panicking on a negative slice index.
+func TestBoundsHelpersRejectNegativeIndexes(t *testing.T) {
+	fixture := fixtureRun("abcdefghijklmnopqrstuvwxyz", 2, 2)
+
+	tests := []struct {
+		name  string
+		check func() error
+	}{
+		{
+			name:  "negative checklist index",
+			check: func() error { return checkChecklistIndex(fixture, -1, "checklist_number") },
+		},
+		{
+			name:  "negative item index",
+			check: func() error { return checkItemIndex(fixture, 0, -1, "checklist_number", "item_number") },
+		},
+		{
+			name:  "negative move destination item index",
+			check: func() error { return checkMoveItemDest(fixture, 0, 1, -1) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.check())
 		})
 	}
 }

--- a/internal/playbooksmcp/tools/playbooks.go
+++ b/internal/playbooksmcp/tools/playbooks.go
@@ -25,9 +25,9 @@ type CreatePlaybookArgs struct {
 	CreatePublicPlaybookRun      *bool                     `json:"create_public_playbook_run,omitempty" jsonschema:"Whether runs started from this playbook should create public channels"`
 	Checklists                   []CreatePlaybookChecklist `json:"checklists,omitempty" jsonschema:"Initial playbook stages/checklists"`
 	Members                      []CreatePlaybookMember    `json:"members,omitempty" jsonschema:"Optional playbook members/admins"`
-	InvitedUserIDs               []string                  `json:"invited_user_ids,omitempty" jsonschema:"Users automatically invited to new run channels. Task assignees are auto-added."`
+	InvitedUserIDs               []string                  `json:"invited_user_ids,omitempty" jsonschema:"Users automatically invited to new run channels. Each entry accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob'). Task assignees are auto-added."`
 	InviteUsersEnabled           *bool                     `json:"invite_users_enabled,omitempty" jsonschema:"Whether invited_user_ids are invited to new run channels. Auto-enabled if tasks are pre-assigned."`
-	DefaultOwnerID               string                    `json:"default_owner_id,omitempty" jsonschema:"Default owner for new runs. Defaults to the requesting user."`
+	DefaultOwnerID               string                    `json:"default_owner_id,omitempty" jsonschema:"Default owner for new runs. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob'). Defaults to the requesting user."`
 	DefaultOwnerEnabled          *bool                     `json:"default_owner_enabled,omitempty" jsonschema:"Whether default_owner_id is used for new runs. Defaults to true."`
 	BroadcastChannelIDs          []string                  `json:"broadcast_channel_ids,omitempty" jsonschema:"Channels where status updates will be broadcast"`
 	BroadcastEnabled             *bool                     `json:"broadcast_enabled,omitempty" jsonschema:"Whether status update broadcasting is enabled. Defaults to true when broadcast_channel_ids is provided."`
@@ -51,11 +51,11 @@ type CreatePlaybookItem struct {
 	Title       string `json:"title"`
 	Description string `json:"description,omitempty"`
 	Command     string `json:"command,omitempty"`
-	AssigneeID  string `json:"assignee_id,omitempty"`
+	AssigneeID  string `json:"assignee_id,omitempty" jsonschema:"Optional user to assign the task to. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
 	DueDate     int64  `json:"due_date,omitempty"`
 }
 type CreatePlaybookMember struct {
-	UserID string   `json:"user_id"`
+	UserID string   `json:"user_id" jsonschema:"Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
 	Roles  []string `json:"roles,omitempty"`
 }
 type CreatePlaybookMetric struct {
@@ -113,7 +113,7 @@ type AddPlaybookTaskArgs struct {
 	Title           string `json:"title" jsonschema:"Title of the new task"`
 	Description     string `json:"description,omitempty" jsonschema:"Optional task description (supports Markdown)"`
 	Command         string `json:"command,omitempty" jsonschema:"Optional slash command to associate with the task"`
-	AssigneeID      string `json:"assignee_id,omitempty" jsonschema:"Optional Mattermost user ID to assign the task to"`
+	AssigneeID      string `json:"assignee_id,omitempty" jsonschema:"Optional user to assign the task to. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
 	DueDate         int64  `json:"due_date,omitempty" jsonschema:"Optional relative offset from run start, in milliseconds (for example, 86400000 = 1 day)"`
 }
 
@@ -124,7 +124,7 @@ type EditPlaybookTaskArgs struct {
 	Title           *string `json:"title,omitempty" jsonschema:"New title for the task"`
 	Description     *string `json:"description,omitempty" jsonschema:"New task description (supports Markdown)"`
 	Command         *string `json:"command,omitempty" jsonschema:"Slash command to associate with the task"`
-	AssigneeID      *string `json:"assignee_id,omitempty" jsonschema:"Mattermost user ID to assign the task to; set empty string to clear"`
+	AssigneeID      *string `json:"assignee_id,omitempty" jsonschema:"User to assign the task to. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob'). Set an empty string to clear."`
 	DueDate         *int64  `json:"due_date,omitempty" jsonschema:"Relative offset from run start, in milliseconds (for example, 86400000 = 1 day); use 0 to clear"`
 }
 
@@ -179,7 +179,7 @@ type listPlaybooksResponse struct {
 }
 
 func (p *PlaybooksToolProvider) addMCPHelperPlaybookTools(server *mcphelper.Server) {
-	addMCPHelperTool(server, p.clientFactory, "create_playbook", "Create a new playbook template (a reusable checklist blueprint for incidents, releases, onboarding) in a team, with optional stages/checklists, tasks, members, invitations, default owner, broadcast settings, metrics, run channel options, and webhooks. This creates the template only — it does not start anything; to start a run from a template (\"start/run the playbook\") call run_playbook. Returns the created playbook template and its browser URL. Example: {\"title\": \"Sev1 Incident\", \"team_id\": \"team123...\", \"checklists\": [{\"title\": \"Triage\", \"items\": [{\"title\": \"Page the on-call\"}]}]}", toolCreatePlaybook)
+	addMCPHelperTool(server, p.clientFactory, "create_playbook", "Create a new playbook template (a reusable checklist blueprint for incidents, releases, onboarding) in a team, with optional stages/checklists, tasks, members, invitations, default owner, broadcast settings, metrics, run channel options, and webhooks. This creates the template only — it does not start anything; to start a run from a template (\"start/run the playbook\") call run_playbook. Every user field (default_owner_id, invited_user_ids, members, task assignees) accepts a username with or without @, 'me', or a user ID. Returns the created playbook template and its browser URL. Example: {\"title\": \"Sev1 Incident\", \"team_id\": \"team123...\", \"checklists\": [{\"title\": \"Triage\", \"items\": [{\"title\": \"Page the on-call\"}]}]}", toolCreatePlaybook)
 	addMCPHelperTool(server, p.clientFactory, "list_playbooks", "List and search playbook templates (reusable run blueprints) by team, title, or archived state. Use this first whenever you know a playbook's name but not its playbook_id — for example before run_playbook starts a run from it. This lists templates, not active runs; call list_runs for runs in progress. Example: {\"team_id\": \"team123...\", \"search_term\": \"Incident\", \"per_page\": 10}", toolListPlaybooks)
 	addMCPHelperTool(server, p.clientFactory, "get_playbook", "Get full details for one playbook template, including its checklists and zero-based task indexes. Use this to confirm the playbook_id and the checklist_number/item_number values before editing template tasks. This reads a template, not a live run — use get_run for a run. Example: {\"playbook_id\": \"abc123...\"}", toolGetPlaybook)
 	addMCPHelperTool(server, p.clientFactory, "update_playbook", "Rename a playbook template or edit its description. Provide title, description, or both — at least one is required. This edits the reusable template, so it does not change runs already started from it; use update_run to rename a run. If you do not know the playbook_id, call list_playbooks first. Example: {\"playbook_id\": \"abc123...\", \"title\": \"Sev1 Incident Response\"}", toolUpdatePlaybook)
@@ -187,10 +187,10 @@ func (p *PlaybooksToolProvider) addMCPHelperPlaybookTools(server *mcphelper.Serv
 	addMCPHelperTool(server, p.clientFactory, "restore_playbook", "Restore (un-archive, bring back) an archived playbook template so runs can be started from it again. Archived templates are hidden by default: call list_playbooks with with_archived=true to find the playbook_id. Example: {\"playbook_id\": \"abc123...\"}", toolRestorePlaybook)
 	addMCPHelperTool(server, p.clientFactory, "duplicate_playbook", "Duplicate (copy, clone) a playbook template into a new template you can then edit, which is far cheaper than rebuilding one with create_playbook. The copy keeps the original's checklists and settings. Call list_playbooks first if you do not know the playbook_id. Returns the new template's title, ID, and browser URL. Example: {\"playbook_id\": \"abc123...\"}", toolDuplicatePlaybook)
 	addMCPHelperTool(server, p.clientFactory, "create_playbook_attribute", "Create a custom attribute/property field (for example Severity or Service) on a playbook template, so runs started from it can carry that value. If you do not already know the playbook_id, call list_playbooks first. Supported types are text, select, multiselect, date, user, and multiuser. Select and multiselect attributes require attrs.options. Returns the created field as formatted JSON. Example: {\"playbook_id\": \"abc123...\", \"name\": \"Severity\", \"type\": \"select\", \"attrs\": {\"visibility\": \"always\", \"sort_order\": 1, \"options\": [{\"name\": \"High\", \"color\": \"red\"}]}}", toolCreatePlaybookAttribute)
-	addMCPHelperTool(server, p.clientFactory, "add_playbook_task", "Add a task to a checklist in a playbook template, so every future run started from it includes that task (use add_checklist_item to add a task to a live run instead). The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist indexes. This fetches the playbook, preserves its existing fields, mutates only checklists, and saves the full playbook. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix\", \"assignee_id\": \"user123...\"}", toolAddPlaybookTask)
-	addMCPHelperTool(server, p.clientFactory, "edit_playbook_task", "Edit a task in a playbook template — its title, description, slash command, assignee, or relative due date (use edit_checklist_item for a task in a live run). Checklist and item numbers are zero-based indexes, and only provided task fields are updated. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This preserves all other playbook and task fields. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task\"}", toolEditPlaybookTask)
+	addMCPHelperTool(server, p.clientFactory, "add_playbook_task", "Add a task to a checklist in a playbook template, so every future run started from it includes that task (use add_checklist_item to add a task to a live run instead). The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist indexes. This fetches the playbook, preserves its existing fields, mutates only checklists, and saves the full playbook. assignee_id accepts a username with or without @, 'me', or a user ID. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix\", \"assignee_id\": \"@alice\"}", toolAddPlaybookTask)
+	addMCPHelperTool(server, p.clientFactory, "edit_playbook_task", "Edit a task in a playbook template — its title, description, slash command, assignee, or relative due date (use edit_checklist_item for a task in a live run). Checklist and item numbers are zero-based indexes, and only provided task fields are updated. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This preserves all other playbook and task fields. assignee_id accepts a username with or without @, 'me', or a user ID; send an empty string to clear it. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task\"}", toolEditPlaybookTask)
 	addMCPHelperTool(server, p.clientFactory, "remove_playbook_task", "Delete a task from a playbook template so future runs no longer include it (use remove_checklist_item for a task in a live run). Checklist and item numbers are zero-based indexes. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This fetches and saves the full playbook while mutating only checklists. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}", toolRemovePlaybookTask)
-	addMCPHelperTool(server, p.clientFactory, "add_playbook_section", "Add a checklist section (stage, task group) to a playbook template, optionally with its initial tasks (use add_section for a live run). The optional checklist_number is a zero-based insertion index; omit it to append. If you do not already know the playbook_id or section indexes, call list_playbooks, then get_playbook first. Initial items use the same shape as create_playbook checklist items, and assignees are invited automatically. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1, \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}", toolAddPlaybookSection)
+	addMCPHelperTool(server, p.clientFactory, "add_playbook_section", "Add a checklist section (stage, task group) to a playbook template, optionally with its initial tasks (use add_section for a live run). The optional checklist_number is a zero-based insertion index; omit it to append. If you do not already know the playbook_id or section indexes, call list_playbooks, then get_playbook first. Initial items use the same shape as create_playbook checklist items; each assignee_id accepts a username with or without @, 'me', or a user ID, and assignees are invited automatically. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1, \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}", toolAddPlaybookSection)
 	addMCPHelperTool(server, p.clientFactory, "rename_playbook_section", "Rename a checklist section in a playbook template (use rename_section for a live run). The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, call list_playbooks, then get_playbook first. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}", toolRenamePlaybookSection)
 	addMCPHelperTool(server, p.clientFactory, "remove_playbook_section", "Delete a whole checklist section and all its tasks from a playbook template (use remove_section for a live run). The checklist_number is a zero-based index; confirm it with get_playbook before using this destructive tool. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1}", toolRemovePlaybookSection)
 	addMCPHelperTool(server, p.clientFactory, "move_playbook_section", "Reorder a checklist section within a playbook template (use move_section for a live run). Source and destination indexes are zero-based existing section indexes (0 = first, section count-1 = last). If you do not already know the playbook_id and indexes, call list_playbooks, then get_playbook first. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}", toolMovePlaybookSection)
@@ -205,6 +205,9 @@ func toolCreatePlaybook(ctx context.Context, client APIClient, args CreatePlaybo
 		return "", err
 	}
 	if err := validateCreatePlaybookArgs(args); err != nil {
+		return "", err
+	}
+	if err := resolveCreatePlaybookUserRefs(ctx, client, &args); err != nil {
 		return "", err
 	}
 
@@ -418,12 +421,12 @@ func toolArchivePlaybook(ctx context.Context, client APIClient, args PlaybookIDA
 	// actually affected, and a wrong ID fails before anything is destroyed.
 	playbook, err := fetchPlaybookForMutation(ctx, client, args.PlaybookID)
 	if err != nil {
-		return "", fmt.Errorf("%w (if you are unsure of the playbook_id, call list_playbooks)", err)
+		return "", err
 	}
 	title, _ := playbook["title"].(string)
 
 	if err := client.Delete(ctx, fmt.Sprintf("playbooks/%s", args.PlaybookID)); err != nil {
-		return "", fmt.Errorf("failed to archive playbook %s: %w", args.PlaybookID, err)
+		return "", wrapPlaybookError(err, args.PlaybookID, "archive")
 	}
 
 	return fmt.Sprintf("Archived playbook template %q (%s). No new runs can be started from it; call restore_playbook to bring it back.", title, args.PlaybookID), nil
@@ -435,7 +438,7 @@ func toolRestorePlaybook(ctx context.Context, client APIClient, args PlaybookIDA
 	}
 
 	if err := client.Put(ctx, fmt.Sprintf("playbooks/%s/restore", args.PlaybookID), nil, nil); err != nil {
-		return "", fmt.Errorf("failed to restore playbook %s: %w (list archived templates with list_playbooks and with_archived=true)", args.PlaybookID, err)
+		return "", wrapPlaybookError(err, args.PlaybookID, "restore")
 	}
 
 	return fmt.Sprintf("Restored playbook template %s. Runs can be started from it again with run_playbook.", args.PlaybookID), nil
@@ -450,10 +453,10 @@ func toolDuplicatePlaybook(ctx context.Context, client APIClient, args PlaybookI
 		ID string `json:"id"`
 	}
 	if err := client.Post(ctx, fmt.Sprintf("playbooks/%s/duplicate", args.PlaybookID), nil, &created); err != nil {
-		return "", fmt.Errorf("failed to duplicate playbook %s: %w (if you are unsure of the playbook_id, call list_playbooks)", args.PlaybookID, err)
+		return "", wrapPlaybookError(err, args.PlaybookID, "duplicate")
 	}
 	if created.ID == "" {
-		return "", fmt.Errorf("failed to duplicate playbook %s: response missing id", args.PlaybookID)
+		return "", fmt.Errorf("failed to duplicate playbook template %s: response missing id", args.PlaybookID)
 	}
 
 	duplicate, err := fetchPlaybookForMutation(ctx, client, created.ID)
@@ -474,7 +477,7 @@ func toolCreatePlaybookAttribute(ctx context.Context, client APIClient, args Cre
 	var created map[string]any
 	endpoint := fmt.Sprintf("playbooks/%s/property_fields", args.PlaybookID)
 	if err := client.Post(ctx, endpoint, body, &created); err != nil {
-		return "", fmt.Errorf("failed to create playbook attribute: %w", err)
+		return "", wrapPlaybookError(err, args.PlaybookID, "create an attribute on")
 	}
 	if len(created) == 0 {
 		return "", fmt.Errorf("failed to create playbook attribute: response was empty")
@@ -502,10 +505,9 @@ func toolAddPlaybookTask(ctx context.Context, client APIClient, args AddPlaybook
 	if title == "" {
 		return "", fmt.Errorf("title is required")
 	}
-	if args.AssigneeID != "" {
-		if err := validateID(args.AssigneeID, "assignee_id"); err != nil {
-			return "", err
-		}
+	assigneeID, err := resolveUserRef(ctx, client, args.AssigneeID, "assignee_id")
+	if err != nil {
+		return "", err
 	}
 
 	playbook, err := fetchPlaybookForMutation(ctx, client, args.PlaybookID)
@@ -526,9 +528,9 @@ func toolAddPlaybookTask(ctx context.Context, client APIClient, args AddPlaybook
 		"description": args.Description,
 		"command":     args.Command,
 	}
-	if args.AssigneeID != "" {
-		item["assignee_id"] = args.AssigneeID
-		ensurePlaybookInvitesUser(playbook, args.AssigneeID)
+	if assigneeID != "" {
+		item["assignee_id"] = assigneeID
+		ensurePlaybookInvitesUser(playbook, assigneeID)
 	}
 	if args.DueDate != 0 {
 		item["due_date"] = args.DueDate
@@ -557,10 +559,15 @@ func toolEditPlaybookTask(ctx context.Context, client APIClient, args EditPlaybo
 	if args.Title != nil && strings.TrimSpace(*args.Title) == "" {
 		return "", fmt.Errorf("title is required")
 	}
-	if args.AssigneeID != nil && *args.AssigneeID != "" {
-		if err := validateID(*args.AssigneeID, "assignee_id"); err != nil {
+	// A nil assignee_id leaves the assignee alone; an explicit empty string
+	// clears it. Only a non-empty value is a reference to resolve.
+	var assigneeID string
+	if args.AssigneeID != nil {
+		resolved, err := resolveUserRef(ctx, client, *args.AssigneeID, "assignee_id")
+		if err != nil {
 			return "", err
 		}
+		assigneeID = resolved
 	}
 
 	playbook, err := fetchPlaybookForMutation(ctx, client, args.PlaybookID)
@@ -582,9 +589,9 @@ func toolEditPlaybookTask(ctx context.Context, client APIClient, args EditPlaybo
 		item["command"] = *args.Command
 	}
 	if args.AssigneeID != nil {
-		item["assignee_id"] = *args.AssigneeID
-		if *args.AssigneeID != "" {
-			ensurePlaybookInvitesUser(playbook, *args.AssigneeID)
+		item["assignee_id"] = assigneeID
+		if assigneeID != "" {
+			ensurePlaybookInvitesUser(playbook, assigneeID)
 		}
 	}
 	if args.DueDate != nil {
@@ -648,6 +655,10 @@ func toolAddPlaybookSection(ctx context.Context, client APIClient, args AddPlayb
 	if err := validateCreatePlaybookItems(args.Items, "items"); err != nil {
 		return "", err
 	}
+	items, err := resolveCreatePlaybookItems(ctx, client, args.Items, "items")
+	if err != nil {
+		return "", err
+	}
 
 	playbook, err := fetchPlaybookForMutation(ctx, client, args.PlaybookID)
 	if err != nil {
@@ -667,7 +678,7 @@ func toolAddPlaybookSection(ctx context.Context, client APIClient, args AddPlayb
 
 	section := map[string]any{
 		"title": title,
-		"items": buildCreatePlaybookItems(args.Items, playbook),
+		"items": buildCreatePlaybookItems(items, playbook),
 	}
 	checklists = insertChecklistAt(checklists, insertAt, section)
 	playbook["checklists"] = checklists
@@ -676,7 +687,7 @@ func toolAddPlaybookSection(ctx context.Context, client APIClient, args AddPlayb
 		return "", err
 	}
 	message := fmt.Sprintf("Added section %q to playbook %s at checklist_number %d.", title, args.PlaybookID, insertAt)
-	if hasAssignedCreatePlaybookItems(args.Items) {
+	if hasAssignedCreatePlaybookItems(items) {
 		message += " Assigned users were added to invited_user_ids and invite_users_enabled was set."
 	}
 	return message, nil
@@ -782,17 +793,17 @@ func toolMovePlaybookSection(ctx context.Context, client APIClient, args MovePla
 func fetchPlaybookForMutation(ctx context.Context, client APIClient, playbookID string) (map[string]any, error) {
 	var playbook map[string]any
 	if err := client.Get(ctx, fmt.Sprintf("playbooks/%s", playbookID), nil, &playbook); err != nil {
-		return nil, fmt.Errorf("failed to get playbook: %w", err)
+		return nil, wrapPlaybookError(err, playbookID, "get")
 	}
 	if playbook == nil {
-		return nil, fmt.Errorf("failed to get playbook: response was empty")
+		return nil, fmt.Errorf("failed to get playbook template %s: response was empty", playbookID)
 	}
 	return playbook, nil
 }
 
 func putMutatedPlaybook(ctx context.Context, client APIClient, playbookID string, playbook map[string]any) error {
 	if err := client.Put(ctx, fmt.Sprintf("playbooks/%s", playbookID), playbook, nil); err != nil {
-		return fmt.Errorf("failed to update playbook: %w", err)
+		return wrapPlaybookError(err, playbookID, "update")
 	}
 	return nil
 }
@@ -1139,12 +1150,73 @@ func validateCreatePlaybookItems(items []CreatePlaybookItem, field string) error
 		if strings.TrimSpace(item.Title) == "" {
 			return fmt.Errorf("%s[%d].title is required", field, i)
 		}
-		if item.AssigneeID != "" {
-			if err := validateID(item.AssigneeID, fmt.Sprintf("%s[%d].assignee_id", field, i)); err != nil {
+	}
+	return nil
+}
+
+// resolveCreatePlaybookItems returns a copy of items whose assignee
+// references have been resolved to user IDs.
+func resolveCreatePlaybookItems(ctx context.Context, client APIClient, items []CreatePlaybookItem, field string) ([]CreatePlaybookItem, error) {
+	resolved := append([]CreatePlaybookItem(nil), items...)
+	for i := range resolved {
+		assignee, err := resolveUserRef(ctx, client, resolved[i].AssigneeID, fmt.Sprintf("%s[%d].assignee_id", field, i))
+		if err != nil {
+			return nil, err
+		}
+		resolved[i].AssigneeID = assignee
+	}
+	return resolved, nil
+}
+
+// resolveCreatePlaybookUserRefs rewrites every user reference in args to a
+// user ID, copying the slices it touches so the caller's arguments are left
+// alone. It runs before any request is sent, so an unknown username fails
+// without creating a half-configured template.
+func resolveCreatePlaybookUserRefs(ctx context.Context, client APIClient, args *CreatePlaybookArgs) error {
+	owner, err := resolveUserRef(ctx, client, args.DefaultOwnerID, "default_owner_id")
+	if err != nil {
+		return err
+	}
+	args.DefaultOwnerID = owner
+
+	if len(args.InvitedUserIDs) > 0 {
+		invited, err := resolveUserRefs(ctx, client, args.InvitedUserIDs, "invited_user_ids")
+		if err != nil {
+			return err
+		}
+		args.InvitedUserIDs = invited
+	}
+
+	if len(args.Members) > 0 {
+		members := append([]CreatePlaybookMember(nil), args.Members...)
+		for i := range members {
+			userID, err := resolveUserRef(ctx, client, members[i].UserID, fmt.Sprintf("members[%d].user_id", i))
+			if err != nil {
 				return err
 			}
+			if userID == "" {
+				return fmt.Errorf("members[%d].user_id is required", i)
+			}
+			members[i].UserID = userID
 		}
+		args.Members = members
 	}
+
+	if len(args.Checklists) > 0 {
+		checklists := append([]CreatePlaybookChecklist(nil), args.Checklists...)
+		for i := range checklists {
+			if len(checklists[i].Items) == 0 {
+				continue
+			}
+			items, err := resolveCreatePlaybookItems(ctx, client, checklists[i].Items, fmt.Sprintf("checklists[%d].items", i))
+			if err != nil {
+				return err
+			}
+			checklists[i].Items = items
+		}
+		args.Checklists = checklists
+	}
+
 	return nil
 }
 
@@ -1157,28 +1229,13 @@ func validateCreatePlaybookArgs(args CreatePlaybookArgs) error {
 	default:
 		return fmt.Errorf("channel_mode must be one of %s or %s", channelModeCreateNew, channelModeLinkExisting)
 	}
-	if args.DefaultOwnerID != "" {
-		if err := validateID(args.DefaultOwnerID, "default_owner_id"); err != nil {
-			return err
-		}
-	}
 	if args.ChannelID != "" {
 		if err := validateID(args.ChannelID, "channel_id"); err != nil {
 			return err
 		}
 	}
-	for i, id := range args.InvitedUserIDs {
-		if err := validateID(id, fmt.Sprintf("invited_user_ids[%d]", i)); err != nil {
-			return err
-		}
-	}
 	for i, id := range args.BroadcastChannelIDs {
 		if err := validateID(id, fmt.Sprintf("broadcast_channel_ids[%d]", i)); err != nil {
-			return err
-		}
-	}
-	for i, m := range args.Members {
-		if err := validateID(m.UserID, fmt.Sprintf("members[%d].user_id", i)); err != nil {
 			return err
 		}
 	}

--- a/internal/playbooksmcp/tools/playbooks.go
+++ b/internal/playbooksmcp/tools/playbooks.go
@@ -35,8 +35,8 @@ type CreatePlaybookArgs struct {
 	ReminderTimerDefaultSeconds  int64                     `json:"reminder_timer_default_seconds,omitempty" jsonschema:"Default status update reminder interval in seconds. Defaults to 86400."`
 	StatusUpdateEnabled          *bool                     `json:"status_update_enabled,omitempty" jsonschema:"Whether status updates are enabled for runs"`
 	Metrics                      []CreatePlaybookMetric    `json:"metrics,omitempty" jsonschema:"Optional key metrics, maximum 4"`
-	ChannelID                    string                    `json:"channel_id,omitempty" jsonschema:"Existing channel to link to new runs when channel_mode links an existing channel"`
-	ChannelMode                  *int                      `json:"channel_mode,omitempty" jsonschema:"Run channel mode. 0=create new channel, 1=link existing channel"`
+	ChannelID                    string                    `json:"channel_id,omitempty" jsonschema:"Existing channel to link to new runs when channel_mode is link_existing_channel"`
+	ChannelMode                  string                    `json:"channel_mode,omitempty" jsonschema:"How runs of this playbook get a channel: create_new_channel (default) or link_existing_channel. When link_existing_channel, also set channel_id."`
 	WebhookOnCreationURLs        []string                  `json:"webhook_on_creation_urls,omitempty" jsonschema:"HTTP/HTTPS URLs to call when a run is created from this playbook"`
 	WebhookOnCreationEnabled     *bool                     `json:"webhook_on_creation_enabled,omitempty" jsonschema:"Whether creation webhooks are enabled. Defaults to true when webhook_on_creation_urls is provided."`
 	WebhookOnStatusUpdateURLs    []string                  `json:"webhook_on_status_update_urls,omitempty" jsonschema:"HTTP/HTTPS URLs to call when a run status is updated"`
@@ -95,6 +95,16 @@ type ListPlaybooksArgs struct {
 
 type GetPlaybookArgs struct {
 	PlaybookID string `json:"playbook_id" jsonschema:"The ID of the playbook template to retrieve"`
+}
+
+type PlaybookIDArgs struct {
+	PlaybookID string `json:"playbook_id" jsonschema:"The ID of the playbook template"`
+}
+
+type UpdatePlaybookArgs struct {
+	PlaybookID  string  `json:"playbook_id" jsonschema:"The ID of the playbook template to edit"`
+	Title       *string `json:"title,omitempty" jsonschema:"New title for the playbook template. Must not be empty."`
+	Description *string `json:"description,omitempty" jsonschema:"New description for the playbook template (supports Markdown). Send an empty string to clear it."`
 }
 
 type AddPlaybookTaskArgs struct {
@@ -169,17 +179,21 @@ type listPlaybooksResponse struct {
 }
 
 func (p *PlaybooksToolProvider) addMCPHelperPlaybookTools(server *mcphelper.Server) {
-	addMCPHelperTool(server, p.clientFactory, "create_playbook", "Create a Mattermost Playbook in a team with optional stages/checklists, tasks, members, invitations, default owner, broadcast settings, metrics, run channel options, and webhooks. Returns the created playbook and browser URL.", toolCreatePlaybook)
-	addMCPHelperTool(server, p.clientFactory, "list_playbooks", "List playbook templates with optional team and search filters. Use this first when you know a template title or team but do not yet know the playbook_id. Example: {\"team_id\": \"team123...\", \"search_term\": \"Incident\", \"per_page\": 10}", toolListPlaybooks)
-	addMCPHelperTool(server, p.clientFactory, "get_playbook", "Get full details for a playbook template, including checklists and task indexes. Use this to confirm the playbook_id and the zero-based checklist_number/item_number values before mutating tasks. Example: {\"playbook_id\": \"abc123...\"}", toolGetPlaybook)
-	addMCPHelperTool(server, p.clientFactory, "create_playbook_attribute", "Create an attribute/property field on an existing playbook template. If you do not already know the playbook_id, call list_playbooks first. Supported types are text, select, multiselect, date, user, and multiuser. Select and multiselect attributes require attrs.options. Returns the created field as formatted JSON. Example: {\"playbook_id\": \"abc123...\", \"name\": \"Severity\", \"type\": \"select\", \"attrs\": {\"visibility\": \"always\", \"sort_order\": 1, \"options\": [{\"name\": \"High\", \"color\": \"red\"}]}}", toolCreatePlaybookAttribute)
-	addMCPHelperTool(server, p.clientFactory, "add_playbook_task", "Add a task to an existing playbook template checklist. The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist indexes. This fetches the playbook, preserves its existing fields, mutates only checklists, and saves the full playbook. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix\", \"assignee_id\": \"user123...\"}", toolAddPlaybookTask)
-	addMCPHelperTool(server, p.clientFactory, "edit_playbook_task", "Edit a task in an existing playbook template. Checklist and item numbers are zero-based indexes, and only provided task fields are updated. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This preserves all other playbook and task fields. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task\"}", toolEditPlaybookTask)
-	addMCPHelperTool(server, p.clientFactory, "remove_playbook_task", "Remove a task from an existing playbook template. Checklist and item numbers are zero-based indexes. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This fetches and saves the full playbook while mutating only checklists. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}", toolRemovePlaybookTask)
-	addMCPHelperTool(server, p.clientFactory, "add_playbook_section", "Add a new section/checklist to an existing playbook template. The optional checklist_number is a zero-based insertion index; omit it to append. If you do not already know the playbook_id or section indexes, call list_playbooks, then get_playbook first. Initial items use the same shape as create_playbook checklist items, and assignees are invited automatically. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1, \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}", toolAddPlaybookSection)
-	addMCPHelperTool(server, p.clientFactory, "rename_playbook_section", "Rename an existing section/checklist in a playbook template. The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, call list_playbooks, then get_playbook first. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}", toolRenamePlaybookSection)
-	addMCPHelperTool(server, p.clientFactory, "remove_playbook_section", "Remove an entire section/checklist and all its tasks from a playbook template. The checklist_number is a zero-based index; confirm it with get_playbook before using this destructive tool. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1}", toolRemovePlaybookSection)
-	addMCPHelperTool(server, p.clientFactory, "move_playbook_section", "Move a section/checklist within a playbook template. Source and destination indexes are zero-based existing section indexes (0 = first, section count-1 = last). If you do not already know the playbook_id and indexes, call list_playbooks, then get_playbook first. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}", toolMovePlaybookSection)
+	addMCPHelperTool(server, p.clientFactory, "create_playbook", "Create a new playbook template (a reusable checklist blueprint for incidents, releases, onboarding) in a team, with optional stages/checklists, tasks, members, invitations, default owner, broadcast settings, metrics, run channel options, and webhooks. This creates the template only — it does not start anything; to start a run from a template (\"start/run the playbook\") call run_playbook. Returns the created playbook template and its browser URL. Example: {\"title\": \"Sev1 Incident\", \"team_id\": \"team123...\", \"checklists\": [{\"title\": \"Triage\", \"items\": [{\"title\": \"Page the on-call\"}]}]}", toolCreatePlaybook)
+	addMCPHelperTool(server, p.clientFactory, "list_playbooks", "List and search playbook templates (reusable run blueprints) by team, title, or archived state. Use this first whenever you know a playbook's name but not its playbook_id — for example before run_playbook starts a run from it. This lists templates, not active runs; call list_runs for runs in progress. Example: {\"team_id\": \"team123...\", \"search_term\": \"Incident\", \"per_page\": 10}", toolListPlaybooks)
+	addMCPHelperTool(server, p.clientFactory, "get_playbook", "Get full details for one playbook template, including its checklists and zero-based task indexes. Use this to confirm the playbook_id and the checklist_number/item_number values before editing template tasks. This reads a template, not a live run — use get_run for a run. Example: {\"playbook_id\": \"abc123...\"}", toolGetPlaybook)
+	addMCPHelperTool(server, p.clientFactory, "update_playbook", "Rename a playbook template or edit its description. Provide title, description, or both — at least one is required. This edits the reusable template, so it does not change runs already started from it; use update_run to rename a run. If you do not know the playbook_id, call list_playbooks first. Example: {\"playbook_id\": \"abc123...\", \"title\": \"Sev1 Incident Response\"}", toolUpdatePlaybook)
+	addMCPHelperTool(server, p.clientFactory, "archive_playbook", "Archive (delete, retire) a playbook template so no new runs can be started from it. Runs already started keep working, and restore_playbook can bring the template back. This is destructive: confirm you have the right template with list_playbooks or get_playbook before calling, because titles are often similar. Example: {\"playbook_id\": \"abc123...\"}", toolArchivePlaybook)
+	addMCPHelperTool(server, p.clientFactory, "restore_playbook", "Restore (un-archive, bring back) an archived playbook template so runs can be started from it again. Archived templates are hidden by default: call list_playbooks with with_archived=true to find the playbook_id. Example: {\"playbook_id\": \"abc123...\"}", toolRestorePlaybook)
+	addMCPHelperTool(server, p.clientFactory, "duplicate_playbook", "Duplicate (copy, clone) a playbook template into a new template you can then edit, which is far cheaper than rebuilding one with create_playbook. The copy keeps the original's checklists and settings. Call list_playbooks first if you do not know the playbook_id. Returns the new template's title, ID, and browser URL. Example: {\"playbook_id\": \"abc123...\"}", toolDuplicatePlaybook)
+	addMCPHelperTool(server, p.clientFactory, "create_playbook_attribute", "Create a custom attribute/property field (for example Severity or Service) on a playbook template, so runs started from it can carry that value. If you do not already know the playbook_id, call list_playbooks first. Supported types are text, select, multiselect, date, user, and multiuser. Select and multiselect attributes require attrs.options. Returns the created field as formatted JSON. Example: {\"playbook_id\": \"abc123...\", \"name\": \"Severity\", \"type\": \"select\", \"attrs\": {\"visibility\": \"always\", \"sort_order\": 1, \"options\": [{\"name\": \"High\", \"color\": \"red\"}]}}", toolCreatePlaybookAttribute)
+	addMCPHelperTool(server, p.clientFactory, "add_playbook_task", "Add a task to a checklist in a playbook template, so every future run started from it includes that task (use add_checklist_item to add a task to a live run instead). The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist indexes. This fetches the playbook, preserves its existing fields, mutates only checklists, and saves the full playbook. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Verify fix\", \"assignee_id\": \"user123...\"}", toolAddPlaybookTask)
+	addMCPHelperTool(server, p.clientFactory, "edit_playbook_task", "Edit a task in a playbook template — its title, description, slash command, assignee, or relative due date (use edit_checklist_item for a task in a live run). Checklist and item numbers are zero-based indexes, and only provided task fields are updated. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This preserves all other playbook and task fields. due_date is a relative offset from run start in milliseconds. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 1, \"title\": \"Updated task\"}", toolEditPlaybookTask)
+	addMCPHelperTool(server, p.clientFactory, "remove_playbook_task", "Delete a task from a playbook template so future runs no longer include it (use remove_checklist_item for a task in a live run). Checklist and item numbers are zero-based indexes. If you do not already know the playbook_id and indexes, do NOT guess them: first call list_playbooks to find the template by team/title, then get_playbook to confirm the checklist_number and item_number. This fetches and saves the full playbook while mutating only checklists. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"item_number\": 2}", toolRemovePlaybookTask)
+	addMCPHelperTool(server, p.clientFactory, "add_playbook_section", "Add a checklist section (stage, task group) to a playbook template, optionally with its initial tasks (use add_section for a live run). The optional checklist_number is a zero-based insertion index; omit it to append. If you do not already know the playbook_id or section indexes, call list_playbooks, then get_playbook first. Initial items use the same shape as create_playbook checklist items, and assignees are invited automatically. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1, \"title\": \"Post-incident review\", \"items\": [{\"title\": \"Schedule retrospective\"}]}", toolAddPlaybookSection)
+	addMCPHelperTool(server, p.clientFactory, "rename_playbook_section", "Rename a checklist section in a playbook template (use rename_section for a live run). The checklist_number is a zero-based index. If you do not already know the playbook_id and checklist_number, call list_playbooks, then get_playbook first. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 0, \"title\": \"Updated section name\"}", toolRenamePlaybookSection)
+	addMCPHelperTool(server, p.clientFactory, "remove_playbook_section", "Delete a whole checklist section and all its tasks from a playbook template (use remove_section for a live run). The checklist_number is a zero-based index; confirm it with get_playbook before using this destructive tool. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"checklist_number\": 1}", toolRemovePlaybookSection)
+	addMCPHelperTool(server, p.clientFactory, "move_playbook_section", "Reorder a checklist section within a playbook template (use move_section for a live run). Source and destination indexes are zero-based existing section indexes (0 = first, section count-1 = last). If you do not already know the playbook_id and indexes, call list_playbooks, then get_playbook first. This preserves all other playbook fields. Example: {\"playbook_id\": \"abc123...\", \"source_checklist_idx\": 1, \"dest_checklist_idx\": 0}", toolMovePlaybookSection)
 }
 
 func toolCreatePlaybook(ctx context.Context, client APIClient, args CreatePlaybookArgs) (string, error) {
@@ -243,8 +257,10 @@ func toolCreatePlaybook(ctx context.Context, client APIClient, args CreatePlaybo
 	if args.CreatePublicPlaybookRun != nil {
 		body["create_public_playbook_run"] = *args.CreatePublicPlaybookRun
 	}
-	if args.ChannelMode != nil {
-		body["channel_mode"] = *args.ChannelMode
+	if args.ChannelMode != "" {
+		// app.ChannelPlaybookMode only implements UnmarshalText, so the server
+		// rejects the whole create request unless this is sent as a string.
+		body["channel_mode"] = args.ChannelMode
 	}
 	if args.StatusUpdateEnabled != nil {
 		body["status_update_enabled"] = *args.StatusUpdateEnabled
@@ -349,6 +365,104 @@ func toolGetPlaybook(ctx context.Context, client APIClient, args GetPlaybookArgs
 		return "", err
 	}
 	return string(data), nil
+}
+
+func toolUpdatePlaybook(ctx context.Context, client APIClient, args UpdatePlaybookArgs) (string, error) {
+	if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
+		return "", err
+	}
+	if args.Title == nil && args.Description == nil {
+		return "", fmt.Errorf("at least one field (title or description) must be provided")
+	}
+	var title string
+	if args.Title != nil {
+		title = strings.TrimSpace(*args.Title)
+		if title == "" {
+			return "", fmt.Errorf("title must not be empty")
+		}
+	}
+
+	// Templates have no granular update endpoint, so mutate only the requested
+	// keys of the raw playbook map and PUT the whole thing back.
+	playbook, err := fetchPlaybookForMutation(ctx, client, args.PlaybookID)
+	if err != nil {
+		return "", err
+	}
+	if args.Title != nil {
+		playbook["title"] = title
+	}
+	if args.Description != nil {
+		playbook["description"] = *args.Description
+	}
+
+	if err := putMutatedPlaybook(ctx, client, args.PlaybookID, playbook); err != nil {
+		return "", err
+	}
+
+	switch {
+	case args.Title != nil && args.Description != nil:
+		return fmt.Sprintf("Renamed playbook template %s to %q and updated its description.", args.PlaybookID, title), nil
+	case args.Title != nil:
+		return fmt.Sprintf("Renamed playbook template %s to %q.", args.PlaybookID, title), nil
+	default:
+		return fmt.Sprintf("Updated the description of playbook template %s.", args.PlaybookID), nil
+	}
+}
+
+func toolArchivePlaybook(ctx context.Context, client APIClient, args PlaybookIDArgs) (string, error) {
+	if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
+		return "", err
+	}
+
+	// Read before archiving so the confirmation names the playbook that was
+	// actually affected, and a wrong ID fails before anything is destroyed.
+	playbook, err := fetchPlaybookForMutation(ctx, client, args.PlaybookID)
+	if err != nil {
+		return "", fmt.Errorf("%w (if you are unsure of the playbook_id, call list_playbooks)", err)
+	}
+	title, _ := playbook["title"].(string)
+
+	if err := client.Delete(ctx, fmt.Sprintf("playbooks/%s", args.PlaybookID)); err != nil {
+		return "", fmt.Errorf("failed to archive playbook %s: %w", args.PlaybookID, err)
+	}
+
+	return fmt.Sprintf("Archived playbook template %q (%s). No new runs can be started from it; call restore_playbook to bring it back.", title, args.PlaybookID), nil
+}
+
+func toolRestorePlaybook(ctx context.Context, client APIClient, args PlaybookIDArgs) (string, error) {
+	if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
+		return "", err
+	}
+
+	if err := client.Put(ctx, fmt.Sprintf("playbooks/%s/restore", args.PlaybookID), nil, nil); err != nil {
+		return "", fmt.Errorf("failed to restore playbook %s: %w (list archived templates with list_playbooks and with_archived=true)", args.PlaybookID, err)
+	}
+
+	return fmt.Sprintf("Restored playbook template %s. Runs can be started from it again with run_playbook.", args.PlaybookID), nil
+}
+
+func toolDuplicatePlaybook(ctx context.Context, client APIClient, args PlaybookIDArgs) (string, error) {
+	if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
+		return "", err
+	}
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := client.Post(ctx, fmt.Sprintf("playbooks/%s/duplicate", args.PlaybookID), nil, &created); err != nil {
+		return "", fmt.Errorf("failed to duplicate playbook %s: %w (if you are unsure of the playbook_id, call list_playbooks)", args.PlaybookID, err)
+	}
+	if created.ID == "" {
+		return "", fmt.Errorf("failed to duplicate playbook %s: response missing id", args.PlaybookID)
+	}
+
+	duplicate, err := fetchPlaybookForMutation(ctx, client, created.ID)
+	if err != nil {
+		return "", fmt.Errorf("duplicated playbook %s into %s, but failed to fetch the copy: %w", args.PlaybookID, created.ID, err)
+	}
+	title, _ := duplicate["title"].(string)
+
+	return fmt.Sprintf("Duplicated playbook template %s into %q (playbook_id: %s).\nURL: %s", args.PlaybookID, title, created.ID, client.GetPlaybookURL(created.ID)), nil
 }
 
 func toolCreatePlaybookAttribute(ctx context.Context, client APIClient, args CreatePlaybookAttributeArgs) (string, error) {
@@ -1037,6 +1151,11 @@ func validateCreatePlaybookItems(items []CreatePlaybookItem, field string) error
 func validateCreatePlaybookArgs(args CreatePlaybookArgs) error {
 	if args.ReminderTimerDefaultSeconds < 0 {
 		return fmt.Errorf("reminder_timer_default_seconds must be non-negative")
+	}
+	switch args.ChannelMode {
+	case "", channelModeCreateNew, channelModeLinkExisting:
+	default:
+		return fmt.Errorf("channel_mode must be one of %s or %s", channelModeCreateNew, channelModeLinkExisting)
 	}
 	if args.DefaultOwnerID != "" {
 		if err := validateID(args.DefaultOwnerID, "default_owner_id"); err != nil {

--- a/internal/playbooksmcp/tools/playbooks_test.go
+++ b/internal/playbooksmcp/tools/playbooks_test.go
@@ -192,7 +192,7 @@ func TestToolCreatePlaybookAttributeWrapsPostErrors(t *testing.T) {
 		Type:       "text",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create playbook attribute")
+	assert.Contains(t, err.Error(), "failed to create an attribute on playbook template")
 	assert.Contains(t, err.Error(), "boom")
 	assert.Equal(t, "playbooks/abcdefghijklmnopqrstuvwxyz/property_fields", client.postEndpoint)
 }
@@ -985,11 +985,11 @@ func TestToolPlaybookTaskValidationErrors(t *testing.T) {
 			wantNoPut: true,
 		},
 		{
-			name: "add invalid assignee ID",
+			name: "add unresolvable assignee",
 			run: func(client *fakeAPIClient) (string, error) {
-				return toolAddPlaybookTask(context.Background(), client, AddPlaybookTaskArgs{PlaybookID: playbookID, ChecklistNumber: 0, Title: "New task", AssigneeID: "bad"})
+				return toolAddPlaybookTask(context.Background(), client, AddPlaybookTaskArgs{PlaybookID: playbookID, ChecklistNumber: 0, Title: "New task", AssigneeID: "@nobody"})
 			},
-			want:      "assignee_id must be a valid Mattermost ID",
+			want:      `assignee_id: no user found with username "nobody"`,
 			wantNoPut: true,
 		},
 		{
@@ -1010,12 +1010,12 @@ func TestToolPlaybookTaskValidationErrors(t *testing.T) {
 			wantNoPut: true,
 		},
 		{
-			name: "edit invalid assignee ID",
+			name: "edit unresolvable assignee",
 			run: func(client *fakeAPIClient) (string, error) {
-				assigneeID := "bad"
+				assigneeID := "@nobody"
 				return toolEditPlaybookTask(context.Background(), client, EditPlaybookTaskArgs{PlaybookID: playbookID, ChecklistNumber: 0, ItemNumber: 0, AssigneeID: &assigneeID})
 			},
-			want:      "assignee_id must be a valid Mattermost ID",
+			want:      `assignee_id: no user found with username "nobody"`,
 			wantNoPut: true,
 		},
 		{
@@ -1127,15 +1127,15 @@ func TestToolPlaybookTaskValidationErrors(t *testing.T) {
 			wantNoPut: true,
 		},
 		{
-			name: "add section invalid initial item assignee",
+			name: "add section unresolvable initial item assignee",
 			run: func(client *fakeAPIClient) (string, error) {
 				return toolAddPlaybookSection(context.Background(), client, AddPlaybookSectionArgs{
 					PlaybookID: playbookID,
 					Title:      "New section",
-					Items:      []CreatePlaybookItem{{Title: "Task", AssigneeID: "bad"}},
+					Items:      []CreatePlaybookItem{{Title: "Task", AssigneeID: "@nobody"}},
 				})
 			},
-			want:      "items[0].assignee_id must be a valid Mattermost ID",
+			want:      `items[0].assignee_id: no user found with username "nobody"`,
 			wantNoPut: true,
 		},
 		{

--- a/internal/playbooksmcp/tools/playbooks_test.go
+++ b/internal/playbooksmcp/tools/playbooks_test.go
@@ -1355,6 +1355,207 @@ func TestToolPlaybookSectionUnexpectedFormatErrorsDescribeExpectedShape(t *testi
 	})
 }
 
+func TestToolCreatePlaybookSendsChannelModeAsString(t *testing.T) {
+	// app.ChannelPlaybookMode only implements UnmarshalText, so a numeric
+	// channel_mode fails to decode and the playbook is never created.
+	tests := []struct {
+		name        string
+		channelMode string
+		channelID   string
+		wantMode    any
+		wantErr     string
+	}{
+		{
+			name:        "forwards link_existing_channel verbatim",
+			channelMode: "link_existing_channel",
+			channelID:   "bcdefghijklmnopqrstuvwxyza",
+			wantMode:    "link_existing_channel",
+		},
+		{
+			name:        "forwards create_new_channel verbatim",
+			channelMode: "create_new_channel",
+			wantMode:    "create_new_channel",
+		},
+		{
+			name:     "omits channel_mode when not provided",
+			wantMode: nil,
+		},
+		{
+			name:        "rejects an unknown mode",
+			channelMode: "1",
+			wantErr:     "channel_mode must be one of create_new_channel or link_existing_channel",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+			args := CreatePlaybookArgs{
+				Title:       "Incident Response",
+				TeamID:      "abcdefghijklmnopqrstuvwxyz",
+				ChannelMode: tt.channelMode,
+				ChannelID:   tt.channelID,
+			}
+
+			_, err := toolCreatePlaybook(context.Background(), client, args)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, client.postEndpoint, "expected no playbook to be created")
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, "playbooks", client.postEndpoint)
+			body := client.postBody.(map[string]any)
+			if tt.wantMode == nil {
+				assert.NotContains(t, body, "channel_mode")
+				return
+			}
+			assert.Equal(t, tt.wantMode, body["channel_mode"])
+		})
+	}
+}
+
+func TestToolUpdatePlaybookMutatesOnlyProvidedKeys(t *testing.T) {
+	playbookID := "abcdefghijklmnopqrstuvwxyz"
+	newTitle := "  Sev1 Incident Response  "
+	emptyDescription := ""
+
+	tests := []struct {
+		name            string
+		args            UpdatePlaybookArgs
+		wantTitle       string
+		wantDescription string
+	}{
+		{
+			name:            "renames without touching the description",
+			args:            UpdatePlaybookArgs{PlaybookID: playbookID, Title: &newTitle},
+			wantTitle:       "Sev1 Incident Response",
+			wantDescription: "Original description",
+		},
+		{
+			name:            "clears the description without touching the title",
+			args:            UpdatePlaybookArgs{PlaybookID: playbookID, Description: &emptyDescription},
+			wantTitle:       "Incident Response",
+			wantDescription: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{
+				playbook: map[string]any{
+					"id":           playbookID,
+					"title":        "Incident Response",
+					"description":  "Original description",
+					"public":       false,
+					"custom_field": "preserve me",
+					"checklists":   []any{map[string]any{"title": "Triage", "items": []any{}}},
+				},
+			}
+
+			_, err := toolUpdatePlaybook(context.Background(), client, tt.args)
+			require.NoError(t, err)
+			require.Equal(t, "playbooks/"+playbookID, client.getEndpoint)
+			require.Equal(t, "playbooks/"+playbookID, client.putEndpoint)
+
+			body := requirePlaybookPutBody(t, client)
+			assert.Equal(t, tt.wantTitle, body["title"])
+			assert.Equal(t, tt.wantDescription, body["description"])
+			assert.Equal(t, false, body["public"])
+			assert.Equal(t, "preserve me", body["custom_field"])
+			assert.Len(t, body["checklists"], 1)
+		})
+	}
+}
+
+func TestToolUpdatePlaybookValidation(t *testing.T) {
+	playbookID := "abcdefghijklmnopqrstuvwxyz"
+	blank := "   "
+
+	tests := []struct {
+		name    string
+		args    UpdatePlaybookArgs
+		wantErr string
+	}{
+		{
+			name:    "rejects an invalid playbook id",
+			args:    UpdatePlaybookArgs{PlaybookID: "invalid"},
+			wantErr: "playbook_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "requires at least one field",
+			args:    UpdatePlaybookArgs{PlaybookID: playbookID},
+			wantErr: "at least one field (title or description) must be provided",
+		},
+		{
+			name:    "rejects a blank title",
+			args:    UpdatePlaybookArgs{PlaybookID: playbookID, Title: &blank},
+			wantErr: "title must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+			_, err := toolUpdatePlaybook(context.Background(), client, tt.args)
+			require.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, client.getEndpoint, "expected validation to fail before fetching")
+			assert.Empty(t, client.putEndpoint, "expected no update call")
+		})
+	}
+}
+
+func TestToolArchivePlaybookFetchesBeforeDeleting(t *testing.T) {
+	playbookID := "abcdefghijklmnopqrstuvwxyz"
+	client := &fakeAPIClient{
+		playbook: map[string]any{"id": playbookID, "title": "Incident Response"},
+	}
+
+	out, err := toolArchivePlaybook(context.Background(), client, PlaybookIDArgs{PlaybookID: playbookID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "playbooks/"+playbookID, client.getEndpoint)
+	assert.Equal(t, "playbooks/"+playbookID, client.deleteEndpoint)
+	assert.Contains(t, out, "Incident Response")
+	assert.Contains(t, out, "restore_playbook")
+}
+
+func TestToolArchivePlaybookRejectsInvalidIDBeforeDeleting(t *testing.T) {
+	client := &fakeAPIClient{}
+
+	_, err := toolArchivePlaybook(context.Background(), client, PlaybookIDArgs{PlaybookID: "invalid"})
+	require.EqualError(t, err, "playbook_id must be a valid Mattermost ID")
+	assert.Empty(t, client.getEndpoint)
+	assert.Empty(t, client.deleteEndpoint, "expected no delete on validation failure")
+}
+
+func TestToolRestorePlaybookPutsRestore(t *testing.T) {
+	playbookID := "abcdefghijklmnopqrstuvwxyz"
+	client := &fakeAPIClient{}
+
+	_, err := toolRestorePlaybook(context.Background(), client, PlaybookIDArgs{PlaybookID: playbookID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "playbooks/"+playbookID+"/restore", client.putEndpoint)
+	assert.Nil(t, client.putBody)
+}
+
+func TestToolDuplicatePlaybookFetchesTheCopy(t *testing.T) {
+	playbookID := "abcdefghijklmnopqrstuvwxyz"
+	client := &fakeAPIClient{
+		playbook: map[string]any{"id": "abcdefghijklmnopqrstuvwxyz", "title": "Copy of Incident Response"},
+	}
+
+	out, err := toolDuplicatePlaybook(context.Background(), client, PlaybookIDArgs{PlaybookID: playbookID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "playbooks/"+playbookID+"/duplicate", client.postEndpoint)
+	assert.Equal(t, "playbooks/abcdefghijklmnopqrstuvwxyz", client.getEndpoint)
+	assert.Contains(t, out, "Copy of Incident Response")
+	assert.Contains(t, out, "https://mattermost.example.com/playbooks/playbooks/abcdefghijklmnopqrstuvwxyz")
+}
+
 func playbookWithOneEmptyChecklist(playbookID string) map[string]any {
 	return map[string]any{
 		"id":    playbookID,

--- a/internal/playbooksmcp/tools/provider.go
+++ b/internal/playbooksmcp/tools/provider.go
@@ -17,9 +17,11 @@ type APIClient interface {
 	Get(ctx context.Context, endpoint string, params url.Values, result any) error
 	Post(ctx context.Context, endpoint string, body any, result any) error
 	Put(ctx context.Context, endpoint string, body any, result any) error
+	Patch(ctx context.Context, endpoint string, body any, result any) error
 	Delete(ctx context.Context, endpoint string) error
 	GetCurrentUserID(ctx context.Context) (string, error)
 	GetPlaybookURL(playbookID string) string
+	GetRunURL(runID string) string
 }
 
 // ClientFactory creates an APIClient for the current MCP request context.

--- a/internal/playbooksmcp/tools/provider.go
+++ b/internal/playbooksmcp/tools/provider.go
@@ -20,6 +20,12 @@ type APIClient interface {
 	Patch(ctx context.Context, endpoint string, body any, result any) error
 	Delete(ctx context.Context, endpoint string) error
 	GetCurrentUserID(ctx context.Context) (string, error)
+	// ResolveUserID turns any user reference a model might produce into a user
+	// ID: "me" for the acting user, a 26-character ID returned as-is, or a
+	// username with or without a leading "@". Not found is an error naming the
+	// reference. Models overwhelmingly say "@bob" rather than an opaque ID, so
+	// every user-taking argument goes through this.
+	ResolveUserID(ctx context.Context, userRef string) (string, error)
 	GetPlaybookURL(playbookID string) string
 	GetRunURL(runID string) string
 }

--- a/internal/playbooksmcp/tools/provider_test.go
+++ b/internal/playbooksmcp/tools/provider_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-agents/public/bridgeclient"
 	"github.com/mattermost/mattermost-plugin-agents/public/mcphelper"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPlaybooksToolProviderRejectsNilClientFactory(t *testing.T) {
@@ -21,6 +24,101 @@ func TestNewPlaybooksToolProviderRejectsNilClientFactory(t *testing.T) {
 	}
 	if provider != nil {
 		t.Fatalf("expected nil provider, got %v", provider)
+	}
+}
+
+// registerToolsForTest wires the provider into a real mcphelper server backed by
+// the given fake, and returns the tools the MCP client can see.
+func registerToolsForTest(t *testing.T, fakeClient APIClient) []*mcp.Tool {
+	t.Helper()
+	ctx := context.Background()
+
+	provider, err := NewPlaybooksToolProvider(func(context.Context) (APIClient, error) {
+		return fakeClient, nil
+	})
+	require.NoError(t, err)
+
+	helperServer := mcphelper.NewServer(nil, mcphelper.PluginMCPServer{
+		PluginID: "playbooks",
+		Name:     "Playbooks MCP",
+		Path:     "/mcp",
+		Version:  "0.0.1",
+	})
+	provider.ProvideMCPHelperTools(helperServer)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Set("Mattermost-Plugin-ID", bridgeclient.AiPluginID)
+		r.Header.Set("X-Mattermost-UserID", "user-id")
+		helperServer.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "playbooks-test-client", Version: "0.0.1"}, nil)
+	session, err := mcpClient.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+
+	listed, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+	return listed.Tools
+}
+
+// A tool that is implemented but never registered is invisible to the model and
+// nothing else in the suite would catch it, since the unit tests call the
+// handlers directly.
+func TestEveryToolIsRegistered(t *testing.T) {
+	registered := make(map[string]*mcp.Tool)
+	for _, tool := range registerToolsForTest(t, &fakeAPIClient{}) {
+		registered[tool.Name] = tool
+	}
+
+	want := []string{
+		// runs
+		"run_playbook", "list_runs", "create_checklist", "get_run", "get_run_metadata",
+		"update_run", "update_run_status", "get_status_updates", "request_status_update",
+		"finish_run", "restore_run", "change_run_owner",
+		"add_run_participants", "remove_run_participant", "follow_run", "unfollow_run",
+		// run checklists
+		"check_item", "add_checklist_item", "set_checklist_item_due_date",
+		"edit_checklist_item", "set_checklist_item_assignee", "remove_checklist_item",
+		"move_checklist_item", "add_section", "rename_section", "remove_section",
+		"skip_section", "restore_section", "move_section",
+		// playbook templates
+		"create_playbook", "list_playbooks", "get_playbook", "update_playbook",
+		"archive_playbook", "restore_playbook", "duplicate_playbook",
+		"create_playbook_attribute", "add_playbook_task", "edit_playbook_task",
+		"remove_playbook_task", "add_playbook_section", "rename_playbook_section",
+		"remove_playbook_section", "move_playbook_section",
+		// discovery
+		"resolve_channel_context", "find_checklist_item",
+	}
+
+	for _, name := range want {
+		assert.Contains(t, registered, "playbooks__"+name)
+	}
+	assert.Len(t, registered, len(want), "a tool was registered without being listed here")
+}
+
+// Descriptions double as BM25 retrieval text under dynamic tool loading, so a
+// thin or misleading one makes the tool unfindable rather than merely terse.
+func TestToolDescriptionsFollowRetrievalConventions(t *testing.T) {
+	for _, tool := range registerToolsForTest(t, &fakeAPIClient{}) {
+		t.Run(tool.Name, func(t *testing.T) {
+			description := tool.Description
+			require.NotEmpty(t, description)
+
+			assert.NotContains(t, description, "\n", "keep descriptions a single paragraph")
+			assert.Contains(t, strings.ToLower(description), "playbook",
+				"say whether the tool acts on a playbook run or a playbook template")
+			assert.Contains(t, description, "Example: {",
+				"include a concrete JSON example of the arguments")
+
+			first, _, _ := strings.Cut(description, ". ")
+			assert.NotContains(t, first, "This tool",
+				"lead with what the tool does, not with boilerplate")
+		})
 	}
 }
 

--- a/internal/playbooksmcp/tools/resolve.go
+++ b/internal/playbooksmcp/tools/resolve.go
@@ -31,11 +31,11 @@ type FindChecklistItemArgs struct {
 
 func (p *PlaybooksToolProvider) addMCPHelperResolveTools(server *mcphelper.Server) {
 	addMCPHelperTool(server, p.clientFactory, "resolve_channel_context",
-		"Resolve the runs and checklist items that live in a Mattermost channel. Use this first, passing the channel the agent is operating in, to discover the run_id and the zero-based checklist/item indexes before calling check_item (or any other item tool). Returns each run with its checklist items formatted as [checklist_number][item_number] title (state). Example: {\"channel_id\": \"abc123...\"}",
+		"Find which playbook runs and checklists live in a Mattermost channel — answers \"what run is this channel about?\". Use this first, passing the channel the agent is operating in, to discover the run_id and the zero-based checklist/item indexes before calling check_item or any other run task tool. Returns each run with its checklist items formatted as [checklist_number][item_number] title (state). Example: {\"channel_id\": \"abc123...\"}",
 		toolResolveChannelContext)
 
 	addMCPHelperTool(server, p.clientFactory, "find_checklist_item",
-		"Find a checklist item by matching text against item titles, so you can mark it done without knowing its indexes. Pass channel_id (the channel the agent is operating in) to search that channel's runs first. Returns the matching item(s) with run_id and the zero-based checklist_number/item_number to feed into check_item. Example: {\"query\": \"deploy to staging\", \"channel_id\": \"abc123...\"}",
+		"Find a task in a playbook run by matching text against task titles, so you can mark it done without knowing its indexes — \"tick off the deploy task\". Pass channel_id (the channel the agent is operating in) to search that channel's runs first, or run_id to search one run. Returns the matching task(s) with run_id and the zero-based checklist_number/item_number to feed into check_item. Example: {\"query\": \"deploy to staging\", \"channel_id\": \"abc123...\"}",
 		toolFindChecklistItem)
 }
 

--- a/internal/playbooksmcp/tools/resolve.go
+++ b/internal/playbooksmcp/tools/resolve.go
@@ -105,7 +105,7 @@ func candidateRuns(ctx context.Context, client APIClient, runID, channelID strin
 	if runID != "" {
 		var run playbookRunDetail
 		if err := client.Get(ctx, fmt.Sprintf("runs/%s", runID), nil, &run); err != nil {
-			return nil, fmt.Errorf("failed to get run: %w", err)
+			return nil, wrapRunError(err, runID, "get")
 		}
 		return []playbookRunDetail{run}, nil
 	}
@@ -179,7 +179,7 @@ func fetchRunDetails(ctx context.Context, client APIClient, params url.Values) (
 		for _, summary := range resp.Items {
 			var run playbookRunDetail
 			if err := client.Get(ctx, fmt.Sprintf("runs/%s", summary.ID), nil, &run); err != nil {
-				return nil, fmt.Errorf("failed to get run %s: %w", summary.ID, err)
+				return nil, wrapRunError(err, summary.ID, "get")
 			}
 			runs = append(runs, run)
 		}

--- a/internal/playbooksmcp/tools/runs.go
+++ b/internal/playbooksmcp/tools/runs.go
@@ -15,11 +15,6 @@ import (
 )
 
 const (
-	// meUserID is the literal the Playbooks API accepts in place of a user ID
-	// for the acting user. Tools resolve it client-side for endpoints that do
-	// not, so the same convention works everywhere.
-	meUserID = "me"
-
 	runTypePlaybook         = "playbook"
 	runTypeChannelChecklist = "channelChecklist"
 
@@ -36,8 +31,8 @@ type ListRunsArgs struct {
 	TeamID        string   `json:"team_id,omitempty" jsonschema:"Filter by team ID (26-char Mattermost ID)"`
 	ChannelID     string   `json:"channel_id,omitempty" jsonschema:"Filter by channel ID (26-char Mattermost ID). If the agent is operating within a channel, set this to that channel's ID to see only its runs."`
 	Status        string   `json:"status,omitempty" jsonschema:"Filter by status: InProgress or Finished"`
-	OwnerUserID   string   `json:"owner_user_id,omitempty" jsonschema:"Filter by the run owner's user ID. Use 'me' for the current user."`
-	ParticipantID string   `json:"participant_id,omitempty" jsonschema:"Filter to runs this user participates in. Use 'me' for the current user (answers 'which runs am I on?'). Combined with owner_user_id this is an AND, not an OR."`
+	OwnerUserID   string   `json:"owner_user_id,omitempty" jsonschema:"Filter by run owner. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
+	ParticipantID string   `json:"participant_id,omitempty" jsonschema:"Filter to runs this user participates in. Accepts a user ID, 'me' for the current user (answers 'which runs am I on?'), or a username with or without @. Combined with owner_user_id this is an AND, not an OR."`
 	PlaybookID    string   `json:"playbook_id,omitempty" jsonschema:"Filter to runs started from this playbook template (26-char ID). Call list_playbooks first if you only know the template's title."`
 	SearchTerm    string   `json:"search_term,omitempty" jsonschema:"Free-text search over run names. Use this to find a run by name instead of paging through everything."`
 	OmitEnded     bool     `json:"omit_ended,omitempty" jsonschema:"If true, exclude finished runs."`
@@ -62,7 +57,7 @@ type CreateChecklistSection struct {
 type CreateChecklistItem struct {
 	Title       string `json:"title" jsonschema:"Item title"`
 	Description string `json:"description,omitempty" jsonschema:"Optional item description (supports Markdown)"`
-	AssigneeID  string `json:"assignee_id,omitempty" jsonschema:"Optional user ID to assign the item to"`
+	AssigneeID  string `json:"assignee_id,omitempty" jsonschema:"Optional user to assign the item to. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
 	Command     string `json:"command,omitempty" jsonschema:"Optional slash command to associate with the item"`
 	DueDate     int64  `json:"due_date,omitempty" jsonschema:"Optional due date as Unix timestamp in milliseconds"`
 }
@@ -84,13 +79,13 @@ type FinishRunArgs struct {
 
 type ChangeRunOwnerArgs struct {
 	RunID   string `json:"run_id" jsonschema:"The ID of the playbook run"`
-	OwnerID string `json:"owner_id" jsonschema:"The user ID of the new owner"`
+	OwnerID string `json:"owner_id" jsonschema:"The new owner. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob')."`
 }
 
 type RunPlaybookArgs struct {
 	PlaybookID      string `json:"playbook_id" jsonschema:"The 26-char ID of the playbook template to start a run from. Call list_playbooks first if you only know its title."`
 	Name            string `json:"name,omitempty" jsonschema:"Name for the new run. Required for most playbooks. Omit it only when the playbook has a locked channel-name template (the server then generates the name) or when channel_id links an existing channel; if the server rejects the call for a missing name, retry with one."`
-	OwnerUserID     string `json:"owner_user_id,omitempty" jsonschema:"User ID to own the run. Use 'me' for the current user. Omit to let the server pick (the playbook's default owner, else the caller)."`
+	OwnerUserID     string `json:"owner_user_id,omitempty" jsonschema:"User to own the run. Accepts a user ID, 'me' for the current user, or a username with or without @ (for example '@bob'). Omit to let the server pick (the playbook's default owner, else the caller)."`
 	TeamID          string `json:"team_id,omitempty" jsonschema:"Team to create the run in. Omit to use the playbook's own team."`
 	ChannelID       string `json:"channel_id,omitempty" jsonschema:"Link the run to this existing channel instead of creating a new one. Omit to follow the playbook's own channel setting."`
 	Summary         string `json:"summary,omitempty" jsonschema:"Optional run summary shown on the run overview (supports Markdown)"`
@@ -113,14 +108,14 @@ type GetStatusUpdatesArgs struct {
 }
 
 type AddRunParticipantsArgs struct {
-	UserIDs           []string `json:"user_ids" jsonschema:"User IDs to add to the run. Use 'me' to add the current user (join the run)."`
+	UserIDs           []string `json:"user_ids" jsonschema:"Users to add to the run. Each entry accepts a user ID, 'me' for the current user (join the run), or a username with or without @ — pass '@bob' directly, no lookup step is needed."`
 	RunID             string   `json:"run_id" jsonschema:"The ID of the playbook run"`
 	ForceAddToChannel bool     `json:"force_add_to_channel,omitempty" jsonschema:"If true, also add the users to the run's channel even when the run does not sync channel membership."`
 }
 
 type RemoveRunParticipantArgs struct {
 	RunID  string `json:"run_id" jsonschema:"The ID of the playbook run"`
-	UserID string `json:"user_id" jsonschema:"User ID to remove from the run. Use 'me' to remove the current user (leave the run)."`
+	UserID string `json:"user_id" jsonschema:"User to remove from the run. Accepts a user ID, 'me' for the current user (leave the run), or a username with or without @ (for example '@bob')."`
 }
 
 // --- API response types (subset of fields for formatting) ---
@@ -247,15 +242,15 @@ type runMetadata struct {
 
 func (p *PlaybooksToolProvider) addMCPHelperRunTools(server *mcphelper.Server) {
 	addMCPHelperTool(server, p.clientFactory, "run_playbook",
-		"Start a playbook run from a playbook template — users say \"start the incident playbook\", \"run/launch/kick off a playbook\", \"begin a new incident\". Creates the active run, its channel, and copies the playbook's checklists. A playbook is a reusable template; a run is one active instance of it, so this tool is how a template becomes something people work in. If you do not know the playbook_id, call list_playbooks first — never guess it. owner_user_id accepts 'me'. Omit name only when the playbook generates it from a locked channel-name template; otherwise supply one. Returns the new run's name, ID, run number, channel, owner, and browser URL. Example: {\"playbook_id\": \"abc123...\", \"name\": \"Sev1 — checkout 500s\", \"owner_user_id\": \"me\", \"summary\": \"Checkout is returning 500s for ~5% of requests.\"}",
+		"Start a playbook run from a playbook template — users say \"start the incident playbook\", \"run/launch/kick off a playbook\", \"begin a new incident\". Creates the active run, its channel, and copies the playbook's checklists. A playbook is a reusable template; a run is one active instance of it, so this tool is how a template becomes something people work in. If you do not know the playbook_id, call list_playbooks first — never guess it. owner_user_id accepts a username with or without @, 'me', or a user ID. Omit name only when the playbook generates it from a locked channel-name template; otherwise supply one. Returns the new run's name, ID, run number, channel, owner, and browser URL. Example: {\"playbook_id\": \"abc123...\", \"name\": \"Sev1 — checkout 500s\", \"owner_user_id\": \"me\", \"summary\": \"Checkout is returning 500s for ~5% of requests.\"}",
 		toolRunPlaybook)
 
 	addMCPHelperTool(server, p.clientFactory, "list_runs",
-		"List and search playbook runs (active playbook instances, incidents, ongoing checklists) with filters for team, channel, owner, participant, playbook template, status, and free-text name search. Use this to find a run_id before acting on a run. status='InProgress' shows active runs; participant_id='me' shows runs the current user is on; playbook_id restricts to runs of one playbook template; types=[\"channelChecklist\"] shows standalone channel checklists. To start a new run from a template use run_playbook instead. Example: {\"status\": \"InProgress\", \"participant_id\": \"me\", \"search_term\": \"checkout\", \"per_page\": 5}",
+		"List and search playbook runs (active playbook instances, incidents, ongoing checklists) with filters for team, channel, owner, participant, playbook template, status, and free-text name search. Use this to find a run_id before acting on a run. status='InProgress' shows active runs; participant_id='me' shows runs the current user is on and also accepts a username such as '@bob'; playbook_id restricts to runs of one playbook template; types=[\"channelChecklist\"] shows standalone channel checklists. To start a new run from a template use run_playbook instead. Example: {\"status\": \"InProgress\", \"participant_id\": \"me\", \"search_term\": \"checkout\", \"per_page\": 5}",
 		toolListRuns)
 
 	addMCPHelperTool(server, p.clientFactory, "create_checklist",
-		"Create a standalone channel checklist (a playbook run with no playbook template behind it) in an existing Mattermost channel. Use this for ad-hoc task lists; to start a run from an existing playbook template use run_playbook instead. The authenticated user becomes the owner. Optionally include initial sections and items. Example: {\"name\": \"Release checklist\", \"channel_id\": \"abc123...\", \"sections\": [{\"title\": \"Pre-release\", \"items\": [{\"title\": \"Confirm changelog\"}]}]}",
+		"Create a standalone ad-hoc channel checklist in an existing Mattermost channel — a playbook run with NO playbook template behind it, which copies no checklists, tasks, or settings from any playbook. This is NOT a way to start a playbook: if the user named a playbook (\"start the incident playbook\"), call run_playbook, which copies the template's content; using this tool instead silently produces an empty run with none of it. Use this only for a task list typed out from scratch. The authenticated user becomes the owner, and you may include initial sections and items; item assignee_id accepts a username with or without @, 'me', or a user ID. Example: {\"name\": \"Release checklist\", \"channel_id\": \"abc123...\", \"sections\": [{\"title\": \"Pre-release\", \"items\": [{\"title\": \"Confirm changelog\"}]}]}",
 		toolCreateChecklist)
 
 	addMCPHelperTool(server, p.clientFactory, "get_run",
@@ -291,15 +286,15 @@ func (p *PlaybooksToolProvider) addMCPHelperRunTools(server *mcphelper.Server) {
 		toolRestoreRun)
 
 	addMCPHelperTool(server, p.clientFactory, "change_run_owner",
-		"Change the owner (lead, commander) of a playbook run. The new owner must be a Mattermost user, and if they are not already in the run's channel you need permission to add channel members — otherwise the server rejects the change. The run must still be in progress. Example: {\"run_id\": \"abc123...\", \"owner_id\": \"def456...\"}",
+		"Change the owner (lead, commander) of a playbook run — \"hand this run to @alice\". owner_id accepts a username with or without @, 'me', or a 26-character user ID. If the new owner is not already in the run's channel you need permission to add channel members, otherwise the server rejects the change. The run must still be in progress. Example: {\"run_id\": \"abc123...\", \"owner_id\": \"@alice\"}",
 		toolChangeRunOwner)
 
 	addMCPHelperTool(server, p.clientFactory, "add_run_participants",
-		"Add people to a playbook run, or join a run yourself — \"add Alice to this run\", \"put me on the incident\". Participants show up on the run and can be assigned tasks. Use 'me' in user_ids to join. Set force_add_to_channel=true to also add them to the run's channel when the run does not sync channel membership. Example: {\"run_id\": \"abc123...\", \"user_ids\": [\"me\", \"def456...\"], \"force_add_to_channel\": true}",
+		"Add people to a playbook run, or join a run yourself — \"add @alice to this run\", \"put me on the incident\". Pass usernames directly in user_ids: each entry accepts a username with or without @, 'me' for the current user, or a 26-character user ID. There is no separate user-lookup tool and you do not need one. Participants show up on the run and can be assigned tasks. Set force_add_to_channel=true to also add them to the run's channel when the run does not sync channel membership. Example: {\"run_id\": \"abc123...\", \"user_ids\": [\"@alice\", \"me\"], \"force_add_to_channel\": true}",
 		toolAddRunParticipants)
 
 	addMCPHelperTool(server, p.clientFactory, "remove_run_participant",
-		"Remove someone from a playbook run, or leave a run yourself — \"take Bob off this run\", \"remove me from the incident\". The removed user also stops following the run. Use 'me' to leave. The run's owner cannot be removed: hand the run over with change_run_owner first. Example: {\"run_id\": \"abc123...\", \"user_id\": \"def456...\"}",
+		"Remove someone from a playbook run, or leave a run yourself — \"take @bob off this run\", \"remove me from the incident\". user_id accepts a username with or without @, 'me' to leave, or a 26-character user ID. The removed user also stops following the run. The run's owner cannot be removed: hand the run over with change_run_owner first. Example: {\"run_id\": \"abc123...\", \"user_id\": \"@bob\"}",
 		toolRemoveRunParticipant)
 
 	addMCPHelperTool(server, p.clientFactory, "follow_run",
@@ -330,13 +325,17 @@ func toolListRuns(ctx context.Context, client APIClient, args ListRunsArgs) (str
 	if args.Status != "" {
 		params.Add("statuses", args.Status)
 	}
-	if args.OwnerUserID != "" {
-		params.Set("owner_user_id", args.OwnerUserID)
+	// The list endpoint resolves the literal "me" itself but knows nothing of
+	// usernames, so resolve both filters here for one consistent convention.
+	if owner, err := resolveUserRef(ctx, client, args.OwnerUserID, "owner_user_id"); err != nil {
+		return "", err
+	} else if owner != "" {
+		params.Set("owner_user_id", owner)
 	}
-	// The list endpoint resolves the literal "me" for owner_user_id and
-	// participant_id itself, so both are forwarded verbatim.
-	if args.ParticipantID != "" {
-		params.Set("participant_id", args.ParticipantID)
+	if participant, err := resolveUserRef(ctx, client, args.ParticipantID, "participant_id"); err != nil {
+		return "", err
+	} else if participant != "" {
+		params.Set("participant_id", participant)
 	}
 	if args.PlaybookID != "" {
 		if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
@@ -388,7 +387,8 @@ func toolCreateChecklist(ctx context.Context, client APIClient, args CreateCheck
 			return "", err
 		}
 	}
-	if err := validateInitialSections(args.Sections); err != nil {
+	sections, err := resolveInitialSections(ctx, client, args.Sections)
+	if err != nil {
 		return "", err
 	}
 
@@ -415,21 +415,17 @@ func toolCreateChecklist(ctx context.Context, client APIClient, args CreateCheck
 		return "", fmt.Errorf("failed to create checklist: %w", err)
 	}
 
-	for i, section := range args.Sections {
-		items := append([]CreateChecklistItem(nil), section.Items...)
-		for j := range items {
-			items[j].Title = strings.TrimSpace(items[j].Title)
-		}
+	for i, section := range sections {
 		sectionBody := map[string]any{
-			"title": strings.TrimSpace(section.Title),
-			"items": items,
+			"title": section.Title,
+			"items": section.Items,
 		}
 		if err := client.Post(ctx, fmt.Sprintf("runs/%s/checklists", run.ID), sectionBody, nil); err != nil {
 			return "", fmt.Errorf("created checklist run %s, but failed to add section %d: %w", run.ID, i, err)
 		}
 	}
 
-	if len(args.Sections) > 0 {
+	if len(sections) > 0 {
 		if err := client.Get(ctx, fmt.Sprintf("runs/%s", run.ID), nil, &run); err != nil {
 			return "", fmt.Errorf("created checklist run %s, but failed to fetch updated details: %w", run.ID, err)
 		}
@@ -445,7 +441,7 @@ func toolGetRun(ctx context.Context, client APIClient, args GetRunArgs) (string,
 
 	var run playbookRunDetail
 	if err := client.Get(ctx, fmt.Sprintf("runs/%s", args.RunID), nil, &run); err != nil {
-		return "", fmt.Errorf("failed to get run: %w", err)
+		return "", wrapRunError(err, args.RunID, "get")
 	}
 
 	return formatRunDetail(run), nil
@@ -482,7 +478,7 @@ func toolUpdateRunStatus(ctx context.Context, client APIClient, args UpdateRunSt
 	}
 
 	if err := client.Post(ctx, fmt.Sprintf("runs/%s/status", args.RunID), body, nil); err != nil {
-		return "", fmt.Errorf("failed to update status: %w", err)
+		return "", wrapRunError(err, args.RunID, "post a status update to")
 	}
 
 	return fmt.Sprintf("Status update posted to run %s.", args.RunID), nil
@@ -494,7 +490,7 @@ func toolFinishRun(ctx context.Context, client APIClient, args FinishRunArgs) (s
 	}
 
 	if err := client.Put(ctx, fmt.Sprintf("runs/%s/finish", args.RunID), nil, nil); err != nil {
-		return "", fmt.Errorf("failed to finish run: %w", err)
+		return "", wrapRunError(err, args.RunID, "finish")
 	}
 
 	return fmt.Sprintf("Run %s has been finished.", args.RunID), nil
@@ -504,19 +500,23 @@ func toolChangeRunOwner(ctx context.Context, client APIClient, args ChangeRunOwn
 	if err := validateID(args.RunID, "run_id"); err != nil {
 		return "", err
 	}
-	if err := validateID(args.OwnerID, "owner_id"); err != nil {
+	ownerID, err := resolveUserRef(ctx, client, args.OwnerID, "owner_id")
+	if err != nil {
 		return "", err
+	}
+	if ownerID == "" {
+		return "", fmt.Errorf("owner_id is required")
 	}
 
 	body := map[string]string{
-		"owner_id": args.OwnerID,
+		"owner_id": ownerID,
 	}
 
 	if err := client.Post(ctx, fmt.Sprintf("runs/%s/owner", args.RunID), body, nil); err != nil {
-		return "", fmt.Errorf("failed to change owner: %w", err)
+		return "", wrapRunError(err, args.RunID, "change the owner of")
 	}
 
-	return fmt.Sprintf("Owner of run %s changed to %s.", args.RunID, args.OwnerID), nil
+	return fmt.Sprintf("Owner of run %s changed to %s.", args.RunID, ownerID), nil
 }
 
 // defaultReminderSecondsForRun picks the reminder interval to send with a
@@ -550,7 +550,7 @@ func toolRunPlaybook(ctx context.Context, client APIClient, args RunPlaybookArgs
 		}
 	}
 
-	ownerUserID, err := resolveUserID(ctx, client, args.OwnerUserID, "owner_user_id")
+	ownerUserID, err := resolveUserRef(ctx, client, args.OwnerUserID, "owner_user_id")
 	if err != nil {
 		return "", err
 	}
@@ -560,7 +560,7 @@ func toolRunPlaybook(ctx context.Context, client APIClient, args RunPlaybookArgs
 	// deliberately does not read (the webapp resolves it client-side too).
 	var playbook playbookForRun
 	if err := client.Get(ctx, fmt.Sprintf("playbooks/%s", args.PlaybookID), nil, &playbook); err != nil {
-		return "", fmt.Errorf("failed to get playbook %s: %w (if you are unsure of the playbook_id, call list_playbooks)", args.PlaybookID, err)
+		return "", wrapPlaybookError(err, args.PlaybookID, "start a run from")
 	}
 	if playbook.DeleteAt != 0 {
 		return "", fmt.Errorf("playbook %s (%q) is archived and cannot be used to start a run; call list_playbooks to pick an active playbook, or restore_playbook to un-archive this one", args.PlaybookID, playbook.Title)
@@ -632,7 +632,7 @@ func toolUpdateRun(ctx context.Context, client APIClient, args UpdateRunArgs) (s
 	}
 
 	if err := client.Patch(ctx, fmt.Sprintf("runs/%s", args.RunID), body, nil); err != nil {
-		return "", fmt.Errorf("failed to update run %s: %w (finished runs cannot be edited — call restore_run first)", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "update", "Finished runs cannot be edited — call restore_run first.")
 	}
 
 	switch {
@@ -650,7 +650,7 @@ func toolRestoreRun(ctx context.Context, client APIClient, args RunIDArgs) (stri
 		return "", err
 	}
 	if err := client.Put(ctx, fmt.Sprintf("runs/%s/restore", args.RunID), nil, nil); err != nil {
-		return "", fmt.Errorf("failed to restore run %s: %w (restoring can require being the run owner or a system admin)", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "restore", "Restoring can require being the run owner or a system admin.")
 	}
 	return fmt.Sprintf("Run %s reopened and is In Progress again.", args.RunID), nil
 }
@@ -660,7 +660,7 @@ func toolRequestStatusUpdate(ctx context.Context, client APIClient, args RunIDAr
 		return "", err
 	}
 	if err := client.Post(ctx, fmt.Sprintf("runs/%s/request-update", args.RunID), nil, nil); err != nil {
-		return "", fmt.Errorf("failed to request a status update for run %s: %w", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "request a status update for")
 	}
 	return fmt.Sprintf("Requested a status update from the owner of run %s.", args.RunID), nil
 }
@@ -670,7 +670,7 @@ func toolFollowRun(ctx context.Context, client APIClient, args RunIDArgs) (strin
 		return "", err
 	}
 	if err := client.Put(ctx, fmt.Sprintf("runs/%s/followers", args.RunID), nil, nil); err != nil {
-		return "", fmt.Errorf("failed to follow run %s: %w", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "follow")
 	}
 	return fmt.Sprintf("Now following run %s; you will be notified about its status updates.", args.RunID), nil
 }
@@ -680,7 +680,7 @@ func toolUnfollowRun(ctx context.Context, client APIClient, args RunIDArgs) (str
 		return "", err
 	}
 	if err := client.Delete(ctx, fmt.Sprintf("runs/%s/followers", args.RunID)); err != nil {
-		return "", fmt.Errorf("failed to unfollow run %s: %w", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "unfollow")
 	}
 	return fmt.Sprintf("No longer following run %s.", args.RunID), nil
 }
@@ -699,7 +699,7 @@ func toolGetStatusUpdates(ctx context.Context, client APIClient, args GetStatusU
 
 	var updates []runStatusUpdate
 	if err := client.Get(ctx, fmt.Sprintf("runs/%s/status-updates", args.RunID), nil, &updates); err != nil {
-		return "", fmt.Errorf("failed to get status updates for run %s: %w", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "get status updates for")
 	}
 
 	return formatStatusUpdates(args.RunID, updates, limit), nil
@@ -712,7 +712,7 @@ func toolGetRunMetadata(ctx context.Context, client APIClient, args RunIDArgs) (
 
 	var metadata runMetadata
 	if err := client.Get(ctx, fmt.Sprintf("runs/%s/metadata", args.RunID), nil, &metadata); err != nil {
-		return "", fmt.Errorf("failed to get metadata for run %s: %w", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "get metadata for")
 	}
 
 	var sb strings.Builder
@@ -739,19 +739,12 @@ func toolAddRunParticipants(ctx context.Context, client APIClient, args AddRunPa
 		return "", err
 	}
 	if len(args.UserIDs) == 0 {
-		return "", fmt.Errorf("user_ids is required; pass 'me' to join the run yourself")
+		return "", fmt.Errorf("user_ids is required; pass 'me' to join the run yourself, or a username such as '@bob'")
 	}
 
-	userIDs := make([]string, 0, len(args.UserIDs))
-	for i, rawID := range args.UserIDs {
-		userID, err := resolveUserID(ctx, client, rawID, fmt.Sprintf("user_ids[%d]", i))
-		if err != nil {
-			return "", err
-		}
-		if userID == "" {
-			return "", fmt.Errorf("user_ids[%d] is required", i)
-		}
-		userIDs = appendUnique(userIDs, userID)
+	userIDs, err := resolveUserRefs(ctx, client, args.UserIDs, "user_ids")
+	if err != nil {
+		return "", err
 	}
 
 	body := map[string]any{
@@ -759,7 +752,8 @@ func toolAddRunParticipants(ctx context.Context, client APIClient, args AddRunPa
 		"force_add_to_channel": args.ForceAddToChannel,
 	}
 	if err := client.Post(ctx, fmt.Sprintf("runs/%s/participants", args.RunID), body, nil); err != nil {
-		return "", fmt.Errorf("failed to add participants to run %s: %w (adding someone other than yourself requires run-manage permission and an in-progress run)", args.RunID, err)
+		return "", wrapRunError(err, args.RunID, "add participants to",
+			"Adding someone other than yourself requires run-manage permission and an in-progress run.")
 	}
 
 	return fmt.Sprintf("Added %d participant(s) to run %s: %s.", len(userIDs), args.RunID, strings.Join(userIDs, ", ")), nil
@@ -769,12 +763,12 @@ func toolRemoveRunParticipant(ctx context.Context, client APIClient, args Remove
 	if err := validateID(args.RunID, "run_id"); err != nil {
 		return "", err
 	}
-	userID, err := resolveUserID(ctx, client, args.UserID, "user_id")
+	userID, err := resolveUserRef(ctx, client, args.UserID, "user_id")
 	if err != nil {
 		return "", err
 	}
 	if userID == "" {
-		return "", fmt.Errorf("user_id is required; pass 'me' to leave the run yourself")
+		return "", fmt.Errorf("user_id is required; pass 'me' to leave the run yourself, or a username such as '@bob'")
 	}
 
 	// Fetch first so removing a non-participant reports the actual roster
@@ -792,31 +786,11 @@ func toolRemoveRunParticipant(ctx context.Context, client APIClient, args Remove
 	}
 
 	if err := client.Delete(ctx, fmt.Sprintf("runs/%s/participants/%s", args.RunID, userID)); err != nil {
-		return "", fmt.Errorf("failed to remove participant %s from run %s: %w (removing someone other than yourself requires run-manage permission and an in-progress run)", userID, args.RunID, err)
+		return "", wrapRunError(err, args.RunID, fmt.Sprintf("remove participant %s from", userID),
+			"Removing someone other than yourself requires run-manage permission and an in-progress run.")
 	}
 
 	return fmt.Sprintf("Removed user %s from run %s; they no longer follow the run.", userID, args.RunID), nil
-}
-
-// resolveUserID turns the literal "me" into the acting user's ID and validates
-// anything else as a Mattermost ID. An empty value stays empty so callers can
-// treat it as "not provided".
-func resolveUserID(ctx context.Context, client APIClient, rawID, field string) (string, error) {
-	trimmed := strings.TrimSpace(rawID)
-	if trimmed == "" {
-		return "", nil
-	}
-	if trimmed == meUserID {
-		userID, err := client.GetCurrentUserID(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed to resolve %q for %s: %w", meUserID, field, err)
-		}
-		return userID, nil
-	}
-	if err := validateID(trimmed, field); err != nil {
-		return "", err
-	}
-	return trimmed, nil
 }
 
 func containsString(values []string, want string) bool {
@@ -837,30 +811,42 @@ func validateRunType(runType string) error {
 	}
 }
 
-func validateInitialSections(sections []CreateChecklistSection) error {
+// resolveInitialSections validates section titles and returns a copy whose
+// item assignees are resolved to user IDs, so a caller may write
+// "assignee_id": "@bob" the same way it can everywhere else.
+func resolveInitialSections(ctx context.Context, client APIClient, sections []CreateChecklistSection) ([]CreateChecklistSection, error) {
+	resolved := make([]CreateChecklistSection, 0, len(sections))
 	for i, section := range sections {
-		if strings.TrimSpace(section.Title) == "" {
-			return fmt.Errorf("sections[%d].title is required", i)
+		title := strings.TrimSpace(section.Title)
+		if title == "" {
+			return nil, fmt.Errorf("sections[%d].title is required", i)
 		}
-		if err := validateChecklistItems(section.Items, fmt.Sprintf("sections[%d].items", i)); err != nil {
-			return err
+		items, err := resolveChecklistItems(ctx, client, section.Items, fmt.Sprintf("sections[%d].items", i))
+		if err != nil {
+			return nil, err
 		}
+		resolved = append(resolved, CreateChecklistSection{Title: title, Items: items})
 	}
-	return nil
+	return resolved, nil
 }
 
-func validateChecklistItems(items []CreateChecklistItem, field string) error {
+// resolveChecklistItems trims titles and resolves assignee references,
+// returning a copy so the caller's arguments are left untouched.
+func resolveChecklistItems(ctx context.Context, client APIClient, items []CreateChecklistItem, field string) ([]CreateChecklistItem, error) {
+	resolved := make([]CreateChecklistItem, 0, len(items))
 	for i, item := range items {
-		if strings.TrimSpace(item.Title) == "" {
-			return fmt.Errorf("%s[%d].title is required", field, i)
+		item.Title = strings.TrimSpace(item.Title)
+		if item.Title == "" {
+			return nil, fmt.Errorf("%s[%d].title is required", field, i)
 		}
-		if item.AssigneeID != "" {
-			if err := validateID(item.AssigneeID, fmt.Sprintf("%s[%d].assignee_id", field, i)); err != nil {
-				return err
-			}
+		assignee, err := resolveUserRef(ctx, client, item.AssigneeID, fmt.Sprintf("%s[%d].assignee_id", field, i))
+		if err != nil {
+			return nil, err
 		}
+		item.AssigneeID = assignee
+		resolved = append(resolved, item)
 	}
-	return nil
+	return resolved, nil
 }
 
 // --- Formatting helpers ---
@@ -970,8 +956,15 @@ func formatStartedRun(client APIClient, playbook playbookForRun, run playbookRun
 	fmt.Fprintf(&sb, "- Channel: %s (%s)\n", displayOrNone(run.ChannelID), channelNote)
 	total, completed := runTaskProgress(run)
 	fmt.Fprintf(&sb, "- Checklists: %d, tasks: %d/%d complete\n", len(run.Checklists), completed, total)
-	fmt.Fprintf(&sb, "- URL: %s", client.GetRunURL(run.ID))
-	return sb.String()
+	fmt.Fprintf(&sb, "- URL: %s\n", client.GetRunURL(run.ID))
+
+	// The checklists copied from the playbook are what the caller acts on
+	// next, so surface their indexes here rather than making them call
+	// get_run just to learn a checklist_number.
+	sb.WriteString("\nSections copied from the playbook:\n")
+	writeRunSectionIndexes(&sb, run, -1)
+
+	return strings.TrimRight(sb.String(), "\n")
 }
 
 func formatStatusUpdates(runID string, updates []runStatusUpdate, limit int) string {

--- a/internal/playbooksmcp/tools/runs.go
+++ b/internal/playbooksmcp/tools/runs.go
@@ -5,25 +5,45 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/public/mcphelper"
+)
+
+const (
+	// meUserID is the literal the Playbooks API accepts in place of a user ID
+	// for the acting user. Tools resolve it client-side for endpoints that do
+	// not, so the same convention works everywhere.
+	meUserID = "me"
+
+	runTypePlaybook         = "playbook"
+	runTypeChannelChecklist = "channelChecklist"
+
+	channelModeCreateNew    = "create_new_channel"
+	channelModeLinkExisting = "link_existing_channel"
+
+	defaultStatusUpdateLimit = 10
+	maxStatusUpdateLimit     = 50
 )
 
 // --- Argument structs ---
 
 type ListRunsArgs struct {
-	TeamID      string   `json:"team_id,omitempty" jsonschema:"Filter by team ID (26-char Mattermost ID)"`
-	ChannelID   string   `json:"channel_id,omitempty" jsonschema:"Filter by channel ID (26-char Mattermost ID). If the agent is operating within a channel, set this to that channel's ID to see only its runs."`
-	Status      string   `json:"status,omitempty" jsonschema:"Filter by status: InProgress or Finished"`
-	OwnerUserID string   `json:"owner_user_id,omitempty" jsonschema:"Filter by owner user ID. Use 'me' for the current user."`
-	Type        string   `json:"type,omitempty" jsonschema:"Filter by run type: playbook or channelChecklist"`
-	Types       []string `json:"types,omitempty" jsonschema:"Filter by run types. Valid values: playbook, channelChecklist"`
-	Page        int      `json:"page,omitempty" jsonschema:"Page number (0-indexed)"`
-	PerPage     int      `json:"per_page,omitempty" jsonschema:"Number of results per page (max 100)"`
+	TeamID        string   `json:"team_id,omitempty" jsonschema:"Filter by team ID (26-char Mattermost ID)"`
+	ChannelID     string   `json:"channel_id,omitempty" jsonschema:"Filter by channel ID (26-char Mattermost ID). If the agent is operating within a channel, set this to that channel's ID to see only its runs."`
+	Status        string   `json:"status,omitempty" jsonschema:"Filter by status: InProgress or Finished"`
+	OwnerUserID   string   `json:"owner_user_id,omitempty" jsonschema:"Filter by the run owner's user ID. Use 'me' for the current user."`
+	ParticipantID string   `json:"participant_id,omitempty" jsonschema:"Filter to runs this user participates in. Use 'me' for the current user (answers 'which runs am I on?'). Combined with owner_user_id this is an AND, not an OR."`
+	PlaybookID    string   `json:"playbook_id,omitempty" jsonschema:"Filter to runs started from this playbook template (26-char ID). Call list_playbooks first if you only know the template's title."`
+	SearchTerm    string   `json:"search_term,omitempty" jsonschema:"Free-text search over run names. Use this to find a run by name instead of paging through everything."`
+	OmitEnded     bool     `json:"omit_ended,omitempty" jsonschema:"If true, exclude finished runs."`
+	Types         []string `json:"types,omitempty" jsonschema:"Filter by run types. Valid values: playbook (a run started from a playbook template), channelChecklist (a standalone channel checklist)."`
+	Page          int      `json:"page,omitempty" jsonschema:"Page number (0-indexed)"`
+	PerPage       int      `json:"per_page,omitempty" jsonschema:"Number of results per page (max 100)"`
 }
 
 type CreateChecklistArgs struct {
@@ -54,7 +74,7 @@ type GetRunArgs struct {
 type UpdateRunStatusArgs struct {
 	RunID           string `json:"run_id" jsonschema:"The ID of the playbook run"`
 	Message         string `json:"message" jsonschema:"Status update message (supports Markdown)"`
-	ReminderSeconds int64  `json:"reminder_seconds,omitempty" jsonschema:"Seconds until the next reminder (default: 3600)"`
+	ReminderSeconds int64  `json:"reminder_seconds,omitempty" jsonschema:"Seconds until the run's next status-update reminder. Omit to keep the run's existing cadence (its previous reminder, or the playbook's default interval)."`
 	FinishRun       bool   `json:"finish_run,omitempty" jsonschema:"If true the run is finished after posting the update"`
 }
 
@@ -65,6 +85,42 @@ type FinishRunArgs struct {
 type ChangeRunOwnerArgs struct {
 	RunID   string `json:"run_id" jsonschema:"The ID of the playbook run"`
 	OwnerID string `json:"owner_id" jsonschema:"The user ID of the new owner"`
+}
+
+type RunPlaybookArgs struct {
+	PlaybookID      string `json:"playbook_id" jsonschema:"The 26-char ID of the playbook template to start a run from. Call list_playbooks first if you only know its title."`
+	Name            string `json:"name,omitempty" jsonschema:"Name for the new run. Required for most playbooks. Omit it only when the playbook has a locked channel-name template (the server then generates the name) or when channel_id links an existing channel; if the server rejects the call for a missing name, retry with one."`
+	OwnerUserID     string `json:"owner_user_id,omitempty" jsonschema:"User ID to own the run. Use 'me' for the current user. Omit to let the server pick (the playbook's default owner, else the caller)."`
+	TeamID          string `json:"team_id,omitempty" jsonschema:"Team to create the run in. Omit to use the playbook's own team."`
+	ChannelID       string `json:"channel_id,omitempty" jsonschema:"Link the run to this existing channel instead of creating a new one. Omit to follow the playbook's own channel setting."`
+	Summary         string `json:"summary,omitempty" jsonschema:"Optional run summary shown on the run overview (supports Markdown)"`
+	CreatePublicRun *bool  `json:"create_public_run,omitempty" jsonschema:"Whether a newly created run channel is public. Omit to inherit the playbook's setting. Ignored when the run links an existing channel."`
+}
+
+type UpdateRunArgs struct {
+	RunID   string  `json:"run_id" jsonschema:"The ID of the playbook run to rename or re-summarize"`
+	Name    *string `json:"name,omitempty" jsonschema:"New name for the run. Must not be empty."`
+	Summary *string `json:"summary,omitempty" jsonschema:"New run summary (supports Markdown). Send an empty string to clear it."`
+}
+
+type RunIDArgs struct {
+	RunID string `json:"run_id" jsonschema:"The ID of the playbook run"`
+}
+
+type GetStatusUpdatesArgs struct {
+	RunID string `json:"run_id" jsonschema:"The ID of the playbook run to read status updates from"`
+	Limit int    `json:"limit,omitempty" jsonschema:"How many of the most recent updates to return (default 10, max 50)"`
+}
+
+type AddRunParticipantsArgs struct {
+	UserIDs           []string `json:"user_ids" jsonschema:"User IDs to add to the run. Use 'me' to add the current user (join the run)."`
+	RunID             string   `json:"run_id" jsonschema:"The ID of the playbook run"`
+	ForceAddToChannel bool     `json:"force_add_to_channel,omitempty" jsonschema:"If true, also add the users to the run's channel even when the run does not sync channel membership."`
+}
+
+type RemoveRunParticipantArgs struct {
+	RunID  string `json:"run_id" jsonschema:"The ID of the playbook run"`
+	UserID string `json:"user_id" jsonschema:"User ID to remove from the run. Use 'me' to remove the current user (leave the run)."`
 }
 
 // --- API response types (subset of fields for formatting) ---
@@ -103,51 +159,156 @@ type checklistItem struct {
 	Command     string `json:"command"`
 	Description string `json:"description"`
 	DueDate     int64  `json:"due_date"`
+	// AssigneeType/AssigneePropertyFieldID describe role-based and
+	// property-based assignment. Without them an item assigned to "the run
+	// owner" looks unassigned, because assignee_id is empty in that case.
+	AssigneeType            string `json:"assignee_type"`
+	AssigneePropertyFieldID string `json:"assignee_property_field_id"`
+	// LastSkipped carries the JSON name "delete_at" on app.ChecklistItem; it
+	// marks when the item was skipped, not when it was deleted.
+	LastSkipped int64 `json:"delete_at"`
+}
+
+type runStatusPost struct {
+	ID       string `json:"id"`
+	CreateAt int64  `json:"create_at"`
+	DeleteAt int64  `json:"delete_at"`
+}
+
+type runTimelineEvent struct {
+	ID        string `json:"id"`
+	EventType string `json:"event_type"`
 }
 
 type playbookRunDetail struct {
-	ID                 string      `json:"id"`
-	Name               string      `json:"name"`
-	Summary            string      `json:"summary"`
-	CurrentStatus      string      `json:"current_status"`
-	OwnerUserID        string      `json:"owner_user_id"`
-	TeamID             string      `json:"team_id"`
-	ChannelID          string      `json:"channel_id"`
-	PlaybookID         string      `json:"playbook_id"`
-	Type               string      `json:"type"`
-	CreateAt           int64       `json:"create_at"`
-	EndAt              int64       `json:"end_at"`
-	LastStatusUpdateAt int64       `json:"last_status_update_at"`
-	ParticipantIDs     []string    `json:"participant_ids"`
-	Checklists         []checklist `json:"checklists"`
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Summary            string   `json:"summary"`
+	CurrentStatus      string   `json:"current_status"`
+	OwnerUserID        string   `json:"owner_user_id"`
+	ReporterUserID     string   `json:"reporter_user_id"`
+	TeamID             string   `json:"team_id"`
+	ChannelID          string   `json:"channel_id"`
+	PlaybookID         string   `json:"playbook_id"`
+	Type               string   `json:"type"`
+	SequentialID       string   `json:"sequential_id"`
+	RunNumber          int64    `json:"run_number"`
+	CreateAt           int64    `json:"create_at"`
+	EndAt              int64    `json:"end_at"`
+	LastStatusUpdateAt int64    `json:"last_status_update_at"`
+	TaskTotal          int      `json:"task_total"`
+	TaskCompleted      int      `json:"task_completed"`
+	ParticipantIDs     []string `json:"participant_ids"`
+
+	StatusUpdateEnabled bool `json:"status_update_enabled"`
+	// PreviousReminder is a time.Duration, so it arrives in nanoseconds even
+	// though every reminder the API accepts is expressed in seconds.
+	PreviousReminder            int64 `json:"previous_reminder"`
+	ReminderTimerDefaultSeconds int64 `json:"reminder_timer_default_seconds"`
+	RetrospectiveEnabled        bool  `json:"retrospective_enabled"`
+	RetrospectivePublishedAt    int64 `json:"retrospective_published_at"`
+
+	StatusPosts    []runStatusPost    `json:"status_posts"`
+	TimelineEvents []runTimelineEvent `json:"timeline_events"`
+	Checklists     []checklist        `json:"checklists"`
+}
+
+// playbookForRun is the slice of a playbook template that run_playbook needs to
+// resolve creation parameters the POST /runs endpoint does not resolve itself.
+type playbookForRun struct {
+	ID                        string `json:"id"`
+	Title                     string `json:"title"`
+	TeamID                    string `json:"team_id"`
+	ChannelID                 string `json:"channel_id"`
+	ChannelMode               string `json:"channel_mode"`
+	ChannelNameTemplate       string `json:"channel_name_template"`
+	ChannelNameTemplateLocked bool   `json:"channel_name_template_locked"`
+	DeleteAt                  int64  `json:"delete_at"`
+}
+
+type runStatusUpdate struct {
+	ID             string `json:"id"`
+	CreateAt       int64  `json:"create_at"`
+	DeleteAt       int64  `json:"delete_at"`
+	Message        string `json:"message"`
+	AuthorUserName string `json:"author_user_name"`
+}
+
+type runMetadata struct {
+	ChannelName        string   `json:"channel_name"`
+	ChannelDisplayName string   `json:"channel_display_name"`
+	TeamName           string   `json:"team_name"`
+	NumParticipants    int64    `json:"num_participants"`
+	TotalPosts         int64    `json:"total_posts"`
+	Followers          []string `json:"followers"`
 }
 
 // --- Tool registration ---
 
 func (p *PlaybooksToolProvider) addMCPHelperRunTools(server *mcphelper.Server) {
+	addMCPHelperTool(server, p.clientFactory, "run_playbook",
+		"Start a playbook run from a playbook template — users say \"start the incident playbook\", \"run/launch/kick off a playbook\", \"begin a new incident\". Creates the active run, its channel, and copies the playbook's checklists. A playbook is a reusable template; a run is one active instance of it, so this tool is how a template becomes something people work in. If you do not know the playbook_id, call list_playbooks first — never guess it. owner_user_id accepts 'me'. Omit name only when the playbook generates it from a locked channel-name template; otherwise supply one. Returns the new run's name, ID, run number, channel, owner, and browser URL. Example: {\"playbook_id\": \"abc123...\", \"name\": \"Sev1 — checkout 500s\", \"owner_user_id\": \"me\", \"summary\": \"Checkout is returning 500s for ~5% of requests.\"}",
+		toolRunPlaybook)
+
 	addMCPHelperTool(server, p.clientFactory, "list_runs",
-		"List playbook runs and channel checklists with optional filters. Returns a paginated list showing ID, name, type, status, owner, and timestamps. Use status='InProgress' to see active runs, type='channelChecklist' to list checklists, and channel_id to restrict to a single channel. Example: {\"status\": \"InProgress\", \"channel_id\": \"abc123...\", \"per_page\": 5}",
+		"List and search playbook runs (active playbook instances, incidents, ongoing checklists) with filters for team, channel, owner, participant, playbook template, status, and free-text name search. Use this to find a run_id before acting on a run. status='InProgress' shows active runs; participant_id='me' shows runs the current user is on; playbook_id restricts to runs of one playbook template; types=[\"channelChecklist\"] shows standalone channel checklists. To start a new run from a template use run_playbook instead. Example: {\"status\": \"InProgress\", \"participant_id\": \"me\", \"search_term\": \"checkout\", \"per_page\": 5}",
 		toolListRuns)
 
 	addMCPHelperTool(server, p.clientFactory, "create_checklist",
-		"Create a channel checklist (a playbook run without an associated playbook) in an existing Mattermost channel. The authenticated user is used as owner. Optionally include initial sections and items. Example: {\"name\": \"Release checklist\", \"channel_id\": \"abc123...\", \"sections\": [{\"title\": \"Pre-release\", \"items\": [{\"title\": \"Confirm changelog\"}]}]}",
+		"Create a standalone channel checklist (a playbook run with no playbook template behind it) in an existing Mattermost channel. Use this for ad-hoc task lists; to start a run from an existing playbook template use run_playbook instead. The authenticated user becomes the owner. Optionally include initial sections and items. Example: {\"name\": \"Release checklist\", \"channel_id\": \"abc123...\", \"sections\": [{\"title\": \"Pre-release\", \"items\": [{\"title\": \"Confirm changelog\"}]}]}",
 		toolCreateChecklist)
 
 	addMCPHelperTool(server, p.clientFactory, "get_run",
-		"Get full details of a specific playbook run, including checklists with item states, participants, and status. Use this to understand the current state of a run before taking action. Example: {\"run_id\": \"abc123...\"}",
+		"Get the full state of one playbook run: status, owner, reporter, run number, task progress, channel/team, participants, and every checklist item with its zero-based [checklist_number][item_number] index, state, assignee and due date. Call this before acting on a run, and to read the indexes the checklist tools need. Status update text is not included — call get_status_updates for that. Example: {\"run_id\": \"abc123...\"}",
 		toolGetRun)
 
+	addMCPHelperTool(server, p.clientFactory, "get_run_metadata",
+		"Get a playbook run's channel name, channel display name, team name, participant count, post count, and followers, so you can say \"the run lives in ~incident-42\" instead of quoting raw 26-character IDs. Example: {\"run_id\": \"abc123...\"}",
+		toolGetRunMetadata)
+
+	addMCPHelperTool(server, p.clientFactory, "update_run",
+		"Rename a playbook run or edit its run summary (the overview description). Provide name, summary, or both — at least one is required. Renaming does not rename the run's channel. Finished runs cannot be edited; restore_run first. If you do not know the run_id, call list_runs or resolve_channel_context. Example: {\"run_id\": \"abc123...\", \"name\": \"Sev2 — checkout latency\", \"summary\": \"Latency recovered; monitoring.\"}",
+		toolUpdateRun)
+
 	addMCPHelperTool(server, p.clientFactory, "update_run_status",
-		"Post a status update to a playbook run. The message supports Markdown. Optionally set a reminder interval or finish the run. You must be a participant to post updates. Example: {\"run_id\": \"abc123...\", \"message\": \"Investigation complete, root cause identified.\", \"reminder_seconds\": 1800}",
+		"Post a status update to a playbook run (progress update, situation report). The message supports Markdown. Posting an update also reschedules the run's next status-update reminder: omit reminder_seconds to keep the run's existing cadence, or set it explicitly. Set finish_run=true to post a final update and close the run in one call. You must be a run participant. Example: {\"run_id\": \"abc123...\", \"message\": \"Investigation complete, root cause identified.\", \"reminder_seconds\": 1800}",
 		toolUpdateRunStatus)
 
+	addMCPHelperTool(server, p.clientFactory, "get_status_updates",
+		"Read the text of past status updates posted to a playbook run, newest first, with author and timestamp. This is the only way to see what previous updates actually said — get_run does not include their text. Use it to summarize how a run or incident has progressed. Example: {\"run_id\": \"abc123...\", \"limit\": 5}",
+		toolGetStatusUpdates)
+
+	addMCPHelperTool(server, p.clientFactory, "request_status_update",
+		"Ask the owner of a playbook run for a status update (nudge them). Posts a request in the run's channel; it does not post an update itself — use update_run_status for that. Example: {\"run_id\": \"abc123...\"}",
+		toolRequestStatusUpdate)
+
 	addMCPHelperTool(server, p.clientFactory, "finish_run",
-		"Finish (close) a playbook run. This marks the run as Finished. Example: {\"run_id\": \"abc123...\"}",
+		"Finish (close, complete, end, resolve) a playbook run, marking it Finished. Depending on the playbook's settings you may need to be the run owner or a system admin rather than just a participant, and an already-finished run cannot be finished again. Reopen a run with restore_run. Example: {\"run_id\": \"abc123...\"}",
 		toolFinishRun)
 
+	addMCPHelperTool(server, p.clientFactory, "restore_run",
+		"Reopen a finished playbook run (un-finish, restore, \"we closed it too early\"), moving it back to In Progress. This is the inverse of finish_run and is required before a finished run can be edited again. Example: {\"run_id\": \"abc123...\"}",
+		toolRestoreRun)
+
 	addMCPHelperTool(server, p.clientFactory, "change_run_owner",
-		"Change the owner of a playbook run. The new owner must be a valid Mattermost user. Example: {\"run_id\": \"abc123...\", \"owner_id\": \"def456...\"}",
+		"Change the owner (lead, commander) of a playbook run. The new owner must be a Mattermost user, and if they are not already in the run's channel you need permission to add channel members — otherwise the server rejects the change. The run must still be in progress. Example: {\"run_id\": \"abc123...\", \"owner_id\": \"def456...\"}",
 		toolChangeRunOwner)
+
+	addMCPHelperTool(server, p.clientFactory, "add_run_participants",
+		"Add people to a playbook run, or join a run yourself — \"add Alice to this run\", \"put me on the incident\". Participants show up on the run and can be assigned tasks. Use 'me' in user_ids to join. Set force_add_to_channel=true to also add them to the run's channel when the run does not sync channel membership. Example: {\"run_id\": \"abc123...\", \"user_ids\": [\"me\", \"def456...\"], \"force_add_to_channel\": true}",
+		toolAddRunParticipants)
+
+	addMCPHelperTool(server, p.clientFactory, "remove_run_participant",
+		"Remove someone from a playbook run, or leave a run yourself — \"take Bob off this run\", \"remove me from the incident\". The removed user also stops following the run. Use 'me' to leave. The run's owner cannot be removed: hand the run over with change_run_owner first. Example: {\"run_id\": \"abc123...\", \"user_id\": \"def456...\"}",
+		toolRemoveRunParticipant)
+
+	addMCPHelperTool(server, p.clientFactory, "follow_run",
+		"Follow a playbook run to get notified about its status updates, without becoming a participant. Use add_run_participants instead to actually join the run. Example: {\"run_id\": \"abc123...\"}",
+		toolFollowRun)
+
+	addMCPHelperTool(server, p.clientFactory, "unfollow_run",
+		"Unfollow a playbook run and stop getting notified about its status updates. This does not remove you as a participant — use remove_run_participant for that. Example: {\"run_id\": \"abc123...\"}",
+		toolUnfollowRun)
 }
 
 // --- Tool implementations ---
@@ -172,11 +333,22 @@ func toolListRuns(ctx context.Context, client APIClient, args ListRunsArgs) (str
 	if args.OwnerUserID != "" {
 		params.Set("owner_user_id", args.OwnerUserID)
 	}
-	if args.Type != "" {
-		if err := validateRunType(args.Type); err != nil {
+	// The list endpoint resolves the literal "me" for owner_user_id and
+	// participant_id itself, so both are forwarded verbatim.
+	if args.ParticipantID != "" {
+		params.Set("participant_id", args.ParticipantID)
+	}
+	if args.PlaybookID != "" {
+		if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
 			return "", err
 		}
-		params.Add("types", args.Type)
+		params.Set("playbook_id", args.PlaybookID)
+	}
+	if search := strings.TrimSpace(args.SearchTerm); search != "" {
+		params.Set("search_term", search)
+	}
+	if args.OmitEnded {
+		params.Set("omit_ended", "true")
 	}
 	for _, runType := range args.Types {
 		if err := validateRunType(runType); err != nil {
@@ -293,7 +465,14 @@ func toolUpdateRunStatus(ctx context.Context, client APIClient, args UpdateRunSt
 	// as seconds, not nanoseconds. Do NOT multiply by time.Second here.
 	reminder := args.ReminderSeconds
 	if reminder <= 0 && !args.FinishRun {
-		reminder = 3600
+		// The API rejects a zero reminder on a non-finishing update, so one has
+		// to be sent. Inherit the run's own cadence rather than imposing an
+		// hour on a run that, say, updates daily.
+		run, err := fetchRunForBounds(ctx, client, args.RunID)
+		if err != nil {
+			return "", err
+		}
+		reminder = defaultReminderSecondsForRun(run)
 	}
 
 	body := map[string]any{
@@ -340,12 +519,321 @@ func toolChangeRunOwner(ctx context.Context, client APIClient, args ChangeRunOwn
 	return fmt.Sprintf("Owner of run %s changed to %s.", args.RunID, args.OwnerID), nil
 }
 
+// defaultReminderSecondsForRun picks the reminder interval to send with a
+// status update when the caller did not specify one: the run's own previous
+// reminder (stored as a time.Duration in nanoseconds), else the interval the
+// playbook configured, else one hour.
+func defaultReminderSecondsForRun(run playbookRunDetail) int64 {
+	if run.PreviousReminder > 0 {
+		if seconds := run.PreviousReminder / int64(time.Second); seconds > 0 {
+			return seconds
+		}
+	}
+	if run.ReminderTimerDefaultSeconds > 0 {
+		return run.ReminderTimerDefaultSeconds
+	}
+	return 3600
+}
+
+func toolRunPlaybook(ctx context.Context, client APIClient, args RunPlaybookArgs) (string, error) {
+	if err := validateID(args.PlaybookID, "playbook_id"); err != nil {
+		return "", err
+	}
+	if args.TeamID != "" {
+		if err := validateID(args.TeamID, "team_id"); err != nil {
+			return "", err
+		}
+	}
+	if args.ChannelID != "" {
+		if err := validateID(args.ChannelID, "channel_id"); err != nil {
+			return "", err
+		}
+	}
+
+	ownerUserID, err := resolveUserID(ctx, client, args.OwnerUserID, "owner_user_id")
+	if err != nil {
+		return "", err
+	}
+
+	// Fetch the playbook first: it validates the ID with an actionable error,
+	// supplies the default team, and carries the channel mode that POST /runs
+	// deliberately does not read (the webapp resolves it client-side too).
+	var playbook playbookForRun
+	if err := client.Get(ctx, fmt.Sprintf("playbooks/%s", args.PlaybookID), nil, &playbook); err != nil {
+		return "", fmt.Errorf("failed to get playbook %s: %w (if you are unsure of the playbook_id, call list_playbooks)", args.PlaybookID, err)
+	}
+	if playbook.DeleteAt != 0 {
+		return "", fmt.Errorf("playbook %s (%q) is archived and cannot be used to start a run; call list_playbooks to pick an active playbook, or restore_playbook to un-archive this one", args.PlaybookID, playbook.Title)
+	}
+
+	channelID := args.ChannelID
+	if channelID == "" && playbook.ChannelMode == channelModeLinkExisting && playbook.ChannelID != "" {
+		channelID = playbook.ChannelID
+	}
+
+	name := strings.TrimSpace(args.Name)
+	templateLocked := playbook.ChannelNameTemplate != "" && playbook.ChannelNameTemplateLocked
+	if name == "" && channelID == "" && !templateLocked {
+		return "", fmt.Errorf("name is required to start a run from playbook %s (%q): it creates a new channel and the playbook has no locked channel-name template to generate a name from", args.PlaybookID, playbook.Title)
+	}
+
+	body := map[string]any{"playbook_id": args.PlaybookID}
+	if name != "" {
+		body["name"] = name
+	}
+	if ownerUserID != "" {
+		body["owner_user_id"] = ownerUserID
+	}
+	if channelID != "" {
+		body["channel_id"] = channelID
+	}
+	// The server derives the team from the channel and rejects a team_id that
+	// disagrees with it, so only default from the playbook when no channel is
+	// being linked.
+	switch {
+	case args.TeamID != "":
+		body["team_id"] = args.TeamID
+	case channelID == "" && playbook.TeamID != "":
+		body["team_id"] = playbook.TeamID
+	}
+	if summary := strings.TrimSpace(args.Summary); summary != "" {
+		body["summary"] = summary
+	}
+	if args.CreatePublicRun != nil {
+		body["create_public_run"] = *args.CreatePublicRun
+	}
+
+	var run playbookRunDetail
+	if err := client.Post(ctx, "runs", body, &run); err != nil {
+		return "", fmt.Errorf("failed to start a run from playbook %s (%q): %w", args.PlaybookID, playbook.Title, err)
+	}
+
+	return formatStartedRun(client, playbook, run, channelID != ""), nil
+}
+
+func toolUpdateRun(ctx context.Context, client APIClient, args UpdateRunArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	if args.Name == nil && args.Summary == nil {
+		return "", fmt.Errorf("at least one field (name or summary) must be provided")
+	}
+
+	body := map[string]any{}
+	if args.Name != nil {
+		name := strings.TrimSpace(*args.Name)
+		if name == "" {
+			return "", fmt.Errorf("name must not be empty")
+		}
+		body["name"] = name
+	}
+	if args.Summary != nil {
+		body["summary"] = *args.Summary
+	}
+
+	if err := client.Patch(ctx, fmt.Sprintf("runs/%s", args.RunID), body, nil); err != nil {
+		return "", fmt.Errorf("failed to update run %s: %w (finished runs cannot be edited — call restore_run first)", args.RunID, err)
+	}
+
+	switch {
+	case args.Name != nil && args.Summary != nil:
+		return fmt.Sprintf("Run %s renamed to %q and its summary updated.", args.RunID, body["name"]), nil
+	case args.Name != nil:
+		return fmt.Sprintf("Run %s renamed to %q.", args.RunID, body["name"]), nil
+	default:
+		return fmt.Sprintf("Summary of run %s updated.", args.RunID), nil
+	}
+}
+
+func toolRestoreRun(ctx context.Context, client APIClient, args RunIDArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	if err := client.Put(ctx, fmt.Sprintf("runs/%s/restore", args.RunID), nil, nil); err != nil {
+		return "", fmt.Errorf("failed to restore run %s: %w (restoring can require being the run owner or a system admin)", args.RunID, err)
+	}
+	return fmt.Sprintf("Run %s reopened and is In Progress again.", args.RunID), nil
+}
+
+func toolRequestStatusUpdate(ctx context.Context, client APIClient, args RunIDArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	if err := client.Post(ctx, fmt.Sprintf("runs/%s/request-update", args.RunID), nil, nil); err != nil {
+		return "", fmt.Errorf("failed to request a status update for run %s: %w", args.RunID, err)
+	}
+	return fmt.Sprintf("Requested a status update from the owner of run %s.", args.RunID), nil
+}
+
+func toolFollowRun(ctx context.Context, client APIClient, args RunIDArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	if err := client.Put(ctx, fmt.Sprintf("runs/%s/followers", args.RunID), nil, nil); err != nil {
+		return "", fmt.Errorf("failed to follow run %s: %w", args.RunID, err)
+	}
+	return fmt.Sprintf("Now following run %s; you will be notified about its status updates.", args.RunID), nil
+}
+
+func toolUnfollowRun(ctx context.Context, client APIClient, args RunIDArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	if err := client.Delete(ctx, fmt.Sprintf("runs/%s/followers", args.RunID)); err != nil {
+		return "", fmt.Errorf("failed to unfollow run %s: %w", args.RunID, err)
+	}
+	return fmt.Sprintf("No longer following run %s.", args.RunID), nil
+}
+
+func toolGetStatusUpdates(ctx context.Context, client APIClient, args GetStatusUpdatesArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = defaultStatusUpdateLimit
+	}
+	if limit > maxStatusUpdateLimit {
+		limit = maxStatusUpdateLimit
+	}
+
+	var updates []runStatusUpdate
+	if err := client.Get(ctx, fmt.Sprintf("runs/%s/status-updates", args.RunID), nil, &updates); err != nil {
+		return "", fmt.Errorf("failed to get status updates for run %s: %w", args.RunID, err)
+	}
+
+	return formatStatusUpdates(args.RunID, updates, limit), nil
+}
+
+func toolGetRunMetadata(ctx context.Context, client APIClient, args RunIDArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+
+	var metadata runMetadata
+	if err := client.Get(ctx, fmt.Sprintf("runs/%s/metadata", args.RunID), nil, &metadata); err != nil {
+		return "", fmt.Errorf("failed to get metadata for run %s: %w", args.RunID, err)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Run %s:\n", args.RunID)
+	if metadata.ChannelDisplayName != "" || metadata.ChannelName != "" {
+		fmt.Fprintf(&sb, "- Channel: %s (~%s)\n", metadata.ChannelDisplayName, metadata.ChannelName)
+	} else {
+		sb.WriteString("- Channel: (not visible to you)\n")
+	}
+	if metadata.TeamName != "" {
+		fmt.Fprintf(&sb, "- Team: %s\n", metadata.TeamName)
+	}
+	fmt.Fprintf(&sb, "- Participants: %d\n", metadata.NumParticipants)
+	fmt.Fprintf(&sb, "- Posts in channel: %d\n", metadata.TotalPosts)
+	fmt.Fprintf(&sb, "- Followers: %d", len(metadata.Followers))
+	if len(metadata.Followers) > 0 {
+		fmt.Fprintf(&sb, " (%s)", strings.Join(metadata.Followers, ", "))
+	}
+	return sb.String(), nil
+}
+
+func toolAddRunParticipants(ctx context.Context, client APIClient, args AddRunParticipantsArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	if len(args.UserIDs) == 0 {
+		return "", fmt.Errorf("user_ids is required; pass 'me' to join the run yourself")
+	}
+
+	userIDs := make([]string, 0, len(args.UserIDs))
+	for i, rawID := range args.UserIDs {
+		userID, err := resolveUserID(ctx, client, rawID, fmt.Sprintf("user_ids[%d]", i))
+		if err != nil {
+			return "", err
+		}
+		if userID == "" {
+			return "", fmt.Errorf("user_ids[%d] is required", i)
+		}
+		userIDs = appendUnique(userIDs, userID)
+	}
+
+	body := map[string]any{
+		"user_ids":             userIDs,
+		"force_add_to_channel": args.ForceAddToChannel,
+	}
+	if err := client.Post(ctx, fmt.Sprintf("runs/%s/participants", args.RunID), body, nil); err != nil {
+		return "", fmt.Errorf("failed to add participants to run %s: %w (adding someone other than yourself requires run-manage permission and an in-progress run)", args.RunID, err)
+	}
+
+	return fmt.Sprintf("Added %d participant(s) to run %s: %s.", len(userIDs), args.RunID, strings.Join(userIDs, ", ")), nil
+}
+
+func toolRemoveRunParticipant(ctx context.Context, client APIClient, args RemoveRunParticipantArgs) (string, error) {
+	if err := validateID(args.RunID, "run_id"); err != nil {
+		return "", err
+	}
+	userID, err := resolveUserID(ctx, client, args.UserID, "user_id")
+	if err != nil {
+		return "", err
+	}
+	if userID == "" {
+		return "", fmt.Errorf("user_id is required; pass 'me' to leave the run yourself")
+	}
+
+	// Fetch first so removing a non-participant reports the actual roster
+	// instead of an opaque API error.
+	run, err := fetchRunForBounds(ctx, client, args.RunID)
+	if err != nil {
+		return "", err
+	}
+	if run.OwnerUserID == userID {
+		return "", fmt.Errorf("user %s owns run %s and cannot be removed from it; hand the run over with change_run_owner first", userID, args.RunID)
+	}
+	if !containsString(run.ParticipantIDs, userID) {
+		return fmt.Sprintf("User %s is not a participant of run %s; no change made. Current participants: %s.",
+			userID, args.RunID, formatIDList(run.ParticipantIDs)), nil
+	}
+
+	if err := client.Delete(ctx, fmt.Sprintf("runs/%s/participants/%s", args.RunID, userID)); err != nil {
+		return "", fmt.Errorf("failed to remove participant %s from run %s: %w (removing someone other than yourself requires run-manage permission and an in-progress run)", userID, args.RunID, err)
+	}
+
+	return fmt.Sprintf("Removed user %s from run %s; they no longer follow the run.", userID, args.RunID), nil
+}
+
+// resolveUserID turns the literal "me" into the acting user's ID and validates
+// anything else as a Mattermost ID. An empty value stays empty so callers can
+// treat it as "not provided".
+func resolveUserID(ctx context.Context, client APIClient, rawID, field string) (string, error) {
+	trimmed := strings.TrimSpace(rawID)
+	if trimmed == "" {
+		return "", nil
+	}
+	if trimmed == meUserID {
+		userID, err := client.GetCurrentUserID(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve %q for %s: %w", meUserID, field, err)
+		}
+		return userID, nil
+	}
+	if err := validateID(trimmed, field); err != nil {
+		return "", err
+	}
+	return trimmed, nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func validateRunType(runType string) error {
 	switch runType {
-	case "playbook", "channelChecklist":
+	case runTypePlaybook, runTypeChannelChecklist:
 		return nil
 	default:
-		return fmt.Errorf("type must be one of playbook or channelChecklist")
+		return fmt.Errorf("types entries must be one of %s or %s", runTypePlaybook, runTypeChannelChecklist)
 	}
 }
 
@@ -354,14 +842,21 @@ func validateInitialSections(sections []CreateChecklistSection) error {
 		if strings.TrimSpace(section.Title) == "" {
 			return fmt.Errorf("sections[%d].title is required", i)
 		}
-		for j, item := range section.Items {
-			if strings.TrimSpace(item.Title) == "" {
-				return fmt.Errorf("sections[%d].items[%d].title is required", i, j)
-			}
-			if item.AssigneeID != "" {
-				if err := validateID(item.AssigneeID, fmt.Sprintf("sections[%d].items[%d].assignee_id", i, j)); err != nil {
-					return err
-				}
+		if err := validateChecklistItems(section.Items, fmt.Sprintf("sections[%d].items", i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateChecklistItems(items []CreateChecklistItem, field string) error {
+	for i, item := range items {
+		if strings.TrimSpace(item.Title) == "" {
+			return fmt.Errorf("%s[%d].title is required", field, i)
+		}
+		if item.AssigneeID != "" {
+			if err := validateID(item.AssigneeID, fmt.Sprintf("%s[%d].assignee_id", field, i)); err != nil {
+				return err
 			}
 		}
 	}
@@ -390,10 +885,230 @@ func formatListRuns(resp listRunsResponse) string {
 	return sb.String()
 }
 
+// formatRunDetail renders a run compactly rather than dumping its JSON: the
+// raw payload is large, low-signal, and the checklist indexes the other tools
+// need get buried in it.
 func formatRunDetail(run playbookRunDetail) string {
-	data, err := json.MarshalIndent(run, "", "  ")
-	if err != nil {
-		return fmt.Sprintf("Run: %s (%s) — Status: %s", run.Name, run.ID, run.CurrentStatus)
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "**%s** (run_id: %s)\n", run.Name, run.ID)
+	if run.SequentialID != "" {
+		fmt.Fprintf(&sb, "- Run number: %s\n", run.SequentialID)
+	} else if run.RunNumber > 0 {
+		fmt.Fprintf(&sb, "- Run number: %d\n", run.RunNumber)
 	}
-	return string(data)
+	fmt.Fprintf(&sb, "- Status: %s | Type: %s\n", displayRunStatus(run.CurrentStatus), displayRunType(run.Type))
+	fmt.Fprintf(&sb, "- Owner: %s | Reporter: %s\n", displayOrNone(run.OwnerUserID), displayOrNone(run.ReporterUserID))
+	fmt.Fprintf(&sb, "- Team: %s | Channel: %s\n", displayOrNone(run.TeamID), displayOrNone(run.ChannelID))
+	if run.PlaybookID != "" {
+		fmt.Fprintf(&sb, "- Started from playbook: %s\n", run.PlaybookID)
+	}
+	fmt.Fprintf(&sb, "- Created at: %d (epoch ms)", run.CreateAt)
+	if run.EndAt != 0 {
+		fmt.Fprintf(&sb, " | Ended at: %d", run.EndAt)
+	}
+	sb.WriteString("\n")
+
+	total, completed := runTaskProgress(run)
+	fmt.Fprintf(&sb, "- Tasks: %d/%d complete\n", completed, total)
+
+	fmt.Fprintf(&sb, "- Status updates: %s", displayEnabled(run.StatusUpdateEnabled))
+	if run.LastStatusUpdateAt != 0 {
+		fmt.Fprintf(&sb, ", last posted at %d", run.LastStatusUpdateAt)
+	}
+	if seconds := run.PreviousReminder / int64(time.Second); seconds > 0 {
+		fmt.Fprintf(&sb, ", next reminder in %ds", seconds)
+	} else if run.ReminderTimerDefaultSeconds > 0 {
+		fmt.Fprintf(&sb, ", default interval %ds", run.ReminderTimerDefaultSeconds)
+	}
+	sb.WriteString("\n")
+
+	fmt.Fprintf(&sb, "- Retrospective: %s", displayEnabled(run.RetrospectiveEnabled))
+	if run.RetrospectivePublishedAt != 0 {
+		fmt.Fprintf(&sb, ", published at %d", run.RetrospectivePublishedAt)
+	} else if run.RetrospectiveEnabled {
+		sb.WriteString(", not published yet")
+	}
+	sb.WriteString("\n")
+
+	if summary := strings.TrimSpace(run.Summary); summary != "" {
+		fmt.Fprintf(&sb, "\nSummary:\n%s\n", summary)
+	}
+
+	fmt.Fprintf(&sb, "\nParticipants (%d): %s\n", len(run.ParticipantIDs), formatIDList(run.ParticipantIDs))
+
+	sb.WriteString("\nChecklists (indexes are zero-based [checklist_number][item_number]):\n")
+	writeRunChecklistsVerbose(&sb, run)
+
+	if count := len(run.StatusPosts); count > 0 {
+		fmt.Fprintf(&sb, "\n%d status update(s) posted — call get_status_updates to read them.\n", count)
+	} else {
+		sb.WriteString("\nNo status updates posted yet.\n")
+	}
+	if count := len(run.TimelineEvents); count > 0 {
+		fmt.Fprintf(&sb, "%d timeline event(s) recorded (not listed here).\n", count)
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// formatStartedRun summarizes a freshly created run: enough for the model to
+// report back and to keep acting on the run, without re-dumping every field.
+func formatStartedRun(client APIClient, playbook playbookForRun, run playbookRunDetail, linkedExistingChannel bool) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Started run **%s** (run_id: %s) from playbook %q.\n", run.Name, run.ID, playbook.Title)
+	if run.SequentialID != "" {
+		fmt.Fprintf(&sb, "- Run number: %s\n", run.SequentialID)
+	} else if run.RunNumber > 0 {
+		fmt.Fprintf(&sb, "- Run number: %d\n", run.RunNumber)
+	}
+	fmt.Fprintf(&sb, "- Owner: %s\n", displayOrNone(run.OwnerUserID))
+	channelNote := "new channel created"
+	if linkedExistingChannel {
+		channelNote = "linked to an existing channel"
+	}
+	fmt.Fprintf(&sb, "- Channel: %s (%s)\n", displayOrNone(run.ChannelID), channelNote)
+	total, completed := runTaskProgress(run)
+	fmt.Fprintf(&sb, "- Checklists: %d, tasks: %d/%d complete\n", len(run.Checklists), completed, total)
+	fmt.Fprintf(&sb, "- URL: %s", client.GetRunURL(run.ID))
+	return sb.String()
+}
+
+func formatStatusUpdates(runID string, updates []runStatusUpdate, limit int) string {
+	visible := make([]runStatusUpdate, 0, len(updates))
+	for _, update := range updates {
+		if update.DeleteAt != 0 {
+			continue
+		}
+		visible = append(visible, update)
+	}
+	if len(visible) == 0 {
+		return fmt.Sprintf("No status updates have been posted to run %s yet.", runID)
+	}
+
+	// Truncating to limit only yields the most recent updates if the newest
+	// sort first, so don't rely on the endpoint's ordering for that.
+	sort.SliceStable(visible, func(i, j int) bool {
+		return visible[i].CreateAt > visible[j].CreateAt
+	})
+
+	shown := visible
+	if len(shown) > limit {
+		shown = shown[:limit]
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d status update(s) on run %s, newest first (showing %d):\n", len(visible), runID, len(shown))
+	for _, update := range shown {
+		fmt.Fprintf(&sb, "\n- @%s at %d (epoch ms):\n  %s\n", displayOrNone(update.AuthorUserName), update.CreateAt, strings.TrimSpace(update.Message))
+	}
+	if len(shown) < len(visible) {
+		fmt.Fprintf(&sb, "\n(%d older update(s) not shown — raise limit to see more.)", len(visible)-len(shown))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// runTaskProgress prefers the server-computed counters and falls back to
+// counting checklist items, since they are computed rather than stored and an
+// older payload may not carry them.
+func runTaskProgress(run playbookRunDetail) (total, completed int) {
+	if run.TaskTotal > 0 {
+		return run.TaskTotal, run.TaskCompleted
+	}
+	for _, cl := range run.Checklists {
+		for _, item := range cl.Items {
+			total++
+			if item.State == "closed" || item.State == "skipped" {
+				completed++
+			}
+		}
+	}
+	return total, completed
+}
+
+// writeRunChecklistsVerbose uses the same [checklist_number][item_number]
+// notation as writeRunChecklists so indexes stay consistent across tools, and
+// adds the per-item detail get_run callers need.
+func writeRunChecklistsVerbose(sb *strings.Builder, run playbookRunDetail) {
+	if len(run.Checklists) == 0 {
+		sb.WriteString("  (no checklists)\n")
+		return
+	}
+	for ci, cl := range run.Checklists {
+		fmt.Fprintf(sb, "  Checklist %d: %q\n", ci, cl.Title)
+		if len(cl.Items) == 0 {
+			sb.WriteString("    (no items)\n")
+			continue
+		}
+		for ii, item := range cl.Items {
+			fmt.Fprintf(sb, "    [%d][%d] %s (%s)", ci, ii, item.Title, displayState(item.State))
+			if assignee := displayAssignee(item); assignee != "" {
+				fmt.Fprintf(sb, " — assignee: %s", assignee)
+			}
+			if item.DueDate != 0 {
+				fmt.Fprintf(sb, " — due: %d (epoch ms)", item.DueDate)
+			}
+			if item.LastSkipped != 0 {
+				fmt.Fprintf(sb, " — skipped at %d", item.LastSkipped)
+			}
+			sb.WriteString("\n")
+		}
+	}
+}
+
+// displayAssignee reports who a task is assigned to, including role-based and
+// property-based assignment where assignee_id is empty by design.
+func displayAssignee(item checklistItem) string {
+	if item.AssigneeID != "" {
+		return item.AssigneeID
+	}
+	switch {
+	case item.AssigneePropertyFieldID != "":
+		return fmt.Sprintf("by property field %s", item.AssigneePropertyFieldID)
+	case item.AssigneeType != "":
+		return fmt.Sprintf("by role (%s)", item.AssigneeType)
+	default:
+		return ""
+	}
+}
+
+func formatIDList(ids []string) string {
+	if len(ids) == 0 {
+		return "none"
+	}
+	return strings.Join(ids, ", ")
+}
+
+func displayOrNone(value string) string {
+	if value == "" {
+		return "none"
+	}
+	return value
+}
+
+func displayEnabled(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func displayRunStatus(status string) string {
+	if status == "" {
+		return "unknown"
+	}
+	return status
+}
+
+func displayRunType(runType string) string {
+	switch runType {
+	case "":
+		return "unknown"
+	case runTypeChannelChecklist:
+		return "channelChecklist (standalone channel checklist)"
+	case runTypePlaybook:
+		return "playbook (run started from a playbook template)"
+	default:
+		return runType
+	}
 }

--- a/internal/playbooksmcp/tools/runs_test.go
+++ b/internal/playbooksmcp/tools/runs_test.go
@@ -153,9 +153,9 @@ func TestToolRunPlaybookRejectsBadInput(t *testing.T) {
 			wantErr: "channel_id must be a valid Mattermost ID",
 		},
 		{
-			name:    "rejects an invalid owner id",
-			args:    RunPlaybookArgs{PlaybookID: testPlaybookID, OwnerUserID: "invalid"},
-			wantErr: "owner_user_id must be a valid Mattermost ID",
+			name:    "rejects an unresolvable owner",
+			args:    RunPlaybookArgs{PlaybookID: testPlaybookID, OwnerUserID: "@nobody"},
+			wantErr: `owner_user_id: no user found with username "nobody"`,
 		},
 		{
 			name:     "rejects an archived playbook",
@@ -214,6 +214,48 @@ func TestToolRunPlaybookReturnsRunSummaryAndURL(t *testing.T) {
 	assert.Contains(t, out, testUserID)
 	assert.Contains(t, out, "1/2 complete")
 	assert.Contains(t, out, "https://mattermost.example.com/playbooks/runs/"+testRunID)
+}
+
+// The checklists copied from the playbook are what the caller acts on next, so
+// the indexes must be in this output rather than behind another get_run.
+func TestToolRunPlaybookOutputCarriesChecklistIndexes(t *testing.T) {
+	client := &fakeAPIClient{
+		runPlaybook: playbookForRun{ID: testPlaybookID, Title: "Sev1 Incident", TeamID: testTeamID},
+		run: playbookRunDetail{
+			ID:   testRunID,
+			Name: "Sev1 — checkout 500s",
+			Checklists: []checklist{
+				{Title: "Triage", Items: []checklistItem{{Title: "Page on-call"}}},
+				{Title: "Mitigation", Items: []checklistItem{{Title: "Roll back"}}},
+			},
+		},
+	}
+
+	out, err := toolRunPlaybook(context.Background(), client, RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Sev1 — checkout 500s"})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, `checklist_number 0: "Triage"`)
+	assert.Contains(t, out, `checklist_number 1: "Mitigation"`)
+}
+
+func TestToolCreateChecklistOutputCarriesChecklistIndexes(t *testing.T) {
+	client := &fakeAPIClient{
+		run: playbookRunDetail{
+			ID:   testRunID,
+			Name: "Release checklist",
+			Checklists: []checklist{
+				{Title: "Pre-release", Items: []checklistItem{{Title: "Confirm changelog"}}},
+			},
+		},
+	}
+
+	out, err := toolCreateChecklist(context.Background(), client, CreateChecklistArgs{
+		Name:      "Release checklist",
+		ChannelID: testRunChannelID,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "[0][0] Confirm changelog")
 }
 
 func TestToolUpdateRunPatchesProvidedFields(t *testing.T) {
@@ -482,19 +524,19 @@ func TestToolAddRunParticipantsValidation(t *testing.T) {
 			name:    "requires at least one user",
 			client:  &fakeAPIClient{},
 			args:    AddRunParticipantsArgs{RunID: testRunID},
-			wantErr: "user_ids is required; pass 'me' to join the run yourself",
+			wantErr: "user_ids is required; pass 'me' to join the run yourself, or a username such as '@bob'",
 		},
 		{
-			name:    "rejects an invalid user id",
+			name:    "rejects an unknown username",
 			client:  &fakeAPIClient{},
-			args:    AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"invalid"}},
-			wantErr: "user_ids[0] must be a valid Mattermost ID",
+			args:    AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"@nobody"}},
+			wantErr: `user_ids[0]: no user found with username "nobody" — check the spelling (usernames are case-insensitive, without the @)`,
 		},
 		{
 			name:    "surfaces a failure to resolve the current user",
 			client:  &fakeAPIClient{currentUserErr: errors.New("missing Mattermost user ID")},
 			args:    AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"me"}},
-			wantErr: `failed to resolve "me" for user_ids[0]: missing Mattermost user ID`,
+			wantErr: `user_ids[0]: missing Mattermost user ID`,
 		},
 	}
 
@@ -542,7 +584,7 @@ func TestToolRemoveRunParticipant(t *testing.T) {
 		client := &fakeAPIClient{}
 
 		_, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID})
-		require.EqualError(t, err, "user_id is required; pass 'me' to leave the run yourself")
+		require.EqualError(t, err, "user_id is required; pass 'me' to leave the run yourself, or a username such as '@bob'")
 		assert.Empty(t, client.deleteEndpoint)
 	})
 }
@@ -634,9 +676,9 @@ func TestToolListRunsForwardsFilters(t *testing.T) {
 	assert.Equal(t, testTeamID, params.Get("team_id"))
 	assert.Equal(t, testRunChannelID, params.Get("channel_id"))
 	assert.Equal(t, "InProgress", params.Get("statuses"))
-	// The list endpoint resolves "me" itself for both user filters.
-	assert.Equal(t, "me", params.Get("owner_user_id"))
-	assert.Equal(t, "me", params.Get("participant_id"))
+	// Both user filters are resolved client-side so usernames work too.
+	assert.Equal(t, testCurrentUser, params.Get("owner_user_id"))
+	assert.Equal(t, testCurrentUser, params.Get("participant_id"))
 	assert.Equal(t, testPlaybookID, params.Get("playbook_id"))
 	assert.Equal(t, "checkout", params.Get("search_term"))
 	assert.Equal(t, "true", params.Get("omit_ended"))

--- a/internal/playbooksmcp/tools/runs_test.go
+++ b/internal/playbooksmcp/tools/runs_test.go
@@ -1,0 +1,753 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testRunID        = "abcdefghijklmnopqrstuvwxyz"
+	testPlaybookID   = "bcdefghijklmnopqrstuvwxyza"
+	testTeamID       = "cdefghijklmnopqrstuvwxyzab"
+	testRunChannelID = "defghijklmnopqrstuvwxyzabc"
+	testUserID       = "efghijklmnopqrstuvwxyzabcd"
+	testCurrentUser  = "abcdefghijklmnopqrstuvwxy0"
+)
+
+func TestToolRunPlaybookBuildsCreateBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		playbook   playbookForRun
+		args       RunPlaybookArgs
+		wantBody   map[string]any
+		absentKeys []string
+	}{
+		{
+			name:     "defaults team from the playbook and creates a new channel",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID, ChannelMode: channelModeCreateNew},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: " Sev1 — checkout ", Summary: "Checkout is down"},
+			wantBody: map[string]any{
+				"playbook_id": testPlaybookID,
+				"name":        "Sev1 — checkout",
+				"team_id":     testTeamID,
+				"summary":     "Checkout is down",
+			},
+			absentKeys: []string{"channel_id", "owner_user_id", "create_public_run"},
+		},
+		{
+			// POST /runs never reads the playbook's channel_mode, so a
+			// link-existing-channel playbook silently creates a new channel
+			// unless the tool passes the playbook's channel through.
+			name:     "passes the playbook channel when the playbook links an existing channel",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Release", TeamID: testTeamID, ChannelMode: channelModeLinkExisting, ChannelID: testRunChannelID},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Release 9.4"},
+			wantBody: map[string]any{
+				"playbook_id": testPlaybookID,
+				"name":        "Release 9.4",
+				"channel_id":  testRunChannelID,
+			},
+			// The server derives the team from the channel and rejects a
+			// conflicting team_id, so none is defaulted in link mode.
+			absentKeys: []string{"team_id"},
+		},
+		{
+			name:     "link mode without a configured channel still creates a new channel",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Release", TeamID: testTeamID, ChannelMode: channelModeLinkExisting},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Release 9.4"},
+			wantBody: map[string]any{
+				"playbook_id": testPlaybookID,
+				"team_id":     testTeamID,
+			},
+			absentKeys: []string{"channel_id"},
+		},
+		{
+			name:     "caller channel overrides the playbook channel",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Release", TeamID: testTeamID, ChannelMode: channelModeLinkExisting, ChannelID: "zzzzzzzzzzzzzzzzzzzzzzzzzz"},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Release 9.4", ChannelID: testRunChannelID},
+			wantBody: map[string]any{
+				"playbook_id": testPlaybookID,
+				"channel_id":  testRunChannelID,
+			},
+		},
+		{
+			name:     "resolves me to the current user as owner",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Sev1", OwnerUserID: "me"},
+			wantBody: map[string]any{
+				"playbook_id":   testPlaybookID,
+				"owner_user_id": testCurrentUser,
+			},
+		},
+		{
+			name:     "omits the name when the playbook has a locked channel-name template",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID, ChannelNameTemplate: "{SEQ} incident", ChannelNameTemplateLocked: true},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID},
+			wantBody: map[string]any{
+				"playbook_id": testPlaybookID,
+				"team_id":     testTeamID,
+			},
+			absentKeys: []string{"name"},
+		},
+		{
+			name:     "forwards an explicit create_public_run",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Sev1", CreatePublicRun: boolPtr(false)},
+			wantBody: map[string]any{
+				"playbook_id":       testPlaybookID,
+				"create_public_run": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{
+				runPlaybook: tt.playbook,
+				run:         playbookRunDetail{ID: testRunID, Name: "Created run"},
+			}
+
+			_, err := toolRunPlaybook(context.Background(), client, tt.args)
+			require.NoError(t, err)
+
+			assert.Equal(t, "playbooks/"+testPlaybookID, client.getEndpoint, "expected the playbook to be fetched first")
+			require.Equal(t, "runs", client.postEndpoint)
+			require.IsType(t, map[string]any{}, client.postBody)
+			body := client.postBody.(map[string]any)
+			for key, want := range tt.wantBody {
+				assert.Equal(t, want, body[key], "body key %q", key)
+			}
+			for _, key := range tt.absentKeys {
+				assert.NotContains(t, body, key)
+			}
+		})
+	}
+}
+
+func TestToolRunPlaybookRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		playbook playbookForRun
+		args     RunPlaybookArgs
+		wantErr  string
+	}{
+		{
+			name:    "rejects an invalid playbook id",
+			args:    RunPlaybookArgs{PlaybookID: "invalid"},
+			wantErr: "playbook_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "rejects an invalid team id",
+			args:    RunPlaybookArgs{PlaybookID: testPlaybookID, TeamID: "invalid"},
+			wantErr: "team_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "rejects an invalid channel id",
+			args:    RunPlaybookArgs{PlaybookID: testPlaybookID, ChannelID: "invalid"},
+			wantErr: "channel_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "rejects an invalid owner id",
+			args:    RunPlaybookArgs{PlaybookID: testPlaybookID, OwnerUserID: "invalid"},
+			wantErr: "owner_user_id must be a valid Mattermost ID",
+		},
+		{
+			name:     "rejects an archived playbook",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Old", TeamID: testTeamID, DeleteAt: 1717200000000},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Attempt"},
+			wantErr:  "is archived",
+		},
+		{
+			name:     "requires a name when a new channel will be created",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID},
+			wantErr:  "name is required",
+		},
+		{
+			// An unlocked template is only a prefill suggestion; the API will
+			// not apply it, so a name is still required.
+			name:     "requires a name when the channel-name template is not locked",
+			playbook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID, ChannelNameTemplate: "{SEQ} incident"},
+			args:     RunPlaybookArgs{PlaybookID: testPlaybookID},
+			wantErr:  "name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{runPlaybook: tt.playbook}
+
+			_, err := toolRunPlaybook(context.Background(), client, tt.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Empty(t, client.postEndpoint, "expected no run to be created")
+		})
+	}
+}
+
+func TestToolRunPlaybookReturnsRunSummaryAndURL(t *testing.T) {
+	client := &fakeAPIClient{
+		runPlaybook: playbookForRun{ID: testPlaybookID, Title: "Sev1 Incident", TeamID: testTeamID},
+		run: playbookRunDetail{
+			ID:           testRunID,
+			Name:         "Sev1 — checkout 500s",
+			SequentialID: "INC-00042",
+			OwnerUserID:  testUserID,
+			ChannelID:    testRunChannelID,
+			Checklists:   []checklist{{Title: "Triage", Items: []checklistItem{{Title: "Page on-call"}, {Title: "Declare", State: "closed"}}}},
+		},
+	}
+
+	out, err := toolRunPlaybook(context.Background(), client, RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Sev1 — checkout 500s"})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Sev1 — checkout 500s")
+	assert.Contains(t, out, testRunID)
+	assert.Contains(t, out, "INC-00042")
+	assert.Contains(t, out, testRunChannelID)
+	assert.Contains(t, out, testUserID)
+	assert.Contains(t, out, "1/2 complete")
+	assert.Contains(t, out, "https://mattermost.example.com/playbooks/runs/"+testRunID)
+}
+
+func TestToolUpdateRunPatchesProvidedFields(t *testing.T) {
+	name := " Renamed run "
+	summary := ""
+
+	tests := []struct {
+		name       string
+		args       UpdateRunArgs
+		wantBody   map[string]any
+		absentKeys []string
+	}{
+		{
+			name:       "renames only",
+			args:       UpdateRunArgs{RunID: testRunID, Name: &name},
+			wantBody:   map[string]any{"name": "Renamed run"},
+			absentKeys: []string{"summary"},
+		},
+		{
+			name:       "clears the summary only",
+			args:       UpdateRunArgs{RunID: testRunID, Summary: &summary},
+			wantBody:   map[string]any{"summary": ""},
+			absentKeys: []string{"name"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+
+			_, err := toolUpdateRun(context.Background(), client, tt.args)
+			require.NoError(t, err)
+
+			require.Equal(t, "runs/"+testRunID, client.patchEndpoint)
+			require.IsType(t, map[string]any{}, client.patchBody)
+			body := client.patchBody.(map[string]any)
+			for key, want := range tt.wantBody {
+				assert.Equal(t, want, body[key], "body key %q", key)
+			}
+			for _, key := range tt.absentKeys {
+				assert.NotContains(t, body, key)
+			}
+		})
+	}
+}
+
+func TestToolUpdateRunValidation(t *testing.T) {
+	empty := "   "
+
+	tests := []struct {
+		name    string
+		args    UpdateRunArgs
+		wantErr string
+	}{
+		{
+			name:    "rejects an invalid run id",
+			args:    UpdateRunArgs{RunID: "invalid"},
+			wantErr: "run_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "requires at least one field",
+			args:    UpdateRunArgs{RunID: testRunID},
+			wantErr: "at least one field (name or summary) must be provided",
+		},
+		{
+			name:    "rejects a blank name",
+			args:    UpdateRunArgs{RunID: testRunID, Name: &empty},
+			wantErr: "name must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+
+			_, err := toolUpdateRun(context.Background(), client, tt.args)
+			require.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, client.patchEndpoint, "expected no update call")
+		})
+	}
+}
+
+func TestRunLifecycleToolEndpoints(t *testing.T) {
+	t.Run("restore run", func(t *testing.T) {
+		client := &fakeAPIClient{}
+		_, err := toolRestoreRun(context.Background(), client, RunIDArgs{RunID: testRunID})
+		require.NoError(t, err)
+		assert.Equal(t, "runs/"+testRunID+"/restore", client.putEndpoint)
+		assert.Nil(t, client.putBody)
+	})
+
+	t.Run("request status update", func(t *testing.T) {
+		client := &fakeAPIClient{}
+		_, err := toolRequestStatusUpdate(context.Background(), client, RunIDArgs{RunID: testRunID})
+		require.NoError(t, err)
+		assert.Equal(t, "runs/"+testRunID+"/request-update", client.postEndpoint)
+		assert.Nil(t, client.postBody)
+	})
+
+	t.Run("follow run", func(t *testing.T) {
+		client := &fakeAPIClient{}
+		_, err := toolFollowRun(context.Background(), client, RunIDArgs{RunID: testRunID})
+		require.NoError(t, err)
+		assert.Equal(t, "runs/"+testRunID+"/followers", client.putEndpoint)
+	})
+
+	t.Run("unfollow run", func(t *testing.T) {
+		client := &fakeAPIClient{}
+		_, err := toolUnfollowRun(context.Background(), client, RunIDArgs{RunID: testRunID})
+		require.NoError(t, err)
+		assert.Equal(t, "runs/"+testRunID+"/followers", client.deleteEndpoint)
+	})
+}
+
+func TestRunLifecycleToolsRejectInvalidRunID(t *testing.T) {
+	tests := []struct {
+		name    string
+		runTool func(context.Context, APIClient) (string, error)
+	}{
+		{"restore run", func(ctx context.Context, c APIClient) (string, error) {
+			return toolRestoreRun(ctx, c, RunIDArgs{RunID: "invalid"})
+		}},
+		{"request status update", func(ctx context.Context, c APIClient) (string, error) {
+			return toolRequestStatusUpdate(ctx, c, RunIDArgs{RunID: "invalid"})
+		}},
+		{"follow run", func(ctx context.Context, c APIClient) (string, error) {
+			return toolFollowRun(ctx, c, RunIDArgs{RunID: "invalid"})
+		}},
+		{"unfollow run", func(ctx context.Context, c APIClient) (string, error) {
+			return toolUnfollowRun(ctx, c, RunIDArgs{RunID: "invalid"})
+		}},
+		{"get status updates", func(ctx context.Context, c APIClient) (string, error) {
+			return toolGetStatusUpdates(ctx, c, GetStatusUpdatesArgs{RunID: "invalid"})
+		}},
+		{"get run metadata", func(ctx context.Context, c APIClient) (string, error) {
+			return toolGetRunMetadata(ctx, c, RunIDArgs{RunID: "invalid"})
+		}},
+		{"add run participants", func(ctx context.Context, c APIClient) (string, error) {
+			return toolAddRunParticipants(ctx, c, AddRunParticipantsArgs{RunID: "invalid", UserIDs: []string{"me"}})
+		}},
+		{"remove run participant", func(ctx context.Context, c APIClient) (string, error) {
+			return toolRemoveRunParticipant(ctx, c, RemoveRunParticipantArgs{RunID: "invalid", UserID: "me"})
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+			_, err := tt.runTool(context.Background(), client)
+			require.EqualError(t, err, "run_id must be a valid Mattermost ID")
+			assert.Empty(t, client.postEndpoint)
+			assert.Empty(t, client.putEndpoint)
+			assert.Empty(t, client.deleteEndpoint)
+			assert.Empty(t, client.getEndpoint)
+		})
+	}
+}
+
+func TestToolGetStatusUpdatesFormatsNewestFirst(t *testing.T) {
+	client := &fakeAPIClient{
+		statusUpdates: []runStatusUpdate{
+			{ID: "p3", CreateAt: 300, Message: "Third", AuthorUserName: "carol"},
+			{ID: "p2", CreateAt: 200, Message: "Second", AuthorUserName: "bob"},
+			{ID: "p1", CreateAt: 100, Message: "First", AuthorUserName: "alice"},
+		},
+	}
+
+	out, err := toolGetStatusUpdates(context.Background(), client, GetStatusUpdatesArgs{RunID: testRunID, Limit: 2})
+	require.NoError(t, err)
+
+	assert.Equal(t, "runs/"+testRunID+"/status-updates", client.getEndpoint)
+	assert.Contains(t, out, "@carol")
+	assert.Contains(t, out, "Third")
+	assert.Contains(t, out, "Second")
+	assert.NotContains(t, out, "First")
+	assert.Contains(t, out, "1 older update(s) not shown")
+}
+
+func TestToolGetStatusUpdatesTruncatesToTheNewestRegardlessOfAPIOrder(t *testing.T) {
+	client := &fakeAPIClient{
+		statusUpdates: []runStatusUpdate{
+			{ID: "p1", CreateAt: 100, Message: "Oldest", AuthorUserName: "alice"},
+			{ID: "p2", CreateAt: 200, Message: "Newest", AuthorUserName: "bob"},
+		},
+	}
+
+	out, err := toolGetStatusUpdates(context.Background(), client, GetStatusUpdatesArgs{RunID: testRunID, Limit: 1})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Newest")
+	assert.NotContains(t, out, "Oldest")
+}
+
+func TestToolGetStatusUpdatesSkipsDeletedAndEmpty(t *testing.T) {
+	t.Run("skips deleted updates", func(t *testing.T) {
+		client := &fakeAPIClient{
+			statusUpdates: []runStatusUpdate{
+				{ID: "p2", CreateAt: 200, DeleteAt: 250, Message: "Retracted", AuthorUserName: "bob"},
+				{ID: "p1", CreateAt: 100, Message: "Kept", AuthorUserName: "alice"},
+			},
+		}
+
+		out, err := toolGetStatusUpdates(context.Background(), client, GetStatusUpdatesArgs{RunID: testRunID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "Kept")
+		assert.NotContains(t, out, "Retracted")
+	})
+
+	t.Run("reports when there are none", func(t *testing.T) {
+		client := &fakeAPIClient{}
+
+		out, err := toolGetStatusUpdates(context.Background(), client, GetStatusUpdatesArgs{RunID: testRunID})
+		require.NoError(t, err)
+		assert.Contains(t, out, "No status updates")
+	})
+}
+
+func TestToolGetRunMetadataFormatsChannelAndFollowers(t *testing.T) {
+	client := &fakeAPIClient{
+		metadata: runMetadata{
+			ChannelName:        "incident-42",
+			ChannelDisplayName: "Incident 42",
+			TeamName:           "core",
+			NumParticipants:    3,
+			TotalPosts:         17,
+			Followers:          []string{testUserID},
+		},
+	}
+
+	out, err := toolGetRunMetadata(context.Background(), client, RunIDArgs{RunID: testRunID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "runs/"+testRunID+"/metadata", client.getEndpoint)
+	assert.Contains(t, out, "Incident 42 (~incident-42)")
+	assert.Contains(t, out, "Team: core")
+	assert.Contains(t, out, "Participants: 3")
+	assert.Contains(t, out, "Posts in channel: 17")
+	assert.Contains(t, out, "Followers: 1")
+}
+
+func TestToolAddRunParticipantsResolvesMeAndDeduplicates(t *testing.T) {
+	client := &fakeAPIClient{}
+
+	_, err := toolAddRunParticipants(context.Background(), client, AddRunParticipantsArgs{
+		RunID:             testRunID,
+		UserIDs:           []string{"me", testUserID, testCurrentUser},
+		ForceAddToChannel: true,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "runs/"+testRunID+"/participants", client.postEndpoint)
+	require.IsType(t, map[string]any{}, client.postBody)
+	body := client.postBody.(map[string]any)
+	assert.Equal(t, []string{testCurrentUser, testUserID}, body["user_ids"])
+	assert.Equal(t, true, body["force_add_to_channel"])
+}
+
+func TestToolAddRunParticipantsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  *fakeAPIClient
+		args    AddRunParticipantsArgs
+		wantErr string
+	}{
+		{
+			name:    "requires at least one user",
+			client:  &fakeAPIClient{},
+			args:    AddRunParticipantsArgs{RunID: testRunID},
+			wantErr: "user_ids is required; pass 'me' to join the run yourself",
+		},
+		{
+			name:    "rejects an invalid user id",
+			client:  &fakeAPIClient{},
+			args:    AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"invalid"}},
+			wantErr: "user_ids[0] must be a valid Mattermost ID",
+		},
+		{
+			name:    "surfaces a failure to resolve the current user",
+			client:  &fakeAPIClient{currentUserErr: errors.New("missing Mattermost user ID")},
+			args:    AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"me"}},
+			wantErr: `failed to resolve "me" for user_ids[0]: missing Mattermost user ID`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := toolAddRunParticipants(context.Background(), tt.client, tt.args)
+			require.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, tt.client.postEndpoint, "expected no participants call")
+		})
+	}
+}
+
+func TestToolRemoveRunParticipant(t *testing.T) {
+	t.Run("resolves me and deletes", func(t *testing.T) {
+		client := &fakeAPIClient{run: playbookRunDetail{ID: testRunID, ParticipantIDs: []string{testCurrentUser, testUserID}}}
+
+		_, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID, UserID: "me"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "runs/"+testRunID, client.getEndpoint)
+		assert.Equal(t, "runs/"+testRunID+"/participants/"+testCurrentUser, client.deleteEndpoint)
+	})
+
+	t.Run("is a no-op for a non-participant", func(t *testing.T) {
+		client := &fakeAPIClient{run: playbookRunDetail{ID: testRunID, ParticipantIDs: []string{testCurrentUser}}}
+
+		out, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID, UserID: testUserID})
+		require.NoError(t, err)
+
+		assert.Contains(t, out, "is not a participant")
+		assert.Contains(t, out, testCurrentUser)
+		assert.Empty(t, client.deleteEndpoint, "expected no delete for a non-participant")
+	})
+
+	t.Run("refuses to remove the run owner", func(t *testing.T) {
+		client := &fakeAPIClient{run: playbookRunDetail{ID: testRunID, OwnerUserID: testUserID, ParticipantIDs: []string{testUserID}}}
+
+		_, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID, UserID: testUserID})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "change_run_owner")
+		assert.Empty(t, client.deleteEndpoint, "expected no delete for the run owner")
+	})
+
+	t.Run("requires a user id", func(t *testing.T) {
+		client := &fakeAPIClient{}
+
+		_, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID})
+		require.EqualError(t, err, "user_id is required; pass 'me' to leave the run yourself")
+		assert.Empty(t, client.deleteEndpoint)
+	})
+}
+
+func TestToolUpdateRunStatusDefaultsReminderFromRun(t *testing.T) {
+	const oneDayNanos = int64(86400) * 1_000_000_000
+
+	tests := []struct {
+		name         string
+		run          playbookRunDetail
+		args         UpdateRunStatusArgs
+		wantReminder int64
+		wantRunFetch bool
+	}{
+		{
+			name:         "uses the run's previous reminder converted from nanoseconds",
+			run:          playbookRunDetail{ID: testRunID, PreviousReminder: oneDayNanos, ReminderTimerDefaultSeconds: 1800},
+			args:         UpdateRunStatusArgs{RunID: testRunID, Message: "Update"},
+			wantReminder: 86400,
+			wantRunFetch: true,
+		},
+		{
+			name:         "falls back to the playbook's default interval",
+			run:          playbookRunDetail{ID: testRunID, ReminderTimerDefaultSeconds: 1800},
+			args:         UpdateRunStatusArgs{RunID: testRunID, Message: "Update"},
+			wantReminder: 1800,
+			wantRunFetch: true,
+		},
+		{
+			name:         "falls back to one hour when the run carries neither",
+			run:          playbookRunDetail{ID: testRunID},
+			args:         UpdateRunStatusArgs{RunID: testRunID, Message: "Update"},
+			wantReminder: 3600,
+			wantRunFetch: true,
+		},
+		{
+			name:         "keeps an explicit reminder without fetching the run",
+			run:          playbookRunDetail{ID: testRunID, PreviousReminder: oneDayNanos},
+			args:         UpdateRunStatusArgs{RunID: testRunID, Message: "Update", ReminderSeconds: 900},
+			wantReminder: 900,
+		},
+		{
+			name:         "sends no reminder when finishing the run",
+			run:          playbookRunDetail{ID: testRunID, PreviousReminder: oneDayNanos},
+			args:         UpdateRunStatusArgs{RunID: testRunID, Message: "All done", FinishRun: true},
+			wantReminder: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{run: tt.run}
+
+			_, err := toolUpdateRunStatus(context.Background(), client, tt.args)
+			require.NoError(t, err)
+
+			require.Equal(t, "runs/"+testRunID+"/status", client.postEndpoint)
+			require.IsType(t, map[string]any{}, client.postBody)
+			body := client.postBody.(map[string]any)
+			assert.Equal(t, tt.wantReminder, body["reminder"])
+			if tt.wantRunFetch {
+				assert.Equal(t, "runs/"+testRunID, client.getEndpoint, "expected the run to be fetched for its cadence")
+			} else {
+				assert.Empty(t, client.getEndpoint, "expected no run fetch")
+			}
+		})
+	}
+}
+
+func TestToolListRunsForwardsFilters(t *testing.T) {
+	client := &fakeAPIClient{}
+
+	_, err := toolListRuns(context.Background(), client, ListRunsArgs{
+		TeamID:        testTeamID,
+		ChannelID:     testRunChannelID,
+		Status:        "InProgress",
+		OwnerUserID:   "me",
+		ParticipantID: "me",
+		PlaybookID:    testPlaybookID,
+		SearchTerm:    "  checkout  ",
+		OmitEnded:     true,
+		Types:         []string{"playbook"},
+		PerPage:       5,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "runs", client.getEndpoint)
+	params := client.getParams
+	assert.Equal(t, testTeamID, params.Get("team_id"))
+	assert.Equal(t, testRunChannelID, params.Get("channel_id"))
+	assert.Equal(t, "InProgress", params.Get("statuses"))
+	// The list endpoint resolves "me" itself for both user filters.
+	assert.Equal(t, "me", params.Get("owner_user_id"))
+	assert.Equal(t, "me", params.Get("participant_id"))
+	assert.Equal(t, testPlaybookID, params.Get("playbook_id"))
+	assert.Equal(t, "checkout", params.Get("search_term"))
+	assert.Equal(t, "true", params.Get("omit_ended"))
+	assert.Equal(t, []string{"playbook"}, params["types"])
+	assert.Equal(t, "5", params.Get("per_page"))
+}
+
+func TestToolListRunsValidatesFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    ListRunsArgs
+		wantErr string
+	}{
+		{
+			name:    "rejects a negative page",
+			args:    ListRunsArgs{Page: -1},
+			wantErr: "page must be >= 0",
+		},
+		{
+			name:    "rejects an invalid playbook id",
+			args:    ListRunsArgs{PlaybookID: "invalid"},
+			wantErr: "playbook_id must be a valid Mattermost ID",
+		},
+		{
+			name:    "rejects an unknown run type",
+			args:    ListRunsArgs{Types: []string{"nope"}},
+			wantErr: "types entries must be one of playbook or channelChecklist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeAPIClient{}
+			_, err := toolListRuns(context.Background(), client, tt.args)
+			require.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, client.getEndpoint)
+		})
+	}
+}
+
+func TestFormatRunDetailRendersCompactSummary(t *testing.T) {
+	run := playbookRunDetail{
+		ID:                          testRunID,
+		Name:                        "Sev1 — checkout 500s",
+		Summary:                     "Checkout is returning 500s.",
+		CurrentStatus:               "InProgress",
+		OwnerUserID:                 testUserID,
+		ReporterUserID:              testCurrentUser,
+		TeamID:                      testTeamID,
+		ChannelID:                   testRunChannelID,
+		PlaybookID:                  testPlaybookID,
+		Type:                        runTypePlaybook,
+		SequentialID:                "INC-00042",
+		RunNumber:                   42,
+		CreateAt:                    1717200000000,
+		TaskTotal:                   3,
+		TaskCompleted:               1,
+		ParticipantIDs:              []string{testUserID, testCurrentUser},
+		StatusUpdateEnabled:         true,
+		PreviousReminder:            int64(3600) * 1_000_000_000,
+		ReminderTimerDefaultSeconds: 86400,
+		RetrospectiveEnabled:        true,
+		StatusPosts:                 []runStatusPost{{ID: "post1"}},
+		TimelineEvents:              []runTimelineEvent{{ID: "ev1", EventType: "incident_created"}, {ID: "ev2"}},
+		Checklists: []checklist{{
+			Title: "Triage",
+			Items: []checklistItem{
+				{Title: "Page the on-call", State: "closed", AssigneeID: testUserID},
+				{Title: "Declare severity", AssigneeType: "owner"},
+				{Title: "Notify comms", State: "skipped", LastSkipped: 1717200500000, DueDate: 1717300000000},
+			},
+		}},
+	}
+
+	out := formatRunDetail(run)
+
+	assert.Contains(t, out, "**Sev1 — checkout 500s** (run_id: "+testRunID+")")
+	assert.Contains(t, out, "Run number: INC-00042")
+	assert.Contains(t, out, "Status: InProgress")
+	assert.Contains(t, out, "Reporter: "+testCurrentUser)
+	assert.Contains(t, out, "Started from playbook: "+testPlaybookID)
+	assert.Contains(t, out, "Tasks: 1/3 complete")
+	assert.Contains(t, out, "Status updates: enabled")
+	assert.Contains(t, out, "next reminder in 3600s")
+	assert.Contains(t, out, "Retrospective: enabled, not published yet")
+	assert.Contains(t, out, "Checkout is returning 500s.")
+	assert.Contains(t, out, "Participants (2)")
+	// Indexes must match writeRunChecklists so they stay usable across tools.
+	assert.Contains(t, out, "[0][0] Page the on-call (closed) — assignee: "+testUserID)
+	assert.Contains(t, out, "[0][1] Declare severity (open) — assignee: by role (owner)")
+	assert.Contains(t, out, "[0][2] Notify comms (skipped)")
+	assert.Contains(t, out, "due: 1717300000000")
+	assert.Contains(t, out, "skipped at 1717200500000")
+	assert.Contains(t, out, "1 status update(s) posted — call get_status_updates")
+	assert.Contains(t, out, "2 timeline event(s) recorded")
+	// The timeline itself must not be dumped.
+	assert.NotContains(t, out, "incident_created")
+}
+
+func TestFormatRunDetailCountsTasksWhenServerCountersAreAbsent(t *testing.T) {
+	run := playbookRunDetail{
+		ID:   testRunID,
+		Name: "Ad-hoc checklist",
+		Checklists: []checklist{{
+			Items: []checklistItem{{State: "closed"}, {State: "skipped"}, {}},
+		}},
+	}
+
+	assert.Contains(t, formatRunDetail(run), "Tasks: 2/3 complete")
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/playbooksmcp/tools/users.go
+++ b/internal/playbooksmcp/tools/users.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// meUserID is the literal that stands in for the acting user anywhere a user
+// reference is accepted. APIClient.ResolveUserID turns it into a real ID, so
+// tools never have to know which endpoints understand it natively.
+const meUserID = "me"
+
+// userRefSchemaHint documents what a user-reference argument accepts. Every
+// user-taking jsonschema tag ends with it so the model learns the convention
+// once and applies it everywhere, instead of inferring that only opaque IDs
+// work and giving up when it only knows a username.
+const userRefSchemaHint = "Accepts a 26-character user ID, 'me' for the current user, or a username with or without a leading @ (for example '@bob' or 'bob')."
+
+// resolveUserRef turns a user reference supplied by the model into a user ID.
+// An empty reference stays empty so callers can treat it as "not provided";
+// everything else is resolved, so a bad reference fails here with an
+// actionable message rather than as an opaque API error later.
+//
+// This replaces validateID for user arguments: a username is a legitimate
+// value, so shape validation alone would reject exactly the input models
+// produce most often.
+func resolveUserRef(ctx context.Context, client APIClient, ref, field string) (string, error) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return "", nil
+	}
+	userID, err := client.ResolveUserID(ctx, trimmed)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", field, err)
+	}
+	if userID == "" {
+		return "", fmt.Errorf("%s: could not resolve %q to a user", field, trimmed)
+	}
+	return userID, nil
+}
+
+// resolveUserRefs resolves a list of user references, reporting the failing
+// index, and drops duplicates that different references resolved to.
+func resolveUserRefs(ctx context.Context, client APIClient, refs []string, field string) ([]string, error) {
+	resolved := make([]string, 0, len(refs))
+	for i, ref := range refs {
+		userID, err := resolveUserRef(ctx, client, ref, fmt.Sprintf("%s[%d]", field, i))
+		if err != nil {
+			return nil, err
+		}
+		if userID == "" {
+			return nil, fmt.Errorf("%s[%d] is required", field, i)
+		}
+		resolved = appendUnique(resolved, userID)
+	}
+	return resolved, nil
+}

--- a/internal/playbooksmcp/tools/users_test.go
+++ b/internal/playbooksmcp/tools/users_test.go
@@ -1,0 +1,641 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bobUserID is the ID the fake resolves the username "bob" to.
+const bobUserID = "fghijklmnopqrstuvwxyzabcde"
+
+func userRefClient() *fakeAPIClient {
+	return &fakeAPIClient{usersByUsername: map[string]string{"bob": bobUserID}}
+}
+
+func TestResolveUserRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "empty stays empty so callers can treat it as unset",
+			ref:  "",
+			want: "",
+		},
+		{
+			name: "whitespace only is treated as unset",
+			ref:  "   ",
+			want: "",
+		},
+		{
+			name: "me becomes the acting user",
+			ref:  "me",
+			want: testCurrentUser,
+		},
+		{
+			name: "a well-formed ID passes through",
+			ref:  testUserID,
+			want: testUserID,
+		},
+		{
+			name: "a bare username is resolved",
+			ref:  "bob",
+			want: bobUserID,
+		},
+		{
+			name: "an @-prefixed username is resolved",
+			ref:  "@bob",
+			want: bobUserID,
+		},
+		{
+			name:    "an unknown username is an actionable error naming the field",
+			ref:     "@nobody",
+			wantErr: `assignee_id: no user found with username "nobody" — check the spelling (usernames are case-insensitive, without the @)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveUserRef(context.Background(), userRefClient(), tt.ref, "assignee_id")
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveUserRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		refs    []string
+		want    []string
+		wantErr string
+	}{
+		{
+			name: "mixed forms all resolve",
+			refs: []string{"@bob", "me", testUserID},
+			want: []string{bobUserID, testCurrentUser, testUserID},
+		},
+		{
+			name: "references that land on the same user are deduplicated",
+			refs: []string{"@bob", "bob", bobUserID},
+			want: []string{bobUserID},
+		},
+		{
+			name:    "an unknown username reports its index",
+			refs:    []string{"@bob", "@nobody"},
+			wantErr: `user_ids[1]: no user found with username "nobody" — check the spelling (usernames are case-insensitive, without the @)`,
+		},
+		{
+			name:    "an empty entry is rejected rather than silently dropped",
+			refs:    []string{""},
+			wantErr: "user_ids[0] is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveUserRefs(context.Background(), userRefClient(), tt.refs, "user_ids")
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestToolsResolveUsernameArguments covers every tool that takes a user
+// reference: passing "@bob" must put bobUserID in the request the tool sends,
+// so a model never has to know an opaque ID.
+func TestToolsResolveUsernameArguments(t *testing.T) {
+	runWithSection := playbookRunDetail{
+		ID:          testRunID,
+		OwnerUserID: testCurrentUser,
+		Checklists:  []checklist{{Title: "Triage", Items: []checklistItem{{Title: "Page on-call"}}}},
+	}
+	playbookWithSection := map[string]any{
+		"id":         testPlaybookID,
+		"title":      "Sev1",
+		"team_id":    testTeamID,
+		"checklists": []any{map[string]any{"title": "Triage", "items": []any{map[string]any{"title": "Page on-call"}}}},
+	}
+
+	tests := []struct {
+		name string
+		// client seeds any run/playbook state the tool reads back.
+		client *fakeAPIClient
+		run    func(client *fakeAPIClient) error
+		// assert inspects the request the tool sent.
+		assert func(t *testing.T, client *fakeAPIClient)
+	}{
+		{
+			name: "add_run_participants",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddRunParticipants(context.Background(), client, AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"@bob"}})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.postBody.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, []string{bobUserID}, body["user_ids"])
+			},
+		},
+		{
+			name:   "remove_run_participant",
+			client: &fakeAPIClient{run: playbookRunDetail{ID: testRunID, OwnerUserID: testCurrentUser, ParticipantIDs: []string{bobUserID}}},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID, UserID: "@bob"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				assert.Equal(t, "runs/"+testRunID+"/participants/"+bobUserID, client.deleteEndpoint)
+			},
+		},
+		{
+			name: "change_run_owner",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolChangeRunOwner(context.Background(), client, ChangeRunOwnerArgs{RunID: testRunID, OwnerID: "@bob"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.postBody.(map[string]string)
+				require.True(t, ok)
+				assert.Equal(t, bobUserID, body["owner_id"])
+			},
+		},
+		{
+			name:   "run_playbook",
+			client: &fakeAPIClient{runPlaybook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID, ChannelMode: channelModeCreateNew}, run: playbookRunDetail{ID: testRunID}},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolRunPlaybook(context.Background(), client, RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Sev1", OwnerUserID: "@bob"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.postBody.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, bobUserID, body["owner_user_id"])
+			},
+		},
+		{
+			name:   "add_checklist_item",
+			client: &fakeAPIClient{run: runWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddChecklistItem(context.Background(), client, AddChecklistItemArgs{RunID: testRunID, ChecklistNumber: 0, Title: "Verify fix", AssigneeID: "@bob"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.postBody.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, bobUserID, body["assignee_id"])
+			},
+		},
+		{
+			name:   "set_checklist_item_assignee",
+			client: &fakeAPIClient{run: runWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolSetChecklistItemAssignee(context.Background(), client, SetChecklistItemAssigneeArgs{RunID: testRunID, ChecklistNumber: 0, ItemNumber: 0, AssigneeID: "@bob"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.putBody.(map[string]string)
+				require.True(t, ok)
+				assert.Equal(t, bobUserID, body["assignee_id"])
+			},
+		},
+		{
+			name: "add_section initial items",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddSection(context.Background(), client, AddSectionArgs{RunID: testRunID, Title: "Recovery", Items: []CreateChecklistItem{{Title: "Verify fix", AssigneeID: "@bob"}}})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.postBody.(map[string]any)
+				require.True(t, ok)
+				items, ok := body["items"].([]CreateChecklistItem)
+				require.True(t, ok)
+				require.Len(t, items, 1)
+				assert.Equal(t, bobUserID, items[0].AssigneeID)
+			},
+		},
+		{
+			name:   "create_checklist section items",
+			client: &fakeAPIClient{run: playbookRunDetail{ID: testRunID}},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolCreateChecklist(context.Background(), client, CreateChecklistArgs{
+					Name:      "Release",
+					ChannelID: testRunChannelID,
+					Sections:  []CreateChecklistSection{{Title: "Pre-release", Items: []CreateChecklistItem{{Title: "Confirm changelog", AssigneeID: "@bob"}}}},
+				})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				// postBody holds the last POST, which is the section.
+				body, ok := client.postBody.(map[string]any)
+				require.True(t, ok)
+				items, ok := body["items"].([]CreateChecklistItem)
+				require.True(t, ok)
+				require.Len(t, items, 1)
+				assert.Equal(t, bobUserID, items[0].AssigneeID)
+			},
+		},
+		{
+			name:   "add_playbook_task",
+			client: &fakeAPIClient{playbook: playbookWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddPlaybookTask(context.Background(), client, AddPlaybookTaskArgs{PlaybookID: testPlaybookID, ChecklistNumber: 0, Title: "Verify fix", AssigneeID: "@bob"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				assert.Equal(t, bobUserID, lastPlaybookTaskAssignee(t, client, 0, 1))
+				assert.Contains(t, playbookInvitedUserIDs(t, client), bobUserID)
+			},
+		},
+		{
+			name:   "edit_playbook_task",
+			client: &fakeAPIClient{playbook: playbookWithSection},
+			run: func(client *fakeAPIClient) error {
+				assignee := "@bob"
+				_, err := toolEditPlaybookTask(context.Background(), client, EditPlaybookTaskArgs{PlaybookID: testPlaybookID, ChecklistNumber: 0, ItemNumber: 0, AssigneeID: &assignee})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				assert.Equal(t, bobUserID, lastPlaybookTaskAssignee(t, client, 0, 0))
+				assert.Contains(t, playbookInvitedUserIDs(t, client), bobUserID)
+			},
+		},
+		{
+			name:   "add_playbook_section initial items",
+			client: &fakeAPIClient{playbook: playbookWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddPlaybookSection(context.Background(), client, AddPlaybookSectionArgs{
+					PlaybookID: testPlaybookID,
+					Title:      "Recovery",
+					Items:      []CreatePlaybookItem{{Title: "Verify fix", AssigneeID: "@bob"}},
+				})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				assert.Equal(t, bobUserID, lastPlaybookTaskAssignee(t, client, 1, 0))
+			},
+		},
+		{
+			name: "create_playbook default owner, invitees, members and assignees",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolCreatePlaybook(context.Background(), client, CreatePlaybookArgs{
+					Title:          "Sev1",
+					TeamID:         testTeamID,
+					DefaultOwnerID: "@bob",
+					InvitedUserIDs: []string{"@bob"},
+					Members:        []CreatePlaybookMember{{UserID: "@bob", Roles: []string{"playbook_member"}}},
+					Checklists:     []CreatePlaybookChecklist{{Title: "Triage", Items: []CreatePlaybookItem{{Title: "Page on-call", AssigneeID: "@bob"}}}},
+				})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				body, ok := client.postBody.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, bobUserID, body["default_owner_id"])
+				assert.Contains(t, body["invited_user_ids"], bobUserID)
+
+				members, ok := body["members"].([]CreatePlaybookMember)
+				require.True(t, ok)
+				require.Len(t, members, 1)
+				assert.Equal(t, bobUserID, members[0].UserID)
+
+				checklists, ok := body["checklists"].([]map[string]any)
+				require.True(t, ok)
+				require.Len(t, checklists, 1)
+				items, ok := checklists[0]["items"].([]map[string]any)
+				require.True(t, ok)
+				require.Len(t, items, 1)
+				assert.Equal(t, bobUserID, items[0]["assignee_id"])
+			},
+		},
+		{
+			name: "list_runs user filters",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolListRuns(context.Background(), client, ListRunsArgs{OwnerUserID: "@bob", ParticipantID: "me"})
+				return err
+			},
+			assert: func(t *testing.T, client *fakeAPIClient) {
+				assert.Equal(t, bobUserID, client.getParams.Get("owner_user_id"))
+				assert.Equal(t, testCurrentUser, client.getParams.Get("participant_id"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := tt.client
+			if client == nil {
+				client = &fakeAPIClient{}
+			}
+			client.usersByUsername = map[string]string{"bob": bobUserID}
+
+			require.NoError(t, tt.run(client))
+			assert.Contains(t, client.resolvedRefs, "@bob", "expected the tool to resolve the username reference")
+			tt.assert(t, client)
+		})
+	}
+}
+
+// TestToolsRejectUnknownUsernameWithoutMutating pairs with the test above: a
+// username that does not exist has to fail with the actionable error and leave
+// the run or template untouched, rather than sending "@nobody" to the API.
+func TestToolsRejectUnknownUsernameWithoutMutating(t *testing.T) {
+	runWithSection := playbookRunDetail{
+		ID:         testRunID,
+		Checklists: []checklist{{Title: "Triage", Items: []checklistItem{{Title: "Page on-call"}}}},
+	}
+	playbookWithSection := map[string]any{
+		"id":         testPlaybookID,
+		"title":      "Sev1",
+		"team_id":    testTeamID,
+		"checklists": []any{map[string]any{"title": "Triage", "items": []any{map[string]any{"title": "Page on-call"}}}},
+	}
+
+	tests := []struct {
+		name    string
+		client  *fakeAPIClient
+		run     func(client *fakeAPIClient) error
+		wantErr string
+	}{
+		{
+			name: "add_run_participants",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddRunParticipants(context.Background(), client, AddRunParticipantsArgs{RunID: testRunID, UserIDs: []string{"@nobody"}})
+				return err
+			},
+			wantErr: `user_ids[0]: no user found with username "nobody"`,
+		},
+		{
+			name: "remove_run_participant",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolRemoveRunParticipant(context.Background(), client, RemoveRunParticipantArgs{RunID: testRunID, UserID: "@nobody"})
+				return err
+			},
+			wantErr: `user_id: no user found with username "nobody"`,
+		},
+		{
+			name: "change_run_owner",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolChangeRunOwner(context.Background(), client, ChangeRunOwnerArgs{RunID: testRunID, OwnerID: "@nobody"})
+				return err
+			},
+			wantErr: `owner_id: no user found with username "nobody"`,
+		},
+		{
+			name:   "run_playbook",
+			client: &fakeAPIClient{runPlaybook: playbookForRun{ID: testPlaybookID, Title: "Sev1", TeamID: testTeamID, ChannelMode: channelModeCreateNew}},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolRunPlaybook(context.Background(), client, RunPlaybookArgs{PlaybookID: testPlaybookID, Name: "Sev1", OwnerUserID: "@nobody"})
+				return err
+			},
+			wantErr: `owner_user_id: no user found with username "nobody"`,
+		},
+		{
+			name:   "add_checklist_item",
+			client: &fakeAPIClient{run: runWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddChecklistItem(context.Background(), client, AddChecklistItemArgs{RunID: testRunID, ChecklistNumber: 0, Title: "Verify fix", AssigneeID: "@nobody"})
+				return err
+			},
+			wantErr: `assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name:   "set_checklist_item_assignee",
+			client: &fakeAPIClient{run: runWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolSetChecklistItemAssignee(context.Background(), client, SetChecklistItemAssigneeArgs{RunID: testRunID, ChecklistNumber: 0, ItemNumber: 0, AssigneeID: "@nobody"})
+				return err
+			},
+			wantErr: `assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name: "add_section",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddSection(context.Background(), client, AddSectionArgs{RunID: testRunID, Title: "Recovery", Items: []CreateChecklistItem{{Title: "Verify fix", AssigneeID: "@nobody"}}})
+				return err
+			},
+			wantErr: `items[0].assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name: "create_checklist",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolCreateChecklist(context.Background(), client, CreateChecklistArgs{
+					Name:      "Release",
+					ChannelID: testRunChannelID,
+					Sections:  []CreateChecklistSection{{Title: "Pre-release", Items: []CreateChecklistItem{{Title: "Confirm changelog", AssigneeID: "@nobody"}}}},
+				})
+				return err
+			},
+			wantErr: `sections[0].items[0].assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name:   "add_playbook_task",
+			client: &fakeAPIClient{playbook: playbookWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddPlaybookTask(context.Background(), client, AddPlaybookTaskArgs{PlaybookID: testPlaybookID, ChecklistNumber: 0, Title: "Verify fix", AssigneeID: "@nobody"})
+				return err
+			},
+			wantErr: `assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name:   "edit_playbook_task",
+			client: &fakeAPIClient{playbook: playbookWithSection},
+			run: func(client *fakeAPIClient) error {
+				assignee := "@nobody"
+				_, err := toolEditPlaybookTask(context.Background(), client, EditPlaybookTaskArgs{PlaybookID: testPlaybookID, ChecklistNumber: 0, ItemNumber: 0, AssigneeID: &assignee})
+				return err
+			},
+			wantErr: `assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name:   "add_playbook_section",
+			client: &fakeAPIClient{playbook: playbookWithSection},
+			run: func(client *fakeAPIClient) error {
+				_, err := toolAddPlaybookSection(context.Background(), client, AddPlaybookSectionArgs{
+					PlaybookID: testPlaybookID,
+					Title:      "Recovery",
+					Items:      []CreatePlaybookItem{{Title: "Verify fix", AssigneeID: "@nobody"}},
+				})
+				return err
+			},
+			wantErr: `items[0].assignee_id: no user found with username "nobody"`,
+		},
+		{
+			name: "create_playbook",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolCreatePlaybook(context.Background(), client, CreatePlaybookArgs{Title: "Sev1", TeamID: testTeamID, DefaultOwnerID: "@nobody"})
+				return err
+			},
+			wantErr: `default_owner_id: no user found with username "nobody"`,
+		},
+		{
+			name: "list_runs",
+			run: func(client *fakeAPIClient) error {
+				_, err := toolListRuns(context.Background(), client, ListRunsArgs{ParticipantID: "@nobody"})
+				return err
+			},
+			wantErr: `participant_id: no user found with username "nobody"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := tt.client
+			if client == nil {
+				client = &fakeAPIClient{}
+			}
+			client.usersByUsername = map[string]string{"bob": bobUserID}
+
+			err := tt.run(client)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Contains(t, err.Error(), "check the spelling")
+
+			assert.Empty(t, client.postEndpoint, "expected no POST")
+			assert.Empty(t, client.putEndpoint, "expected no PUT")
+			assert.Empty(t, client.patchEndpoint, "expected no PATCH")
+			assert.Empty(t, client.deleteEndpoint, "expected no DELETE")
+		})
+	}
+}
+
+// userRefPropertyNames are the argument names that carry a user reference.
+// Any property with one of these names, at any nesting depth, must tell the
+// model that a username works — otherwise it falls back to hunting for an ID.
+var userRefPropertyNames = map[string]bool{
+	"assignee_id":      true,
+	"default_owner_id": true,
+	"invited_user_ids": true,
+	"owner_id":         true,
+	"owner_user_id":    true,
+	"participant_id":   true,
+	"user_id":          true,
+	"user_ids":         true,
+}
+
+func TestUserRefSchemasAdvertiseUsernames(t *testing.T) {
+	// The hint is the canonical wording; these are the load-bearing phrases
+	// every user-ref description has to carry, however it is worded.
+	for _, phrase := range []string{"user ID", "'me'", "username"} {
+		require.Contains(t, userRefSchemaHint, phrase)
+	}
+
+	for _, tool := range registerToolsForTest(t, &fakeAPIClient{}) {
+		t.Run(tool.Name, func(t *testing.T) {
+			raw, err := json.Marshal(tool.InputSchema)
+			require.NoError(t, err)
+
+			var schema any
+			require.NoError(t, json.Unmarshal(raw, &schema))
+
+			found := false
+			walkSchemaProperties(schema, func(name string, property map[string]any) {
+				if !userRefPropertyNames[name] {
+					return
+				}
+				found = true
+				description, _ := property["description"].(string)
+				assert.Contains(t, description, "user ID", "%s must say a user ID is accepted", name)
+				assert.Contains(t, description, "'me'", "%s must say 'me' is accepted", name)
+				assert.Contains(t, description, "username", "%s must say a username is accepted", name)
+			})
+			if !found {
+				t.Skip("no user-reference arguments")
+			}
+		})
+	}
+}
+
+// walkSchemaProperties visits every named property in a JSON schema, including
+// those nested in object properties and array items, so a user reference
+// buried in a checklist item is checked too.
+func walkSchemaProperties(node any, visit func(name string, property map[string]any)) {
+	object, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if properties, ok := object["properties"].(map[string]any); ok {
+		for name, raw := range properties {
+			property, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			visit(name, property)
+			walkSchemaProperties(property, visit)
+			if items, ok := property["items"].(map[string]any); ok {
+				// An array of user references describes them on the array
+				// itself, so re-check the item schema under the same name.
+				visit(name, mergeDescriptions(property, items))
+				walkSchemaProperties(items, visit)
+			}
+		}
+	}
+	if items, ok := object["items"].(map[string]any); ok {
+		walkSchemaProperties(items, visit)
+	}
+}
+
+// mergeDescriptions lets an array's own description satisfy the convention for
+// its items, since that is where the guidance naturally goes.
+func mergeDescriptions(array, items map[string]any) map[string]any {
+	arrayDescription, _ := array["description"].(string)
+	itemDescription, _ := items["description"].(string)
+	merged := map[string]any{"description": arrayDescription + " " + itemDescription}
+	return merged
+}
+
+func lastPlaybookTaskAssignee(t *testing.T, client *fakeAPIClient, checklistIdx, itemIdx int) string {
+	t.Helper()
+
+	saved, ok := client.putBody.(map[string]any)
+	require.True(t, ok, "expected the playbook to be saved")
+	checklists, ok := saved["checklists"].([]any)
+	require.True(t, ok)
+	require.Greater(t, len(checklists), checklistIdx)
+	checklist, ok := checklists[checklistIdx].(map[string]any)
+	require.True(t, ok)
+	items, ok := checklist["items"].([]any)
+	require.True(t, ok)
+	require.Greater(t, len(items), itemIdx)
+	item, ok := items[itemIdx].(map[string]any)
+	require.True(t, ok)
+	assignee, _ := item["assignee_id"].(string)
+	return assignee
+}
+
+func playbookInvitedUserIDs(t *testing.T, client *fakeAPIClient) []string {
+	t.Helper()
+
+	saved, ok := client.putBody.(map[string]any)
+	require.True(t, ok, "expected the playbook to be saved")
+	raw, ok := saved["invited_user_ids"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -145,6 +145,12 @@ func NewPlaybookRunHandler(
 	followersRouter.HandleFunc("", withContext(handler.unfollow)).Methods(http.MethodDelete)
 	followersRouter.HandleFunc("", withContext(handler.getFollowers)).Methods(http.MethodGet)
 
+	// Deliberately not on playbookRunRouterAuthorized: joining and leaving a run must stay
+	// available to a user who only has RunView, which checkEditPermissions would reject.
+	participantsRouter := playbookRunRouter.PathPrefix("/participants").Subrouter()
+	participantsRouter.HandleFunc("", withContext(handler.addParticipants)).Methods(http.MethodPost)
+	participantsRouter.HandleFunc("/{user_id:[A-Za-z0-9]+}", withContext(handler.removeParticipant)).Methods(http.MethodDelete)
+
 	propertyFieldsRouter := playbookRunRouter.PathPrefix("/property_fields").Subrouter()
 	propertyFieldsRouter.HandleFunc("", withContext(handler.getRunPropertyFields)).Methods(http.MethodGet)
 	propertyFieldsRouter.HandleFunc("/{fieldID:[A-Za-z0-9]+}/value", withContext(handler.setRunPropertyValue)).Methods(http.MethodPut)
@@ -2156,6 +2162,125 @@ func (h *PlaybookRunHandler) getFollowers(c *Context, w http.ResponseWriter, r *
 	}
 
 	ReturnJSON(w, followers, http.StatusOK)
+}
+
+// AddParticipantsRequest is the body of POST /runs/{id}/participants.
+type AddParticipantsRequest struct {
+	UserIDs           []string `json:"user_ids"`
+	ForceAddToChannel bool     `json:"force_add_to_channel"`
+}
+
+// addParticipants handles the POST /runs/{id}/participants endpoint. It is the REST
+// equivalent of the addRunParticipants GraphQL mutation: a user adding only themselves is
+// joining the run, which needs no more than RunView, while adding anybody else requires
+// RunManageProperties on a run that is still active.
+func (h *PlaybookRunHandler) addParticipants(c *Context, w http.ResponseWriter, r *http.Request) {
+	playbookRunID := mux.Vars(r)["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var request AddParticipantsRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "unable to decode request body", err)
+		return
+	}
+
+	if len(request.UserIDs) == 0 {
+		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "user_ids must not be empty", nil)
+		return
+	}
+
+	for _, participantID := range request.UserIDs {
+		if !model.IsValidId(participantID) {
+			h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "user_ids must only contain valid user IDs", nil)
+			return
+		}
+	}
+
+	if updatesOnlyRequesterMembership(userID, request.UserIDs) {
+		if !h.PermissionsCheck(w, c.logger, h.permissions.RunView(userID, playbookRunID)) {
+			return
+		}
+	} else {
+		if !h.PermissionsCheck(w, c.logger, h.permissions.RunManageProperties(userID, playbookRunID)) {
+			return
+		}
+
+		playbookRun, err := h.playbookRunService.GetPlaybookRun(playbookRunID)
+		if err != nil {
+			h.HandleError(w, c.logger, err)
+			return
+		}
+		if err := app.EnsureRunIsActive(playbookRun); err != nil {
+			h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "cannot modify a finished run", err)
+			return
+		}
+	}
+
+	if _, err := h.playbookRunService.AddParticipants(playbookRunID, request.UserIDs, userID, request.ForceAddToChannel, true); err != nil {
+		h.HandleError(w, c.logger, err)
+		return
+	}
+
+	ReturnJSON(w, map[string]string{"status": "OK"}, http.StatusOK)
+}
+
+// removeParticipant handles the DELETE /runs/{id}/participants/{user_id} endpoint. It is the
+// REST equivalent of the removeRunParticipants GraphQL mutation for a single user: a user
+// removing themselves is leaving the run, which needs no more than RunView, while removing
+// anybody else requires RunManageProperties on a run that is still active. The removed user
+// also stops following the run, matching the mutation.
+func (h *PlaybookRunHandler) removeParticipant(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	playbookRunID := vars["id"]
+	participantID := vars["user_id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	if !model.IsValidId(participantID) {
+		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "user_id must be a valid user ID", nil)
+		return
+	}
+
+	isLeavingRun := participantID == userID
+	if isLeavingRun {
+		if !h.PermissionsCheck(w, c.logger, h.permissions.RunView(userID, playbookRunID)) {
+			return
+		}
+	} else {
+		if !h.PermissionsCheck(w, c.logger, h.permissions.RunManageProperties(userID, playbookRunID)) {
+			return
+		}
+	}
+
+	playbookRun, err := h.playbookRunService.GetPlaybookRun(playbookRunID)
+	if err != nil {
+		h.HandleError(w, c.logger, err)
+		return
+	}
+
+	if !isLeavingRun {
+		if err := app.EnsureRunIsActive(playbookRun); err != nil {
+			h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "cannot modify a finished run", err)
+			return
+		}
+	}
+
+	// The app layer refuses this too, but only with an opaque error that would surface as a 500.
+	if playbookRun.OwnerUserID == participantID {
+		h.HandleErrorWithCode(w, c.logger, http.StatusBadRequest, "the run owner cannot be removed from the run", nil)
+		return
+	}
+
+	if err := h.playbookRunService.RemoveParticipants(playbookRunID, []string{participantID}, userID); err != nil {
+		h.HandleError(w, c.logger, err)
+		return
+	}
+
+	if err := h.playbookRunService.Unfollow(playbookRunID, participantID); err != nil {
+		h.HandleError(w, c.logger, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // parsePlaybookRunsFilterOptions is only for parsing. Put validation logic in app.validateOptions.

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -6070,3 +6070,303 @@ func TestAssigneeAutoAddParticipant(t *testing.T) {
 		assert.True(t, receivedDM(t, targetUser.Id, run.Name), "resolved user must receive the assignment DM")
 	})
 }
+
+// createParticipantsRun creates a run owned by RegularUser off the basic public playbook so
+// each participant test case starts from an independent membership list.
+func createParticipantsRun(t *testing.T, e *TestEnvironment, name string) *client.PlaybookRun {
+	t.Helper()
+
+	run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+		Name:        name,
+		OwnerUserID: e.RegularUser.Id,
+		TeamID:      e.BasicTeam.Id,
+		PlaybookID:  e.BasicPlaybook.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, run)
+
+	return run
+}
+
+// loginClient4As returns a Mattermost API client authenticated as the given user, for the raw
+// REST calls the typed Playbooks client does not cover.
+func loginClient4As(t *testing.T, e *TestEnvironment, user *model.User) *model.Client4 {
+	t.Helper()
+
+	c := model.NewAPIv4Client(fmt.Sprintf("http://localhost:%v", e.A.Srv().ListenAddr.Port))
+	_, _, err := c.Login(context.Background(), user.Email, testUserPassword)
+	require.NoError(t, err)
+
+	return c
+}
+
+// followRunAs makes the client's user follow the run via PUT /runs/{id}/followers.
+func followRunAs(t *testing.T, e *TestEnvironment, c *model.Client4, runID string) {
+	t.Helper()
+
+	resp, err := e.DoPluginAPIRequestWithHeaders(context.Background(), c, http.MethodPut, "/api/v0/runs/"+runID+"/followers", "", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// runFollowers returns the run's followers via GET /runs/{id}/followers.
+func runFollowers(t *testing.T, e *TestEnvironment, c *model.Client4, runID string) []string {
+	t.Helper()
+
+	resp, err := e.DoPluginAPIRequestWithHeaders(context.Background(), c, http.MethodGet, "/api/v0/runs/"+runID+"/followers", "", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var followers []string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&followers))
+
+	return followers
+}
+
+// TestRESTAddRunParticipants covers POST /runs/{id}/participants, the REST counterpart of the
+// addRunParticipants GraphQL mutation.
+func TestRESTAddRunParticipants(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	for _, tc := range []struct {
+		name string
+		// actor is the client issuing the request.
+		actor   *client.Client
+		userIDs []string
+		// expectedStatus is zero when the request is expected to succeed.
+		expectedStatus int
+	}{
+		{
+			name:    "owner adds another user",
+			actor:   e.PlaybooksClient,
+			userIDs: []string{e.RegularUser2.Id},
+		},
+		{
+			name:    "user with only run view access joins the run",
+			actor:   e.PlaybooksClient2,
+			userIDs: []string{e.RegularUser2.Id},
+		},
+		{
+			name:    "system admin adds another user",
+			actor:   e.PlaybooksAdminClient,
+			userIDs: []string{e.RegularUser2.Id},
+		},
+		{
+			name:           "non-participant cannot add somebody else",
+			actor:          e.PlaybooksClient2,
+			userIDs:        []string{e.AdminUser.Id},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "user outside the team cannot join the run",
+			actor:          e.PlaybooksClientNotInTeam,
+			userIDs:        []string{e.RegularUserNotInTeam.Id},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "malformed user id is rejected",
+			actor:          e.PlaybooksClient,
+			userIDs:        []string{"not-a-valid-user-id"},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "empty user id list is rejected",
+			actor:          e.PlaybooksClient,
+			userIDs:        []string{},
+			expectedStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run := createParticipantsRun(t, e, "add participants - "+tc.name)
+
+			err := tc.actor.PlaybookRuns.AddParticipants(context.Background(), run.ID, tc.userIDs, false)
+
+			updated, getErr := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+			require.NoError(t, getErr)
+
+			if tc.expectedStatus != 0 {
+				requireErrorWithStatusCode(t, err, tc.expectedStatus)
+				assert.ElementsMatch(t, []string{e.RegularUser.Id}, updated.ParticipantIDs,
+					"a rejected request must not change the run's participants")
+				return
+			}
+
+			require.NoError(t, err)
+			for _, userID := range tc.userIDs {
+				assert.Contains(t, updated.ParticipantIDs, userID)
+			}
+		})
+	}
+
+	t.Run("adding a user who already participates is a no-op", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "add participants - already a participant")
+
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+
+		updated, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{e.RegularUser.Id, e.RegularUser2.Id}, updated.ParticipantIDs)
+	})
+
+	t.Run("a well-formed but unknown user id is silently skipped", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "add participants - unknown user")
+
+		err := e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{model.NewId()}, false)
+		require.NoError(t, err)
+
+		updated, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{e.RegularUser.Id}, updated.ParticipantIDs)
+	})
+
+	t.Run("adding somebody else to a finished run is rejected", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "add participants - finished run")
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.Finish(context.Background(), run.ID))
+
+		err := e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false)
+		requireErrorWithStatusCode(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("joining a finished run is allowed", func(t *testing.T) {
+		// The finished-run guard only covers managing somebody else's membership, matching
+		// the addRunParticipants mutation.
+		run := createParticipantsRun(t, e, "add participants - join finished run")
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.Finish(context.Background(), run.ID))
+
+		require.NoError(t, e.PlaybooksClient2.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+
+		updated, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.Contains(t, updated.ParticipantIDs, e.RegularUser2.Id)
+	})
+
+	t.Run("a body that is not valid json is rejected", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "add participants - malformed body")
+
+		resp, err := e.DoPluginAPIRequestWithHeaders(context.Background(), e.ServerClient, http.MethodPost,
+			"/api/v0/runs/"+run.ID+"/participants", "{not json", map[string]string{"Content-Type": "application/json"})
+		require.Error(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+// TestRESTRemoveRunParticipant covers DELETE /runs/{id}/participants/{user_id}, the REST
+// counterpart of the removeRunParticipants GraphQL mutation.
+func TestRESTRemoveRunParticipant(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	for _, tc := range []struct {
+		name string
+		// actor is the client issuing the request.
+		actor    *client.Client
+		targetID string
+		// expectedStatus is zero when the request is expected to succeed.
+		expectedStatus int
+	}{
+		{
+			name:     "owner removes another participant",
+			actor:    e.PlaybooksClient,
+			targetID: e.RegularUser2.Id,
+		},
+		{
+			name:     "participant leaves the run",
+			actor:    e.PlaybooksClient2,
+			targetID: e.RegularUser2.Id,
+		},
+		{
+			name:     "system admin removes a participant",
+			actor:    e.PlaybooksAdminClient,
+			targetID: e.RegularUser2.Id,
+		},
+		{
+			name:           "user outside the team cannot remove a participant",
+			actor:          e.PlaybooksClientNotInTeam,
+			targetID:       e.RegularUser2.Id,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "the run owner cannot be removed",
+			actor:          e.PlaybooksClient,
+			targetID:       e.RegularUser.Id,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "malformed user id is rejected",
+			actor:          e.PlaybooksClient,
+			targetID:       strings.Repeat("a", 25),
+			expectedStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run := createParticipantsRun(t, e, "remove participant - "+tc.name)
+			require.NoError(t, e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+
+			err := tc.actor.PlaybookRuns.RemoveParticipant(context.Background(), run.ID, tc.targetID)
+
+			updated, getErr := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+			require.NoError(t, getErr)
+
+			if tc.expectedStatus != 0 {
+				requireErrorWithStatusCode(t, err, tc.expectedStatus)
+				assert.ElementsMatch(t, []string{e.RegularUser.Id, e.RegularUser2.Id}, updated.ParticipantIDs,
+					"a rejected request must not change the run's participants")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotContains(t, updated.ParticipantIDs, tc.targetID)
+		})
+	}
+
+	t.Run("removing a participant also stops them following the run", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "remove participant - unfollow")
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+
+		followRunAs(t, e, loginClient4As(t, e, e.RegularUser2), run.ID)
+		require.Contains(t, runFollowers(t, e, e.ServerClient, run.ID), e.RegularUser2.Id)
+
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.RemoveParticipant(context.Background(), run.ID, e.RegularUser2.Id))
+
+		updated, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.NotContains(t, updated.ParticipantIDs, e.RegularUser2.Id)
+		assert.NotContains(t, runFollowers(t, e, e.ServerClient, run.ID), e.RegularUser2.Id)
+	})
+
+	t.Run("removing a user who does not participate is a no-op", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "remove participant - not a participant")
+
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.RemoveParticipant(context.Background(), run.ID, e.RegularUser2.Id))
+
+		updated, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{e.RegularUser.Id}, updated.ParticipantIDs)
+	})
+
+	t.Run("removing somebody else from a finished run is rejected", func(t *testing.T) {
+		run := createParticipantsRun(t, e, "remove participant - finished run")
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.Finish(context.Background(), run.ID))
+
+		err := e.PlaybooksClient.PlaybookRuns.RemoveParticipant(context.Background(), run.ID, e.RegularUser2.Id)
+		requireErrorWithStatusCode(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("leaving a finished run is allowed", func(t *testing.T) {
+		// The finished-run guard only covers managing somebody else's membership, matching
+		// the removeRunParticipants mutation.
+		run := createParticipantsRun(t, e, "remove participant - leave finished run")
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.AddParticipants(context.Background(), run.ID, []string{e.RegularUser2.Id}, false))
+		require.NoError(t, e.PlaybooksClient.PlaybookRuns.Finish(context.Background(), run.ID))
+
+		require.NoError(t, e.PlaybooksClient2.PlaybookRuns.RemoveParticipant(context.Background(), run.ID, e.RegularUser2.Id))
+
+		updated, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		assert.NotContains(t, updated.ParticipantIDs, e.RegularUser2.Id)
+	})
+}

--- a/server/mcp.go
+++ b/server/mcp.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-plugin-agents/public/mcphelper"
+	"github.com/mattermost/mattermost-plugin-playbooks/client"
 	"github.com/mattermost/mattermost-plugin-playbooks/internal/playbooksmcp/tools"
 	"github.com/mattermost/mattermost-plugin-playbooks/server/api"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,10 +26,16 @@ const (
 	playbooksLocalAPIBase = "/api/v0/"
 )
 
+// usernameResolver looks a username up and returns its user ID. It is passed
+// in rather than reached for through the Plugin struct so newPlaybooksMCPServer
+// stays constructible in tests.
+type usernameResolver func(ctx context.Context, username string) (string, error)
+
 type pluginMCPClient struct {
-	handler http.Handler
-	userID  string
-	siteURL string
+	handler         http.Handler
+	userID          string
+	siteURL         string
+	resolveUsername usernameResolver
 }
 
 type pluginMCPRegistrationAPI struct {
@@ -115,6 +123,42 @@ func (c *pluginMCPClient) GetCurrentUserID(context.Context) (string, error) {
 	return c.userID, nil
 }
 
+// ResolveUserID accepts any of the three forms a model realistically produces
+// for a person: "me", a raw user ID, or a username (with or without the "@"
+// Mattermost renders). Only the last needs a lookup, so the short-circuits live
+// here — every APIClient implementation then agrees on the semantics and only
+// has to supply the username lookup itself.
+func (c *pluginMCPClient) ResolveUserID(ctx context.Context, userRef string) (string, error) {
+	ref := strings.TrimSpace(userRef)
+	if ref == "" {
+		return "", fmt.Errorf("a user reference is required: pass a user ID, %q, or a username such as \"@bob\"", client.Me)
+	}
+	if ref == client.Me {
+		return c.GetCurrentUserID(ctx)
+	}
+	if model.IsValidId(ref) {
+		return ref, nil
+	}
+
+	// Mattermost usernames are stored lowercase, so folding the case here is
+	// what makes the "case-insensitive" promise in the error below true.
+	username := strings.ToLower(strings.TrimPrefix(ref, "@"))
+	if username == "" {
+		return "", fmt.Errorf("%q is not a valid user reference: pass a user ID, %q, or a username such as \"@bob\"", userRef, client.Me)
+	}
+	if c.resolveUsername == nil {
+		return "", fmt.Errorf("user lookup unavailable: cannot resolve username %q to a user ID; pass the 26-character user ID instead", username)
+	}
+	userID, err := c.resolveUsername(ctx, username)
+	if err != nil {
+		return "", fmt.Errorf("no user found with username %q — check the spelling (usernames are case-insensitive, without the @). Underlying error: %w", username, err)
+	}
+	if userID == "" {
+		return "", fmt.Errorf("no user found with username %q — check the spelling (usernames are case-insensitive, without the @)", username)
+	}
+	return userID, nil
+}
+
 func (c *pluginMCPClient) GetPlaybookURL(playbookID string) string {
 	return strings.TrimRight(c.siteURL, "/") + "/playbooks/playbooks/" + playbookID
 }
@@ -168,7 +212,7 @@ func (c *pluginMCPClient) do(ctx context.Context, method, endpoint string, body 
 	return nil
 }
 
-func newPlaybooksMCPServer(api mcphelper.PluginAPI, handler http.Handler, exposeExternal bool, siteURL string) (*mcphelper.Server, error) {
+func newPlaybooksMCPServer(api mcphelper.PluginAPI, handler http.Handler, exposeExternal bool, siteURL string, resolveUsername usernameResolver) (*mcphelper.Server, error) {
 	server := mcphelper.NewServer(newPluginMCPRegistrationAPI(api, manifest.Id), mcphelper.PluginMCPServer{
 		PluginID:       manifest.Id,
 		Name:           "Playbooks MCP",
@@ -181,7 +225,7 @@ func newPlaybooksMCPServer(api mcphelper.PluginAPI, handler http.Handler, expose
 		if userID == "" {
 			return nil, fmt.Errorf("missing Mattermost user ID")
 		}
-		return &pluginMCPClient{handler: handler, userID: userID, siteURL: siteURL}, nil
+		return &pluginMCPClient{handler: handler, userID: userID, siteURL: siteURL, resolveUsername: resolveUsername}, nil
 	}
 	provider, err := tools.NewPlaybooksToolProvider(factory)
 	if err != nil {
@@ -201,7 +245,7 @@ func (p *Plugin) ensureMCPServer() error {
 	}
 	p.mcpMu.RUnlock()
 
-	server, err := newPlaybooksMCPServer(p.API, p.handler, exposeExternal, p.currentSiteURL())
+	server, err := newPlaybooksMCPServer(p.API, p.handler, exposeExternal, p.currentSiteURL(), p.usernameResolver())
 	if err != nil {
 		return err
 	}
@@ -222,6 +266,23 @@ func (p *Plugin) ensureMCPServer() error {
 		}
 	}
 	return nil
+}
+
+// usernameResolver returns nil when the plugin API is not available yet, which
+// pluginMCPClient.ResolveUserID reports as "user lookup unavailable" rather
+// than panicking mid-request.
+func (p *Plugin) usernameResolver() usernameResolver {
+	pluginAPI := p.pluginAPI
+	if pluginAPI == nil {
+		return nil
+	}
+	return func(_ context.Context, username string) (string, error) {
+		user, err := pluginAPI.User.GetByUsername(username)
+		if err != nil {
+			return "", err
+		}
+		return user.Id, nil
+	}
 }
 
 func (p *Plugin) currentMCPExposeExternal() bool {

--- a/server/mcp.go
+++ b/server/mcp.go
@@ -100,6 +100,10 @@ func (c *pluginMCPClient) Put(ctx context.Context, endpoint string, body any, re
 	return c.do(ctx, http.MethodPut, endpoint, body, result)
 }
 
+func (c *pluginMCPClient) Patch(ctx context.Context, endpoint string, body any, result any) error {
+	return c.do(ctx, http.MethodPatch, endpoint, body, result)
+}
+
 func (c *pluginMCPClient) Delete(ctx context.Context, endpoint string) error {
 	return c.do(ctx, http.MethodDelete, endpoint, nil, nil)
 }
@@ -113,6 +117,12 @@ func (c *pluginMCPClient) GetCurrentUserID(context.Context) (string, error) {
 
 func (c *pluginMCPClient) GetPlaybookURL(playbookID string) string {
 	return strings.TrimRight(c.siteURL, "/") + "/playbooks/playbooks/" + playbookID
+}
+
+// GetRunURL mirrors app.GetRunDetailsRelativeURL ("/playbooks/runs/{id}"), the
+// route the webapp serves the run overview from.
+func (c *pluginMCPClient) GetRunURL(runID string) string {
+	return strings.TrimRight(c.siteURL, "/") + "/playbooks/runs/" + runID
 }
 
 func (c *pluginMCPClient) do(ctx context.Context, method, endpoint string, body any, result any) error {

--- a/server/mcp_agent_eval_helpers_test.go
+++ b/server/mcp_agent_eval_helpers_test.go
@@ -1,0 +1,829 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-agents/public/bridgeclient"
+	"github.com/mattermost/mattermost-plugin-agents/public/mcphelper"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	pbtools "github.com/mattermost/mattermost-plugin-playbooks/internal/playbooksmcp/tools"
+)
+
+const (
+	evalMaxIterations   = 15
+	evalMaxTokens       = 4096
+	evalLLMMaxRetries   = 3
+	evalToolResultLimit = 8000
+
+	anthropicMessagesURL = "https://api.anthropic.com/v1/messages"
+	anthropicVersion     = "2023-06-01"
+	openAIChatURL        = "https://api.openai.com/v1/chat/completions"
+)
+
+// evalSystemPrompt mirrors the context the Mattermost Agents plugin puts in
+// front of an LLM: who is asking, and where they are asking from.
+func evalSystemPrompt(username, userID, teamName, teamID, channelName, channelID string) string {
+	return fmt.Sprintf(
+		"You are an AI assistant inside Mattermost. You are chatting with @%s (user ID %s). "+
+			"Current team: %s (ID %s). Current channel: %s (ID %s). "+
+			"Use the available tools to fulfill the user's request. Take actions directly when the "+
+			"request is clear; if the request is truly ambiguous, say so. When finished, reply with a "+
+			"concise summary of what you did.",
+		username, userID, teamName, teamID, channelName, channelID)
+}
+
+// --- APIClient over real HTTP -------------------------------------------------
+
+// evalAPIClient implements internal/playbooksmcp/tools.APIClient by talking to
+// the plugin's REST API over real HTTP as a specific user. Its error strings
+// mirror pluginMCPClient.do in server/mcp.go so the model sees the same text it
+// would in production.
+type evalAPIClient struct {
+	baseURL string
+	token   string
+	userID  string
+	siteURL string
+	client  *http.Client
+}
+
+func newEvalAPIClient(serverURL, token, userID string) *evalAPIClient {
+	base := strings.TrimRight(serverURL, "/")
+	return &evalAPIClient{
+		baseURL: base + "/plugins/" + manifest.Id + "/api/v0/",
+		token:   token,
+		userID:  userID,
+		siteURL: base,
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (c *evalAPIClient) Get(ctx context.Context, endpoint string, params url.Values, result any) error {
+	if len(params) > 0 {
+		endpoint += "?" + params.Encode()
+	}
+	return c.do(ctx, http.MethodGet, endpoint, nil, result)
+}
+
+func (c *evalAPIClient) Post(ctx context.Context, endpoint string, body any, result any) error {
+	return c.do(ctx, http.MethodPost, endpoint, body, result)
+}
+
+func (c *evalAPIClient) Put(ctx context.Context, endpoint string, body any, result any) error {
+	return c.do(ctx, http.MethodPut, endpoint, body, result)
+}
+
+func (c *evalAPIClient) Patch(ctx context.Context, endpoint string, body any, result any) error {
+	return c.do(ctx, http.MethodPatch, endpoint, body, result)
+}
+
+func (c *evalAPIClient) Delete(ctx context.Context, endpoint string) error {
+	return c.do(ctx, http.MethodDelete, endpoint, nil, nil)
+}
+
+func (c *evalAPIClient) GetCurrentUserID(context.Context) (string, error) {
+	if c.userID == "" {
+		return "", fmt.Errorf("missing Mattermost user ID")
+	}
+	return c.userID, nil
+}
+
+func (c *evalAPIClient) GetPlaybookURL(playbookID string) string {
+	return c.siteURL + "/playbooks/playbooks/" + playbookID
+}
+
+// GetRunURL and Patch are implemented unconditionally so this harness compiles
+// against both the baseline tools.APIClient and the widened one.
+func (c *evalAPIClient) GetRunURL(runID string) string {
+	return c.siteURL + "/playbooks/runs/" + runID
+}
+
+func (c *evalAPIClient) do(ctx context.Context, method, endpoint string, body any, result any) error {
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		r = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+strings.TrimLeft(endpoint, "/"), r)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, rerr := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		if rerr != nil {
+			return fmt.Errorf("API error (status %d); failed to read response body: %w", resp.StatusCode, rerr)
+		}
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(data))
+	}
+
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+		return nil
+	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return fmt.Errorf("failed to drain response body: %w", err)
+	}
+	return nil
+}
+
+// --- MCP session --------------------------------------------------------------
+
+type evalTool struct {
+	Name        string
+	Description string
+	Schema      map[string]any
+}
+
+// evalMCPHarness is an in-process MCP server for the Playbooks tools, fronted by
+// an httptest server that injects the two headers mcphelper authenticates on.
+type evalMCPHarness struct {
+	httpServer *httptest.Server
+	session    *mcp.ClientSession
+	Tools      []evalTool
+}
+
+func newEvalMCPHarness(ctx context.Context, actingUserID string, factory pbtools.ClientFactory) (*evalMCPHarness, error) {
+	provider, err := pbtools.NewPlaybooksToolProvider(factory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tool provider: %w", err)
+	}
+
+	helperServer := mcphelper.NewServer(nil, mcphelper.PluginMCPServer{
+		PluginID: manifest.Id,
+		Name:     "Playbooks MCP",
+		Path:     playbooksMCPEndpoint,
+		Version:  manifest.Version,
+	})
+	provider.ProvideMCPHelperTools(helperServer)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Set("Mattermost-Plugin-ID", bridgeclient.AiPluginID)
+		r.Header.Set("X-Mattermost-UserID", actingUserID)
+		helperServer.ServeHTTP(w, r)
+	}))
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "playbooks-agent-eval", Version: "0.0.1"}, nil)
+	session, err := mcpClient.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	if err != nil {
+		ts.Close()
+		return nil, fmt.Errorf("failed to connect MCP client: %w", err)
+	}
+
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		_ = session.Close()
+		ts.Close()
+		return nil, fmt.Errorf("ListTools failed: %w", err)
+	}
+
+	harness := &evalMCPHarness{httpServer: ts, session: session}
+	for _, tool := range listed.Tools {
+		schema, serr := normalizeToolSchema(tool.InputSchema)
+		if serr != nil {
+			_ = session.Close()
+			ts.Close()
+			return nil, fmt.Errorf("failed to normalize schema for %s: %w", tool.Name, serr)
+		}
+		harness.Tools = append(harness.Tools, evalTool{
+			Name:        tool.Name,
+			Description: tool.Description,
+			Schema:      schema,
+		})
+	}
+	sort.Slice(harness.Tools, func(i, j int) bool { return harness.Tools[i].Name < harness.Tools[j].Name })
+	return harness, nil
+}
+
+func (h *evalMCPHarness) Close() {
+	if h == nil {
+		return
+	}
+	if h.session != nil {
+		_ = h.session.Close()
+	}
+	if h.httpServer != nil {
+		h.httpServer.Close()
+	}
+}
+
+// CallTool executes an MCP tool and returns its text output plus whether the
+// tool reported an error. Tool errors are returned to the model as text, which
+// is how a real agent sees them.
+func (h *evalMCPHarness) CallTool(ctx context.Context, name string, rawArgs json.RawMessage) (string, bool) {
+	args := map[string]any{}
+	trimmed := strings.TrimSpace(string(rawArgs))
+	if trimmed != "" && trimmed != "null" {
+		if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
+			return fmt.Sprintf("invalid tool arguments: %v", err), true
+		}
+	}
+
+	result, err := h.session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		return fmt.Sprintf("tool call failed: %v", err), true
+	}
+
+	var sb strings.Builder
+	for _, content := range result.Content {
+		if text, ok := content.(*mcp.TextContent); ok {
+			sb.WriteString(text.Text)
+		}
+	}
+	out := sb.String()
+	if out == "" {
+		out = "(no output)"
+	}
+	return truncateForModel(out, evalToolResultLimit), result.IsError
+}
+
+// normalizeToolSchema round-trips the schema through JSON so it is a plain map,
+// and drops $schema which some provider APIs reject.
+func normalizeToolSchema(schema any) (map[string]any, error) {
+	if schema == nil {
+		return map[string]any{"type": "object", "properties": map[string]any{}}, nil
+	}
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	delete(out, "$schema")
+	if _, ok := out["type"]; !ok {
+		out["type"] = "object"
+	}
+	if _, ok := out["properties"]; !ok {
+		out["properties"] = map[string]any{}
+	}
+	return out, nil
+}
+
+func truncateForModel(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + fmt.Sprintf("\n… (truncated, %d more characters)", len(s)-limit)
+}
+
+// --- Transcript ---------------------------------------------------------------
+
+type evalToolCall struct {
+	Iteration int
+	Name      string
+	Args      string
+	Result    string
+	IsError   bool
+}
+
+type evalTranscriptStep struct {
+	Iteration int
+	Kind      string // "assistant_text", "tool_use", "tool_result", "error"
+	Name      string
+	Text      string
+}
+
+type evalTranscript struct {
+	Scenario  string
+	Provider  string
+	Model     string
+	System    string
+	Prompt    string
+	Steps     []evalTranscriptStep
+	ToolCalls []evalToolCall
+	FinalText string
+	RunErr    error
+	Duration  time.Duration
+}
+
+func (tr *evalTranscript) addStep(iteration int, kind, name, text string) {
+	tr.Steps = append(tr.Steps, evalTranscriptStep{Iteration: iteration, Kind: kind, Name: name, Text: text})
+}
+
+func (tr *evalTranscript) addToolCall(iteration int, name, args, result string, isError bool) {
+	tr.ToolCalls = append(tr.ToolCalls, evalToolCall{Iteration: iteration, Name: name, Args: args, Result: result, IsError: isError})
+	tr.addStep(iteration, "tool_use", name, args)
+	kind := "tool_result"
+	if isError {
+		kind = "tool_error"
+	}
+	tr.addStep(iteration, kind, name, result)
+}
+
+// ToolNames returns the distinct tools called, in first-call order.
+func (tr *evalTranscript) ToolNames() []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, call := range tr.ToolCalls {
+		if seen[call.Name] {
+			continue
+		}
+		seen[call.Name] = true
+		names = append(names, call.Name)
+	}
+	return names
+}
+
+func (tr *evalTranscript) Called(name string) bool {
+	for _, call := range tr.ToolCalls {
+		if call.Name == name || call.Name == "playbooks__"+name {
+			return true
+		}
+	}
+	return false
+}
+
+// ToolErrors returns the text of every tool call the MCP server rejected.
+func (tr *evalTranscript) ToolErrors() []evalToolCall {
+	var errs []evalToolCall
+	for _, call := range tr.ToolCalls {
+		if call.IsError {
+			errs = append(errs, call)
+		}
+	}
+	return errs
+}
+
+// evalLimitationPatterns match an assistant saying the capability is missing.
+// They deliberately require a capability noun near the negation so that ordinary
+// hedging ("I could not find the run yet") does not count as a refusal.
+var evalLimitationPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(cannot|can't|can not|couldn't|could not|unable to|not able to)\b`),
+	regexp.MustCompile(`(?i)\b(don't|do not|doesn't|does not|didn't|did not)\b[^.\n]{0,70}\b(tool|api|endpoint|support|expose|function|capabilit|permission|way|option|method|action)`),
+	regexp.MustCompile(`(?i)\b(there (is|'s) no|there are no|isn't (a|an|any)|is not (a|an|any)|no (direct )?(tool|way|api|endpoint|method|option|function))\b`),
+	regexp.MustCompile(`(?i)\bnot (currently )?(supported|possible|available|exposed|implemented|offered)\b`),
+	regexp.MustCompile(`(?i)\b(you'll|you will|you) (need to|have to|can) .{0,40}\b(ui|web app|interface|manually)\b`),
+	regexp.MustCompile(`(?i)\b(available tools?|tools? (available|here|i have)|tools? i have access to)\b[^.\n]{0,80}\b(only|not|cannot|can't)\b`),
+}
+
+// DisclosedLimitation reports whether the assistant told the user it could not
+// do (all of) what was asked. Used to separate an honest refusal from a silent
+// failure or a hallucinated success.
+func (tr *evalTranscript) DisclosedLimitation() bool {
+	text := tr.FinalText
+	for _, step := range tr.Steps {
+		if step.Kind == "assistant_text" {
+			text += "\n" + step.Text
+		}
+	}
+	text = normalizeApostrophes(text)
+	for _, pattern := range evalLimitationPatterns {
+		if pattern.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeApostrophes folds the typographic apostrophes models like to emit
+// ("don’t") onto ASCII so the refusal patterns match either spelling.
+func normalizeApostrophes(s string) string {
+	return strings.NewReplacer("\u2019", "'", "\u2018", "'", "\u02bc", "'").Replace(s)
+}
+
+// --- LLM agent loop -----------------------------------------------------------
+
+type evalToolExecutor func(ctx context.Context, name string, args json.RawMessage) (string, bool)
+
+var evalLLMHTTPClient = &http.Client{Timeout: 10 * time.Minute}
+
+func postJSONWithRetry(ctx context.Context, endpoint string, headers map[string]string, payload any) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= evalLLMMaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(1<<uint(attempt-1)) * 2 * time.Second
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, rerr := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if rerr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", rerr)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+
+		resp, derr := evalLLMHTTPClient.Do(req)
+		if derr != nil {
+			lastErr = derr
+			continue
+		}
+		data, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+			continue
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("LLM API error (status %d): %s", resp.StatusCode, truncateForModel(string(data), 500))
+			continue
+		case resp.StatusCode >= 400:
+			return nil, fmt.Errorf("LLM API error (status %d): %s", resp.StatusCode, truncateForModel(string(data), 2000))
+		}
+		return data, nil
+	}
+	return nil, fmt.Errorf("LLM request failed after %d attempts: %w", evalLLMMaxRetries+1, lastErr)
+}
+
+type evalAgent interface {
+	Provider() string
+	Model() string
+	Run(ctx context.Context, system, prompt string, tools []evalTool, exec evalToolExecutor, tr *evalTranscript) error
+}
+
+// --- Anthropic ----------------------------------------------------------------
+
+type anthropicAgent struct {
+	apiKey string
+	model  string
+}
+
+func (a *anthropicAgent) Provider() string { return "anthropic" }
+func (a *anthropicAgent) Model() string    { return a.model }
+
+type anthropicBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+type anthropicResponse struct {
+	Content    []json.RawMessage `json:"content"`
+	StopReason string            `json:"stop_reason"`
+}
+
+func (a *anthropicAgent) Run(ctx context.Context, system, prompt string, tools []evalTool, exec evalToolExecutor, tr *evalTranscript) error {
+	apiTools := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		apiTools = append(apiTools, map[string]any{
+			"name":         tool.Name,
+			"description":  tool.Description,
+			"input_schema": tool.Schema,
+		})
+	}
+
+	headers := map[string]string{
+		"x-api-key":         a.apiKey,
+		"anthropic-version": anthropicVersion,
+	}
+
+	messages := []any{map[string]any{"role": "user", "content": prompt}}
+
+	for iteration := 1; iteration <= evalMaxIterations; iteration++ {
+		payload := map[string]any{
+			"model":      a.model,
+			"max_tokens": evalMaxTokens,
+			"system":     system,
+			"tools":      apiTools,
+			"messages":   messages,
+		}
+
+		data, err := postJSONWithRetry(ctx, anthropicMessagesURL, headers, payload)
+		if err != nil {
+			return err
+		}
+
+		var resp anthropicResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return fmt.Errorf("failed to decode Anthropic response: %w", err)
+		}
+
+		// Rebuild the assistant turn from the blocks we understand rather than
+		// echoing the response verbatim, so provider-added fields can't make the
+		// next request invalid.
+		var assistantBlocks []any
+		var toolResults []any
+		lastText := ""
+
+		for _, raw := range resp.Content {
+			var block anthropicBlock
+			if err := json.Unmarshal(raw, &block); err != nil {
+				continue
+			}
+			switch block.Type {
+			case "text":
+				if strings.TrimSpace(block.Text) == "" {
+					continue
+				}
+				lastText = block.Text
+				tr.addStep(iteration, "assistant_text", "", block.Text)
+				assistantBlocks = append(assistantBlocks, map[string]any{"type": "text", "text": block.Text})
+			case "tool_use":
+				input := block.Input
+				if len(input) == 0 {
+					input = json.RawMessage("{}")
+				}
+				assistantBlocks = append(assistantBlocks, map[string]any{
+					"type":  "tool_use",
+					"id":    block.ID,
+					"name":  block.Name,
+					"input": input,
+				})
+				result, isError := exec(ctx, block.Name, input)
+				tr.addToolCall(iteration, block.Name, string(input), result, isError)
+				toolResults = append(toolResults, map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": block.ID,
+					"content":     result,
+					"is_error":    isError,
+				})
+			}
+		}
+
+		if len(toolResults) == 0 {
+			tr.FinalText = lastText
+			return nil
+		}
+		if len(assistantBlocks) == 0 {
+			return fmt.Errorf("anthropic returned tool results with no usable assistant blocks")
+		}
+
+		messages = append(messages,
+			map[string]any{"role": "assistant", "content": assistantBlocks},
+			map[string]any{"role": "user", "content": toolResults})
+
+		if lastText != "" {
+			tr.FinalText = lastText
+		}
+	}
+
+	return fmt.Errorf("agent did not finish within %d iterations", evalMaxIterations)
+}
+
+// --- OpenAI -------------------------------------------------------------------
+
+type openAIAgent struct {
+	apiKey string
+	model  string
+}
+
+func (o *openAIAgent) Provider() string { return "openai" }
+func (o *openAIAgent) Model() string    { return o.model }
+
+type openAIToolCall struct {
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type openAIResponse struct {
+	Choices []struct {
+		Message struct {
+			Content   *string          `json:"content"`
+			ToolCalls []openAIToolCall `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+func (o *openAIAgent) Run(ctx context.Context, system, prompt string, tools []evalTool, exec evalToolExecutor, tr *evalTranscript) error {
+	apiTools := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		apiTools = append(apiTools, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        tool.Name,
+				"description": tool.Description,
+				"parameters":  tool.Schema,
+			},
+		})
+	}
+
+	headers := map[string]string{"Authorization": "Bearer " + o.apiKey}
+
+	messages := []json.RawMessage{}
+	appendMessage := func(v any) error {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		messages = append(messages, raw)
+		return nil
+	}
+	if err := appendMessage(map[string]any{"role": "system", "content": system}); err != nil {
+		return err
+	}
+	if err := appendMessage(map[string]any{"role": "user", "content": prompt}); err != nil {
+		return err
+	}
+
+	for iteration := 1; iteration <= evalMaxIterations; iteration++ {
+		payload := map[string]any{
+			"model":                 o.model,
+			"max_completion_tokens": evalMaxTokens,
+			"tools":                 apiTools,
+			"messages":              messages,
+		}
+
+		data, err := postJSONWithRetry(ctx, openAIChatURL, headers, payload)
+		if err != nil {
+			return err
+		}
+
+		// Keep the assistant message exactly as returned; the Chat Completions
+		// API round-trips provider-specific fields on later turns.
+		var rawResp struct {
+			Choices []struct {
+				Message json.RawMessage `json:"message"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal(data, &rawResp); err != nil {
+			return fmt.Errorf("failed to decode OpenAI response: %w", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return fmt.Errorf("failed to decode OpenAI response: %w", err)
+		}
+		if len(resp.Choices) == 0 || len(rawResp.Choices) == 0 {
+			return fmt.Errorf("openai returned no choices: %s", truncateForModel(string(data), 500))
+		}
+
+		message := resp.Choices[0].Message
+		if message.Content != nil && strings.TrimSpace(*message.Content) != "" {
+			tr.addStep(iteration, "assistant_text", "", *message.Content)
+			tr.FinalText = *message.Content
+		}
+
+		if len(message.ToolCalls) == 0 {
+			if message.Content != nil {
+				tr.FinalText = *message.Content
+			}
+			return nil
+		}
+
+		messages = append(messages, rawResp.Choices[0].Message)
+
+		for _, call := range message.ToolCalls {
+			args := json.RawMessage(call.Function.Arguments)
+			if strings.TrimSpace(call.Function.Arguments) == "" {
+				args = json.RawMessage("{}")
+			}
+			result, isError := exec(ctx, call.Function.Name, args)
+			tr.addToolCall(iteration, call.Function.Name, string(args), result, isError)
+			if err := appendMessage(map[string]any{
+				"role":         "tool",
+				"tool_call_id": call.ID,
+				"content":      result,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return fmt.Errorf("agent did not finish within %d iterations", evalMaxIterations)
+}
+
+// --- Transcript output --------------------------------------------------------
+
+type evalResult struct {
+	Scenario  string
+	Outcome   string
+	ToolNames []string
+	Notes     []string
+	Duration  time.Duration
+}
+
+func writeEvalTranscript(dir string, tr *evalTranscript, res *evalResult) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s — %s\n\n", tr.Scenario, tr.Provider)
+	fmt.Fprintf(&sb, "- Model: `%s`\n", tr.Model)
+	fmt.Fprintf(&sb, "- Outcome: **%s**\n", res.Outcome)
+	fmt.Fprintf(&sb, "- Duration: %s\n", tr.Duration.Round(time.Millisecond))
+	fmt.Fprintf(&sb, "- Tools called: %s\n", formatToolList(res.ToolNames))
+	if len(res.Notes) > 0 {
+		sb.WriteString("- Notes:\n")
+		for _, note := range res.Notes {
+			fmt.Fprintf(&sb, "  - %s\n", note)
+		}
+	}
+	if tr.RunErr != nil {
+		fmt.Fprintf(&sb, "- Agent loop error: `%s`\n", tr.RunErr)
+	}
+
+	sb.WriteString("\n## System prompt\n\n```\n" + tr.System + "\n```\n")
+	sb.WriteString("\n## User prompt\n\n```\n" + tr.Prompt + "\n```\n")
+
+	sb.WriteString("\n## Conversation\n")
+	for _, step := range tr.Steps {
+		switch step.Kind {
+		case "assistant_text":
+			fmt.Fprintf(&sb, "\n### [%d] assistant\n\n%s\n", step.Iteration, step.Text)
+		case "tool_use":
+			fmt.Fprintf(&sb, "\n### [%d] tool call → `%s`\n\n```json\n%s\n```\n", step.Iteration, step.Name, prettyJSON(step.Text))
+		case "tool_result":
+			fmt.Fprintf(&sb, "\n### [%d] tool result ← `%s`\n\n```\n%s\n```\n", step.Iteration, step.Name, step.Text)
+		case "tool_error":
+			fmt.Fprintf(&sb, "\n### [%d] tool ERROR ← `%s`\n\n```\n%s\n```\n", step.Iteration, step.Name, step.Text)
+		default:
+			fmt.Fprintf(&sb, "\n### [%d] %s\n\n%s\n", step.Iteration, step.Kind, step.Text)
+		}
+	}
+
+	sb.WriteString("\n## Final answer\n\n")
+	if tr.FinalText == "" {
+		sb.WriteString("_(none)_\n")
+	} else {
+		sb.WriteString(tr.FinalText + "\n")
+	}
+
+	return os.WriteFile(filepath.Join(dir, tr.Scenario+".md"), []byte(sb.String()), 0o644)
+}
+
+func writeEvalSummary(path, provider, model string, results []*evalResult) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	counts := map[string]int{}
+	for _, res := range results {
+		counts[res.Outcome]++
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Playbooks MCP agent eval — %s\n\n", provider)
+	fmt.Fprintf(&sb, "Model: `%s`\n\n", model)
+	fmt.Fprintf(&sb, "PASS %d · PARTIAL %d · FAIL %d · ERROR %d (of %d)\n\n",
+		counts["PASS"], counts["PARTIAL"], counts["FAIL"], counts["ERROR"], len(results))
+	sb.WriteString("| scenario | outcome | tools called | notes |\n|---|---|---|---|\n")
+	for _, res := range results {
+		notes := strings.Join(res.Notes, "; ")
+		notes = strings.ReplaceAll(notes, "|", "\\|")
+		notes = strings.ReplaceAll(notes, "\n", " ")
+		fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n",
+			res.Scenario, res.Outcome, formatToolList(res.ToolNames), notes)
+	}
+	return os.WriteFile(path, []byte(sb.String()), 0o644)
+}
+
+func formatToolList(names []string) string {
+	if len(names) == 0 {
+		return "_(none)_"
+	}
+	trimmed := make([]string, 0, len(names))
+	for _, name := range names {
+		trimmed = append(trimmed, "`"+strings.TrimPrefix(name, "playbooks__")+"`")
+	}
+	return strings.Join(trimmed, ", ")
+}
+
+func prettyJSON(raw string) string {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, []byte(raw), "", "  "); err != nil {
+		return raw
+	}
+	return buf.String()
+}

--- a/server/mcp_agent_eval_helpers_test.go
+++ b/server/mcp_agent_eval_helpers_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/public/bridgeclient"
 	"github.com/mattermost/mattermost-plugin-agents/public/mcphelper"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	pbtools "github.com/mattermost/mattermost-plugin-playbooks/internal/playbooksmcp/tools"
@@ -112,6 +113,30 @@ func (c *evalAPIClient) GetPlaybookURL(playbookID string) string {
 // against both the baseline tools.APIClient and the widened one.
 func (c *evalAPIClient) GetRunURL(runID string) string {
 	return c.siteURL + "/playbooks/runs/" + runID
+}
+
+// ResolveUserID mirrors pluginMCPClient.ResolveUserID in server/mcp.go, so an
+// eval sees the same handling of "me", raw IDs, and usernames that production
+// gives. The username lookup goes to the core API as the acting user.
+func (c *evalAPIClient) ResolveUserID(ctx context.Context, userRef string) (string, error) {
+	ref := strings.TrimSpace(userRef)
+	if ref == "" {
+		return "", fmt.Errorf(`a user reference is required: pass a user ID, "me", or a username such as "@bob"`)
+	}
+	if ref == "me" {
+		return c.GetCurrentUserID(ctx)
+	}
+	if model.IsValidId(ref) {
+		return ref, nil
+	}
+	username := strings.ToLower(strings.TrimPrefix(ref, "@"))
+	c4 := model.NewAPIv4Client(c.siteURL)
+	c4.SetToken(c.token)
+	user, _, err := c4.GetUserByUsername(ctx, username, "")
+	if err != nil {
+		return "", fmt.Errorf("no user found with username %q — check the spelling (usernames are case-insensitive, without the @). Underlying error: %w", username, err)
+	}
+	return user.Id, nil
 }
 
 func (c *evalAPIClient) do(ctx context.Context, method, endpoint string, body any, result any) error {
@@ -367,6 +392,19 @@ func (tr *evalTranscript) Called(name string) bool {
 	return false
 }
 
+// CallArgs returns the raw JSON arguments of every call to a tool, so a
+// scenario can assert on what the model actually passed (bare tool name or
+// playbooks__-prefixed both match).
+func (tr *evalTranscript) CallArgs(name string) []string {
+	var args []string
+	for _, call := range tr.ToolCalls {
+		if call.Name == name || call.Name == "playbooks__"+name {
+			args = append(args, call.Args)
+		}
+	}
+	return args
+}
+
 // ToolErrors returns the text of every tool call the MCP server rejected.
 func (tr *evalTranscript) ToolErrors() []evalToolCall {
 	var errs []evalToolCall
@@ -388,6 +426,10 @@ var evalLimitationPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\bnot (currently )?(supported|possible|available|exposed|implemented|offered)\b`),
 	regexp.MustCompile(`(?i)\b(you'll|you will|you) (need to|have to|can) .{0,40}\b(ui|web app|interface|manually)\b`),
 	regexp.MustCompile(`(?i)\b(available tools?|tools? (available|here|i have)|tools? i have access to)\b[^.\n]{0,80}\b(only|not|cannot|can't)\b`),
+	// Handing the request back to the user for missing input is also an honest
+	// non-completion: the user knows the task did not happen.
+	regexp.MustCompile(`(?i)\b(could|can|would) you\b[^.\n]{0,40}\b(provide|give|share|tell me|confirm|send)\b`),
+	regexp.MustCompile(`(?i)\bi('ll)? (need|require|would need)\b[^.\n]{0,60}\b(id|identifier|name|value|permission)\b`),
 }
 
 // DisclosedLimitation reports whether the assistant told the user it could not

--- a/server/mcp_agent_eval_test.go
+++ b/server/mcp_agent_eval_test.go
@@ -133,9 +133,10 @@ func runEvalScenario(t *testing.T, agent evalAgent, e *TestEnvironment, scenario
 
 	sc.BeforeRun = snapshotRun(e, sc.RunID)
 	sc.BeforePlaybook = snapshotPlaybook(e, sc.PlaybookID)
+	sc.RunIDsAtSeed = evalRunIDSet(e)
 
 	harness, err := newEvalMCPHarness(ctx, e.RegularUser.Id, func(context.Context) (pbtools.APIClient, error) {
-		return newEvalAPIClient(e.ServerClient.URL, e.ServerClient.AuthToken, e.RegularUser.Id), nil
+		return evalRESTClient(e), nil
 	})
 	require.NoError(t, err, "failed to build MCP harness")
 	defer harness.Close()
@@ -176,6 +177,9 @@ type evalScenarioContext struct {
 	Values         map[string]string
 	BeforeRun      *client.PlaybookRun
 	BeforePlaybook *client.Playbook
+	// RunIDsAtSeed lets a scenario tell the run the agent just created apart
+	// from an identically-named run an earlier scenario left behind.
+	RunIDsAtSeed map[string]bool
 }
 
 type evalScenario struct {
@@ -278,6 +282,18 @@ func (s *evalSeeder) StatusUpdate(runID, message string) {
 	require.NoError(s.t, s.e.PlaybooksClient.PlaybookRuns.UpdateStatus(context.Background(), runID, message, 3600))
 }
 
+func (s *evalSeeder) Finish(runID string) {
+	s.t.Helper()
+	require.NoError(s.t, s.e.PlaybooksClient.PlaybookRuns.Finish(context.Background(), runID))
+}
+
+// Unfollow drops the auto-follow that comes with being a run participant, so a
+// follow scenario starts from a state where following is actually a change.
+func (s *evalSeeder) Unfollow(runID string) {
+	s.t.Helper()
+	require.NoError(s.t, evalRESTClient(s.e).Delete(context.Background(), "runs/"+runID+"/followers"))
+}
+
 func evalChecklist(title string, items ...string) client.Checklist {
 	checklist := client.Checklist{Title: title}
 	for _, item := range items {
@@ -308,6 +324,39 @@ func snapshotPlaybook(e *TestEnvironment, playbookID string) *client.Playbook {
 		return nil
 	}
 	return playbook
+}
+
+// evalRESTClient is the acting user's HTTP client for the plugin REST API. The
+// harness hands the same client to the MCP tools, and verification uses it for
+// endpoints the Go client does not wrap (followers).
+func evalRESTClient(e *TestEnvironment) *evalAPIClient {
+	return newEvalAPIClient(e.ServerClient.URL, e.ServerClient.AuthToken, e.RegularUser.Id)
+}
+
+func evalRunFollowers(e *TestEnvironment, runID string) []string {
+	var followers []string
+	if err := evalRESTClient(e).Get(context.Background(), "runs/"+runID+"/followers", nil, &followers); err != nil {
+		return nil
+	}
+	return followers
+}
+
+func evalRunIDSet(e *TestEnvironment) map[string]bool {
+	set := map[string]bool{}
+	for _, run := range listTeamRuns(e) {
+		set[run.ID] = true
+	}
+	return set
+}
+
+func runsCreatedDuringScenario(e *TestEnvironment, sc *evalScenarioContext) []client.PlaybookRun {
+	var created []client.PlaybookRun
+	for _, run := range listTeamRuns(e) {
+		if !sc.RunIDsAtSeed[run.ID] {
+			created = append(created, run)
+		}
+	}
+	return created
 }
 
 func listTeamRuns(e *TestEnvironment) []client.PlaybookRun {
@@ -347,6 +396,31 @@ func findTeamPlaybook(e *TestEnvironment, title string) *client.Playbook {
 		}
 	}
 	return nil
+}
+
+func evalFindPlaybooksContaining(e *TestEnvironment, substr string) []client.Playbook {
+	results, err := e.PlaybooksAdminClient.Playbooks.List(context.Background(), e.BasicTeam.Id, 0, 200, client.PlaybookListOptions{
+		WithArchived: true,
+	})
+	if err != nil {
+		return nil
+	}
+	var matches []client.Playbook
+	for i := range results.Items {
+		if containsFold(results.Items[i].Title, substr) {
+			matches = append(matches, results.Items[i])
+		}
+	}
+	return matches
+}
+
+func evalContainsID(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func findChecklistItem(checklists []client.Checklist, title string) (int, int, client.ChecklistItem, bool) {
@@ -460,6 +534,498 @@ func evalScenarios() []evalScenario {
 		scenarioArchivePlaybook(),
 		scenarioTemplateVsRunDisambiguation(),
 		scenarioSkipTask(),
+
+		// Scenarios below cover capabilities added after the baseline. The 12
+		// above are unchanged so the before/after comparison stays honest.
+		scenarioAddParticipantNatural(),
+		scenarioAddParticipantWithID(),
+		scenarioFollowRunNatural(),
+		scenarioReopenRun(),
+		scenarioDuplicatePlaybookNatural(),
+		scenarioUpdatePlaybookDescription(),
+		scenarioSkipSectionNatural(),
+		scenarioSectionThenItem(),
+		scenarioMistypedReferenceResilience(),
+		scenarioRunPlaybookFull(),
+		scenarioStatusHistoryNowWorks(),
+		scenarioRunPlaybookLinkedChannel(),
+	}
+}
+
+func scenarioAddParticipantNatural() evalScenario {
+	return evalScenario{
+		name: "add_participant_natural",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Cache eviction storm")
+			sc.PlaybookID = s.Playbook("Cache Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Flush the hot keys", "Confirm hit rate recovered"))
+			sc.RunID = s.Run("Cache eviction storm", sc.PlaybookID, sc.Channel.Id).ID
+			sc.Values["username"] = s.e.RegularUser2.Username
+			sc.Values["userID"] = s.e.RegularUser2.Id
+		},
+		prompt: func(sc *evalScenarioContext) string {
+			return fmt.Sprintf("Add @%s to this run.", sc.Values["username"])
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			added := evalContainsID(run.ParticipantIDs, sc.Values["userID"])
+			for _, args := range tr.CallArgs("add_run_participants") {
+				if containsFold(args, sc.Values["username"]) {
+					notes = append(notes, "passed the @username where a 26-char user ID was expected — no user-lookup tool exists in this MCP server")
+					break
+				}
+			}
+			if !added && len(tr.CallArgs("add_run_participants")) == 0 {
+				notes = append(notes, "never called add_run_participants")
+			}
+			return verdict(added, tr, notes...)
+		},
+	}
+}
+
+func scenarioAddParticipantWithID() evalScenario {
+	return evalScenario{
+		name: "add_participant_with_id",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Queue backlog growth")
+			sc.PlaybookID = s.Playbook("Queue Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Scale the consumers", "Confirm backlog draining"))
+			sc.RunID = s.Run("Queue backlog growth", sc.PlaybookID, sc.Channel.Id).ID
+			sc.Values["username"] = s.e.RegularUser2.Username
+			sc.Values["userID"] = s.e.RegularUser2.Id
+		},
+		prompt: func(sc *evalScenarioContext) string {
+			return fmt.Sprintf("Add %s (user ID %s) to this run.", sc.Values["username"], sc.Values["userID"])
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+			return verdict(evalContainsID(run.ParticipantIDs, sc.Values["userID"]), tr)
+		},
+	}
+}
+
+func scenarioFollowRunNatural() evalScenario {
+	return evalScenario{
+		name: "follow_run_natural",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("CDN purge rollout")
+			sc.PlaybookID = s.Playbook("CDN Rollout Template", sc.Channel.Id,
+				evalChecklist("Rollout", "Purge the edge cache", "Verify asset versions"))
+			sc.RunID = s.Run("CDN purge rollout", sc.PlaybookID, sc.Channel.Id).ID
+			s.Unfollow(sc.RunID)
+			sc.Values["actingUserID"] = s.e.RegularUser.Id
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Keep me posted on this run — follow it for me."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			followers := evalRunFollowers(e, sc.RunID)
+			following := evalContainsID(followers, sc.Values["actingUserID"])
+			if !following {
+				notes = append(notes, fmt.Sprintf("followers after run: %v", followers))
+			}
+			return verdict(following, tr, notes...)
+		},
+	}
+}
+
+func scenarioReopenRun() evalScenario {
+	return evalScenario{
+		name: "reopen_run",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("TLS certificate expiry")
+			sc.PlaybookID = s.Playbook("Certificate Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Reissue the certificate", "Verify the chain"))
+			sc.RunID = s.Run("TLS certificate expiry", sc.PlaybookID, sc.Channel.Id).ID
+			s.Finish(sc.RunID)
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "We closed this incident too early — reopen it."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+			reopened := run.CurrentStatus == "InProgress" && run.EndAt == 0
+			if !reopened && tr.Called("create_checklist") {
+				notes = append(notes, "WRONG TOOL: created a new checklist instead of restoring the finished run")
+			}
+			return verdict(reopened, tr, notes...)
+		},
+	}
+}
+
+func scenarioDuplicatePlaybookNatural() evalScenario {
+	// Titles are unique across the suite on purpose: scenarios share one team,
+	// so a title that prefix-matches another scenario's playbook turns that
+	// scenario's list_playbooks lookup into a genuine ambiguity.
+	const playbookTitle = "Postmortem Review Gold"
+
+	return evalScenario{
+		name: "duplicate_playbook_natural",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Playbook authoring")
+			sc.PlaybookID = s.Playbook(playbookTitle, "",
+				evalChecklist("Detect", "Acknowledge the page", "Declare severity"),
+				evalChecklist("Resolve", "Apply the mitigation", "Confirm recovery"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Make a copy of the Postmortem Review Gold playbook I can experiment with."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			var copyID string
+			for _, playbook := range evalFindPlaybooksContaining(e, playbookTitle) {
+				if playbook.ID != sc.PlaybookID {
+					copyID = playbook.ID
+					notes = append(notes, fmt.Sprintf("copy titled %q", playbook.Title))
+					break
+				}
+			}
+			if copyID == "" && tr.Called("create_playbook") {
+				notes = append(notes, "rebuilt a playbook with create_playbook instead of duplicating")
+			}
+			if original := snapshotPlaybook(e, sc.PlaybookID); original != nil && original.DeleteAt != 0 {
+				notes = append(notes, "DESTRUCTIVE: archived the original while copying it")
+			}
+			return verdict(copyID != "", tr, notes...)
+		},
+	}
+}
+
+func scenarioUpdatePlaybookDescription() evalScenario {
+	const playbookTitle = "Checkout Service Runbook"
+	const wantDescription = "Owned by the SRE team"
+
+	return evalScenario{
+		name: "update_playbook_description",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Checkout service")
+			sc.PlaybookID = s.Playbook(playbookTitle, "",
+				evalChecklist("Response", "Check the payment provider status", "Roll back the last deploy"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Update the description of the Checkout Service Runbook playbook to 'Owned by the SRE team.'"
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			playbook := snapshotPlaybook(e, sc.PlaybookID)
+			if playbook == nil {
+				return outcomeError, []string{"could not read the seeded playbook"}
+			}
+			updated := containsFold(playbook.Description, wantDescription)
+			if !updated {
+				notes = append(notes, fmt.Sprintf("description is %q", playbook.Description))
+			}
+			if !titlesMatch(playbook.Title, playbookTitle) {
+				notes = append(notes, fmt.Sprintf("WRONG FIELD: title was changed to %q", playbook.Title))
+			}
+			return verdict(updated, tr, notes...)
+		},
+	}
+}
+
+func scenarioSkipSectionNatural() evalScenario {
+	const skipSection = "Legal review"
+	const keepSection = "Technical response"
+
+	return evalScenario{
+		name: "skip_section_natural",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Data exposure review")
+			sc.PlaybookID = s.Playbook("Data Exposure Template", sc.Channel.Id,
+				evalChecklist(keepSection, "Revoke the leaked token", "Audit access logs"),
+				evalChecklist(skipSection, "Draft the breach notice", "Brief outside counsel"))
+			sc.RunID = s.Run("Data exposure review", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Skip the whole Legal review section, it doesn't apply."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			_, target, found := findChecklist(run.Checklists, skipSection)
+			if !found {
+				notes = append(notes, "DESTRUCTIVE: the Legal review section no longer exists")
+				return outcomeFail, notes
+			}
+			allSkipped := len(target.Items) > 0
+			for _, item := range target.Items {
+				if item.State != "skipped" {
+					allSkipped = false
+					notes = append(notes, fmt.Sprintf("%q is %q, not skipped", item.Title, displayItemState(item.State)))
+				}
+			}
+			if _, other, ok := findChecklist(run.Checklists, keepSection); ok {
+				for _, item := range other.Items {
+					if item.State == "skipped" {
+						notes = append(notes, fmt.Sprintf("COLLATERAL: also skipped %q in the %s section", item.Title, keepSection))
+					}
+				}
+			}
+			return verdict(allSkipped, tr, notes...)
+		},
+	}
+}
+
+func scenarioSectionThenItem() evalScenario {
+	const sectionTitle = "Cleanup"
+	const taskTitle = "Rotate credentials"
+
+	return evalScenario{
+		name: "section_then_item",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Bastion host compromise")
+			sc.PlaybookID = s.Playbook("Bastion Incident Template", sc.Channel.Id,
+				evalChecklist("Containment", "Isolate the host", "Snapshot the disk"))
+			sc.RunID = s.Run("Bastion host compromise", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Add a section called 'Cleanup' to this run, then add a task 'Rotate credentials' to it."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			// The point of this scenario is whether the agent knows the new
+			// section's index without a failed guess, so count index errors.
+			indexErrors := 0
+			for _, call := range tr.ToolErrors() {
+				if containsFold(call.Result, "out of range") {
+					indexErrors++
+				}
+			}
+			if indexErrors > 0 {
+				notes = append(notes, fmt.Sprintf("%d out-of-range index error(s) before landing on the new section", indexErrors))
+			}
+
+			_, section, found := findChecklist(run.Checklists, sectionTitle)
+			if !found {
+				notes = append(notes, "no Cleanup section was created")
+				return verdict(false, tr, notes...)
+			}
+			_, _, _, inSection := findChecklistItem([]client.Checklist{section}, taskTitle)
+			if !inSection {
+				if _, _, _, anywhere := findChecklistItem(run.Checklists, taskTitle); anywhere {
+					notes = append(notes, "WRONG SECTION: the task landed outside Cleanup")
+				}
+				return outcomePartial, notes
+			}
+			return outcomePass, notes
+		},
+	}
+}
+
+func scenarioMistypedReferenceResilience() evalScenario {
+	const runName = "Payment outage — May"
+
+	return evalScenario{
+		name: "mistyped_reference_resilience",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			// The run deliberately lives somewhere other than the channel the
+			// agent is "in", so resolve_channel_context cannot find it and the
+			// agent has to search by name.
+			sc.Channel = s.Channel("Ops standup")
+			runChannel := s.Channel("Payments war room")
+			sc.PlaybookID = s.Playbook("Payment Outage Template", runChannel.Id,
+				evalChecklist("Response", "Confirm the failing processor", "Switch to the backup processor"))
+			sc.RunID = s.Run(runName, sc.PlaybookID, runChannel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Mark the first task in the payment outage run as done."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+			if len(run.Checklists) == 0 || len(run.Checklists[0].Items) == 0 {
+				return outcomeError, []string{"seeded run lost its checklist"}
+			}
+
+			first := run.Checklists[0].Items[0]
+			closed := first.State == "closed"
+			for ci, checklist := range run.Checklists {
+				for ii, item := range checklist.Items {
+					if (ci != 0 || ii != 0) && item.State == "closed" {
+						notes = append(notes, fmt.Sprintf("COLLATERAL: also closed %q", item.Title))
+					}
+				}
+			}
+			if !closed {
+				notes = append(notes, fmt.Sprintf("first task %q is %q", first.Title, displayItemState(first.State)))
+			}
+			if errs := tr.ToolErrors(); len(errs) > 0 {
+				notes = append(notes, fmt.Sprintf("recovered through %d tool error(s)", len(errs)))
+			}
+			return verdict(closed, tr, notes...)
+		},
+	}
+}
+
+func scenarioRunPlaybookFull() evalScenario {
+	const wantRun = "Checkout API 500s"
+
+	return evalScenario{
+		name: "run_playbook_full",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Incident bridge")
+			sc.PlaybookID = s.Playbook("Sev1 Escalation Runbook", "",
+				evalChecklist("Detection", "Acknowledge the alert", "Assess customer impact"),
+				evalChecklist("Mitigation", "Roll back the last deploy", "Confirm error rate recovered"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Start the Sev1 Escalation Runbook, call it 'Checkout API 500s'"
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			template := snapshotPlaybook(e, sc.PlaybookID)
+			if template == nil {
+				return outcomeError, []string{"could not read the seeded playbook"}
+			}
+
+			var created *client.PlaybookRun
+			candidates := runsCreatedDuringScenario(e, sc)
+			for i := range candidates {
+				if titlesMatch(candidates[i].Name, wantRun) {
+					created = &candidates[i]
+					break
+				}
+			}
+			if created == nil {
+				if len(candidates) > 0 {
+					notes = append(notes, fmt.Sprintf("created %d run(s) but none named %q", len(candidates), wantRun))
+				}
+				return verdict(false, tr, notes...)
+			}
+
+			full := snapshotRun(e, created.ID)
+			if full == nil {
+				return outcomeError, []string{"could not read the created run"}
+			}
+
+			fromTemplate := full.PlaybookID == sc.PlaybookID
+			isPlaybookRun := full.Type == "playbook"
+			tasksCopied := normalizeTitle(checklistTitles(full.Checklists)) == normalizeTitle(checklistTitles(template.Checklists))
+
+			if !fromTemplate {
+				notes = append(notes, fmt.Sprintf("run is not linked to the seeded template (playbook_id=%q, type=%q)", full.PlaybookID, full.Type))
+			}
+
+			if !isPlaybookRun {
+				notes = append(notes, fmt.Sprintf("run type is %q, not \"playbook\"", full.Type))
+			}
+			if !tasksCopied {
+				notes = append(notes, fmt.Sprintf("checklists differ from the template: run=%s template=%s",
+					checklistTitles(full.Checklists), checklistTitles(template.Checklists)))
+			}
+			if tr.Called("create_checklist") {
+				notes = append(notes, "REGRESSION: still reached for create_checklist")
+			}
+			return verdict(fromTemplate && isPlaybookRun && tasksCopied, tr, notes...)
+		},
+	}
+}
+
+func scenarioStatusHistoryNowWorks() evalScenario {
+	const marker = "YANKEE-42"
+	const latestUpdate = "Index rebuild finished, query latency back to baseline. Tracking marker " + marker + "."
+
+	return evalScenario{
+		name: "status_history_now_works",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Index rebuild stall")
+			sc.PlaybookID = s.Playbook("Index Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Pause the indexer", "Rebuild the shard"))
+			run := s.Run("Index rebuild stall", sc.PlaybookID, sc.Channel.Id)
+			sc.RunID = run.ID
+			s.StatusUpdate(run.ID, "Initial triage: the indexer is stuck on shard 7 and queries are timing out.")
+			s.StatusUpdate(run.ID, latestUpdate)
+			sc.Values["marker"] = marker
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "What did the last status update on this run say?"
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			answered := containsFold(tr.FinalText, sc.Values["marker"]) || containsFold(tr.FinalText, "index rebuild finished")
+
+			if !tr.Called("get_status_updates") {
+				notes = append(notes, "did not call get_status_updates")
+			}
+			updates, err := e.PlaybooksClient.PlaybookRuns.GetStatusUpdates(context.Background(), sc.RunID)
+			if err == nil && len(updates) > 2 {
+				notes = append(notes, fmt.Sprintf("SIDE EFFECT: posted a new status update (now %d, seeded 2)", len(updates)))
+			}
+			if !answered {
+				notes = append(notes, "final answer did not quote the latest update")
+			}
+			return verdict(answered, tr, notes...)
+		},
+	}
+}
+
+func scenarioRunPlaybookLinkedChannel() evalScenario {
+	const playbookTitle = "Bridge Ops Playbook"
+
+	return evalScenario{
+		name: "run_playbook_linked_channel",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Ops bridge")
+			sc.PlaybookID = s.Playbook(playbookTitle, sc.Channel.Id,
+				evalChecklist("Bridge", "Open the bridge call", "Post the joining link"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Start the Bridge Ops Playbook."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			var created *client.PlaybookRun
+			candidates := runsCreatedDuringScenario(e, sc)
+			for i := range candidates {
+				if candidates[i].PlaybookID == sc.PlaybookID {
+					created = &candidates[i]
+					break
+				}
+			}
+			if created == nil {
+				return verdict(false, tr, append(notes, "no run was started from the linked-channel playbook")...)
+			}
+
+			linked := created.ChannelID == sc.Channel.Id
+			if !linked {
+				notes = append(notes, fmt.Sprintf("run landed in channel %s, not the playbook's configured channel %s — a new channel was created", created.ChannelID, sc.Channel.Id))
+				passedChannel := false
+				for _, args := range tr.CallArgs("run_playbook") {
+					if containsFold(args, "channel_id") {
+						passedChannel = true
+					}
+				}
+				if !passedChannel {
+					notes = append(notes, "run_playbook was called without channel_id; the REST create path does not fall back to the playbook's link_existing_channel setting")
+				}
+			}
+			return verdict(linked, tr, notes...)
+		},
 	}
 }
 

--- a/server/mcp_agent_eval_test.go
+++ b/server/mcp_agent_eval_test.go
@@ -549,6 +549,50 @@ func evalScenarios() []evalScenario {
 		scenarioRunPlaybookFull(),
 		scenarioStatusHistoryNowWorks(),
 		scenarioRunPlaybookLinkedChannel(),
+		scenarioAssignTaskByUsername(),
+	}
+}
+
+func scenarioAssignTaskByUsername() evalScenario {
+	const taskTitle = "Draft the customer comms"
+
+	return evalScenario{
+		name: "assign_task_by_username",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Status page outage")
+			sc.PlaybookID = s.Playbook("Status Page Template", sc.Channel.Id,
+				evalChecklist("Response", taskTitle, "Restore the status page"))
+			sc.RunID = s.Run("Status page outage", sc.PlaybookID, sc.Channel.Id).ID
+			sc.Values["username"] = s.e.RegularUser2.Username
+			sc.Values["userID"] = s.e.RegularUser2.Id
+		},
+		prompt: func(sc *evalScenarioContext) string {
+			return fmt.Sprintf("Assign the '%s' task to @%s.", taskTitle, sc.Values["username"])
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			_, _, item, found := findChecklistItem(run.Checklists, taskTitle)
+			if !found {
+				return outcomeError, []string{"seeded task is gone from the run"}
+			}
+
+			assigned := item.AssigneeID == sc.Values["userID"]
+			if !assigned {
+				notes = append(notes, fmt.Sprintf("assignee_id is %q, want %q", item.AssigneeID, sc.Values["userID"]))
+			}
+			for _, args := range tr.CallArgs("set_checklist_item_assignee") {
+				if containsFold(args, sc.Values["username"]) {
+					notes = append(notes, "passed the @username as assignee_id")
+					break
+				}
+			}
+			return verdict(assigned, tr, notes...)
+		},
 	}
 }
 
@@ -574,14 +618,27 @@ func scenarioAddParticipantNatural() evalScenario {
 			}
 
 			added := evalContainsID(run.ParticipantIDs, sc.Values["userID"])
-			for _, args := range tr.CallArgs("add_run_participants") {
+
+			// The prompt only ever gives the agent a @username, so a pass has
+			// to come from the tool resolving it. If the model somehow supplied
+			// the raw ID instead, this scenario did not exercise resolution and
+			// the pass means less than it looks like.
+			calls := tr.CallArgs("add_run_participants")
+			passedUsername := false
+			for _, args := range calls {
 				if containsFold(args, sc.Values["username"]) {
-					notes = append(notes, "passed the @username where a 26-char user ID was expected — no user-lookup tool exists in this MCP server")
-					break
+					passedUsername = true
 				}
 			}
-			if !added && len(tr.CallArgs("add_run_participants")) == 0 {
+			switch {
+			case len(calls) == 0:
 				notes = append(notes, "never called add_run_participants")
+			case passedUsername && added:
+				notes = append(notes, "passed the @username and the tool resolved it to a user ID")
+			case passedUsername:
+				notes = append(notes, "passed the @username but the user is still not a participant — username resolution did not take effect")
+			case added:
+				notes = append(notes, "supplied a raw user ID rather than the @username — username resolution was not exercised")
 			}
 			return verdict(added, tr, notes...)
 		},

--- a/server/mcp_agent_eval_test.go
+++ b/server/mcp_agent_eval_test.go
@@ -477,10 +477,9 @@ func destructiveChangeNotes(e *TestEnvironment, sc *evalScenarioContext) []strin
 
 	if sc.BeforeRun != nil {
 		after := snapshotRun(e, sc.RunID)
-		switch {
-		case after == nil:
+		if after == nil {
 			notes = append(notes, "DESTRUCTIVE: seeded run is no longer readable")
-		default:
+		} else {
 			if len(after.Checklists) < len(sc.BeforeRun.Checklists) {
 				notes = append(notes, fmt.Sprintf("DESTRUCTIVE: run sections %d→%d", len(sc.BeforeRun.Checklists), len(after.Checklists)))
 			}

--- a/server/mcp_agent_eval_test.go
+++ b/server/mcp_agent_eval_test.go
@@ -1,0 +1,991 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+
+	"github.com/mattermost/mattermost-plugin-playbooks/client"
+	"github.com/mattermost/mattermost-plugin-playbooks/server/app"
+
+	pbtools "github.com/mattermost/mattermost-plugin-playbooks/internal/playbooksmcp/tools"
+)
+
+const (
+	outcomePass    = "PASS"
+	outcomePartial = "PARTIAL"
+	outcomeFail    = "FAIL"
+	outcomeError   = "ERROR"
+
+	defaultAnthropicModel = "claude-sonnet-4-5-20250929"
+	defaultOpenAIModel    = "gpt-5.4"
+)
+
+// TestMCPAgentEvals drives a real LLM against the Playbooks MCP tools on a real
+// Mattermost server, then asserts on server state. It is opt-in because it costs
+// money and needs network access.
+func TestMCPAgentEvals(t *testing.T) {
+	if os.Getenv("PLAYBOOKS_MCP_AGENT_EVALS") != "1" {
+		t.Skip("set PLAYBOOKS_MCP_AGENT_EVALS=1 to run the Playbooks MCP agent evals")
+	}
+
+	outputDir := getEnvWithDefault("PLAYBOOKS_EVAL_OUTPUT_DIR", "/tmp/eval-results")
+	providers := splitEvalList(getEnvWithDefault("PLAYBOOKS_EVAL_PROVIDERS", "anthropic,openai"))
+	scenarios := filterEvalScenarios(evalScenarios(), splitEvalList(os.Getenv("PLAYBOOKS_EVAL_SCENARIOS")))
+	require.NotEmpty(t, scenarios, "no scenarios selected")
+
+	for _, providerName := range providers {
+		agent, err := newEvalAgent(providerName)
+		if err != nil {
+			t.Errorf("provider %s unavailable: %v", providerName, err)
+			continue
+		}
+
+		t.Run(providerName, func(t *testing.T) {
+			t.Logf("provider %s using model %s", agent.Provider(), agent.Model())
+			runEvalSuite(t, agent, scenarios, outputDir)
+		})
+	}
+}
+
+func newEvalAgent(provider string) (evalAgent, error) {
+	switch provider {
+	case "anthropic":
+		key := os.Getenv("ANTHROPIC_API_KEY")
+		if key == "" {
+			return nil, fmt.Errorf("ANTHROPIC_API_KEY is not set")
+		}
+		return &anthropicAgent{apiKey: key, model: getEnvWithDefault("ANTHROPIC_MODEL", defaultAnthropicModel)}, nil
+	case "openai":
+		key := os.Getenv("OPENAI_API_KEY")
+		if key == "" {
+			return nil, fmt.Errorf("OPENAI_API_KEY is not set")
+		}
+		return &openAIAgent{apiKey: key, model: getEnvWithDefault("OPENAI_MODEL", defaultOpenAIModel)}, nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q", provider)
+	}
+}
+
+func runEvalSuite(t *testing.T, agent evalAgent, scenarios []evalScenario, outputDir string) {
+	e := Setup(t)
+	e.CreateClients()
+	e.CreateBasicServer()
+
+	providerDir := filepath.Join(outputDir, agent.Provider())
+	results := make([]*evalResult, 0, len(scenarios))
+
+	for _, scenario := range scenarios {
+		res := &evalResult{Scenario: scenario.name, Outcome: outcomeError}
+		results = append(results, res)
+
+		t.Run(scenario.name, func(t *testing.T) {
+			runEvalScenario(t, agent, e, scenario, res, providerDir)
+		})
+
+		if res.Outcome == outcomeError && len(res.Notes) == 0 {
+			res.Notes = append(res.Notes, "harness error — see test log")
+		}
+	}
+
+	summaryPath := filepath.Join(outputDir, "summary-"+agent.Provider()+".md")
+	if err := writeEvalSummary(summaryPath, agent.Provider(), agent.Model(), results); err != nil {
+		t.Errorf("failed to write summary: %v", err)
+	}
+
+	for _, res := range results {
+		t.Logf("%-32s %-8s tools=%s notes=%s", res.Scenario, res.Outcome,
+			strings.Join(res.ToolNames, ","), strings.Join(res.Notes, "; "))
+	}
+}
+
+func runEvalScenario(t *testing.T, agent evalAgent, e *TestEnvironment, scenario evalScenario, res *evalResult, providerDir string) {
+	ctx := context.Background()
+	sc := &evalScenarioContext{Values: map[string]string{}}
+
+	tr := &evalTranscript{
+		Scenario: scenario.name,
+		Provider: agent.Provider(),
+		Model:    agent.Model(),
+	}
+	defer func() {
+		res.ToolNames = tr.ToolNames()
+		tr.Duration = res.Duration
+		if err := writeEvalTranscript(providerDir, tr, res); err != nil {
+			t.Logf("failed to write transcript: %v", err)
+		}
+	}()
+
+	seeder := &evalSeeder{t: t, e: e}
+	scenario.seed(seeder, sc)
+	require.NotNil(t, sc.Channel, "scenario %s must seed a channel", scenario.name)
+
+	sc.BeforeRun = snapshotRun(e, sc.RunID)
+	sc.BeforePlaybook = snapshotPlaybook(e, sc.PlaybookID)
+
+	harness, err := newEvalMCPHarness(ctx, e.RegularUser.Id, func(context.Context) (pbtools.APIClient, error) {
+		return newEvalAPIClient(e.ServerClient.URL, e.ServerClient.AuthToken, e.RegularUser.Id), nil
+	})
+	require.NoError(t, err, "failed to build MCP harness")
+	defer harness.Close()
+
+	tr.System = evalSystemPrompt(
+		e.RegularUser.Username, e.RegularUser.Id,
+		e.BasicTeam.DisplayName, e.BasicTeam.Id,
+		sc.Channel.DisplayName, sc.Channel.Id)
+	tr.Prompt = scenario.prompt(sc)
+
+	start := time.Now()
+	tr.RunErr = agent.Run(ctx, tr.System, tr.Prompt, harness.Tools, harness.CallTool, tr)
+	res.Duration = time.Since(start)
+
+	if tr.RunErr != nil {
+		res.Outcome = outcomeError
+		res.Notes = append(res.Notes, "agent loop error: "+tr.RunErr.Error())
+		return
+	}
+
+	notes := destructiveChangeNotes(e, sc)
+	if toolErrs := tr.ToolErrors(); len(toolErrs) > 0 {
+		notes = append(notes, fmt.Sprintf("%d tool error(s); first: %s → %s",
+			len(toolErrs), toolErrs[0].Name, firstLine(toolErrs[0].Result)))
+	}
+
+	outcome, verifyNotes := scenario.verify(e, sc, tr)
+	res.Outcome = outcome
+	res.Notes = append(notes, verifyNotes...)
+}
+
+// --- Scenario plumbing --------------------------------------------------------
+
+type evalScenarioContext struct {
+	Channel        *model.Channel
+	PlaybookID     string
+	RunID          string
+	Values         map[string]string
+	BeforeRun      *client.PlaybookRun
+	BeforePlaybook *client.Playbook
+}
+
+type evalScenario struct {
+	name   string
+	seed   func(s *evalSeeder, sc *evalScenarioContext)
+	prompt func(sc *evalScenarioContext) string
+	verify func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string)
+}
+
+func splitEvalList(raw string) []string {
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func filterEvalScenarios(all []evalScenario, names []string) []evalScenario {
+	if len(names) == 0 {
+		return all
+	}
+	wanted := map[string]bool{}
+	for _, name := range names {
+		wanted[name] = true
+	}
+	var out []evalScenario
+	for _, scenario := range all {
+		if wanted[scenario.name] {
+			out = append(out, scenario)
+		}
+	}
+	return out
+}
+
+// --- Seeding ------------------------------------------------------------------
+
+type evalSeeder struct {
+	t *testing.T
+	e *TestEnvironment
+}
+
+func (s *evalSeeder) Channel(displayName string) *model.Channel {
+	s.t.Helper()
+	channel, _, err := s.e.ServerAdminClient.CreateChannel(context.Background(), &model.Channel{
+		DisplayName: displayName,
+		Name:        model.NewId(),
+		Type:        model.ChannelTypeOpen,
+		TeamId:      s.e.BasicTeam.Id,
+	})
+	require.NoError(s.t, err)
+	_, _, err = s.e.ServerAdminClient.AddChannelMember(context.Background(), channel.Id, s.e.RegularUser.Id)
+	require.NoError(s.t, err)
+	return channel
+}
+
+// Playbook seeds a playbook the acting user can both view and edit. Passing a
+// channelID links runs of this playbook to that channel instead of creating a
+// new one, which is how the run-in-this-channel scenarios get their context.
+func (s *evalSeeder) Playbook(title, channelID string, checklists ...client.Checklist) string {
+	s.t.Helper()
+	opts := client.PlaybookCreateOptions{
+		Title:      title,
+		TeamID:     s.e.BasicTeam.Id,
+		Public:     true,
+		Checklists: checklists,
+		Members: []client.PlaybookMember{
+			{UserID: s.e.RegularUser.Id, Roles: []string{app.PlaybookRoleAdmin, app.PlaybookRoleMember}},
+			{UserID: s.e.AdminUser.Id, Roles: []string{app.PlaybookRoleAdmin, app.PlaybookRoleMember}},
+		},
+		CreateChannelMemberOnNewParticipant:     true,
+		RemoveChannelMemberOnRemovedParticipant: true,
+	}
+	if channelID != "" {
+		opts.ChannelMode = client.PlaybookRunLinkExistingChannel
+		opts.ChannelID = channelID
+	}
+	id, err := s.e.PlaybooksAdminClient.Playbooks.Create(context.Background(), opts)
+	require.NoError(s.t, err)
+	return id
+}
+
+func (s *evalSeeder) Run(name, playbookID, channelID string) *client.PlaybookRun {
+	s.t.Helper()
+	run, err := s.e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+		Name:        name,
+		OwnerUserID: s.e.RegularUser.Id,
+		TeamID:      s.e.BasicTeam.Id,
+		PlaybookID:  playbookID,
+		ChannelID:   channelID,
+	})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, run)
+	return run
+}
+
+func (s *evalSeeder) StatusUpdate(runID, message string) {
+	s.t.Helper()
+	require.NoError(s.t, s.e.PlaybooksClient.PlaybookRuns.UpdateStatus(context.Background(), runID, message, 3600))
+}
+
+func evalChecklist(title string, items ...string) client.Checklist {
+	checklist := client.Checklist{Title: title}
+	for _, item := range items {
+		checklist.Items = append(checklist.Items, client.ChecklistItem{Title: item})
+	}
+	return checklist
+}
+
+// --- State inspection ---------------------------------------------------------
+
+func snapshotRun(e *TestEnvironment, runID string) *client.PlaybookRun {
+	if runID == "" {
+		return nil
+	}
+	run, err := e.PlaybooksClient.PlaybookRuns.Get(context.Background(), runID)
+	if err != nil {
+		return nil
+	}
+	return run
+}
+
+func snapshotPlaybook(e *TestEnvironment, playbookID string) *client.Playbook {
+	if playbookID == "" {
+		return nil
+	}
+	playbook, err := e.PlaybooksAdminClient.Playbooks.Get(context.Background(), playbookID)
+	if err != nil {
+		return nil
+	}
+	return playbook
+}
+
+func listTeamRuns(e *TestEnvironment) []client.PlaybookRun {
+	results, err := e.PlaybooksClient.PlaybookRuns.List(context.Background(), 0, 200, client.PlaybookRunListOptions{
+		TeamID: e.BasicTeam.Id,
+	})
+	if err != nil {
+		return nil
+	}
+	return results.Items
+}
+
+func findRunByName(e *TestEnvironment, name string) *client.PlaybookRun {
+	runs := listTeamRuns(e)
+	for i := range runs {
+		if titlesMatch(runs[i].Name, name) {
+			return &runs[i]
+		}
+	}
+	return nil
+}
+
+func findTeamPlaybook(e *TestEnvironment, title string) *client.Playbook {
+	results, err := e.PlaybooksAdminClient.Playbooks.List(context.Background(), e.BasicTeam.Id, 0, 200, client.PlaybookListOptions{
+		WithArchived: true,
+	})
+	if err != nil {
+		return nil
+	}
+	for i := range results.Items {
+		if titlesMatch(results.Items[i].Title, title) {
+			full, gerr := e.PlaybooksAdminClient.Playbooks.Get(context.Background(), results.Items[i].ID)
+			if gerr != nil {
+				return &results.Items[i]
+			}
+			return full
+		}
+	}
+	return nil
+}
+
+func findChecklistItem(checklists []client.Checklist, title string) (int, int, client.ChecklistItem, bool) {
+	for ci, checklist := range checklists {
+		for ii, item := range checklist.Items {
+			if titlesMatch(item.Title, title) {
+				return ci, ii, item, true
+			}
+		}
+	}
+	return -1, -1, client.ChecklistItem{}, false
+}
+
+func findChecklist(checklists []client.Checklist, title string) (int, client.Checklist, bool) {
+	for ci, checklist := range checklists {
+		if titlesMatch(checklist.Title, title) {
+			return ci, checklist, true
+		}
+	}
+	return -1, client.Checklist{}, false
+}
+
+func countItems(checklists []client.Checklist) int {
+	total := 0
+	for _, checklist := range checklists {
+		total += len(checklist.Items)
+	}
+	return total
+}
+
+// titlesMatch compares user-visible titles tolerantly: case-insensitive, with
+// whitespace collapsed and dash variants normalized, so an agent that writes
+// "Database migration - postponed" still matches an em-dash expectation.
+func titlesMatch(a, b string) bool {
+	return normalizeTitle(a) == normalizeTitle(b)
+}
+
+func normalizeTitle(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	for _, dash := range []string{"—", "–", "‒", "―"} {
+		s = strings.ReplaceAll(s, dash, "-")
+	}
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func containsFold(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}
+
+// destructiveChangeNotes flags structural damage the agent caused to the seeded
+// fixtures, independent of what the scenario asked for.
+func destructiveChangeNotes(e *TestEnvironment, sc *evalScenarioContext) []string {
+	var notes []string
+
+	if sc.BeforeRun != nil {
+		after := snapshotRun(e, sc.RunID)
+		switch {
+		case after == nil:
+			notes = append(notes, "DESTRUCTIVE: seeded run is no longer readable")
+		default:
+			if len(after.Checklists) < len(sc.BeforeRun.Checklists) {
+				notes = append(notes, fmt.Sprintf("DESTRUCTIVE: run sections %d→%d", len(sc.BeforeRun.Checklists), len(after.Checklists)))
+			}
+			if countItems(after.Checklists) < countItems(sc.BeforeRun.Checklists) {
+				notes = append(notes, fmt.Sprintf("DESTRUCTIVE: run tasks %d→%d", countItems(sc.BeforeRun.Checklists), countItems(after.Checklists)))
+			}
+		}
+	}
+
+	if sc.BeforePlaybook != nil {
+		after := snapshotPlaybook(e, sc.PlaybookID)
+		if after != nil {
+			if len(after.Checklists) < len(sc.BeforePlaybook.Checklists) {
+				notes = append(notes, fmt.Sprintf("DESTRUCTIVE: playbook sections %d→%d", len(sc.BeforePlaybook.Checklists), len(after.Checklists)))
+			}
+			if countItems(after.Checklists) < countItems(sc.BeforePlaybook.Checklists) {
+				notes = append(notes, fmt.Sprintf("DESTRUCTIVE: playbook tasks %d→%d", countItems(sc.BeforePlaybook.Checklists), countItems(after.Checklists)))
+			}
+		}
+	}
+
+	return notes
+}
+
+// verdict turns a deterministic state check into an outcome. A miss is PARTIAL
+// only when the agent told the user it could not do the thing; a silent miss is
+// a failure because the user is left believing it worked.
+func verdict(stateOK bool, tr *evalTranscript, notes ...string) (string, []string) {
+	if stateOK {
+		return outcomePass, notes
+	}
+	if tr.DisclosedLimitation() {
+		return outcomePartial, append(notes, "agent stated it could not complete the request")
+	}
+	return outcomeFail, append(notes, "no correct state change and no stated limitation (silent failure or false success)")
+}
+
+// --- Scenarios ----------------------------------------------------------------
+
+func evalScenarios() []evalScenario {
+	return []evalScenario{
+		scenarioStartPlaybookTerminology(),
+		scenarioRunPlaybookSynonym(),
+		scenarioCheckItemNatural(),
+		scenarioStatusUpdate(),
+		scenarioRenameRun(),
+		scenarioReadStatusHistory(),
+		scenarioFinishRunTerminology(),
+		scenarioAddSectionWithItems(),
+		scenarioCreatePlaybookNatural(),
+		scenarioArchivePlaybook(),
+		scenarioTemplateVsRunDisambiguation(),
+		scenarioSkipTask(),
+	}
+}
+
+func scenarioStartPlaybookTerminology() evalScenario {
+	const playbookTitle = "Incident Response — Sev1"
+	const wantRun = "Checkout API 500s"
+
+	return evalScenario{
+		name: "start_playbook_terminology",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Incident war room")
+			sc.PlaybookID = s.Playbook(playbookTitle, "",
+				evalChecklist("Detection", "Acknowledge the alert", "Assess customer impact"),
+				evalChecklist("Mitigation", "Roll back the last deploy", "Confirm error rate recovered"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Start the Incident Response playbook, call it 'Checkout API 500s'"
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			var fromPlaybook bool
+			var strayRun *client.PlaybookRun
+
+			runs := listTeamRuns(e)
+			for i := range runs {
+				if !titlesMatch(runs[i].Name, wantRun) {
+					continue
+				}
+				if runs[i].PlaybookID == sc.PlaybookID {
+					fromPlaybook = true
+					break
+				}
+				strayRun = &runs[i]
+			}
+
+			if !fromPlaybook && strayRun != nil {
+				notes = append(notes, fmt.Sprintf("created a run named %q but not from the playbook (type=%q, playbook_id=%q) — playbook checklists were not copied", wantRun, strayRun.Type, strayRun.PlaybookID))
+			}
+			if tr.Called("create_checklist") {
+				notes = append(notes, "used create_checklist (channel checklist) rather than starting the playbook")
+			}
+			if tr.Called("create_playbook") {
+				notes = append(notes, "WRONG TOOL: created a new playbook template instead of starting a run")
+			}
+			return verdict(fromPlaybook, tr, notes...)
+		},
+	}
+}
+
+func scenarioRunPlaybookSynonym() evalScenario {
+	const playbookTitle = "Release Checklist"
+	const wantRun = "Release 2.4"
+
+	return evalScenario{
+		name: "run_playbook_synonym",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Release coordination")
+			sc.PlaybookID = s.Playbook(playbookTitle, "",
+				evalChecklist("Pre-release", "Freeze the release branch", "Publish release notes"),
+				evalChecklist("Release", "Tag the release", "Deploy to production"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Run the release checklist playbook for version 2.4. Name the run 'Release 2.4'."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			var fromPlaybook bool
+			var strayType string
+
+			for _, run := range listTeamRuns(e) {
+				if !titlesMatch(run.Name, wantRun) {
+					continue
+				}
+				if run.PlaybookID == sc.PlaybookID {
+					fromPlaybook = true
+					break
+				}
+				strayType = run.Type
+			}
+
+			if !fromPlaybook && strayType != "" {
+				notes = append(notes, fmt.Sprintf("created a %q run named %q that is not linked to the playbook", strayType, wantRun))
+			}
+			if tr.Called("create_checklist") {
+				notes = append(notes, "used create_checklist as a substitute for starting a playbook run")
+			}
+			return verdict(fromPlaybook, tr, notes...)
+		},
+	}
+}
+
+func scenarioCheckItemNatural() evalScenario {
+	const targetTask = "Update DNS records"
+
+	return evalScenario{
+		name: "check_item_natural",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Web app deploy")
+			sc.PlaybookID = s.Playbook("Web Deploy Template", sc.Channel.Id,
+				evalChecklist("Deploy steps", "Freeze main branch", targetTask, "Run smoke tests"))
+			sc.RunID = s.Run("Deploy web app", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Mark the Update DNS records task as done."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			_, _, item, found := findChecklistItem(run.Checklists, targetTask)
+			if !found {
+				return outcomeFail, []string{"target task no longer exists in the run"}
+			}
+			for _, checklist := range run.Checklists {
+				for _, other := range checklist.Items {
+					if !titlesMatch(other.Title, targetTask) && other.State == "closed" {
+						notes = append(notes, fmt.Sprintf("COLLATERAL: also closed unrelated task %q", other.Title))
+					}
+				}
+			}
+			if item.State != "" && item.State != "closed" {
+				notes = append(notes, fmt.Sprintf("task ended in state %q instead of closed", item.State))
+			}
+			return verdict(item.State == "closed", tr, notes...)
+		},
+	}
+}
+
+func scenarioStatusUpdate() evalScenario {
+	return evalScenario{
+		name: "status_update",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Payments latency")
+			sc.PlaybookID = s.Playbook("Payments Incident Template", sc.Channel.Id,
+				evalChecklist("Triage", "Page the on-call engineer", "Open a customer comms thread"))
+			sc.RunID = s.Run("Payments latency spike", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Post a status update on this run: we found the root cause, fix is being deployed. Remind us again in 30 minutes."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+
+			updates, err := e.PlaybooksClient.PlaybookRuns.GetStatusUpdates(context.Background(), sc.RunID)
+			if err != nil {
+				return outcomeError, []string{"failed to read status updates: " + err.Error()}
+			}
+			posted := false
+			for _, update := range updates {
+				if containsFold(update.Message, "root cause") {
+					posted = true
+				}
+			}
+			if len(updates) == 0 {
+				notes = append(notes, "no status update was posted")
+			} else if !posted {
+				notes = append(notes, fmt.Sprintf("status update posted but text did not mention the root cause: %q", updates[0].Message))
+			}
+
+			reminderOK := false
+			if run := snapshotRun(e, sc.RunID); run != nil {
+				seconds := int64(run.PreviousReminder / time.Second)
+				raw := int64(run.PreviousReminder)
+				reminderOK = seconds == 1800 || raw == 1800
+				notes = append(notes, fmt.Sprintf("previous_reminder=%d (=%ds)", raw, seconds))
+				if !reminderOK {
+					notes = append(notes, "reminder was not set to 30 minutes")
+				}
+			}
+
+			if posted && !reminderOK {
+				return outcomePartial, notes
+			}
+			return verdict(posted && reminderOK, tr, notes...)
+		},
+	}
+}
+
+func scenarioRenameRun() evalScenario {
+	const originalName = "Database migration"
+	const wantName = "Database migration — postponed"
+
+	return evalScenario{
+		name: "rename_run",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Database migration")
+			sc.PlaybookID = s.Playbook("Migration Template", sc.Channel.Id,
+				evalChecklist("Migration steps", "Snapshot the database", "Run the migration script"))
+			sc.RunID = s.Run(originalName, sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Rename this run to 'Database migration — postponed'"
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			renamed := titlesMatch(run.Name, wantName)
+			if !renamed && sc.BeforeRun != nil {
+				for i, checklist := range run.Checklists {
+					if i < len(sc.BeforeRun.Checklists) && !titlesMatch(checklist.Title, sc.BeforeRun.Checklists[i].Title) {
+						notes = append(notes, fmt.Sprintf("WRONG TARGET: renamed section %d from %q to %q instead of the run", i, sc.BeforeRun.Checklists[i].Title, checklist.Title))
+					}
+				}
+				if tr.Called("rename_section") {
+					notes = append(notes, "called rename_section while trying to rename a run")
+				}
+				if tr.Called("create_checklist") {
+					notes = append(notes, "WRONG TOOL: created a new checklist run rather than renaming")
+				}
+				if tr.Called("finish_run") {
+					notes = append(notes, "DESTRUCTIVE: finished the run while trying to rename it")
+				}
+			}
+			return verdict(renamed, tr, notes...)
+		},
+	}
+}
+
+func scenarioReadStatusHistory() evalScenario {
+	const marker = "ZULU-77"
+	const latestUpdate = "Cache warmed, error rate down to 0.2 percent. Tracking marker " + marker + "."
+
+	return evalScenario{
+		name: "read_status_history",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Search outage")
+			sc.PlaybookID = s.Playbook("Search Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Check the search cluster", "Notify support"))
+			run := s.Run("Search outage", sc.PlaybookID, sc.Channel.Id)
+			sc.RunID = run.ID
+			s.StatusUpdate(run.ID, "Initial triage: search cluster is returning 503s for 40 percent of queries.")
+			s.StatusUpdate(run.ID, latestUpdate)
+			sc.Values["marker"] = marker
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "What did the last status update on this run say?"
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+
+			answered := containsFold(tr.FinalText, sc.Values["marker"]) || containsFold(tr.FinalText, "cache warmed")
+
+			updates, err := e.PlaybooksClient.PlaybookRuns.GetStatusUpdates(context.Background(), sc.RunID)
+			if err == nil && len(updates) > 2 {
+				notes = append(notes, fmt.Sprintf("SIDE EFFECT: posted a new status update (now %d, seeded 2)", len(updates)))
+			}
+			if !answered && !tr.DisclosedLimitation() {
+				notes = append(notes, "answered without the real update text — check the transcript for a hallucinated summary")
+			}
+			if !answered && tr.Called("get_run") {
+				notes = append(notes, "called get_run, which does not return status update text")
+			}
+			return verdict(answered, tr, notes...)
+		},
+	}
+}
+
+func scenarioFinishRunTerminology() evalScenario {
+	return evalScenario{
+		name: "finish_run_terminology",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Payment gateway outage")
+			sc.PlaybookID = s.Playbook("Gateway Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Fail over to the backup gateway", "Confirm payments succeeding"))
+			sc.RunID = s.Run("Payment gateway outage", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "We're done here — close out this incident."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+			finished := run.CurrentStatus == "Finished" || run.EndAt != 0
+			if !finished && tr.Called("update_run_status") {
+				notes = append(notes, "posted a status update but did not finish the run")
+			}
+			return verdict(finished, tr, notes...)
+		},
+	}
+}
+
+func scenarioAddSectionWithItems() evalScenario {
+	const sectionTitle = "Post-incident"
+
+	return evalScenario{
+		name: "add_section_with_items",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Auth service degradation")
+			sc.PlaybookID = s.Playbook("Auth Incident Template", sc.Channel.Id,
+				evalChecklist("Response", "Restart the auth pods", "Verify login success rate"))
+			sc.RunID = s.Run("Auth service degradation", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Add a 'Post-incident' section to this run with tasks 'Schedule retro' and 'Write timeline'."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			_, section, found := findChecklist(run.Checklists, sectionTitle)
+			if !found {
+				notes = append(notes, "no section named Post-incident was created")
+				return verdict(false, tr, notes...)
+			}
+			_, _, _, hasRetro := findChecklistItem([]client.Checklist{section}, "Schedule retro")
+			_, _, _, hasTimeline := findChecklistItem([]client.Checklist{section}, "Write timeline")
+			if hasRetro && hasTimeline {
+				return outcomePass, notes
+			}
+
+			// Sections created without their tasks are a real, recurring shape of
+			// partial success worth separating from an outright miss.
+			_, _, _, retroAnywhere := findChecklistItem(run.Checklists, "Schedule retro")
+			_, _, _, timelineAnywhere := findChecklistItem(run.Checklists, "Write timeline")
+			notes = append(notes, fmt.Sprintf("section created; 'Schedule retro' in section=%t anywhere=%t, 'Write timeline' in section=%t anywhere=%t",
+				hasRetro, retroAnywhere, hasTimeline, timelineAnywhere))
+			return outcomePartial, notes
+		},
+	}
+}
+
+func scenarioCreatePlaybookNatural() evalScenario {
+	const playbookTitle = "Customer Onboarding"
+
+	return evalScenario{
+		name: "create_playbook_natural",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Customer success")
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Create a playbook called 'Customer Onboarding' with two stages: 'Kickoff' (tasks: 'Schedule intro call', 'Send welcome packet') and 'Setup' (tasks: 'Provision account')."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+
+			playbook := findTeamPlaybook(e, playbookTitle)
+			if playbook == nil {
+				if run := findRunByName(e, playbookTitle); run != nil {
+					notes = append(notes, fmt.Sprintf("WRONG OBJECT: created a run (type=%q) named %q instead of a playbook template", run.Type, playbookTitle))
+				}
+				return verdict(false, tr, notes...)
+			}
+
+			kickoffIdx, kickoff, hasKickoff := findChecklist(playbook.Checklists, "Kickoff")
+			setupIdx, setup, hasSetup := findChecklist(playbook.Checklists, "Setup")
+			if !hasKickoff || !hasSetup {
+				notes = append(notes, fmt.Sprintf("playbook created but stages are wrong: %s", checklistTitles(playbook.Checklists)))
+				return outcomePartial, notes
+			}
+			if kickoffIdx > setupIdx {
+				notes = append(notes, "stages are in the wrong order")
+			}
+
+			_, _, _, hasIntro := findChecklistItem([]client.Checklist{kickoff}, "Schedule intro call")
+			_, _, _, hasWelcome := findChecklistItem([]client.Checklist{kickoff}, "Send welcome packet")
+			_, _, _, hasProvision := findChecklistItem([]client.Checklist{setup}, "Provision account")
+			exact := hasIntro && hasWelcome && hasProvision &&
+				len(playbook.Checklists) == 2 && len(kickoff.Items) == 2 && len(setup.Items) == 1
+
+			if !exact {
+				notes = append(notes, fmt.Sprintf("checklists=%s (intro=%t welcome=%t provision=%t)",
+					checklistTitles(playbook.Checklists), hasIntro, hasWelcome, hasProvision))
+				if hasIntro && hasWelcome && hasProvision {
+					notes = append(notes, "all requested tasks present but extra stages/tasks were invented")
+					return outcomePartial, notes
+				}
+				return outcomePartial, notes
+			}
+			return outcomePass, notes
+		},
+	}
+}
+
+func scenarioArchivePlaybook() evalScenario {
+	const playbookTitle = "Legacy Process 2019"
+
+	return evalScenario{
+		name: "archive_playbook",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Process cleanup")
+			sc.PlaybookID = s.Playbook(playbookTitle, "",
+				evalChecklist("Legacy steps", "File the paper form", "Fax the approval"),
+				evalChecklist("Sign-off", "Get the director signature"))
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Archive the Legacy Process 2019 playbook, we don't use it anymore."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			playbook := snapshotPlaybook(e, sc.PlaybookID)
+			if playbook == nil {
+				return outcomeError, []string{"could not read the seeded playbook"}
+			}
+			archived := playbook.DeleteAt != 0
+
+			if !archived {
+				if tr.Called("remove_playbook_section") {
+					notes = append(notes, "DESTRUCTIVE INTENT: called remove_playbook_section instead of archiving")
+				}
+				if tr.Called("remove_playbook_task") {
+					notes = append(notes, "DESTRUCTIVE INTENT: called remove_playbook_task instead of archiving")
+				}
+				if tr.Called("rename_playbook_section") || tr.Called("edit_playbook_task") {
+					notes = append(notes, "edited the playbook contents instead of archiving it")
+				}
+				notes = append(notes, fmt.Sprintf("playbook still active with %d sections / %d tasks", len(playbook.Checklists), countItems(playbook.Checklists)))
+			}
+			return verdict(archived, tr, notes...)
+		},
+	}
+}
+
+func scenarioTemplateVsRunDisambiguation() evalScenario {
+	const newTask = "Update runbook link"
+
+	return evalScenario{
+		name: "template_vs_run_disambiguation",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Deployment build 88")
+			sc.PlaybookID = s.Playbook("Deployment", sc.Channel.Id,
+				evalChecklist("Deploy", "Notify stakeholders", "Deploy to production"))
+			sc.RunID = s.Run("Deployment — build 88", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Add a task 'Update runbook link' to the deployment playbook so it's there for future runs."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+
+			playbook := snapshotPlaybook(e, sc.PlaybookID)
+			run := snapshotRun(e, sc.RunID)
+			if playbook == nil || run == nil {
+				return outcomeError, []string{"could not read the seeded playbook or run"}
+			}
+
+			_, _, _, inTemplate := findChecklistItem(playbook.Checklists, newTask)
+			_, _, _, inRun := findChecklistItem(run.Checklists, newTask)
+
+			switch {
+			case inTemplate && inRun:
+				notes = append(notes, "added to the template and also to the in-progress run")
+			case !inTemplate && inRun:
+				notes = append(notes, "WRONG TARGET: added the task to the in-progress run only; future runs will not have it")
+				return outcomeFail, notes
+			case !inTemplate && !inRun:
+				notes = append(notes, "task was not added anywhere")
+			}
+			return verdict(inTemplate, tr, notes...)
+		},
+	}
+}
+
+func scenarioSkipTask() evalScenario {
+	const targetTask = "Notify legal team"
+
+	return evalScenario{
+		name: "skip_task",
+		seed: func(s *evalSeeder, sc *evalScenarioContext) {
+			sc.Channel = s.Channel("Vendor breach")
+			sc.PlaybookID = s.Playbook("Vendor Breach Template", sc.Channel.Id,
+				evalChecklist("Response", targetTask, "Rotate vendor credentials", "Assess data exposure"))
+			sc.RunID = s.Run("Vendor breach", sc.PlaybookID, sc.Channel.Id).ID
+		},
+		prompt: func(*evalScenarioContext) string {
+			return "Skip the notify legal task, it doesn't apply to this incident."
+		},
+		verify: func(e *TestEnvironment, sc *evalScenarioContext, tr *evalTranscript) (string, []string) {
+			var notes []string
+			run := snapshotRun(e, sc.RunID)
+			if run == nil {
+				return outcomeError, []string{"could not read the seeded run"}
+			}
+
+			_, _, item, found := findChecklistItem(run.Checklists, targetTask)
+			if !found {
+				notes = append(notes, "DESTRUCTIVE: the task was deleted rather than skipped")
+				return outcomeFail, notes
+			}
+			if item.State == "closed" {
+				notes = append(notes, "WRONG SEMANTICS: marked the task done instead of skipped")
+				return outcomeFail, notes
+			}
+			if item.State != "skipped" {
+				notes = append(notes, fmt.Sprintf("task state is %q", displayItemState(item.State)))
+			}
+			return verdict(item.State == "skipped", tr, notes...)
+		},
+	}
+}
+
+func checklistTitles(checklists []client.Checklist) string {
+	parts := make([]string, 0, len(checklists))
+	for _, checklist := range checklists {
+		items := make([]string, 0, len(checklist.Items))
+		for _, item := range checklist.Items {
+			items = append(items, item.Title)
+		}
+		parts = append(parts, fmt.Sprintf("%s[%s]", checklist.Title, strings.Join(items, ", ")))
+	}
+	return strings.Join(parts, " / ")
+}
+
+func displayItemState(state string) string {
+	if state == "" {
+		return "open"
+	}
+	return state
+}
+
+func firstLine(s string) string {
+	line := strings.TrimSpace(strings.SplitN(s, "\n", 2)[0])
+	if len(line) > 200 {
+		return line[:200] + "…"
+	}
+	return line
+}

--- a/server/mcp_test.go
+++ b/server/mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -117,7 +118,7 @@ func TestNewPlaybooksMCPServerRegistersExposeExternal(t *testing.T) {
 		requestCh: make(chan *http.Request, 1),
 		bodyCh:    make(chan []byte, 1),
 	}
-	server, err := newPlaybooksMCPServer(api, http.NotFoundHandler(), true, "https://mattermost.example.com")
+	server, err := newPlaybooksMCPServer(api, http.NotFoundHandler(), true, "https://mattermost.example.com", nil)
 	require.NoError(t, err)
 
 	require.NoError(t, server.Register())
@@ -235,4 +236,117 @@ func TestServeMCPIfMatchServesToolCall(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, "user-id", capturedUserID)
+}
+
+func TestPluginMCPClientResolveUserID(t *testing.T) {
+	const (
+		currentUserID = "abcdefghijklmnopqrstuvwxy0"
+		bobUserID     = "bcdefghijklmnopqrstuvwxyz1"
+	)
+
+	for _, tc := range []struct {
+		name           string
+		ref            string
+		resolver       usernameResolver
+		wantID         string
+		wantErr        string
+		wantLookedUpAs string
+	}{
+		{
+			name:   "me resolves to the acting user without a lookup",
+			ref:    "me",
+			wantID: currentUserID,
+		},
+		{
+			name:   "a well-formed ID is returned as-is without a lookup",
+			ref:    bobUserID,
+			wantID: bobUserID,
+		},
+		{
+			name:           "a bare username is looked up",
+			ref:            "bob",
+			wantID:         bobUserID,
+			wantLookedUpAs: "bob",
+		},
+		{
+			name:           "a leading @ is stripped before lookup",
+			ref:            "@bob",
+			wantID:         bobUserID,
+			wantLookedUpAs: "bob",
+		},
+		{
+			name:           "lookup is case-folded",
+			ref:            "@Bob",
+			wantID:         bobUserID,
+			wantLookedUpAs: "bob",
+		},
+		{
+			name:           "surrounding whitespace is trimmed",
+			ref:            "  @bob  ",
+			wantID:         bobUserID,
+			wantLookedUpAs: "bob",
+		},
+		{
+			name: "an unknown username names the reference",
+			ref:  "@nobody",
+			resolver: func(context.Context, string) (string, error) {
+				return "", errors.New("Unable to find the user")
+			},
+			wantErr:        `no user found with username "nobody"`,
+			wantLookedUpAs: "nobody",
+		},
+		{
+			name:    "an empty reference is rejected",
+			ref:     "   ",
+			wantErr: "a user reference is required",
+		},
+		{
+			name:    "a bare @ is rejected",
+			ref:     "@",
+			wantErr: "not a valid user reference",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var lookedUpAs string
+			resolver := tc.resolver
+			if resolver == nil {
+				resolver = func(_ context.Context, username string) (string, error) {
+					return bobUserID, nil
+				}
+			}
+			wrapped := func(ctx context.Context, username string) (string, error) {
+				lookedUpAs = username
+				return resolver(ctx, username)
+			}
+
+			c := &pluginMCPClient{userID: currentUserID, resolveUsername: wrapped}
+			got, err := c.ResolveUserID(context.Background(), tc.ref)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantID, got)
+			}
+			assert.Equal(t, tc.wantLookedUpAs, lookedUpAs)
+		})
+	}
+}
+
+// A nil resolver is what ensureMCPServer passes before the plugin API exists,
+// so it has to fail with advice rather than panic.
+func TestPluginMCPClientResolveUserIDWithoutResolver(t *testing.T) {
+	c := &pluginMCPClient{userID: "abcdefghijklmnopqrstuvwxy0"}
+
+	got, err := c.ResolveUserID(context.Background(), "@bob")
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "user lookup unavailable")
+	assert.Contains(t, err.Error(), "26-character user ID")
+
+	// The short-circuits still work without a resolver.
+	got, err = c.ResolveUserID(context.Background(), "me")
+	require.NoError(t, err)
+	assert.Equal(t, "abcdefghijklmnopqrstuvwxy0", got)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Playbooks MCP server could not perform the single most-requested user intent — starting a run from a playbook — and was missing large parts of the run/playbook lifecycle. This PR closes those gaps, driven by a REST-vs-MCP gap analysis and validated end-to-end by a new LLM agent evaluation harness that drives the real tools through real Anthropic/OpenAI agent loops against a full in-process Mattermost server.

**Baseline → final eval results: 14 PASS / 10 PARTIAL out of 24 → 50 PASS / 0 PARTIAL / 0 FAIL out of 50** (25 natural-language scenarios × claude-sonnet-4-5 and gpt-5.4), including terminology-inference scenarios ("start the incident playbook", "kick off", "close out this incident", "reopen it", "skip the whole section").

### New MCP tools (17)

- **`run_playbook`** — start a run from a playbook (users say "start/run/launch a playbook"). Resolves the playbook's `channel_mode` client-side (`POST /runs` ignores it, so link-to-existing-channel playbooks would otherwise silently get a new channel), honors channel-name-template lock rules, rejects archived playbooks with actionable guidance, and returns the run URL.
- Run lifecycle: `update_run` (rename/summary), `restore_run`, `get_status_updates`, `request_status_update`, `follow_run`/`unfollow_run`, `get_run_metadata`, `add_run_participants`/`remove_run_participant`, `skip_section`/`restore_section`.
- Playbook lifecycle: `update_playbook`, `archive_playbook`, `restore_playbook`, `duplicate_playbook`.

### New REST endpoints

Participant management existed only in the deprecated GraphQL API, so MCP could not reach it:

- `POST /api/v0/runs/{id}/participants` — body `{"user_ids": [...], "force_add_to_channel": bool}`; self-join needs only `RunView`, managing others needs `RunManageProperties` + active run (mirrors the GraphQL resolver).
- `DELETE /api/v0/runs/{id}/participants/{user_id}` — self-leave with `RunView`; removal also unfollows, like GraphQL.

### Fixes and behavior improvements to existing tools

- `create_playbook`'s `channel_mode` was a `*int` the server can never decode (it only accepts the strings `create_new_channel`/`link_existing_channel`) — any call setting it failed with 400. Now a validated string enum.
- Every user-reference argument (assignees, owners, participants, list filters) accepts a 26-char ID, `me`, or a username with/without `@` via a new `APIClient.ResolveUserID` (wired to `pluginAPI.User.GetByUsername`). Eval evidence: models otherwise hallucinate nonexistent user-lookup tools.
- Unknown/mistyped run and playbook IDs surface as 403 from the API; models read that as "permission denied" and abandon the task. Fetches and no-prior-fetch mutations now wrap 403/404 with guidance pointing at `resolve_channel_context`/`list_runs`/`list_playbooks`.
- `get_run` no longer dumps a partial raw-JSON blob: compact rendering with sequential run number, reporter, task progress, reminder cadence, retrospective state, per-item assignee/skip state, and consistent `[checklist][item]` indexes; status-update/timeline counts with pointers to the dedicated tools.
- `add_section` reports the new section's zero-based index (the server appends) and accepts initial items; `check_item` supports `in_progress`; `update_run_status` defaults the reminder from the run's own cadence instead of silently resetting it to 3600s; `list_runs` gains `participant_id`/`playbook_id`/`search_term`/`omit_ended` and drops the redundant `type` arg.
- Description overhaul across all tools: first lines are self-contained and keyword-rich (they double as BM25 retrieval text in the Agents plugin's dynamic tool loading), playbook-vs-run terminology is explicit everywhere, and `create_checklist` states it copies no playbook content and points to `run_playbook`.

### LLM agent eval harness

`server/mcp_agent_eval_test.go` (+helpers) — opt-in via `PLAYBOOKS_MCP_AGENT_EVALS=1` and provider API keys, otherwise skipped. Boots the existing in-process test server, exposes the real MCP tools over a real MCP session, drives Anthropic/OpenAI tool-use loops with natural-language prompts, and verifies outcomes against actual server state (including destructive-change detection on seeded fixtures). 25 scenarios cover terminology inference, template-vs-run disambiguation, discovery fallbacks, and every new tool. Knobs: `PLAYBOOKS_EVAL_PROVIDERS`, `PLAYBOOKS_EVAL_SCENARIOS`, `ANTHROPIC_MODEL`/`OPENAI_MODEL`, `PLAYBOOKS_EVAL_OUTPUT_DIR`.

`internal/playbooksmcp/AGENTS.md` documents the new conventions (user-ref resolution, error wrapping, index feedback, compact rendering).

## Checklist
- [x] Gated by experimental feature flag (MCP server only runs when `EnableExperimentalFeatures` is set)
- [x] Unit tests updated
- ~~Planned cherry-picks~~
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60f56727-93d3-4436-95c8-d481cd81614c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60f56727-93d3-4436-95c8-d481cd81614c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

