### PR TITLE
Honor req.Context() cancellation in interPluginTransport.RoundTrip

### DIFF
--- a/client/interplugin.go
+++ b/client/interplugin.go
@@ -64,6 +64,15 @@ type interPluginTransport struct {
 func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
+	// Fail fast if the context is already done: skip invoking the calling plugin's handler entirely
+	// rather than starting the goroutine below only to discard whatever it returns.
+	if err := ctx.Err(); err != nil {
+		if req.Body != nil {
+			req.Body.Close()
+		}
+		return nil, err
+	}
+
 	// RoundTrip must not modify the original request, so operate on a clone. The clone shares the
 	// original's Body, so closing it below also discharges RoundTrip's duty to close req.Body.
 	outReq := req.Clone(ctx)
@@ -92,9 +101,14 @@ func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, err
 
 	select {
 	case <-ctx.Done():
-		// The goroutine above is abandoned: it keeps running PluginHTTP to completion and, on
-		// success, its response body is never closed. That's an accepted leak on the cancellation
-		// path, not something this layer can fix without PluginHTTP itself observing a context.
+		// The goroutine above is abandoned: it keeps running PluginHTTP to completion regardless,
+		// since PluginHTTP itself never observes ctx. Wait for its result on another goroutine so a
+		// response that does eventually arrive still has its body closed instead of leaking.
+		go func() {
+			if resp := <-respCh; resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+		}()
 		return nil, ctx.Err()
 	case resp := <-respCh:
 		if resp == nil {

--- a/client/interplugin.go
+++ b/client/interplugin.go
@@ -62,30 +62,53 @@ type interPluginTransport struct {
 }
 
 func (t *interPluginTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
 	// RoundTrip must not modify the original request, so operate on a clone. The clone shares the
 	// original's Body, so closing it below also discharges RoundTrip's duty to close req.Body.
-	outReq := req.Clone(req.Context())
+	outReq := req.Clone(ctx)
 	outReq.Header.Set(actingUserIDHeader, t.actingUserID)
 
-	// RoundTrip must always close the request body. PluginHTTP's buffered path closes and nils the
-	// body itself, but its streaming path does not, so close whatever remains once the call returns.
-	defer func() {
-		if outReq.Body != nil {
-			outReq.Body.Close()
-		}
+	// PluginHTTP is a synchronous in-process call that never looks at ctx, so it cannot be
+	// interrupted directly. Run it on a goroutine and race it against ctx.Done() so a canceled or
+	// timed-out context still lets RoundTrip return promptly, instead of blocking forever. This
+	// cannot abort the calling plugin's handler, which keeps running to completion regardless; it
+	// only stops this method from waiting on it.
+	//
+	// The goroutine owns outReq for its entire lifetime, including closing its body: RoundTrip may
+	// return on the ctx path while t.do is still running, so nothing on this side of the select may
+	// touch outReq after starting the goroutine.
+	respCh := make(chan *http.Response, 1)
+	go func() {
+		// RoundTrip must always close the request body. PluginHTTP's buffered path closes and nils
+		// the body itself, but its streaming path does not, so close whatever remains.
+		defer func() {
+			if outReq.Body != nil {
+				outReq.Body.Close()
+			}
+		}()
+		respCh <- t.do(outReq)
 	}()
 
-	resp := t.do(outReq)
-	if resp == nil {
-		return nil, errors.Errorf("no response from the %s plugin; is it installed and enabled?", manifestID)
-	}
+	select {
+	case <-ctx.Done():
+		// The goroutine above is abandoned: it keeps running PluginHTTP to completion and, on
+		// success, its response body is never closed. That's an accepted leak on the cancellation
+		// path, not something this layer can fix without PluginHTTP itself observing a context.
+		return nil, ctx.Err()
+	case resp := <-respCh:
+		if resp == nil {
+			return nil, errors.Errorf("no response from the %s plugin; is it installed and enabled?", manifestID)
+		}
 
-	// PluginHTTP does not populate Response.Request, but the client dereferences it when building
-	// error responses for non-2xx replies. Set it as net/http's Transport does for real network
-	// requests, so a non-2xx response yields an error rather than a nil-pointer panic.
-	if resp.Request == nil {
-		resp.Request = outReq
-	}
+		// PluginHTTP does not populate Response.Request, but the client dereferences it when
+		// building error responses for non-2xx replies. Set it as net/http's Transport does for
+		// real network requests, so a non-2xx response yields an error rather than a nil-pointer
+		// panic.
+		if resp.Request == nil {
+			resp.Request = outReq
+		}
 
-	return resp, nil
+		return resp, nil
+	}
 }

--- a/client/interplugin_test.go
+++ b/client/interplugin_test.go
@@ -5,10 +5,12 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -77,5 +79,51 @@ func TestNewInterPluginClient(t *testing.T) {
 
 		_, err = c.PlaybookRuns.Get(context.Background(), "run123")
 		require.Error(t, err)
+	})
+
+	t.Run("closes a body-bearing request on the success path", func(t *testing.T) {
+		// Create sends a JSON-encoded body, unlike the other subtests' bodyless GETs, so this is
+		// the one that exercises the goroutine's outReq.Body.Close() under the race detector.
+		var gotBody []byte
+		do := func(req *http.Request) *http.Response {
+			gotBody, _ = io.ReadAll(req.Body)
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"id":"run123"}`)),
+			}
+		}
+
+		c, err := client.NewInterPluginClient(do, "user_abc")
+		require.NoError(t, err)
+
+		run, err := c.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{Name: "test run"})
+		require.NoError(t, err)
+		require.Equal(t, "run123", run.ID)
+		require.Contains(t, string(gotBody), "test run")
+	})
+
+	t.Run("returns promptly when the context expires mid-call, instead of blocking", func(t *testing.T) {
+		release := make(chan struct{})
+		defer close(release)
+
+		do := func(*http.Request) *http.Response {
+			<-release
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"id":"run123"}`)),
+			}
+		}
+
+		c, err := client.NewInterPluginClient(do, "user_abc")
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		_, err = c.PlaybookRuns.Get(ctx, "run123")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.DeadlineExceeded))
 	})
 }

