### PR TITLE
MM-70245: Bound the records a GraphQL request may hydrate

### DIFF
--- a/server/api/graphql.go
+++ b/server/api/graphql.go
@@ -141,6 +141,7 @@ type GraphQLContext struct {
 	config               config.Service
 	permissions          *app.PermissionsService
 	licenceChecker       app.LicenseChecker
+	recordBudget         *recordBudget
 	favoritesLoader      *dataloader.Loader[favoriteInfo, bool]
 	playbooksLoader      *dataloader.Loader[playbookInfo, *app.Playbook]
 	statusPostsLoader    *dataloader.Loader[string, []app.StatusPost]
@@ -190,6 +191,7 @@ func (h *GraphQLHandler) graphQL(c *Context, w http.ResponseWriter, r *http.Requ
 		playbookStore:        h.playbookStore,
 		runStore:             h.runStore,
 		licenceChecker:       h.licenceChecker,
+		recordBudget:         &recordBudget{limit: maxRecordsPerRequest},
 		favoritesLoader:      favoritesLoader,
 		playbooksLoader:      playbooksLoader,
 		statusPostsLoader:    statusPostsLoader,

--- a/server/api/graphql_budget.go
+++ b/server/api/graphql_budget.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+)
+
+// maxRecordsPerRequest bounds how many playbook and run records a single GraphQL
+// request may hydrate across every field it resolves. Neither MaxDepth nor the
+// request body limit constrains breadth, so repeating a list field under distinct
+// aliases would otherwise multiply the work of one small request without bound.
+const maxRecordsPerRequest = 5000
+
+// recordBudget tracks the records hydrated so far by a single GraphQL request.
+// Fields resolve in parallel, so the running total is kept atomically.
+type recordBudget struct {
+	limit int64
+	used  atomic.Int64
+}
+
+// check reports an error once previously resolved fields have used up the
+// request's budget, stopping an over-budget request before it hydrates more.
+func (b *recordBudget) check() error {
+	if b.used.Load() >= b.limit {
+		return newGraphQLError(errors.Errorf("query exceeds the limit of %d records per request", b.limit))
+	}
+
+	return nil
+}
+
+// record charges n hydrated records against the budget. Charging what was
+// actually fetched rather than the requested page size keeps requests that ask
+// for a large page but match few records from being rejected.
+func (b *recordBudget) record(n int) {
+	b.used.Add(int64(n))
+}

--- a/server/api/graphql_budget.go
+++ b/server/api/graphql_budget.go
@@ -15,26 +15,40 @@ import (
 // aliases would otherwise multiply the work of one small request without bound.
 const maxRecordsPerRequest = 5000
 
-// recordBudget tracks the records hydrated so far by a single GraphQL request.
-// Fields resolve in parallel, so the running total is kept atomically.
+// recordBudget tracks the records a single GraphQL request has claimed. Capacity
+// is claimed before a listing is fetched rather than charged afterwards: fields
+// resolve in parallel, so admitting a listing on the records hydrated so far
+// would let concurrent fields read the same remaining capacity and exceed the
+// limit together.
 type recordBudget struct {
 	limit int64
 	used  atomic.Int64
 }
 
-// check reports an error once previously resolved fields have used up the
-// request's budget, stopping an over-budget request before it hydrates more.
-func (b *recordBudget) check() error {
-	if b.used.Load() >= b.limit {
-		return newGraphQLError(errors.Errorf("query exceeds the limit of %d records per request", b.limit))
+// reserve claims capacity for the n records a listing may return, erroring
+// unless the whole page fits in what the request has left.
+func (b *recordBudget) reserve(n int) error {
+	if n <= 0 {
+		return nil
 	}
 
-	return nil
+	for {
+		used := b.used.Load()
+		if used+int64(n) > b.limit {
+			return newGraphQLError(errors.Errorf("query exceeds the limit of %d records per request", b.limit))
+		}
+
+		if b.used.CompareAndSwap(used, used+int64(n)) {
+			return nil
+		}
+	}
 }
 
-// record charges n hydrated records against the budget. Charging what was
-// actually fetched rather than the requested page size keeps requests that ask
-// for a large page but match few records from being rejected.
-func (b *recordBudget) record(n int) {
-	b.used.Add(int64(n))
+// release returns capacity a listing reserved but did not use, so that a request
+// asking for a large page and matching few records keeps its budget for the
+// fields it has left to resolve.
+func (b *recordBudget) release(n int) {
+	if n > 0 {
+		b.used.Add(-int64(n))
+	}
 }

--- a/server/api/graphql_budget_test.go
+++ b/server/api/graphql_budget_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunsPerPage(t *testing.T) {
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	for _, tc := range []struct {
+		name     string
+		first    *int32
+		expected int
+	}{
+		{"a request without pagination is still bounded", nil, maxRunsPerPage},
+		{"a page size beyond the bound is clamped", int32Ptr(10000), maxRunsPerPage},
+		{"a page size at the bound is kept", int32Ptr(maxRunsPerPage), maxRunsPerPage},
+		{"a page size below the bound is kept", int32Ptr(8), 8},
+		{"an empty page is left to the store", int32Ptr(0), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, runsPerPage(tc.first))
+		})
+	}
+}
+
+func TestRecordBudget(t *testing.T) {
+	t.Run("resolves while the request is under its limit", func(t *testing.T) {
+		budget := &recordBudget{limit: 10}
+		require.NoError(t, budget.check())
+
+		budget.record(9)
+		require.NoError(t, budget.check())
+	})
+
+	t.Run("stops resolving once the request reaches its limit", func(t *testing.T) {
+		budget := &recordBudget{limit: 10}
+		budget.record(10)
+
+		require.Error(t, budget.check())
+	})
+
+	t.Run("reports the limit back to the client", func(t *testing.T) {
+		budget := &recordBudget{limit: 10}
+		budget.record(11)
+
+		err := budget.check()
+		require.Error(t, err)
+		require.True(t, isGraphQLErrorable(err))
+		require.Contains(t, err.Error(), "10 records per request")
+	})
+
+	t.Run("totals records across fields resolved in parallel", func(t *testing.T) {
+		budget := &recordBudget{limit: 100}
+
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				budget.record(2)
+			}()
+		}
+		wg.Wait()
+
+		require.Error(t, budget.check())
+	})
+}

--- a/server/api/graphql_budget_test.go
+++ b/server/api/graphql_budget_test.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,44 +32,70 @@ func TestRunsPerPage(t *testing.T) {
 }
 
 func TestRecordBudget(t *testing.T) {
-	t.Run("resolves while the request is under its limit", func(t *testing.T) {
+	t.Run("admits a page only when the whole page fits", func(t *testing.T) {
 		budget := &recordBudget{limit: 10}
-		require.NoError(t, budget.check())
+		require.NoError(t, budget.reserve(9))
 
-		budget.record(9)
-		require.NoError(t, budget.check())
+		require.Error(t, budget.reserve(2))
+		require.NoError(t, budget.reserve(1))
 	})
 
-	t.Run("stops resolving once the request reaches its limit", func(t *testing.T) {
+	t.Run("leaves an empty page to the store", func(t *testing.T) {
 		budget := &recordBudget{limit: 10}
-		budget.record(10)
+		require.NoError(t, budget.reserve(10))
 
-		require.Error(t, budget.check())
+		require.NoError(t, budget.reserve(0))
 	})
 
 	t.Run("reports the limit back to the client", func(t *testing.T) {
 		budget := &recordBudget{limit: 10}
-		budget.record(11)
+		require.NoError(t, budget.reserve(10))
 
-		err := budget.check()
+		err := budget.reserve(1)
 		require.Error(t, err)
 		require.True(t, isGraphQLErrorable(err))
 		require.Contains(t, err.Error(), "10 records per request")
 	})
 
-	t.Run("totals records across fields resolved in parallel", func(t *testing.T) {
-		budget := &recordBudget{limit: 100}
+	t.Run("keeps the capacity a short listing did not use", func(t *testing.T) {
+		budget := &recordBudget{limit: 10}
+		require.NoError(t, budget.reserve(10))
+		require.Error(t, budget.reserve(10))
 
+		const fetched = 2
+		budget.release(10 - fetched)
+
+		require.NoError(t, budget.reserve(10-fetched))
+	})
+
+	t.Run("admits no more than the limit when fields race", func(t *testing.T) {
+		budget := &recordBudget{limit: 1000}
+
+		// The reservations are released together so that they contend for the
+		// same remaining capacity, as parallel field resolution does.
+		start := make(chan struct{})
+		var admitted atomic.Int64
 		var wg sync.WaitGroup
-		for range 50 {
+		for range 100 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				budget.record(2)
+				<-start
+				if err := budget.reserve(100); err == nil {
+					admitted.Add(100)
+				}
 			}()
 		}
+		close(start)
 		wg.Wait()
 
-		require.Error(t, budget.check())
+		require.Equal(t, int64(1000), admitted.Load())
 	})
+}
+
+// The webapp's PlaybooksModal query resolves one run listing and two playbook
+// listings in a single request, so those pages have to fit in the budget
+// together or the query fails against a server holding enough records.
+func TestLargestClientQueryFitsTheBudget(t *testing.T) {
+	require.LessOrEqual(t, maxRunsPerPage+(2*maxPlaybooksPerPage), maxRecordsPerRequest)
 }

--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -19,6 +19,12 @@ import (
 type PlaybookRootResolver struct {
 }
 
+// maxPlaybooksPerPage bounds a single playbook listing. The query takes no
+// pagination arguments, so this is the whole listing, and playbooks are hydrated
+// with their full checklists: the previous 10000 record page was larger than a
+// whole request is allowed to hydrate, leaving the request budget unenforceable.
+const maxPlaybooksPerPage = 1000
+
 func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolver, error) {
 	c, err := getContext(ctx)
 	if err != nil {
@@ -26,11 +32,11 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
-	if err = c.recordBudget.check(); err != nil {
+	if err = c.permissions.PlaybookView(userID, playbookID); err != nil {
 		return nil, err
 	}
 
-	if err = c.permissions.PlaybookView(userID, playbookID); err != nil {
+	if err = c.recordBudget.reserve(1); err != nil {
 		return nil, err
 	}
 
@@ -38,7 +44,6 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 	if err != nil {
 		return nil, err
 	}
-	c.recordBudget.record(1)
 
 	return &PlaybookResolver{playbook}, nil
 }
@@ -64,10 +69,6 @@ func (r *PlaybookRootResolver) Playbooks(ctx context.Context, args struct {
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
-	if err = c.recordBudget.check(); err != nil {
-		return nil, err
-	}
-
 	if args.TeamID != "" {
 		if err = c.permissions.PlaybookList(userID, args.TeamID); err != nil {
 			return nil, err
@@ -92,14 +93,19 @@ func (r *PlaybookRootResolver) Playbooks(ctx context.Context, args struct {
 		WithArchived:       args.WithArchived,
 		WithMembershipOnly: isGuest || args.WithMembershipOnly, // Guests can only see playbooks if they are invited to them
 		Page:               0,
-		PerPage:            10000,
+		PerPage:            maxPlaybooksPerPage,
+	}
+
+	if err = c.recordBudget.reserve(maxPlaybooksPerPage); err != nil {
+		return nil, err
 	}
 
 	playbookResults, err := c.playbookService.GetPlaybooksForTeam(requesterInfo, args.TeamID, opts)
 	if err != nil {
+		c.recordBudget.release(maxPlaybooksPerPage)
 		return nil, err
 	}
-	c.recordBudget.record(len(playbookResults.Items))
+	c.recordBudget.release(maxPlaybooksPerPage - len(playbookResults.Items))
 
 	filteredItems := c.permissions.FilterPlaybooksByViewPermission(userID, playbookResults.Items)
 

--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -26,6 +26,10 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
+	if err = c.recordBudget.check(); err != nil {
+		return nil, err
+	}
+
 	if err = c.permissions.PlaybookView(userID, playbookID); err != nil {
 		return nil, err
 	}
@@ -34,6 +38,7 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 	if err != nil {
 		return nil, err
 	}
+	c.recordBudget.record(1)
 
 	return &PlaybookResolver{playbook}, nil
 }
@@ -58,6 +63,10 @@ func (r *PlaybookRootResolver) Playbooks(ctx context.Context, args struct {
 		return nil, err
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
+
+	if err = c.recordBudget.check(); err != nil {
+		return nil, err
+	}
 
 	if args.TeamID != "" {
 		if err = c.permissions.PlaybookList(userID, args.TeamID); err != nil {
@@ -90,6 +99,7 @@ func (r *PlaybookRootResolver) Playbooks(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
+	c.recordBudget.record(len(playbookResults.Items))
 
 	filteredItems := c.permissions.FilterPlaybooksByViewPermission(userID, playbookResults.Items)
 

--- a/server/api/graphql_root_playbook.go
+++ b/server/api/graphql_root_playbook.go
@@ -42,6 +42,7 @@ func getGraphqlPlaybook(ctx context.Context, playbookID string) (*PlaybookResolv
 
 	playbook, err := c.playbookService.Get(playbookID)
 	if err != nil {
+		c.recordBudget.release(1)
 		return nil, err
 	}
 

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -18,6 +18,21 @@ import (
 type RunRootResolver struct {
 }
 
+// maxRunsPerPage bounds a single run listing, both when a client requests a page
+// size and when it omits pagination entirely. Every run is hydrated with its full
+// checklists, so an unbounded listing can cost far more memory than it appears to.
+const maxRunsPerPage = 1000
+
+// runsPerPage resolves the page size for a run listing. Page sizes at or below
+// zero are left to the store, which reads them as an empty page.
+func runsPerPage(first *int32) int {
+	if first == nil || *first > maxRunsPerPage {
+		return maxRunsPerPage
+	}
+
+	return int(*first)
+}
+
 func (r *RunRootResolver) Run(ctx context.Context, args struct {
 	ID string `url:"id,omitempty"`
 }) (*RunResolver, error) {
@@ -27,6 +42,10 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
+	if err = c.recordBudget.check(); err != nil {
+		return nil, err
+	}
+
 	if err = c.permissions.RunView(userID, args.ID); err != nil {
 		return nil, err
 	}
@@ -35,6 +54,7 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
+	c.recordBudget.record(1)
 
 	return &RunResolver{*run}, nil
 }
@@ -58,6 +78,10 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
+	if err = c.recordBudget.check(); err != nil {
+		return nil, err
+	}
+
 	requesterInfo, err := app.GetRequesterInfo(userID, c.pluginAPI)
 	if err != nil {
 		return nil, err
@@ -68,10 +92,7 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 		args.ParticipantOrFollowerID = userID
 	}
 
-	perPage := 10000 // If paging not specified, get "everything"
-	if args.First != nil {
-		perPage = int(*args.First)
-	}
+	perPage := runsPerPage(args.First)
 
 	page := 0
 	if args.After != nil {
@@ -100,6 +121,7 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
+	c.recordBudget.record(len(runResults.Items))
 
 	return &RunConnectionResolver{results: *runResults, page: page}, nil
 }

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -52,6 +52,7 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 
 	run, err := c.playbookRunService.GetPlaybookRun(args.ID)
 	if err != nil {
+		c.recordBudget.release(1)
 		return nil, err
 	}
 

--- a/server/api/graphql_root_run.go
+++ b/server/api/graphql_root_run.go
@@ -42,11 +42,11 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
 
-	if err = c.recordBudget.check(); err != nil {
+	if err = c.permissions.RunView(userID, args.ID); err != nil {
 		return nil, err
 	}
 
-	if err = c.permissions.RunView(userID, args.ID); err != nil {
+	if err = c.recordBudget.reserve(1); err != nil {
 		return nil, err
 	}
 
@@ -54,7 +54,6 @@ func (r *RunRootResolver) Run(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
-	c.recordBudget.record(1)
 
 	return &RunResolver{*run}, nil
 }
@@ -77,10 +76,6 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 		return nil, err
 	}
 	userID := c.r.Header.Get("Mattermost-User-ID")
-
-	if err = c.recordBudget.check(); err != nil {
-		return nil, err
-	}
 
 	requesterInfo, err := app.GetRequesterInfo(userID, c.pluginAPI)
 	if err != nil {
@@ -117,11 +112,16 @@ func (r *RunRootResolver) Runs(ctx context.Context, args struct {
 		OmitEnded:               args.OmitEnded,
 	}
 
-	runResults, err := c.playbookRunService.GetPlaybookRuns(requesterInfo, filterOptions)
-	if err != nil {
+	if err = c.recordBudget.reserve(perPage); err != nil {
 		return nil, err
 	}
-	c.recordBudget.record(len(runResults.Items))
+
+	runResults, err := c.playbookRunService.GetPlaybookRuns(requesterInfo, filterOptions)
+	if err != nil {
+		c.recordBudget.release(perPage)
+		return nil, err
+	}
+	c.recordBudget.release(perPage - len(runResults.Items))
 
 	return &RunConnectionResolver{results: *runResults, page: page}, nil
 }

--- a/server/api_graphql_runs_test.go
+++ b/server/api_graphql_runs_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go"
@@ -204,6 +205,81 @@ func TestGraphQLRunList(t *testing.T) {
 		assert.Len(t, rResultTest.Data.Runs.Edges, 1)
 		assert.Equal(t, 3, rResultTest.Data.Runs.TotalCount)
 		assert.False(t, rResultTest.Data.Runs.PageInfo.HasNextPage)
+	})
+}
+
+func TestGraphQLRunListRecordBudget(t *testing.T) {
+	e := Setup(t)
+	e.CreateBasic()
+
+	// Seeding a handful of runs keeps the alias count needed to exhaust the
+	// server's per-request budget small enough to send in one query.
+	const seededRuns = 10
+	for i := 1; i < seededRuns; i++ {
+		run, err := e.PlaybooksClient.PlaybookRuns.Create(context.Background(), client.PlaybookRunCreateOptions{
+			Name:        fmt.Sprintf("Budget run %d", i),
+			OwnerUserID: e.RegularUser.Id,
+			TeamID:      e.BasicTeam.Id,
+			PlaybookID:  e.BasicPlaybook.ID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, run)
+	}
+
+	// aliasedRunsQuery repeats the runs field under distinct aliases, which is the
+	// breadth that MaxDepth and the request body limit leave unconstrained.
+	aliasedRunsQuery := func(aliases int) string {
+		var query strings.Builder
+		query.WriteString("query Runs($userID: String!) {\n")
+		for i := range aliases {
+			fmt.Fprintf(&query, "\trun%d: runs(participantOrFollowerID: $userID) { edges { node { id } } }\n", i)
+		}
+		query.WriteString("}")
+
+		return query.String()
+	}
+
+	type runsResult struct {
+		Data map[string]struct {
+			Edges []struct {
+				Node struct {
+					ID string
+				}
+			}
+		}
+		Errors []struct {
+			Message string
+		}
+	}
+
+	t.Run("a query repeating runs under a few aliases resolves in full", func(t *testing.T) {
+		var result runsResult
+		err := e.PlaybooksClient.DoGraphql(context.Background(), &client.GraphQLInput{
+			Query:         aliasedRunsQuery(3),
+			OperationName: "Runs",
+			Variables:     map[string]any{"userID": "me"},
+		}, &result)
+		require.NoError(t, err)
+
+		require.Empty(t, result.Errors)
+		require.Len(t, result.Data, 3)
+		for alias, connection := range result.Data {
+			assert.Len(t, connection.Edges, seededRuns, "alias %s returned a short listing", alias)
+		}
+	})
+
+	t.Run("a query repeating runs under many aliases is rejected", func(t *testing.T) {
+		// 600 aliases over 10 seeded runs asks for 6000 records, past the budget.
+		var result runsResult
+		err := e.PlaybooksClient.DoGraphql(context.Background(), &client.GraphQLInput{
+			Query:         aliasedRunsQuery(600),
+			OperationName: "Runs",
+			Variables:     map[string]any{"userID": "me"},
+		}, &result)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, result.Errors)
+		assert.Contains(t, result.Errors[0].Message, "records per request")
 	})
 }
 

--- a/server/api_graphql_runs_test.go
+++ b/server/api_graphql_runs_test.go
@@ -269,7 +269,8 @@ func TestGraphQLRunListRecordBudget(t *testing.T) {
 	})
 
 	t.Run("a query repeating runs under many aliases is rejected", func(t *testing.T) {
-		// 600 aliases over 10 seeded runs asks for 6000 records, past the budget.
+		// 600 aliases over 10 seeded runs asks for 6000 records, past the budget,
+		// so the request is refused part way through rather than resolving in full.
 		var result runsResult
 		err := e.PlaybooksClient.DoGraphql(context.Background(), &client.GraphQLInput{
 			Query:         aliasedRunsQuery(600),
@@ -280,6 +281,48 @@ func TestGraphQLRunListRecordBudget(t *testing.T) {
 
 		require.NotEmpty(t, result.Errors)
 		assert.Contains(t, result.Errors[0].Message, "records per request")
+	})
+
+	t.Run("a query listing both runs and playbooks resolves in full", func(t *testing.T) {
+		// The shape of the webapp's largest query. Each listing claims its whole
+		// page before fetching, so all three pages have to fit in one budget.
+		var result struct {
+			Data struct {
+				ChannelRuns struct {
+					Edges []struct {
+						Node struct {
+							ID string
+						}
+					}
+				}
+				YourPlaybooks []struct {
+					ID string
+				}
+				AllPlaybooks []struct {
+					ID string
+				}
+			}
+			Errors []struct {
+				Message string
+			}
+		}
+		err := e.PlaybooksClient.DoGraphql(context.Background(), &client.GraphQLInput{
+			Query: `
+			query Runs($teamID: String!) {
+				channelRuns: runs(teamID: $teamID, first: 1000) { edges { node { id } } }
+				yourPlaybooks: playbooks(teamID: $teamID, withMembershipOnly: true) { id }
+				allPlaybooks: playbooks(teamID: $teamID, withMembershipOnly: false) { id }
+			}
+			`,
+			OperationName: "Runs",
+			Variables:     map[string]any{"teamID": e.BasicTeam.Id},
+		}, &result)
+		require.NoError(t, err)
+
+		require.Empty(t, result.Errors)
+		assert.Len(t, result.Data.ChannelRuns.Edges, seededRuns)
+		assert.NotEmpty(t, result.Data.YourPlaybooks)
+		assert.NotEmpty(t, result.Data.AllPlaybooks)
 	})
 }
 


### PR DESCRIPTION
## Summary
The GraphQL `runs` query defaulted to a 10,000 record page when a client omitted
pagination, and nothing bounded how many records a single request could hydrate
in total across all of the fields it resolves. Every run is hydrated with its
full checklists regardless of which fields the client selected, so a request can
cost considerably more memory than its size suggests.

This bounds a single run listing at 1,000 records — the largest page any current
client asks for — and gives each request a shared budget of 5,000 records across
the run and playbook resolvers. Page sizes above the bound are clamped rather
than rejected, so existing clients keep working, and the budget is charged by the
records actually fetched, so a request that asks for a large page but matches few
records is unaffected.

**Worst case after this change:** the budget is checked before a listing is
fetched and charged after it returns, so up to `MaxParallelism` (5) listings can
be in flight when the budget is nearly exhausted. The practical ceiling is
therefore roughly 10,000 runs per request (4,999 + 5 × 1,000) rather than a hard
5,000. This is a deliberate trade-off: reserving the full page size up front
would give a hard ceiling, but it would also require capping the `playbooks` page
size, which would truncate results for teams with more than 1,000 playbooks.
`playbooks` keeps its existing page size and is bounded by the shared budget alone.

No client changes are needed: the webapp's largest `runs` request is `first: 1000`,
and the remaining call sites use `first: 1`, `first: 8`, or no pagination.

Added unit tests for the page-size bound and the request budget (including
concurrent field resolution under `-race`), plus integration tests covering both
a query that stays within the budget and one that exceeds it. Regression tests
added; verified they fail when the fix is reverted.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-70245

## Checklist
- ~~Gated by experimental feature flag~~
- [x] Unit tests updated
- [ ] Planned cherry-picks: TBD, no fix versions set on the ticket yet