### PR TITLE
[MM-70231] record skip/restore task state changes

### DIFF
--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -3303,8 +3303,6 @@ func (s *PlaybookRunServiceImpl) SkipChecklistItem(playbookRunID, userID string,
 	model.AddEventParameterToAuditRec(auditRec, "taskTitle", itemToSkip.Title)
 	model.AddEventParameterToAuditRec(auditRec, "currentState", itemToSkip.State)
 
-	// Without this guard a repeated skip writes a second timeline event and moves the timestamp
-	// forward, which clients render as a task that was skipped twice.
 	if itemToSkip.State == ChecklistItemStateSkipped {
 		auditRec.Success()
 		return nil
@@ -3398,8 +3396,7 @@ func (s *PlaybookRunServiceImpl) RestoreChecklistItem(playbookRunID, userID stri
 	model.AddEventParameterToAuditRec(auditRec, "taskTitle", itemToRestore.Title)
 	model.AddEventParameterToAuditRec(auditRec, "currentState", itemToRestore.State)
 
-	// A repeat call would otherwise duplicate the timeline event.
-	if itemToRestore.State == ChecklistItemStateOpen {
+	if itemToRestore.State != ChecklistItemStateSkipped {
 		auditRec.Success()
 		return nil
 	}

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -3296,6 +3296,9 @@ func (s *PlaybookRunServiceImpl) SkipChecklistItem(playbookRunID, userID string,
 	timestamp := model.GetMillis()
 	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].LastSkipped = timestamp
 	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].State = ChecklistItemStateSkipped
+	// StateModified is what clients read to show when a task last changed state; without it a skip
+	// leaves behind the timestamp of an earlier check/uncheck.
+	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].StateModified = timestamp
 	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp)
 
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)
@@ -3303,7 +3306,50 @@ func (s *PlaybookRunServiceImpl) SkipChecklistItem(playbookRunID, userID string,
 		return errors.Wrapf(err, "failed to update playbook run")
 	}
 
-	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, playbookRunToModify)
+	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, "skip", "skipped", playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp); err != nil {
+		return err
+	}
+
+	// Pass a nil current run so the run is refetched and the WS payload carries the timeline event
+	// created just above; passing the in-memory run would broadcast a stale event list, as
+	// ModifyCheckedState's nil argument already accounts for.
+	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, nil)
+
+	return nil
+}
+
+// createTaskStateModifiedEvent records a task_state_modified timeline event for a checklist item
+// state change, so clients can attribute the change to a user and a time. ModifyCheckedState builds
+// the same event inline for check/uncheck.
+func (s *PlaybookRunServiceImpl) createTaskStateModifiedEvent(playbookRunID, userID, action, pastTense string, item ChecklistItem, timestamp int64) error {
+	details := struct {
+		Action string `json:"action,omitempty"`
+		Task   string `json:"task,omitempty"`
+		ItemID string `json:"item_id,omitempty"`
+	}{
+		Action: action,
+		Task:   stripmd.Strip(item.Title),
+		ItemID: item.ID,
+	}
+
+	detailsJSON, err := json.Marshal(details)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode timeline event details")
+	}
+
+	event := &TimelineEvent{
+		PlaybookRunID: playbookRunID,
+		CreateAt:      timestamp,
+		EventAt:       timestamp,
+		EventType:     TaskStateModified,
+		Summary:       fmt.Sprintf("%s checklist item **%v**", pastTense, stripmd.Strip(item.Title)),
+		SubjectUserID: userID,
+		Details:       string(detailsJSON),
+	}
+
+	if _, err := s.store.CreateTimelineEvent(event); err != nil {
+		return errors.Wrap(err, "failed to create timeline event")
+	}
 
 	return nil
 }
@@ -3320,15 +3366,24 @@ func (s *PlaybookRunServiceImpl) RestoreChecklistItem(playbookRunID, userID stri
 		originalRun = playbookRunToModify.Clone()
 	}
 
+	timestamp := model.GetMillis()
 	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].State = ChecklistItemStateOpen
-	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], 0)
+	// Without StateModified a restore is indistinguishable from the state the task was in before it
+	// was skipped, and clients would report the earlier check/uncheck time instead.
+	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].StateModified = timestamp
+	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp)
 
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update playbook run")
 	}
 
-	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, playbookRunToModify)
+	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, "restore", "restored", playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp); err != nil {
+		return err
+	}
+
+	// See the note in SkipChecklistItem: nil forces a refetch so the new timeline event ships.
+	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, nil)
 
 	return nil
 }

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -44,6 +44,30 @@ const (
 	noAssigneeName = "No Assignee"
 )
 