--- a/client/interplugin_test.go
+++ b/client/interplugin_test.go
@@ -131,10 +131,12 @@ func TestNewInterPluginClient(t *testing.T) {
 	})
 
 	t.Run("returns promptly when the context expires mid-call, instead of blocking", func(t *testing.T) {
+		started := make(chan struct{})
 		release := make(chan struct{})
 		respBodyClosed := make(chan struct{})
 
 		do := func(*http.Request) *http.Response {
+			close(started)
 			<-release
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -149,9 +151,33 @@ func TestNewInterPluginClient(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 
-		_, err = c.PlaybookRuns.Get(ctx, "run123")
-		require.Error(t, err)
-		require.True(t, errors.Is(err, context.DeadlineExceeded))
+		// Run Get on its own goroutine and bound every wait below: if a regression ever made
+		// RoundTrip stop honoring ctx, this test fails fast with a clear message instead of
+		// hanging until the suite's global timeout.
+		getErr := make(chan error, 1)
+		go func() {
+			_, err := c.PlaybookRuns.Get(ctx, "run123")
+			getErr <- err
+		}()
+
+		// Confirm PluginHTTP actually entered its blocking call before judging Get's behavior, so
+		// this proves the context wins a real race against an in-flight call, not that the handler
+		// simply never ran.
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("PluginHTTP was never invoked")
+		}
+
+		select {
+		case err := <-getErr:
+			require.Error(t, err)
+			require.True(t, errors.Is(err, context.DeadlineExceeded))
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("Get did not return promptly once its context expired")
+		}
 
 		// The call above only abandons the in-flight PluginHTTP call; it keeps running underneath.
 		// Release it and confirm its late response body still gets closed instead of leaking.

--- a/client/interplugin_test.go
+++ b/client/interplugin_test.go
@@ -85,7 +85,9 @@ func TestNewInterPluginClient(t *testing.T) {
 		// Create sends a JSON-encoded body, unlike the other subtests' bodyless GETs, so this is
 		// the one that exercises the goroutine's outReq.Body.Close() under the race detector.
 		var gotBody []byte
+		closed := make(chan struct{})
 		do := func(req *http.Request) *http.Response {
+			req.Body = &closeTrackingReadCloser{ReadCloser: req.Body, closed: closed}
 			gotBody, _ = io.ReadAll(req.Body)
 			return &http.Response{
 				StatusCode: http.StatusCreated,
@@ -101,18 +103,43 @@ func TestNewInterPluginClient(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "run123", run.ID)
 		require.Contains(t, string(gotBody), "test run")
+
+		select {
+		case <-closed:
+		case <-time.After(time.Second):
+			t.Fatal("RoundTrip did not close the request body")
+		}
+	})
+
+	t.Run("returns immediately without invoking PluginHTTP when the context is already canceled", func(t *testing.T) {
+		called := false
+		do := func(*http.Request) *http.Response {
+			called = true
+			return nil
+		}
+
+		c, err := client.NewInterPluginClient(do, "user_abc")
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err = c.PlaybookRuns.Get(ctx, "run123")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.Canceled))
+		require.False(t, called)
 	})
 
 	t.Run("returns promptly when the context expires mid-call, instead of blocking", func(t *testing.T) {
 		release := make(chan struct{})
-		defer close(release)
+		respBodyClosed := make(chan struct{})
 
 		do := func(*http.Request) *http.Response {
 			<-release
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(`{"id":"run123"}`)),
+				Body:       &closeTrackingReadCloser{ReadCloser: io.NopCloser(strings.NewReader(`{"id":"run123"}`)), closed: respBodyClosed},
 			}
 		}
 
@@ -125,5 +152,27 @@ func TestNewInterPluginClient(t *testing.T) {
 		_, err = c.PlaybookRuns.Get(ctx, "run123")
 		require.Error(t, err)
 		require.True(t, errors.Is(err, context.DeadlineExceeded))
+
+		// The call above only abandons the in-flight PluginHTTP call; it keeps running underneath.
+		// Release it and confirm its late response body still gets closed instead of leaking.
+		close(release)
+		select {
+		case <-respBodyClosed:
+		case <-time.After(time.Second):
+			t.Fatal("late response body was never closed")
+		}
 	})
+}
+
+// closeTrackingReadCloser wraps an io.ReadCloser and signals closed when Close is called, so tests
+// can assert that a body was actually closed rather than just read.
+type closeTrackingReadCloser struct {
+	io.ReadCloser
+	closed chan struct{}
+}
+
+func (c *closeTrackingReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	close(c.closed)
+	return err
 }


