### PR TITLE
MM-69943: Require channel post permission to run checklist slash commands

### DIFF
--- a/server/api/playbook_runs.go
+++ b/server/api/playbook_runs.go
@@ -1653,7 +1653,11 @@ func (h *PlaybookRunHandler) itemRun(c *Context, w http.ResponseWriter, r *http.
 
 	triggerID, err := h.playbookRunService.RunChecklistItemSlashCommand(playbookRunID, userID, checklistNum, itemNum)
 	if err != nil {
-		h.HandleError(w, c.logger, err)
+		if errors.Is(err, app.ErrNoPermissions) {
+			h.HandleErrorWithCode(w, c.logger, http.StatusForbidden, "Not authorized", err)
+		} else {
+			h.HandleError(w, c.logger, err)
+		}
 		return
 	}
 

--- a/server/api_runs_test.go
+++ b/server/api_runs_test.go
@@ -2618,6 +2618,66 @@ func TestChecklisItem_SetCommand(t *testing.T) {
 	})
 }
 
+func TestChecklistItem_RunCommandRequiresChannelPostPermission(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	playbookID, err := e.PlaybooksAdminClient.Playbooks.Create(context.Background(), client.PlaybookCreateOptions{
+		Title:                               "Public playbook private run",
+		TeamID:                              e.BasicTeam.Id,
+		Public:                              true,
+		CreatePublicPlaybookRun:             false,
+		CreateChannelMemberOnNewParticipant: false,
+		Members: []client.PlaybookMember{
+			{UserID: e.RegularUser.Id, Roles: []string{app.PlaybookRoleMember}},
+			{UserID: e.AdminUser.Id, Roles: []string{app.PlaybookRoleAdmin, app.PlaybookRoleMember}},
+		},
+	})
+	require.NoError(t, err)
+
+	run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+		Name:        "Private channel run",
+		OwnerUserID: e.RegularUser.Id,
+		TeamID:      e.BasicTeam.Id,
+		PlaybookID:  playbookID,
+	})
+	require.NoError(t, err)
+
+	err = e.PlaybooksClient.PlaybookRuns.CreateChecklist(context.Background(), run.ID, client.Checklist{
+		Title: "Test Checklist",
+		Items: []client.ChecklistItem{{Title: "Test Item"}},
+	})
+	require.NoError(t, err)
+
+	err = e.PlaybooksClient.PlaybookRuns.SetItemCommand(context.Background(), run.ID, 0, 0, "/playbook todo")
+	require.NoError(t, err)
+
+	response, err := addParticipants(e.PlaybooksClient, run.ID, []string{e.RegularUser2.Id})
+	require.NoError(t, err)
+	require.Empty(t, response.Errors)
+
+	run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+	require.NoError(t, err)
+	require.Contains(t, run.ParticipantIDs, e.RegularUser2.Id)
+
+	_, _, err = e.ServerAdminClient.GetChannelMember(context.Background(), run.ChannelID, e.RegularUser2.Id, "")
+	require.Error(t, err)
+
+	t.Run("participant without channel membership cannot run slash command", func(t *testing.T) {
+		err = e.PlaybooksClient2.PlaybookRuns.RunItemCommand(context.Background(), run.ID, 0, 0)
+		requireErrorWithStatusCode(t, err, http.StatusForbidden)
+	})
+
+	t.Run("channel member can still run slash command", func(t *testing.T) {
+		err = e.PlaybooksClient.PlaybookRuns.RunItemCommand(context.Background(), run.ID, 0, 0)
+		require.NoError(t, err)
+
+		run, err = e.PlaybooksClient.PlaybookRuns.Get(context.Background(), run.ID)
+		require.NoError(t, err)
+		require.NotZero(t, run.Checklists[0].Items[0].CommandLastRun)
+	})
+}
+
 func TestGetByChannelID(t *testing.T) {
 	e := Setup(t)
 	e.CreateBasic()

--- a/server/app/playbook_run_service.go
+++ b/server/app/playbook_run_service.go
@@ -2820,6 +2820,10 @@ func (s *PlaybookRunServiceImpl) RunChecklistItemSlashCommand(playbookRunID, use
 		return "", err
 	}
 
+	if !CanPostToChannel(userID, playbookRun.ChannelID, s.pluginAPI) {
+		return "", errors.Wrapf(ErrNoPermissions, "user `%s` does not have permission to post in run channel `%s`", userID, playbookRun.ChannelID)
+	}
+
 	if !IsValidChecklistItemIndex(playbookRun.Checklists, checklistNumber, itemNumber) {
 		return "", errors.New("invalid checklist item indices")
 	}


### PR DESCRIPTION
## Summary

Executing a checklist slash command was authorized only by run-level permissions, which did not
account for whether the caller can post in the run's channel. `RunChecklistItemSlashCommand` now
requires `PermissionCreatePost` on the run's channel, checked before the checklist item is
resolved so the response does not vary with the item's contents.

The check is applied in the app service rather than the API handler, so it covers every caller of
this operation. It is a no-op for channel checklists and DM/GM runs, where `RunManageProperties`
already requires posting permission on the channel; it only tightens playbook-based runs.
`itemRun` maps `ErrNoPermissions` to a 403, matching the `checkEditPermissions` middleware and the
other handlers in this file that surface this sentinel from a service call.

## Ticket Link

Fixes [MM-69943](https://mattermost.atlassian.net/browse/MM-69943).

## Checklist

- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
- [ ] ~~Planned cherry-picks~~ handled by backend automation

[MM-69943]: https://mattermost.atlassian.net/browse/MM-69943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