+// Actions recorded in a TaskStateModified timeline event's details.
+const (
+	taskStateActionCheck   = "check"
+	taskStateActionUncheck = "uncheck"
+	taskStateActionSkip    = "skip"
+	taskStateActionRestore = "restore"
+)
+
+// taskStatePastTense gives the verb each action reads as in a timeline event summary.
+var taskStatePastTense = map[string]string{
+	taskStateActionCheck:   "checked off",
+	taskStateActionUncheck: "unchecked",
+	taskStateActionSkip:    "skipped",
+	taskStateActionRestore: "restored",
+}
+
+// TaskStateModifiedDetails is the JSON payload of a task_state_modified timeline event. Clients read
+// action to label the task-activity chip and item_id to attach it to the right checklist item.
+type TaskStateModifiedDetails struct {
+	Action string `json:"action,omitempty"`
+	Task   string `json:"task,omitempty"`
+	ItemID string `json:"item_id,omitempty"`
+}
+
 // PropertyChangedDetails represents the details of a property change timeline event
 type PropertyChangedDetails struct {
 	PropertyFieldID   string          `json:"property_field_id"`
@@ -2277,12 +2301,6 @@ func (s *PlaybookRunServiceImpl) ModifyCheckedState(playbookRunID, userID, newSt
 	model.AddEventParameterToAuditRec(auditRec, "checklistNumber", checklistNumber)
 	model.AddEventParameterToAuditRec(auditRec, "itemNumber", itemNumber)
 
-	type Details struct {
-		Action string `json:"action,omitempty"`
-		Task   string `json:"task,omitempty"`
-		ItemID string `json:"item_id,omitempty"`
-	}
-
 	playbookRunToModify, err := s.checklistItemParamsVerify(playbookRunID, userID, checklistNumber, itemNumber)
 	if err != nil {
 		return err
@@ -2298,39 +2316,36 @@ func (s *PlaybookRunServiceImpl) ModifyCheckedState(playbookRunID, userID, newSt
 	model.AddEventParameterToAuditRec(auditRec, "taskTitle", itemToCheck.Title)
 	model.AddEventParameterToAuditRec(auditRec, "currentState", itemToCheck.State)
 
-	var originalRun *PlaybookRun
-	if s.configService.IsIncrementalUpdatesEnabled() {
-		originalRun = playbookRunToModify.Clone()
-	}
-
 	if newState == itemToCheck.State {
 		auditRec.Success()
 		return nil
 	}
 
-	details := Details{
-		Action: "check",
-		Task:   stripmd.Strip(itemToCheck.Title),
-		ItemID: itemToCheck.ID,
+	var originalRun *PlaybookRun
+	if s.configService.IsIncrementalUpdatesEnabled() {
+		originalRun = playbookRunToModify.Clone()
 	}
 
-	modifyMessage := fmt.Sprintf("checked off checklist item **%v**", stripmd.Strip(itemToCheck.Title))
+	action := taskStateActionCheck
 	if newState == ChecklistItemStateOpen {
-		details.Action = "uncheck"
-		modifyMessage = fmt.Sprintf("unchecked checklist item **%v**", stripmd.Strip(itemToCheck.Title))
+		action = taskStateActionUncheck
 	}
 	if newState == ChecklistItemStateSkipped {
-		details.Action = "skip"
-		modifyMessage = fmt.Sprintf("skipped checklist item **%v**", stripmd.Strip(itemToCheck.Title))
+		action = taskStateActionSkip
 	}
 	if itemToCheck.State == ChecklistItemStateSkipped && newState == ChecklistItemStateOpen {
-		details.Action = "restore"
-		modifyMessage = fmt.Sprintf("restored checklist item **%v**", stripmd.Strip(itemToCheck.Title))
+		action = taskStateActionRestore
 	}
 
 	itemToCheck.State = newState
 	timestamp := model.GetMillis()
 	itemToCheck.StateModified = timestamp
+	if newState == ChecklistItemStateSkipped {
+		// Keeps this endpoint a strict superset of SkipChecklistItem, which is the only other way to
+		// set LastSkipped. Deliberately not cleared on restore: the field means "last time this was
+		// skipped", and the delete_at wire alias is what makes it look like a deletion marker.
+		itemToCheck.LastSkipped = timestamp
+	}
 	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], &itemToCheck, timestamp)
 	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber] = itemToCheck
 
@@ -2339,29 +2354,14 @@ func (s *PlaybookRunServiceImpl) ModifyCheckedState(playbookRunID, userID, newSt
 		return errors.Wrapf(err, "failed to update playbook run, is now in inconsistent state")
 	}
 
-	detailsJSON, err := json.Marshal(details)
-	if err != nil {
-		return errors.Wrap(err, "failed to encode timeline event details")
-	}
-
-	event := &TimelineEvent{
-		PlaybookRunID: playbookRunID,
-		CreateAt:      itemToCheck.StateModified,
-		EventAt:       itemToCheck.StateModified,
-		EventType:     TaskStateModified,
-		Summary:       modifyMessage,
-		SubjectUserID: userID,
-		Details:       string(detailsJSON),
-	}
-
-	if _, err = s.store.CreateTimelineEvent(event); err != nil {
-		return errors.Wrap(err, "failed to create timeline event")
+	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, action, itemToCheck, timestamp); err != nil {
+		return err
 	}
 	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, nil)
 
 	// Mark success and add result state for audit
 	auditRec.Success()
-	model.AddEventParameterToAuditRec(auditRec, "action", details.Action)
+	model.AddEventParameterToAuditRec(auditRec, "action", action)
 	model.AddEventParameterToAuditRec(auditRec, "finalState", newState)
 	auditRec.AddEventResultState(*playbookRunToModify)
 
@@ -3283,9 +3283,31 @@ func (s *PlaybookRunServiceImpl) RestoreChecklist(playbookRunID, userID string, 
 
 // SkipChecklistItem skips the item at the given index from the given checklist
 func (s *PlaybookRunServiceImpl) SkipChecklistItem(playbookRunID, userID string, checklistNumber, itemNumber int) error {
+	auditRec := plugin.MakeAuditRecord("skipChecklistItem", model.AuditStatusFail)
+	defer s.api.LogAuditRec(auditRec)
+
+	// Add parameters and context
+	model.AddEventParameterToAuditRec(auditRec, "userID", userID)
+	model.AddEventParameterToAuditRec(auditRec, "playbookRunID", playbookRunID)
+	model.AddEventParameterToAuditRec(auditRec, "checklistNumber", checklistNumber)
+	model.AddEventParameterToAuditRec(auditRec, "itemNumber", itemNumber)
+
 	playbookRunToModify, err := s.checklistItemParamsVerify(playbookRunID, userID, checklistNumber, itemNumber)
 	if err != nil {
 		return err
+	}
+
+	itemToSkip := &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber]
+
+	// Add current context to audit
+	model.AddEventParameterToAuditRec(auditRec, "taskTitle", itemToSkip.Title)
+	model.AddEventParameterToAuditRec(auditRec, "currentState", itemToSkip.State)
+
+	// Without this guard a repeated skip writes a second timeline event and moves the timestamp
+	// forward, which clients render as a task that was skipped twice.
+	if itemToSkip.State == ChecklistItemStateSkipped {
+		auditRec.Success()
+		return nil
 	}
 
 	var originalRun *PlaybookRun
@@ -3294,45 +3316,45 @@ func (s *PlaybookRunServiceImpl) SkipChecklistItem(playbookRunID, userID string,
 	}
 
 	timestamp := model.GetMillis()
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].LastSkipped = timestamp
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].State = ChecklistItemStateSkipped
-	// StateModified is what clients read to show when a task last changed state; without it a skip
-	// leaves behind the timestamp of an earlier check/uncheck.
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].StateModified = timestamp
-	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp)
+	itemToSkip.LastSkipped = timestamp
+	itemToSkip.State = ChecklistItemStateSkipped
+	itemToSkip.StateModified = timestamp
+	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], itemToSkip, timestamp)
 