### PR DESCRIPTION
## Summary

`interPluginTransport.RoundTrip` (in `client/interplugin.go`) calls the calling plugin's
`PluginHTTP` entrypoint synchronously and never consults `req.Context()`. As a result, every
`ctx` a caller passes into `pbc.Playbooks.Get(ctx, ...)`, `pbc.PlaybookRuns.Create(ctx, ...)`, etc.
is silently inert on this transport: `context.WithTimeout` and cancellation do nothing. If the
Playbooks plugin's HTTP handler hangs, the calling plugin blocks indefinitely. `NewInterPluginClient`
shipped in v2.11.1, so every consumer has had this latent hang since then —
[`mattermost-plugin-fl3xx` #62](https://github.com/mattermost/mattermost-plugin-fl3xx/pull/62)
already works around it caller-side by wrapping each call in a goroutine + select; that workaround
can be simplified once this lands.

## Why the stdlib doesn't already handle this

- `http.Client.do` → `send` → `setRequestCancel(req, rt, deadline)` returns a no-op immediately when
  `deadline.IsZero()`. `NewInterPluginClient` builds `&http.Client{Transport: ...}` with no
  `Timeout`, so this path is inert — this is about `Client.Timeout`, not `req.Context()`.
- All the `ctx.Done()` watching and cancellation machinery lives in `net/http/transport.go`, inside
  `*http.Transport`'s own `RoundTrip` implementation — it is not something `http.Client` provides for
  arbitrary `RoundTripper`s.
- Even setting a non-zero `Client.Timeout` wouldn't help: `knownRoundTripperImpl` only recognizes
  `*http.Transport` and the http2 transports, so an unknown `RoundTripper` like
  `interPluginTransport` falls back to the deprecated `Request.Cancel` path, which it implements
  neither.
- `client.go`'s `do()` has a `select { case <-ctx.Done(): ... }`, but it runs *after*
  `c.client.Do(req)` has already returned an error — it only improves the error message, it cancels
  nothing.

So honoring `req.Context()` is squarely `interPluginTransport.RoundTrip`'s own responsibility, and it
wasn't doing it.

## The fix

Race the `PluginHTTP` call against `req.Context().Done()`: the in-process call runs on a goroutine
that owns the cloned request end-to-end (including closing its body), because `RoundTrip` may return
on the context path while the call is still in flight. `select`s on `ctx.Done()` vs. the goroutine's
result channel.

Two refinements added during review:
- `RoundTrip` now checks `ctx.Err()` up front and returns immediately (closing the request body)
  without ever invoking the calling plugin's handler if the context is already done.
- On the cancellation path, a second goroutine drains the abandoned call's result and closes its
  response body if one eventually arrives, instead of leaking it.

## Limitation (can't be engineered around at this layer)

- This lets the *caller* return control promptly, but it **cannot actually cancel** the in-flight
  call itself — the plugin's handler runs to completion regardless. That's a property of the
  context-free `PluginHTTP` RPC boundary, not something this transport can fix.

## Testing

Subtests added to `TestNewInterPluginClient` in `client/interplugin_test.go`:
- Context that expires mid-call returns promptly with an error (`errors.Is(err, context.DeadlineExceeded)`) instead of blocking, using a controllable blocking `do`, and confirms the late response body is eventually closed once the call is released.
- An already-canceled context returns immediately without invoking `PluginHTTP` at all.
- A body-bearing success-path request (`PlaybookRuns.Create`) that asserts the request body is actually closed (via a close-tracking `io.ReadCloser`), not just read — exercises the goroutine's body-close under `-race`, since the pre-existing subtests are all bodyless GETs.
- Existing happy-path / acting-user-header / nil-response / non-2xx subtests are unchanged and still pass.

```
cd client && go build ./... && go test -race ./...   # PASS
go build ./... && go vet ./...                        # root module, clean
```

## Checklist
- [ ] Gated by experimental feature flag — N/A, this is a bug fix in the client library's transport
- [x] Unit tests updated
- ~~Planned cherry-picks~~ — no cherry-picks planned; can be added if a maintainer wants this backported

## Ticket Link
N/A — no tracked issue/ticket for this; found and fixed while auditing `client/interplugin.go`.