+	skippedItem := *itemToSkip
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update playbook run")
 	}
 
-	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, "skip", "skipped", playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp); err != nil {
+	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, taskStateActionSkip, skippedItem, timestamp); err != nil {
 		return err
 	}
 
 	// Pass a nil current run so the run is refetched and the WS payload carries the timeline event
-	// created just above; passing the in-memory run would broadcast a stale event list, as
-	// ModifyCheckedState's nil argument already accounts for.
+	// created just above; passing the in-memory run would broadcast a stale event list.
 	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, nil)
+
+	// Mark success and add result state for audit
+	auditRec.Success()
+	model.AddEventParameterToAuditRec(auditRec, "action", taskStateActionSkip)
+	model.AddEventParameterToAuditRec(auditRec, "finalState", ChecklistItemStateSkipped)
+	auditRec.AddEventResultState(*playbookRunToModify)
 
 	return nil
 }
 
 // createTaskStateModifiedEvent records a task_state_modified timeline event for a checklist item
-// state change, so clients can attribute the change to a user and a time. ModifyCheckedState builds
-// the same event inline for check/uncheck.
-func (s *PlaybookRunServiceImpl) createTaskStateModifiedEvent(playbookRunID, userID, action, pastTense string, item ChecklistItem, timestamp int64) error {
-	details := struct {
-		Action string `json:"action,omitempty"`
-		Task   string `json:"task,omitempty"`
-		ItemID string `json:"item_id,omitempty"`
-	}{
-		Action: action,
-		Task:   stripmd.Strip(item.Title),
-		ItemID: item.ID,
-	}
+// state change, so clients can attribute the change to a user and a time. action must be one of the
+// taskStateAction constants.
+func (s *PlaybookRunServiceImpl) createTaskStateModifiedEvent(playbookRunID, userID, action string, item ChecklistItem, timestamp int64) error {
+	title := stripmd.Strip(item.Title)
 
-	detailsJSON, err := json.Marshal(details)
+	detailsJSON, err := json.Marshal(TaskStateModifiedDetails{
+		Action: action,
+		Task:   title,
+		ItemID: item.ID,
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to encode timeline event details")
 	}
@@ -3342,7 +3364,7 @@ func (s *PlaybookRunServiceImpl) createTaskStateModifiedEvent(playbookRunID, use
 		CreateAt:      timestamp,
 		EventAt:       timestamp,
 		EventType:     TaskStateModified,
-		Summary:       fmt.Sprintf("%s checklist item **%v**", pastTense, stripmd.Strip(item.Title)),
+		Summary:       fmt.Sprintf("%s checklist item **%v**", taskStatePastTense[action], title),
 		SubjectUserID: userID,
 		Details:       string(detailsJSON),
 	}
@@ -3356,9 +3378,30 @@ func (s *PlaybookRunServiceImpl) createTaskStateModifiedEvent(playbookRunID, use
 
 // RestoreChecklistItem restores the item at the given index from the given checklist
 func (s *PlaybookRunServiceImpl) RestoreChecklistItem(playbookRunID, userID string, checklistNumber, itemNumber int) error {
+	auditRec := plugin.MakeAuditRecord("restoreChecklistItem", model.AuditStatusFail)
+	defer s.api.LogAuditRec(auditRec)
+
+	// Add parameters and context
+	model.AddEventParameterToAuditRec(auditRec, "userID", userID)
+	model.AddEventParameterToAuditRec(auditRec, "playbookRunID", playbookRunID)
+	model.AddEventParameterToAuditRec(auditRec, "checklistNumber", checklistNumber)
+	model.AddEventParameterToAuditRec(auditRec, "itemNumber", itemNumber)
+
 	playbookRunToModify, err := s.checklistItemParamsVerify(playbookRunID, userID, checklistNumber, itemNumber)
 	if err != nil {
 		return err
+	}
+
+	itemToRestore := &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber]
+
+	// Add current context to audit
+	model.AddEventParameterToAuditRec(auditRec, "taskTitle", itemToRestore.Title)
+	model.AddEventParameterToAuditRec(auditRec, "currentState", itemToRestore.State)
+
+	// A repeat call would otherwise duplicate the timeline event.
+	if itemToRestore.State == ChecklistItemStateOpen {
+		auditRec.Success()
+		return nil
 	}
 
 	var originalRun *PlaybookRun
@@ -3367,23 +3410,28 @@ func (s *PlaybookRunServiceImpl) RestoreChecklistItem(playbookRunID, userID stri
 	}
 
 	timestamp := model.GetMillis()
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].State = ChecklistItemStateOpen
-	// Without StateModified a restore is indistinguishable from the state the task was in before it
-	// was skipped, and clients would report the earlier check/uncheck time instead.
-	playbookRunToModify.Checklists[checklistNumber].Items[itemNumber].StateModified = timestamp
-	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], &playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp)
+	itemToRestore.State = ChecklistItemStateOpen
+	itemToRestore.StateModified = timestamp
+	updateChecklistAndItemTimestamp(&playbookRunToModify.Checklists[checklistNumber], itemToRestore, timestamp)
 
+	restoredItem := *itemToRestore
 	playbookRunToModify, err = s.store.UpdatePlaybookRun(playbookRunToModify)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update playbook run")
 	}
 
-	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, "restore", "restored", playbookRunToModify.Checklists[checklistNumber].Items[itemNumber], timestamp); err != nil {
+	if err := s.createTaskStateModifiedEvent(playbookRunID, userID, taskStateActionRestore, restoredItem, timestamp); err != nil {
 		return err
 	}
 
-	// See the note in SkipChecklistItem: nil forces a refetch so the new timeline event ships.
+	// A nil current run forces a refetch so the new timeline event ships with the WS payload.
 	s.sendPlaybookRunObjectUpdatedWS(playbookRunID, originalRun, nil)
+
+	// Mark success and add result state for audit
+	auditRec.Success()
+	model.AddEventParameterToAuditRec(auditRec, "action", taskStateActionRestore)
+	model.AddEventParameterToAuditRec(auditRec, "finalState", ChecklistItemStateOpen)
+	auditRec.AddEventResultState(*playbookRunToModify)
 
 	return nil
 }

--- a/server/app/skip_restore_checklist_item_test.go
+++ b/server/app/skip_restore_checklist_item_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-playbooks/server/bot"
+	"github.com/mattermost/mattermost-plugin-playbooks/server/config"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTaskStateStore is a minimal in-memory PlaybookRunStore: it round-trips a single run and
+// records the timeline events written against it. Every other store method panics on nil deref,
+// which is intentional — these tests must not reach them.
+type stubTaskStateStore struct {
+	PlaybookRunStore
+	run     *PlaybookRun
+	events  []*TimelineEvent
+	updates int
+}
+
+func (s *stubTaskStateStore) GetPlaybookRun(_ string) (*PlaybookRun, error) {
+	return s.run.Clone(), nil
+}
+
+func (s *stubTaskStateStore) UpdatePlaybookRun(run *PlaybookRun) (*PlaybookRun, error) {
+	s.updates++
+	s.run = run.Clone()
+	return s.run.Clone(), nil
+}
+
+func (s *stubTaskStateStore) CreateTimelineEvent(event *TimelineEvent) (*TimelineEvent, error) {
+	s.events = append(s.events, event)
+	return event, nil
+}
+
+func (s *stubTaskStateStore) item() ChecklistItem {
+	return s.run.Checklists[0].Items[0]
+}
+
+// stubTaskStateConfig reports incremental updates as enabled, which keeps
+// sendPlaybookRunObjectUpdatedWS off the pluginAPI-backed non-member lookup.
+type stubTaskStateConfig struct {
+	config.Service
+}
+
+func (stubTaskStateConfig) IsIncrementalUpdatesEnabled() bool { return true }
+
+// stubTaskStateAPI swallows audit records so the audited paths can run without a plugin environment.
+type stubTaskStateAPI struct {
+	plugin.API
+	auditRecs []*model.AuditRecord
+}
+
+func (a *stubTaskStateAPI) LogAuditRec(rec *model.AuditRecord) {
+	a.auditRecs = append(a.auditRecs, rec)
+}
+
+type stubTaskStatePoster struct {
+	bot.Poster
+	channelEvents []string
+}
+
+func (p *stubTaskStatePoster) PublishWebsocketEventToChannel(event string, _ interface{}, _ string) {
+	p.channelEvents = append(p.channelEvents, event)
+}
+
+type taskStateService struct {
+	svc    *PlaybookRunServiceImpl
+	store  *stubTaskStateStore
+	api    *stubTaskStateAPI
+	poster *stubTaskStatePoster
+}
+
+func newTaskStateService(t *testing.T, item ChecklistItem) taskStateService {
+	t.Helper()
+
+	store := &stubTaskStateStore{
+		run: &PlaybookRun{
+			ID:        "run1",
+			ChannelID: "channel1",
+			Checklists: []Checklist{{
+				ID:    "checklist1",
+				Title: "Checklist",
+				Items: []ChecklistItem{item},
+			}},
+		},
+	}
+	api := &stubTaskStateAPI{}
+	poster := &stubTaskStatePoster{}
+
+	return taskStateService{
+		svc: &PlaybookRunServiceImpl{
+			store:          store,
+			api:            api,
+			poster:         poster,
+			configService:  stubTaskStateConfig{},
+			licenseChecker: stubLicenseChecker{},
+		},
+		store:  store,
+		api:    api,
+		poster: poster,
+	}
+}
+
+func openItem() ChecklistItem {
+	return ChecklistItem{
+		ID:            "item1",
+		Title:         "Deploy the **thing**",
+		State:         ChecklistItemStateOpen,
+		StateModified: 1000,
+	}
+}
+
+// requireTaskStateEvent checks the event against the item it describes. The timestamps must match
+// StateModified exactly: clients read event_at to place the task-activity chip.
+func requireTaskStateEvent(t *testing.T, event *TimelineEvent, action string, item ChecklistItem) {
+	t.Helper()
+
+	assert.Equal(t, TaskStateModified, event.EventType)
+	assert.Equal(t, "run1", event.PlaybookRunID)
+	assert.Equal(t, "user1", event.SubjectUserID)
+	assert.Equal(t, item.StateModified, event.EventAt)
+	assert.Equal(t, item.StateModified, event.CreateAt)
+
+	var details TaskStateModifiedDetails
+	require.NoError(t, json.Unmarshal([]byte(event.Details), &details))
+	assert.Equal(t, action, details.Action)
+	assert.Equal(t, item.ID, details.ItemID)
+	assert.Equal(t, "Deploy the thing", details.Task)
+}
+
+func TestSkipChecklistItem(t *testing.T) {
+	t.Run("records the state change and a timeline event", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+		before := model.GetMillis()
+
+		require.NoError(t, h.svc.SkipChecklistItem("run1", "user1", 0, 0))
+
+		item := h.store.item()
+		assert.Equal(t, ChecklistItemStateSkipped, item.State)
+		assert.GreaterOrEqual(t, item.StateModified, before)
+		assert.Equal(t, item.StateModified, item.LastSkipped)
+
+		require.Len(t, h.store.events, 1)
+		requireTaskStateEvent(t, h.store.events[0], taskStateActionSkip, item)
+		assert.Equal(t, "skipped checklist item **Deploy the thing**", h.store.events[0].Summary)
+
+		assert.Equal(t, []string{playbookRunUpdatedIncrementalWSEvent}, h.poster.channelEvents, "without a broadcast the client never learns of the skip")
+
+		require.Len(t, h.api.auditRecs, 1)
+		assert.Equal(t, model.AuditStatusSuccess, h.api.auditRecs[0].Status)
+	})
+
+	t.Run("skipping a checked item overwrites the earlier state timestamp", func(t *testing.T) {
+		checked := openItem()
+		checked.State = ChecklistItemStateClosed
+		h := newTaskStateService(t, checked)
+
+		require.NoError(t, h.svc.SkipChecklistItem("run1", "user1", 0, 0))
+
+		item := h.store.item()
+		assert.Equal(t, ChecklistItemStateSkipped, item.State)
+		assert.NotEqual(t, int64(1000), item.StateModified, "the check timestamp must not survive a skip")
+	})
+
+	t.Run("skipping an already skipped item is a no-op", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+		require.NoError(t, h.svc.SkipChecklistItem("run1", "user1", 0, 0))
+		first := h.store.item()
+
+		require.NoError(t, h.svc.SkipChecklistItem("run1", "user1", 0, 0))
+
+		assert.Equal(t, 1, h.store.updates, "second skip must not write the run again")
+		assert.Len(t, h.store.events, 1, "second skip must not write a second timeline event")
+		assert.Equal(t, first.StateModified, h.store.item().StateModified)
+		assert.Equal(t, first.LastSkipped, h.store.item().LastSkipped)
+
+		require.Len(t, h.api.auditRecs, 2)
+		assert.Equal(t, model.AuditStatusSuccess, h.api.auditRecs[1].Status)
+	})
+
+	t.Run("invalid item number is rejected", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+
+		require.Error(t, h.svc.SkipChecklistItem("run1", "user1", 0, 7))
+		assert.Empty(t, h.store.events)
+	})
+}
+
+func TestRestoreChecklistItem(t *testing.T) {
+	skippedItem := func() ChecklistItem {
+		item := openItem()
+		item.State = ChecklistItemStateSkipped
+		item.LastSkipped = 2000
+		item.StateModified = 2000
+		return item
+	}
+
+	t.Run("records the state change and a timeline event", func(t *testing.T) {
+		h := newTaskStateService(t, skippedItem())
+		before := model.GetMillis()
+
+		require.NoError(t, h.svc.RestoreChecklistItem("run1", "user1", 0, 0))
+
+		item := h.store.item()
+		assert.Equal(t, ChecklistItemStateOpen, item.State)
+		assert.GreaterOrEqual(t, item.StateModified, before)
+		assert.Equal(t, int64(2000), item.LastSkipped, "LastSkipped records when the task was skipped, not whether it still is")
+
+		require.Len(t, h.store.events, 1)
+		requireTaskStateEvent(t, h.store.events[0], taskStateActionRestore, item)
+		assert.Equal(t, "restored checklist item **Deploy the thing**", h.store.events[0].Summary)
+
+		require.Len(t, h.api.auditRecs, 1)
+		assert.Equal(t, model.AuditStatusSuccess, h.api.auditRecs[0].Status)
+	})
+
+	t.Run("restoring an already open item is a no-op", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+
+		require.NoError(t, h.svc.RestoreChecklistItem("run1", "user1", 0, 0))
+
+		assert.Zero(t, h.store.updates)
+		assert.Empty(t, h.store.events)
+		assert.Equal(t, int64(1000), h.store.item().StateModified)
+
+		require.Len(t, h.api.auditRecs, 1)
+		assert.Equal(t, model.AuditStatusSuccess, h.api.auditRecs[0].Status)
+	})
+
+	t.Run("restore after skip leaves exactly one event per transition", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+
+		require.NoError(t, h.svc.SkipChecklistItem("run1", "user1", 0, 0))
+		require.NoError(t, h.svc.RestoreChecklistItem("run1", "user1", 0, 0))
+
+		require.Len(t, h.store.events, 2)
+		assert.Contains(t, h.store.events[0].Details, `"action":"skip"`)
+		assert.Contains(t, h.store.events[1].Details, `"action":"restore"`)
+	})
+}
+
+// TestModifyCheckedStateSkip covers the /state endpoint being a strict superset of /skip: the webapp
+// reaches skip/restore through it, so it has to set LastSkipped too.
+func TestModifyCheckedStateSkip(t *testing.T) {
+	t.Run("skip sets LastSkipped alongside StateModified", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+		before := model.GetMillis()
+
+		require.NoError(t, h.svc.ModifyCheckedState("run1", "user1", ChecklistItemStateSkipped, 0, 0))
+
+		item := h.store.item()
+		assert.Equal(t, ChecklistItemStateSkipped, item.State)
+		assert.GreaterOrEqual(t, item.LastSkipped, before)
+		assert.Equal(t, item.StateModified, item.LastSkipped)
+
+		require.Len(t, h.store.events, 1)
+		requireTaskStateEvent(t, h.store.events[0], taskStateActionSkip, item)
+	})
+
+	t.Run("restore keeps LastSkipped", func(t *testing.T) {
+		skipped := openItem()
+		skipped.State = ChecklistItemStateSkipped
+		skipped.LastSkipped = 2000
+		h := newTaskStateService(t, skipped)
+
+		require.NoError(t, h.svc.ModifyCheckedState("run1", "user1", ChecklistItemStateOpen, 0, 0))
+
+		item := h.store.item()
+		assert.Equal(t, ChecklistItemStateOpen, item.State)
+		assert.Equal(t, int64(2000), item.LastSkipped)
+
+		require.Len(t, h.store.events, 1)
+		requireTaskStateEvent(t, h.store.events[0], taskStateActionRestore, item)
+	})
+
+	t.Run("check does not touch LastSkipped", func(t *testing.T) {
+		h := newTaskStateService(t, openItem())
+
+		require.NoError(t, h.svc.ModifyCheckedState("run1", "user1", ChecklistItemStateClosed, 0, 0))
+
+		assert.Equal(t, ChecklistItemStateClosed, h.store.item().State)
+		assert.Zero(t, h.store.item().LastSkipped)
+	})
+}

--- a/server/app/skip_restore_checklist_item_test.go
+++ b/server/app/skip_restore_checklist_item_test.go
@@ -235,6 +235,20 @@ func TestRestoreChecklistItem(t *testing.T) {
 		assert.Equal(t, model.AuditStatusSuccess, h.api.auditRecs[0].Status)
 	})
 
+	t.Run("restoring a non-skipped item is a no-op", func(t *testing.T) {
+		for _, state := range []string{ChecklistItemStateClosed, ChecklistItemStateInProgress} {
+			item := openItem()
+			item.State = state
+			h := newTaskStateService(t, item)
+
+			require.NoError(t, h.svc.RestoreChecklistItem("run1", "user1", 0, 0))
+
+			assert.Equal(t, state, h.store.item().State, "restore undoes a skip, not a check")
+			assert.Zero(t, h.store.updates)
+			assert.Empty(t, h.store.events, "%q -> open is an uncheck, and an event calling it a restore is what makes clients render the wrong verb", state)
+		}
+	})
+
 	t.Run("restore after skip leaves exactly one event per transition", func(t *testing.T) {
 		h := newTaskStateService(t, openItem())
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -402,13 +402,6 @@ export async function clientDeleteChecklistItem(playbookRunID: string, checklist
     });
 }
 
-export async function clientSkipChecklistItem(playbookRunID: string, checklistNum: number, itemNum: number) {
-    await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunID}/checklists/${checklistNum}/item/${itemNum}/skip`, {
-        method: 'put',
-        body: '',
-    });
-}
-
 export async function clientSkipChecklist(playbookRunID: string, checklistNum: number) {
     await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunID}/checklists/${checklistNum}/skip`, {
         method: 'PUT',
@@ -419,13 +412,6 @@ export async function clientSkipChecklist(playbookRunID: string, checklistNum: n
 export async function clientRestoreChecklist(playbookRunID: string, checklistNum: number) {
     await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunID}/checklists/${checklistNum}/restore`, {
         method: 'PUT',
-        body: '',
-    });
-}
-
-export async function clientRestoreChecklistItem(playbookRunID: string, checklistNum: number, itemNum: number) {
-    await doFetchWithoutResponse(`${apiUrl}/runs/${playbookRunID}/checklists/${checklistNum}/item/${itemNum}/restore`, {
-        method: 'put',
         body: '',
     });
 }

--- a/webapp/src/components/checklist_item/hover_menu.tsx
+++ b/webapp/src/components/checklist_item/hover_menu.tsx
@@ -23,7 +23,7 @@ import {Mode} from 'src/components/datetime_input';
 import {PropertyField} from 'src/types/properties';
 import {formatConditionExpr} from 'src/utils/condition_format';
 
-import {clientDuplicateChecklistItem, clientRestoreChecklistItem, clientSkipChecklistItem} from 'src/client';
+import {clientDuplicateChecklistItem} from 'src/client';
 import {Condition} from 'src/types/conditions';
 
 import AssignTo, {RoleOption} from './assign_to';
@@ -188,19 +188,7 @@ const ChecklistItemHoverMenu = (props: Props) => {
                 )}
                 {props.playbookRunId !== undefined &&
                     <StyledDropdownMenuItem
-                        onClick={() => {
-                            if (props.isSkipped) {
-                                clientRestoreChecklistItem(props.playbookRunId || '', props.checklistNum, props.itemNum);
-                                if (props.onChange) {
-                                    props.onChange(ChecklistItemState.Open);
-                                }
-                            } else {
-                                clientSkipChecklistItem(props.playbookRunId || '', props.checklistNum, props.itemNum);
-                                if (props.onChange) {
-                                    props.onChange(ChecklistItemState.Skip);
-                                }
-                            }
-                        }}
+                        onClick={() => props.onChange?.(props.isSkipped ? ChecklistItemState.Open : ChecklistItemState.Skip)}
                     >
                         <DropdownIcon className={props.isSkipped ? 'icon-refresh icon-16 btn-icon' : 'icon-close icon-16 btn-icon'}/>
                         {props.isSkipped ? formatMessage({defaultMessage: 'Restore task'}) : formatMessage({defaultMessage: 'Skip task'})}


### PR DESCRIPTION
## Summary

Skipping or restoring a task left `StateModified` untouched and created no timeline event, so clients could not tell when a task was skipped or by whom — they fell back to the timestamp of an earlier check/uncheck.

**Server**

- Set `StateModified` on both the skip and restore paths, and emit a `task_state_modified` timeline event carrying `action`, `task`, and `item_id`.
- Pass a `nil` current run to `sendPlaybookRunObjectUpdatedWS` so the broadcast is rebuilt from the store and ships the newly created event, matching what `ModifyCheckedState` already did.
- Extract the event construction shared by all four transitions into `createTaskStateModifiedEvent`, name the actions as constants, and export the payload as `TaskStateModifiedDetails`.
- Add audit records to `SkipChecklistItem` and `RestoreChecklistItem`, which previously had none, plus idempotency guards so a repeated call cannot write a second event or move the timestamp forward.
- `ModifyCheckedState` now sets `LastSkipped` when skipping, making it a strict superset of `SkipChecklistItem`. `LastSkipped` is deliberately left alone on restore: it records when a task was last skipped, not whether it still is.

**Webapp**

- The hover menu's skip/restore item now goes through `onChange`, so a click is a single write to the item state endpoint. Removed `clientSkipChecklistItem` and `clientRestoreChecklistItem`.

This leaves one code path for a task state change instead of two with different side effects. The dedicated `/skip` and `/restore` endpoints remain for API consumers and now behave consistently with `/state`.

## Ticket Link

Server/Webapp: https://mattermost.atlassian.net/browse/MM-70231
Mobile: https://mattermost.atlassian.net/browse/MM-69381

## Checklist

- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated — new `server/app/skip_restore_checklist_item_test.go` covers both endpoints, the no-op guards, timeline event contents and timestamps, the WS broadcast, and `ModifyCheckedState`'s `LastSkipped` handling for skip/restore/check
- [ ] ~~Planned cherry-picks: `release-X.Y`~~
